### PR TITLE
Config changes to allow app plugins local development

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,47 @@
+name: publish-npm
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish to NPM Package Registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: main
+      # limit releases to version changes - https://github.com/EndBug/version-check
+      - name: Check version changes
+        uses: EndBug/version-check@v1
+        id: version_check
+        with:
+          # diff the commits rather than commit message for version changes
+          diff-search: true
+
+      - name: Version update detected
+        if: steps.version_check.outputs.changed == 'true'
+        run: 'echo "Version change found! New version: ${{ steps.version_check.outputs.version }} (${{ steps.version_check.outputs.type }})"'
+
+      - name: Setup .npmrc file for NPM registry
+        if: steps.version_check.outputs.changed == 'true'
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        if: steps.version_check.outputs.changed == 'true'
+        run: yarn
+
+      - name: Build library
+        if: steps.version_check.outputs.changed == 'true'
+        run: yarn build:prod
+
+      - name: Publish package to NPM
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 # Build
 compiled
 dist
+node_modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
-nodeLinker: pnp
+nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-3.3.1.cjs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 ## Development
 
+### Working with Grafana
+
 @grafana/scenes does not come with dedicated playground yet. It is currently possible to run Scene demos using Grafana. To do that, the following setup is required.
 
 1. Clone @grafana/scenes repository.
@@ -24,3 +26,10 @@
 1. From Grafana directory run `yarn install`.
 1. Start Grafana with `scenes` [feature toggle enabled](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles)
 1. Navigate to `http://localhost:3000/scenes` to explore demo scenes.
+
+### Working with Grafana app plugin
+
+1. Run `YARN_IGNORE_PATH=1 yarn link` from @grafana/scenes directory.
+1. Run `yarn dev` from @grafana/scenes directory.
+1. Run `yarn link @grafana/scenes` from app plugin directory.
+1. Start app plugin development server.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "Grafana Labs",
     "license": "AGPL-3.0-only",
     "name": "@grafana/scenes",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Grafana framework for building dynamic dashboards",
     "keywords": [
         "typescript"
@@ -35,13 +35,19 @@
         "test": "jest",
         "lint": "eslint --ignore-path .gitignore . --ext .js,.tsx,.ts --cache"
     },
+    "dependencies": {
+        "@grafana/e2e-selectors": "canary",
+        "@grafana/experimental": "1.0.1",
+        "react-grid-layout": "1.3.4",
+        "react-use": "17.4.0",
+        "react-virtualized-auto-sizer": "1.0.7",
+        "uuid": "^9.0.0"
+    },
     "devDependencies": {
         "@emotion/css": "11.10.5",
         "@emotion/react": "11.10.5",
         "@grafana/data": "canary",
-        "@grafana/e2e-selectors": "canary",
         "@grafana/eslint-config": "5.1.0",
-        "@grafana/experimental": "1.0.1",
         "@grafana/runtime": "canary",
         "@grafana/schema": "canary",
         "@grafana/tsconfig": "^1.2.0-rc1",
@@ -80,9 +86,6 @@
         "prettier": "2.5.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-grid-layout": "1.3.4",
-        "react-use": "17.4.0",
-        "react-virtualized-auto-sizer": "1.0.7",
         "rimraf": "^3.0.2",
         "rollup": "2.79.1",
         "rollup-plugin-dts": "^5.0.0",
@@ -94,8 +97,7 @@
         "ts-node": "10.9.1",
         "tsc-watch": "^4.5.0",
         "tslib": "2.4.1",
-        "typescript": "4.9.3",
-        "uuid": "^9.0.0"
+        "typescript": "4.9.3"
     },
     "resolutions": {
         "@types/react": "17.0.42"


### PR DESCRIPTION
This introduces changes that allows using scenes in app plugins:
1. Changes PnP linker to NodeModules - otherwise local plugins cannot resolve dependencies in scenes when the package is linked.
2. Moves required deps from `devDependencies` to `dependencies`.
3. Adds workflow for automatic NPM publishing when package.json version changes