### PR TITLE
SceneQueryRunner: Enable datasource property interpolation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "Grafana Labs",
     "license": "AGPL-3.0-only",
     "name": "@grafana/scenes",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Grafana framework for building dynamic dashboards",
     "keywords": [
         "typescript"

--- a/src/utils/getDataSource.ts
+++ b/src/utils/getDataSource.ts
@@ -1,0 +1,12 @@
+import { DataSourceApi, DataSourceRef, ScopedVars } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+
+export async function getDataSource(
+  datasource: DataSourceRef | undefined,
+  scopedVars: ScopedVars
+): Promise<DataSourceApi> {
+  if (datasource && (datasource as any).query) {
+    return datasource as DataSourceApi;
+  }
+  return await getDataSourceSrv().get(datasource as string, scopedVars);
+}

--- a/src/variables/variants/query/QueryVariable.tsx
+++ b/src/variables/variants/query/QueryVariable.tsx
@@ -15,13 +15,13 @@ import {
   VariableRefresh,
   VariableSort,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
 
 import { sceneGraph } from '../../../core/sceneGraph';
 import { SceneComponentProps } from '../../../core/types';
 import { VariableDependencyConfig } from '../../VariableDependencyConfig';
 import { VariableValueSelect } from '../../components/VariableValueSelect';
 import { VariableValueOption } from '../../types';
+import { getDataSource } from '../../../utils/getDataSource';
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from '../MultiValueVariable';
 
 import { createQueryVariableRunner } from './createQueryVariableRunner';
@@ -92,7 +92,11 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       return of([]);
     }
 
-    return from(this.getDataSource()).pipe(
+    return from(
+      getDataSource(this.state.datasource, {
+        __sceneObject: { text: '__sceneObject', value: this },
+      })
+    ).pipe(
       mergeMap((ds) => {
         const runner = createQueryVariableRunner(ds);
         const target = runner.getTarget(this);
@@ -123,12 +127,6 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
         );
       })
     );
-  }
-
-  private async getDataSource(): Promise<DataSourceApi> {
-    return getDataSourceSrv().get(this.state.datasource, {
-      __sceneObject: { text: '__sceneObject', value: this },
-    });
   }
 
   private getRequest(target: DataQuery) {


### PR DESCRIPTION
Query variable can now depend on dynamically configured data source. This PR: 

1. Unifies data source retrieval between QueryVariable and SceneQueryRunner
2. Adds interpolation to `datasource` property of QueryVariable