### PR TITLE
SceneQueryRunner: Pass scene object via scoped vars to enable query interpolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "Grafana Labs",
     "license": "AGPL-3.0-only",
     "name": "@grafana/scenes",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Grafana framework for building dynamic dashboards",
     "keywords": [
         "typescript"

--- a/src/querying/SceneQueryRunner.ts
+++ b/src/querying/SceneQueryRunner.ts
@@ -9,6 +9,7 @@ import {
   DataTransformerConfig,
   PanelData,
   rangeUtil,
+  ScopedVar,
   TimeRange,
   transformDataFrame,
 } from '@grafana/data';
@@ -122,7 +123,9 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
 
   private async runWithTimeRange(timeRange: TimeRange) {
     const { datasource, minInterval, queries } = this.state;
-
+    const sceneObjectScopedVar: Record<string, ScopedVar<SceneQueryRunner>> = {
+      __sceneObject: { text: '__sceneObject', value: this },
+    };
     const request: DataQueryRequest = {
       app: CoreApp.Dashboard,
       requestId: getNextRequestId(),
@@ -134,14 +137,14 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
       intervalMs: 1000,
       targets: cloneDeep(queries),
       maxDataPoints: this.getMaxDataPoints(),
-      scopedVars: {},
+      scopedVars: sceneObjectScopedVar,
       startTime: Date.now(),
     };
 
     try {
       const ds = await getDataSource(datasource, {
         ...request.scopedVars,
-        __sceneObject: { text: '__sceneObject', value: this },
+        ...sceneObjectScopedVar,
       });
 
       // Attach the data source name to each query

--- a/src/querying/SceneQueryRunner.ts
+++ b/src/querying/SceneQueryRunner.ts
@@ -142,10 +142,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     };
 
     try {
-      const ds = await getDataSource(datasource, {
-        ...request.scopedVars,
-        ...sceneObjectScopedVar,
-      });
+      const ds = await getDataSource(datasource, request.scopedVars);
 
       // Attach the data source name to each query
       request.targets = request.targets.map((query) => {


### PR DESCRIPTION
This PR makes sure the SceneQueryRunner scene object is passed down to `runRequest` function via scoped vars for `template_srv` to interpolate queries when interpolation is handled in the data source implementation.

This can be observed i.e. :
- in http://localhost:3000/scenes/Variables?var-server=AA&var-pod=AAA&var-handler=AAAA&from=now-6h&to=now - legend is now correctly shown.
- in any Prometheus query that uses template vars.