### PR TITLE
SceneVariableSet: Fixes issue with deactivation cleanup

### DIFF
--- a/src/variables/sets/SceneVariableSet.test.tsx
+++ b/src/variables/sets/SceneVariableSet.test.tsx
@@ -86,16 +86,36 @@ describe('SceneVariableList', () => {
   describe('When deactivated', () => {
     it('Should cancel running variable queries', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const set = new SceneVariableSet({ variables: [A] });
 
-      const scene = new TestScene({
-        $variables: new SceneVariableSet({ variables: [A] }),
-      });
+      const scene = new TestScene({ $variables: set });
 
       scene.activate();
       expect(A.isGettingValues).toBe(true);
 
       scene.deactivate();
       expect(A.isGettingValues).toBe(false);
+    });
+
+    it.only('Can reactivate after can', async () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const B = new TestVariable({ name: 'B', query: 'A.$A.*', value: '', text: '', options: [] });
+      const set = new SceneVariableSet({ variables: [A, B] });
+      const scene = new TestScene({ $variables: set });
+
+      // Active and complete first variable
+      scene.activate();
+      A.signalUpdateCompleted();
+      expect(B.isGettingValues).toBe(true);
+
+      // Deactivate and reactivate
+      scene.deactivate();
+      expect(B.isGettingValues).toBe(false);
+
+      // Reactivate and complete A again
+      scene.activate();
+      A.signalUpdateCompleted();
+      expect(B.isGettingValues).toBe(true);
     });
 
     describe('When update process completed and variables have changed values', () => {

--- a/src/variables/sets/SceneVariableSet.test.tsx
+++ b/src/variables/sets/SceneVariableSet.test.tsx
@@ -97,25 +97,21 @@ describe('SceneVariableList', () => {
       expect(A.isGettingValues).toBe(false);
     });
 
-    it.only('Can reactivate after can', async () => {
+    it('Can re-activate after deactivated', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
-      const B = new TestVariable({ name: 'B', query: 'A.$A.*', value: '', text: '', options: [] });
-      const set = new SceneVariableSet({ variables: [A, B] });
-      const scene = new TestScene({ $variables: set });
+      const scene = new TestScene({ $variables: new SceneVariableSet({ variables: [A] }) });
 
       // Active and complete first variable
       scene.activate();
-      A.signalUpdateCompleted();
-      expect(B.isGettingValues).toBe(true);
+      expect(A.isGettingValues).toBe(true);
 
       // Deactivate and reactivate
       scene.deactivate();
-      expect(B.isGettingValues).toBe(false);
+      expect(A.isGettingValues).toBe(false);
 
       // Reactivate and complete A again
       scene.activate();
-      A.signalUpdateCompleted();
-      expect(B.isGettingValues).toBe(true);
+      expect(A.isGettingValues).toBe(true);
     });
 
     describe('When update process completed and variables have changed values', () => {

--- a/src/variables/sets/SceneVariableSet.test.tsx
+++ b/src/variables/sets/SceneVariableSet.test.tsx
@@ -86,9 +86,7 @@ describe('SceneVariableList', () => {
   describe('When deactivated', () => {
     it('Should cancel running variable queries', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
-      const set = new SceneVariableSet({ variables: [A] });
-
-      const scene = new TestScene({ $variables: set });
+      const scene = new TestScene({ $variables: new SceneVariableSet({ variables: [A] }) });
 
       scene.activate();
       expect(A.isGettingValues).toBe(true);

--- a/src/variables/sets/SceneVariableSet.ts
+++ b/src/variables/sets/SceneVariableSet.ts
@@ -37,11 +37,14 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
    */
   public deactivate(): void {
     super.deactivate();
-    this.variablesToUpdate.clear();
 
     for (const update of this.updating.values()) {
       update.subscription?.unsubscribe();
     }
+
+    this.variablesToUpdate.clear();
+    this.updating.clear();
+    this.variablesThatHaveChanged.clear();
   }
 
   /**


### PR DESCRIPTION
I somehow thought calling unsubscribe was enough but of course not we also need to clear these other sets in deactivate 