### PR TITLE
Embedded scene: Allow initialising URL sync for an EmbeddedScene externally

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "name": "@grafana/scenes",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Grafana framework for building dynamic dashboards",
   "keywords": [
     "typescript"

--- a/src/components/EmbeddedScene.tsx
+++ b/src/components/EmbeddedScene.tsx
@@ -23,15 +23,25 @@ export class EmbeddedScene extends SceneObjectBase<EmbeddedSceneState> {
 
   private urlSyncManager?: UrlSyncManager;
 
-  public activate() {
-    super.activate();
+  /**
+   * initUrlSync should be called before the scene is rendered to ensure that objects are in sync
+   * before they get activated. This saves some unnecessary re-renders and makes sure variables
+   * queries are issued as needed.
+   */
+  public initUrlSync() {
     this.urlSyncManager = new UrlSyncManager(this);
     this.urlSyncManager.initSync();
   }
 
+  public activate() {
+    super.activate();
+  }
+
   public deactivate() {
     super.deactivate();
-    this.urlSyncManager!.cleanUp();
+    if (this.urlSyncManager) {
+      this.urlSyncManager!.cleanUp();
+    }
   }
 }
 


### PR DESCRIPTION
This is just a nit to make sure k8s demo works as expected. Will be soon replaced by SceneAppPage.