### PR TITLE
SceneQueryRunner: Run queries when variables changed before re-activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "name": "@grafana/scenes",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Grafana framework for building dynamic dashboards",
   "keywords": [
     "typescript"


### PR DESCRIPTION
When working on a demo app, I discovered an issue with queries not being re-run if the variable value has changed before the activation (or re-activation) of the `SceneQueryRunner`.

This can happen i.e. in drill-down views, when variable values are initialized from URL before the SceneQueryRunner is activated. When URL sync happens this way - and it should at least for now ref https://github.com/grafana/scenes/pull/15 - the `SceneVariableValueChangedEvent` listeners are not yet activated, hence the changes are not propagated to `SceneQueryRunner`.

