### PR TITLE
SceneVariableSet: Improved logic for when to validateAndUpdate variables and notify scene of changes

### DIFF
--- a/src/variables/sets/SceneVariableSet.test.tsx
+++ b/src/variables/sets/SceneVariableSet.test.tsx
@@ -5,11 +5,10 @@ import { act } from 'react-dom/test-utils';
 import { SceneCanvasText } from '../../components/SceneCanvasText';
 import { SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneObjectStatePlain } from '../../core/types';
+import { SceneObjectStatePlain, SceneLayoutChildState, SceneObject } from '../../core/types';
 import { TestVariable } from '../variants/TestVariable';
 
 import { SceneVariableSet } from './SceneVariableSet';
-import { SceneLayoutChildState, SceneObject } from '@grafana/scenes';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 


### PR DESCRIPTION
This tries to solve two major things

* Figure out when we do not need to call validateAndUpdate again after re-activation (when the current value & options are valid)
* Notify the scene of changes when the variable was changed while in-active (Both for other variables, and other scene objects)
