### PR TITLE
SceneQueryRunner: Update container width only when it is greater than 0

### DIFF
--- a/src/querying/SceneQueryRunner.ts
+++ b/src/querying/SceneQueryRunner.ts
@@ -107,8 +107,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
         }, 0);
       }
     } else {
-      // let's just remember the width until next query issue
-      this._containerWidth = width;
+      // if the updated container width is bigger than 0 let's remember the width until next query issue
+      if (width > 0) {
+        this._containerWidth = width;
+      }
     }
   }
 


### PR DESCRIPTION
This fixes an issue with queries being issued with maxDataPoints=0, when i.e. queries are issued before the consumer (VizPanel) has set it's final width. This can be observed with scenes that are re-activated and queries are triggered by i.e. variable change.

This PR makes sure than `width=0` updates are ignored if the container width was previously set.