### PR TITLE
SceneTimeRange: Some time range model changes 

### DIFF
--- a/src/components/SceneTimePicker.tsx
+++ b/src/components/SceneTimePicker.tsx
@@ -38,8 +38,7 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
         onChangeTimeZone={() => {}}
         onChangeFiscalYearStartMonth={() => {}}
       />
-
-      <RefreshPicker onRefresh={timeRange.onRefresh} onIntervalChanged={timeRange.onIntervalChanged} />
+      <RefreshPicker onRefresh={timeRange.onRefresh} onIntervalChanged={() => {}} />
     </ToolbarButtonRow>
   );
 }

--- a/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/src/components/VizPanel/VizPanelRenderer.tsx
@@ -55,14 +55,16 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     $data.setContainerWidth(width);
   }
 
+  const leftItems = isDraggable ? [dragHandle] : [];
+
+  // If we have local time range show that in panel header
+  if (model.state.$timeRange) {
+    leftItems.push(<model.state.$timeRange.Component model={model.state.$timeRange} />);
+  }
+
   return (
     <div ref={ref as RefCallback<HTMLDivElement>} style={{ position: 'absolute', width: '100%', height: '100%' }}>
-      <PanelChrome
-        title={titleInterpolated}
-        width={width}
-        height={height}
-        leftItems={isDraggable ? [dragHandle] : undefined}
-      >
+      <PanelChrome title={titleInterpolated} width={width} height={height} leftItems={leftItems}>
         {(innerWidth, innerHeight) => (
           <>
             {!dataWithOverrides && <div>No data...</div>}

--- a/src/core/SceneObjectBase.test.ts
+++ b/src/core/SceneObjectBase.test.ts
@@ -4,6 +4,7 @@ import { SceneDataNode } from './SceneDataNode';
 import { SceneObjectBase } from './SceneObjectBase';
 import { SceneObjectStateChangedEvent } from './events';
 import { SceneLayoutChild, SceneObject, SceneObjectStatePlain } from './types';
+import { SceneTimeRange } from '../core/SceneTimeRange';
 
 interface TestSceneState extends SceneObjectStatePlain {
   name?: string;
@@ -94,6 +95,7 @@ describe('SceneObject', () => {
     const scene = new TestScene({
       $data: new SceneDataNode({}),
       $variables: new SceneVariableSet({ variables: [] }),
+      $timeRange: new SceneTimeRange({}),
     });
 
     scene.activate();
@@ -108,6 +110,10 @@ describe('SceneObject', () => {
 
     it('Should activate $variables', () => {
       expect(scene.state.$variables!.isActive).toBe(true);
+    });
+
+    it('Should activate $timeRange', () => {
+      expect(scene.state.$timeRange!.isActive).toBe(true);
     });
   });
 

--- a/src/core/SceneObjectBase.tsx
+++ b/src/core/SceneObjectBase.tsx
@@ -139,7 +139,11 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   public activate() {
     this._isActive = true;
 
-    const { $data, $variables } = this.state;
+    const { $data, $variables, $timeRange } = this.state;
+
+    if ($timeRange && !$timeRange.isActive) {
+      $timeRange.activate();
+    }
 
     if ($data && !$data.isActive) {
       $data.activate();
@@ -156,7 +160,11 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   public deactivate(): void {
     this._isActive = false;
 
-    const { $data, $variables } = this.state;
+    const { $data, $variables, $timeRange } = this.state;
+
+    if ($timeRange && $timeRange.isActive) {
+      $timeRange.deactivate();
+    }
 
     if ($data && $data.isActive) {
       $data.deactivate();

--- a/src/core/SceneTimeRange.tsx
+++ b/src/core/SceneTimeRange.tsx
@@ -16,6 +16,8 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     super({ from, to, timeZone, value, ...state });
   }
 
+  public onIntervalChanged(value: string): void {}
+
   public onTimeRangeChange = (timeRange: TimeRange) => {
     const update: Partial<SceneTimeRangeState> = {};
 
@@ -38,8 +40,6 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   public onRefresh = () => {
     this.setState({ value: evaluateTimeRange(this.state.from, this.state.to, this.state.timeZone) });
   };
-
-  public onIntervalChanged = (_: string) => {};
 
   public getUrlState(state: SceneTimeRangeState) {
     return { from: state.from, to: state.to };

--- a/src/core/SceneTimeRange.tsx
+++ b/src/core/SceneTimeRange.tsx
@@ -16,8 +16,6 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     super({ from, to, timeZone, value, ...state });
   }
 
-  public onIntervalChanged(value: string): void {}
-
   public onTimeRangeChange = (timeRange: TimeRange) => {
     const update: Partial<SceneTimeRangeState> = {};
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -132,8 +132,8 @@ export interface SceneTimeRangeState extends SceneObjectStatePlain {
 
 export interface SceneTimeRangeLike extends SceneObject<SceneTimeRangeState> {
   onTimeRangeChange(timeRange: TimeRange): void;
-  onIntervalChanged(interval: string): void;
   onRefresh(): void;
+  onIntervalChanged(value: string): void;
 }
 
 export interface SceneObjectRef {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -133,7 +133,6 @@ export interface SceneTimeRangeState extends SceneObjectStatePlain {
 export interface SceneTimeRangeLike extends SceneObject<SceneTimeRangeState> {
   onTimeRangeChange(timeRange: TimeRange): void;
   onRefresh(): void;
-  onIntervalChanged(value: string): void;
 }
 
 export interface SceneObjectRef {


### PR DESCRIPTION

* Activate time range objects 
* When VizPanel detects a local time range render it's component in the PanelChrome header 
* Remove onIntervalChanged from SceneTimeRangeLike interface 