### PR TITLE
SceneComponentWrapper: Wrap in React.memo to eliminate unnessary re-renders

### DIFF
--- a/src/core/SceneComponentWrapper.tsx
+++ b/src/core/SceneComponentWrapper.tsx
@@ -22,10 +22,6 @@ function SceneComponentWrapperWithoutMemo<T extends SceneObject>({
     };
   }, [model]);
 
-  /** Useful for tests and evaluating efficiency in reducing renderings */
-  // @ts-ignore
-  model._renderCount += 1;
-
   if (!isEditing) {
     return inner;
   }

--- a/src/core/SceneComponentWrapper.tsx
+++ b/src/core/SceneComponentWrapper.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import { SceneComponentProps, SceneEditor, SceneObject } from './types';
 
-export function SceneComponentWrapper<T extends SceneObject>({
+function SceneComponentWrapperWithoutMemo<T extends SceneObject>({
   model,
   isEditing,
   ...otherProps
@@ -39,6 +39,8 @@ export function SceneComponentWrapper<T extends SceneObject>({
     </EditWrapper>
   );
 }
+
+export const SceneComponentWrapper = React.memo(SceneComponentWrapperWithoutMemo);
 
 function EmptyRenderer<T>(_: SceneComponentProps<T>): React.ReactElement | null {
   return null;

--- a/src/core/SceneObjectBase.tsx
+++ b/src/core/SceneObjectBase.tsx
@@ -19,8 +19,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   private _state: TState;
   private _events = new EventBusSrv();
 
-  /** Incremented in SceneComponentWrapper, useful for tests and rendering optimizations */
-  protected _renderCount = 0;
   protected _parent?: SceneObject;
   protected _subs = new Subscription();
 


### PR DESCRIPTION
Noticed that using SceneApp with scenes with variables and URL sync enabled causes a lot of unnessary re-renders due to re-renders being triggered due to location changes (due to useLocation or useRouteParams),
these re-renders trickles all the way down.

By wrapping all components in React.memo we make
sure the only thing that triggers re-render is

* State update
* New instance
* isEditing change


