### PR TITLE
QueryVariable: Enable custom variable support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "AGPL-3.0-only",
   "name": "@grafana/scenes",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Grafana framework for building dynamic dashboards",
   "keywords": [
     "typescript"


### PR DESCRIPTION
When working on o11y app, @domas and @bfmatei noticed an issue with resolving template variables. The issue is described in https://github.com/grafana/app-o11y-kwl/pull/176#pullrequestreview-1330604155.

After some investigation I found out that there was variables support change in Prometheus data source, introduced in https://github.com/grafana/grafana/pull/63529.

This change surfaced an issue of Scene's `QueryVariable` missing custom variables support implementation. This PR brings this according to how it's implemented in core.