### PR TITLE
Fix using minified version

### DIFF
--- a/src/components/layout/SceneGridRow.tsx
+++ b/src/components/layout/SceneGridRow.tsx
@@ -5,7 +5,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { sceneGraph } from '../../core/sceneGraph';
 import { SceneComponentProps, SceneLayoutChildState, SceneObject, SceneObjectUrlValues } from '../../core/types';
 import { SceneObjectUrlSyncConfig } from '../../services/SceneObjectUrlSyncConfig';
 import { SceneDragHandle } from '../SceneDragHandle';
@@ -40,18 +39,22 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
     });
   }
 
-  public onCollapseToggle = () => {
-    if (!this.state.isCollapsible) {
-      return;
-    }
-
+  public get layout(): SceneGridLayout {
     const layout = this.parent;
 
     if (!layout || !(layout instanceof SceneGridLayout)) {
       throw new Error('SceneGridRow must be a child of SceneGridLayout');
     }
 
-    layout.toggleRow(this);
+    return layout;
+  }
+
+  public onCollapseToggle = () => {
+    if (!this.state.isCollapsible) {
+      return;
+    }
+
+    this.layout.toggleRow(this);
   };
 
   public getUrlState(state: SceneGridRowState) {
@@ -69,8 +72,7 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
 export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow>) {
   const styles = useStyles2(getSceneGridRowStyles);
   const { isCollapsible, isCollapsed, title, placement } = model.useState();
-  const layout = sceneGraph.getLayout(model);
-  const dragHandle = <SceneDragHandle layoutKey={layout.state.key!} />;
+  const dragHandle = <SceneDragHandle layoutKey={model.layout.state.key!} />;
 
   return (
     <div className={styles.row}>

--- a/src/core/sceneGraph.ts
+++ b/src/core/sceneGraph.ts
@@ -6,6 +6,8 @@ import { SceneVariables } from '../variables/types';
 
 import { SceneDataState, SceneEditor, SceneLayoutState, SceneObject, SceneTimeRangeLike } from './types';
 import { lookupVariable } from '../variables/lookupVariable';
+import { SceneFlexLayout } from '../components/layout/SceneFlexLayout';
+import { SceneGridLayout } from '../components/layout/SceneGridLayout';
 
 /**
  * Get the closest node with variables
@@ -74,7 +76,7 @@ export function getSceneEditor(sceneObject: SceneObject): SceneEditor {
  * Will walk up the scene object graph to the closest $layout scene object
  */
 export function getLayout(scene: SceneObject): SceneObject<SceneLayoutState> {
-  if (scene.constructor.name === 'SceneFlexLayout' || scene.constructor.name === 'SceneGridLayout') {
+  if (scene instanceof SceneFlexLayout || scene instanceof SceneGridLayout) {
     return scene as SceneObject<SceneLayoutState>;
   }
 


### PR DESCRIPTION
When using a minified version of the library, Terser and/or other uglifiers are tampering with the class names and the constructor name. This is the case for a plugin generate by `@grafana/create-plugin` package.

Checking if an object is instance of class fixes this.