### PR TITLE
QueryRunner: POC of a custom query handler

### DIFF
--- a/src/querying/CustomQueryHandlerDataSource.ts
+++ b/src/querying/CustomQueryHandlerDataSource.ts
@@ -37,7 +37,6 @@ export class CustomQueryHandlerDataSource extends DataSourceApi {
   }
 
   public query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
-    console.log('asd');
     return this.customQueryHandler(request);
   }
 

--- a/src/querying/CustomQueryHandlerDataSource.ts
+++ b/src/querying/CustomQueryHandlerDataSource.ts
@@ -1,0 +1,47 @@
+import { Observable } from 'rxjs';
+import { DataQuery, DataQueryRequest, DataSourceApi, DataQueryResponse, PluginType } from '@grafana/data';
+import { CustomQueryHandler } from './SceneQueryRunner';
+
+export class CustomQueryHandlerDataSource extends DataSourceApi {
+  public constructor(private customQueryHandler: CustomQueryHandler) {
+    super({
+      name: 'CustomQueryHandlerDataSource',
+      uid: 'CustomQueryHandlerDataSource',
+      type: 'CustomQueryHandlerDataSource',
+      id: 1,
+      readOnly: true,
+      jsonData: {},
+      access: 'direct',
+      meta: {
+        id: 'CustomQueryHandlerDataSource',
+        name: 'CustomQueryHandlerDataSource',
+        type: PluginType.datasource,
+        info: {
+          author: {
+            name: '',
+          },
+          description: '',
+          links: [],
+          logos: {
+            large: '',
+            small: '',
+          },
+          screenshots: [],
+          updated: '',
+          version: '',
+        },
+        module: '',
+        baseUrl: '',
+      },
+    });
+  }
+
+  public query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
+    console.log('asd');
+    return this.customQueryHandler(request);
+  }
+
+  public testDatasource(): Promise<any> {
+    return Promise.resolve({});
+  }
+}


### PR DESCRIPTION
I think the use case of custom query handler came up in tasks with k6 team and mentioned by a11y (Bogdan). 

This PR explores a way that app plugins can use SceneQueryRunner but instead of h
having to reference a DataSource using data source uid (which needs to be added instance and installed plugin)
they can instead just  provide the implementation of a custom query handler.

If thee is need to combine data from a normal data source with a custom query handler I was thinking of
testing implementing a CompositeQueryRunner that has an internal array of SceneQueryRunners. Not
 sure how easy that is to implement yet.


