### PR TITLE
Return value without stringify

### DIFF
--- a/src/variables/interpolation/formatRegistry.test.ts
+++ b/src/variables/interpolation/formatRegistry.test.ts
@@ -14,7 +14,7 @@ function formatValue<T extends VariableValue>(
 }
 
 describe('formatRegistry', () => {
-  it('Can format values acccording to format', () => {
+  it('Can format values according to format', () => {
     expect(formatValue(FormatRegistryID.lucene, 'foo bar')).toBe('foo\\ bar');
     expect(formatValue(FormatRegistryID.lucene, '-1')).toBe('-1');
     expect(formatValue(FormatRegistryID.lucene, '-test')).toBe('\\-test');
@@ -46,6 +46,7 @@ describe('formatRegistry', () => {
     );
 
     expect(formatValue(FormatRegistryID.json, ['test', 12])).toBe('["test",12]');
+    expect(formatValue(FormatRegistryID.json, 'test')).toBe('test');
 
     expect(formatValue(FormatRegistryID.percentEncode, ['foo()bar BAZ', 'test2'])).toBe(
       '%7Bfoo%28%29bar%20BAZ%2Ctest2%7D'

--- a/src/variables/interpolation/formatRegistry.ts
+++ b/src/variables/interpolation/formatRegistry.ts
@@ -179,6 +179,9 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       name: 'JSON',
       description: 'JSON stringify value',
       formatter: (value) => {
+        if (typeof value === 'string') {
+          return value
+        }
         return JSON.stringify(value);
       },
     },


### PR DESCRIPTION
When interpolating variables for json format in [template_srv.ts](https://github.com/grafana/grafana/blob/f8d89eff562dfb7c90b0bb617c639339af30d55c/public/app/features/templating/template_srv.ts#L128), when the variable value is a string, the formatter wraps it in an extra set of unnecessary quotation marks:
<img width="201" alt="Screen Shot 2023-03-09 at 6 27 56 PM" src="https://user-images.githubusercontent.com/16140639/224289745-0fca58a9-6f6d-4b04-a212-ff709109fcd8.png">

I added a check for typeof variable to prevent this. 