### PR TITLE
QueryRunner: Support triggering processing transformations without re-issung query

### DIFF
--- a/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/src/components/VizPanel/VizPanelRenderer.tsx
@@ -6,8 +6,7 @@ import { getAppEvents } from '@grafana/runtime';
 import { PanelChrome, ErrorBoundaryAlert, useTheme2 } from '@grafana/ui';
 
 import { sceneGraph } from '../../core/sceneGraph';
-import { SceneComponentProps } from '../../core/types';
-import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
+import { isSceneQueryRunner, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
 
@@ -56,8 +55,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   const PanelComponent = plugin.panel;
 
-  // Query runner needs to with for auto maxDataPoints
-  if ($data instanceof SceneQueryRunner) {
+  // If we have a query runner on our level inform it of the container width (used to set auto max data points)
+  if ($data && isSceneQueryRunner($data)) {
     $data.setContainerWidth(width);
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -178,7 +178,6 @@ export type DeepPartial<T> = {
 
 export interface SceneQueryRunnerInterface extends SceneObject<SceneDataState> {
   setContainerWidth: (width: number) => void;
-  // Might add ways here to subscribe or access raw data before transformations
 }
 
 export function isSceneQueryRunner(obj: SceneObject): obj is SceneQueryRunnerInterface {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -175,3 +175,12 @@ export type CustomTransformOperator = (context: DataTransformContext) => MonoTyp
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
+
+export interface SceneQueryRunnerInterface extends SceneObject<SceneDataState> {
+  setContainerWidth: (width: number) => void;
+  // Might add ways here to subscribe or access raw data before transformations
+}
+
+export function isSceneQueryRunner(obj: SceneObject): obj is SceneQueryRunnerInterface {
+  return 'setContainerWidth' in obj;
+}

--- a/src/querying/SceneQueryRunner.test.ts
+++ b/src/querying/SceneQueryRunner.test.ts
@@ -24,7 +24,7 @@ import {
   SceneQueryRunnerDataTransformer,
 } from './transformations';
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectStatePlain } from '../core/types';
+import { SceneObjectStatePlain, SceneQueryRunnerInterface } from '../core/types';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   getRef: () => ({ uid: 'test' }),
@@ -361,7 +361,7 @@ describe('SceneQueryRunner', () => {
     });
 
     describe('custom transformer object', () => {
-      it.only('Can re-trigger transformations without issuing new query', async () => {
+      it('Can re-trigger transformations without issuing new query', async () => {
         const customDataTransfomer = new CustomQueryRunnerDataTransformer({ structureRev: 10 });
 
         const queryRunner = new SceneQueryRunner({
@@ -583,7 +583,10 @@ class CustomQueryRunnerDataTransformer
 {
   public updateStateAndRetriggerTransformation() {
     this.setState({ structureRev: this.state.structureRev + 1 });
-    this.publishEvent(new ReprocessTransformationsEvent());
+
+    if (this.parent instanceof SceneQueryRunner) {
+      this.parent.reprocessData();
+    }
   }
 
   public transform(data: PanelData): Observable<PanelData> {

--- a/src/querying/SceneQueryRunner.ts
+++ b/src/querying/SceneQueryRunner.ts
@@ -82,7 +82,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     // Pipe raw data through the transformations and store in state
     this._subs.add(
       this._rawDataSubject.pipe(mergeMap(this.transformData)).subscribe((data) => {
-        console.log('got transformed data');
         this.setState({ data, dataPreTransforms: this._dataPreTransforms });
       })
     );
@@ -93,14 +92,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
       // Subscribe to transformer wanting to re-process transformations
       this._subs.add(
         this.state.transformer.subscribeToEvent(ReprocessTransformationsEvent, () => {
-          console.log('re-processing transformations');
           this._rawDataSubject.next(this.state.dataPreTransforms!);
         })
       );
     }
-
-    // this._rawDataSubject.next({ state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() });
-    // this._rawDataSubject.next({ state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() });
 
     if (this.shouldRunQueriesOnActivate()) {
       this.runQueries();

--- a/src/querying/transformations.ts
+++ b/src/querying/transformations.ts
@@ -1,0 +1,43 @@
+import { BusEventBase, DataTransformerConfig, PanelData, transformDataFrame } from '@grafana/data';
+import { map, Observable, of } from 'rxjs';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { CustomTransformOperator, SceneObject, SceneObjectStatePlain } from '../core/types';
+
+export interface SceneQueryRunnerDataTransformer extends SceneObject {
+  transform(data: PanelData): Observable<PanelData>;
+}
+
+export class ReprocessTransformationsEvent extends BusEventBase {
+  public static readonly type = 'reprocess-transformations';
+}
+
+export interface DefaultQueryRunnerDataTransformerState extends SceneObjectStatePlain {
+  // Array of standard transformation configs and custom transform operators
+  transformations?: Array<DataTransformerConfig | CustomTransformOperator>;
+}
+
+export class DefaultQueryRunnerDataTransformer
+  extends SceneObjectBase<DefaultQueryRunnerDataTransformerState>
+  implements SceneQueryRunnerDataTransformer
+{
+  // TODO add variable dependency config
+
+  // Should this automatically trigger ReprocessTransformationsEvent on state change?
+
+  public transform(data: PanelData): Observable<PanelData> {
+    const transformations = this.state.transformations || [];
+
+    if (transformations.length === 0) {
+      return of(data);
+    }
+
+    const ctx = {
+      interpolate: (value: string) => {
+        return sceneGraph.interpolate(this, value, data.request?.scopedVars);
+      },
+    };
+
+    return transformDataFrame(transformations, data.series, ctx).pipe(map((series) => ({ ...data, series })));
+  }
+}


### PR DESCRIPTION
This refactors SceneQueryRunner to provide more flexibility around transformations

* To support getting data without transforms applied (not fully implmented in this PR but would be easy to add)
* To support re-process transformations without triggering query
* Support custom transformation scene objects that transform data based on changing variables, or other scene objects they subscribe to (like search box) 
* To support variable use in transformations (When change only triggers transform), not fully implemented in PR

Example use case is to simplify use cases like:
the point of this is component is to simplify use cases covered in https://github.com/grafana/grafana/blob/f7d37a34b2e110d4edb21100535333456da4e8db/public/app/features/scenes/apps/SceneSearchBox.tsx#L53

