### PR TITLE
QueryRunner: Alternative more compositional approach to transformations

### DIFF
--- a/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/src/components/VizPanel/VizPanelRenderer.tsx
@@ -6,8 +6,7 @@ import { getAppEvents } from '@grafana/runtime';
 import { PanelChrome, ErrorBoundaryAlert, useTheme2 } from '@grafana/ui';
 
 import { sceneGraph } from '../../core/sceneGraph';
-import { SceneComponentProps } from '../../core/types';
-import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
+import { isSceneQueryRunner, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
 
@@ -56,8 +55,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   const PanelComponent = plugin.panel;
 
-  // Query runner needs to with for auto maxDataPoints
-  if ($data instanceof SceneQueryRunner) {
+  // If we have a query runner on our level inform it of the container width (used to set auto max data points)
+  if ($data && isSceneQueryRunner($data)) {
     $data.setContainerWidth(width);
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -178,7 +178,6 @@ export type DeepPartial<T> = {
 
 export interface SceneQueryRunnerInterface extends SceneObject<SceneDataState> {
   setContainerWidth: (width: number) => void;
-  // Might add ways here to subscribe or access raw data before transformations
 }
 
 export function isSceneQueryRunner(obj: SceneObject): obj is SceneQueryRunnerInterface {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -175,3 +175,12 @@ export type CustomTransformOperator = (context: DataTransformContext) => MonoTyp
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
+
+export interface SceneQueryRunnerInterface extends SceneObject<SceneDataState> {
+  setContainerWidth: (width: number) => void;
+  // Might add ways here to subscribe or access raw data before transformations
+}
+
+export function isSceneQueryRunner(obj: SceneObject): obj is SceneQueryRunnerInterface {
+  return 'setContainerWidth' in obj;
+}

--- a/src/querying/SceneQueryRunner.test.ts
+++ b/src/querying/SceneQueryRunner.test.ts
@@ -18,14 +18,9 @@ import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
 import { TestVariable } from '../variables/variants/TestVariable';
 import { getCustomTransformOperator } from '../core/SceneDataTransformer.test';
 import { mockTransformationsRegistry } from '../utils/mockTransformationsRegistry';
-import {
-  DefaultQueryRunnerDataTransformer,
-  QueryRunnerWithTransformations,
-  ReprocessTransformationsEvent,
-  SceneQueryRunnerDataTransformer,
-} from './transformations';
+import { QueryRunnerWithTransformations } from './transformations';
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectStatePlain, SceneQueryRunnerInterface } from '../core/types';
+import { SceneObjectStatePlain } from '../core/types';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   getRef: () => ({ uid: 'test' }),

--- a/src/querying/SceneQueryRunner.test.ts
+++ b/src/querying/SceneQueryRunner.test.ts
@@ -590,27 +590,6 @@ describe('SceneQueryRunner', () => {
   });
 });
 
-// interface CustomQueryRunnerDataTransformerState extends SceneObjectStatePlain {
-//   structureRev: number;
-// }
-
-// class CustomQueryRunnerDataTransformer
-//   extends SceneObjectBase<CustomQueryRunnerDataTransformerState>
-//   implements SceneQueryRunnerDataTransformer
-// {
-//   public updateStateAndRetriggerTransformation() {
-//     this.setState({ structureRev: this.state.structureRev + 1 });
-
-//     if (this.parent instanceof SceneQueryRunner) {
-//       this.parent.reprocessData();
-//     }
-//   }
-
-//   public transform(data: PanelData): Observable<PanelData> {
-//     return of(data).pipe(map((d) => ({ ...d, structureRev: this.state.structureRev })));
-//   }
-// }
-
 export interface SceneObjectSearchBoxState extends SceneObjectStatePlain {
   value: string;
 }

--- a/src/querying/SceneQueryRunner.test.ts
+++ b/src/querying/SceneQueryRunner.test.ts
@@ -24,7 +24,7 @@ import {
   SceneQueryRunnerDataTransformer,
 } from './transformations';
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectStatePlain } from '../core/types';
+import { SceneObjectStatePlain, SceneQueryRunnerInterface } from '../core/types';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   getRef: () => ({ uid: 'test' }),
@@ -361,7 +361,7 @@ describe('SceneQueryRunner', () => {
     });
 
     describe('custom transformer object', () => {
-      it.only('Can re-trigger transformations without issuing new query', async () => {
+      it('Can re-trigger transformations without issuing new query', async () => {
         const customDataTransfomer = new CustomQueryRunnerDataTransformer({ structureRev: 10 });
 
         const queryRunner = new SceneQueryRunner({
@@ -583,7 +583,10 @@ class CustomQueryRunnerDataTransformer
 {
   public updateStateAndRetriggerTransformation() {
     this.setState({ structureRev: this.state.structureRev + 1 });
-    this.publishEvent(new ReprocessTransformationsEvent());
+
+    if (this.parent instanceof SceneQueryRunner) {
+      this.parent.reprocessData();
+    }
   }
 
   public transform(data: PanelData): Observable<PanelData> {

--- a/src/querying/SceneQueryRunner.test.ts
+++ b/src/querying/SceneQueryRunner.test.ts
@@ -246,120 +246,120 @@ describe('SceneQueryRunner', () => {
       expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([6, 12, 18]);
     });
 
-    // describe('custom transformations', () => {
-    //   it('applies leading custom transformer', async () => {
-    //     const queryRunner = new SceneQueryRunner({
-    //       queries: [{ refId: 'A' }],
-    //       $timeRange: new SceneTimeRange(),
-    //       maxDataPoints: 100,
-    //       // divide by 100, multiply by 2, multiply by 3
-    //       transformer: new DefaultQueryRunnerDataTransformer({
-    //         transformations: [
-    //           customTransformOperator,
-    //           {
-    //             id: 'transformer1',
-    //             options: {
-    //               option: 'value1',
-    //             },
-    //           },
-    //           {
-    //             id: 'transformer2',
-    //             options: {
-    //               option: 'value2',
-    //             },
-    //           },
-    //         ],
-    //       }),
-    //     });
+    describe('custom transformations', () => {
+      it('applies leading custom transformer', async () => {
+        const queryRunner = new QueryRunnerWithTransformations({
+          queryRunner: new SceneQueryRunner({
+            queries: [{ refId: 'A' }],
+            $timeRange: new SceneTimeRange(),
+            maxDataPoints: 100,
+          }),
+          // divide by 100, multiply by 2, multiply by 3
+          transformations: [
+            customTransformOperator,
+            {
+              id: 'transformer1',
+              options: {
+                option: 'value1',
+              },
+            },
+            {
+              id: 'transformer2',
+              options: {
+                option: 'value2',
+              },
+            },
+          ],
+        });
 
-    //     queryRunner.activate();
+        queryRunner.activate();
 
-    //     await new Promise((r) => setTimeout(r, 1));
+        await new Promise((r) => setTimeout(r, 1));
 
-    //     expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
-    //     expect(customTransformerSpy).toHaveBeenCalledTimes(1);
-    //     expect(queryRunner.state.data?.series).toHaveLength(1);
-    //     expect(queryRunner.state.data?.series[0].fields).toHaveLength(2);
-    //     expect(queryRunner.state.data?.series[0].fields[0].values.toArray()).toEqual([6, 12, 18]);
-    //     expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([0.06, 0.12, 0.18]);
-    //   });
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+        expect(customTransformerSpy).toHaveBeenCalledTimes(1);
+        expect(queryRunner.state.data?.series).toHaveLength(1);
+        expect(queryRunner.state.data?.series[0].fields).toHaveLength(2);
+        expect(queryRunner.state.data?.series[0].fields[0].values.toArray()).toEqual([6, 12, 18]);
+        expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([0.06, 0.12, 0.18]);
+      });
 
-    //   it('applies trailing custom transformer', async () => {
-    //     const queryRunner = new SceneQueryRunner({
-    //       queries: [{ refId: 'A' }],
-    //       $timeRange: new SceneTimeRange(),
-    //       maxDataPoints: 100,
-    //       // multiply by 2, multiply by 3, divide by 100
-    //       transformer: new DefaultQueryRunnerDataTransformer({
-    //         transformations: [
-    //           {
-    //             id: 'transformer1',
-    //             options: {
-    //               option: 'value1',
-    //             },
-    //           },
-    //           {
-    //             id: 'transformer2',
-    //             options: {
-    //               option: 'value2',
-    //             },
-    //           },
-    //           customTransformOperator,
-    //         ],
-    //       }),
-    //     });
+      it('applies trailing custom transformer', async () => {
+        const queryRunner = new QueryRunnerWithTransformations({
+          queryRunner: new SceneQueryRunner({
+            queries: [{ refId: 'A' }],
+            $timeRange: new SceneTimeRange(),
+            maxDataPoints: 100,
+          }),
+          // multiply by 2, multiply by 3, divide by 100
+          transformations: [
+            {
+              id: 'transformer1',
+              options: {
+                option: 'value1',
+              },
+            },
+            {
+              id: 'transformer2',
+              options: {
+                option: 'value2',
+              },
+            },
+            customTransformOperator,
+          ],
+        });
 
-    //     queryRunner.activate();
+        queryRunner.activate();
 
-    //     await new Promise((r) => setTimeout(r, 1));
+        await new Promise((r) => setTimeout(r, 1));
 
-    //     expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
-    //     expect(customTransformerSpy).toHaveBeenCalledTimes(1);
-    //     expect(queryRunner.state.data?.series).toHaveLength(1);
-    //     expect(queryRunner.state.data?.series[0].fields).toHaveLength(2);
-    //     expect(queryRunner.state.data?.series[0].fields[0].values.toArray()).toEqual([6, 12, 18]);
-    //     expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([0.06, 0.12, 0.18]);
-    //   });
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+        expect(customTransformerSpy).toHaveBeenCalledTimes(1);
+        expect(queryRunner.state.data?.series).toHaveLength(1);
+        expect(queryRunner.state.data?.series[0].fields).toHaveLength(2);
+        expect(queryRunner.state.data?.series[0].fields[0].values.toArray()).toEqual([6, 12, 18]);
+        expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([0.06, 0.12, 0.18]);
+      });
 
-    //   it('applies mixed transforms', async () => {
-    //     const queryRunner = new SceneQueryRunner({
-    //       queries: [{ refId: 'A' }],
-    //       $timeRange: new SceneTimeRange(),
-    //       maxDataPoints: 100,
-    //       // divide by 100,multiply by 2, divide by 100, multiply by 3, divide by 100
-    //       transformer: new DefaultQueryRunnerDataTransformer({
-    //         transformations: [
-    //           customTransformOperator,
-    //           {
-    //             id: 'transformer1',
-    //             options: {
-    //               option: 'value1',
-    //             },
-    //           },
-    //           customTransformOperator,
-    //           {
-    //             id: 'transformer2',
-    //             options: {
-    //               option: 'value2',
-    //             },
-    //           },
-    //           customTransformOperator,
-    //         ],
-    //       }),
-    //     });
+      it('applies mixed transforms', async () => {
+        const queryRunner = new QueryRunnerWithTransformations({
+          queryRunner: new SceneQueryRunner({
+            queries: [{ refId: 'A' }],
+            $timeRange: new SceneTimeRange(),
+            maxDataPoints: 100,
+          }),
+          // divide by 100,multiply by 2, divide by 100, multiply by 3, divide by 100
+          transformations: [
+            customTransformOperator,
+            {
+              id: 'transformer1',
+              options: {
+                option: 'value1',
+              },
+            },
+            customTransformOperator,
+            {
+              id: 'transformer2',
+              options: {
+                option: 'value2',
+              },
+            },
+            customTransformOperator,
+          ],
+        });
 
-    //     queryRunner.activate();
+        queryRunner.activate();
 
-    //     await new Promise((r) => setTimeout(r, 1));
+        await new Promise((r) => setTimeout(r, 1));
 
-    //     expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
-    //     expect(customTransformerSpy).toHaveBeenCalledTimes(3);
-    //     expect(queryRunner.state.data?.series).toHaveLength(1);
-    //     expect(queryRunner.state.data?.series[0].fields).toHaveLength(2);
-    //     expect(queryRunner.state.data?.series[0].fields[0].values.toArray()).toEqual([0.0006, 0.0012, 0.0018]);
-    //     expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([0.000006, 0.000012, 0.000018]);
-    //   });
-    // });
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+        expect(customTransformerSpy).toHaveBeenCalledTimes(3);
+        expect(queryRunner.state.data?.series).toHaveLength(1);
+        expect(queryRunner.state.data?.series[0].fields).toHaveLength(2);
+        expect(queryRunner.state.data?.series[0].fields[0].values.toArray()).toEqual([0.0006, 0.0012, 0.0018]);
+        expect(queryRunner.state.data?.series[0].fields[1].values.toArray()).toEqual([0.000006, 0.000012, 0.000018]);
+      });
+    });
 
     describe('custom transformer object', () => {
       it('Can re-trigger transformations without issuing new query', async () => {

--- a/src/querying/SceneQueryRunner.ts
+++ b/src/querying/SceneQueryRunner.ts
@@ -82,7 +82,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     // Pipe raw data through the transformations and store in state
     this._subs.add(
       this._rawDataSubject.pipe(mergeMap(this.transformData)).subscribe((data) => {
-        console.log('got transformed data');
         this.setState({ data, dataPreTransforms: this._dataPreTransforms });
       })
     );
@@ -93,14 +92,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
       // Subscribe to transformer wanting to re-process transformations
       this._subs.add(
         this.state.transformer.subscribeToEvent(ReprocessTransformationsEvent, () => {
-          console.log('re-processing transformations');
           this._rawDataSubject.next(this.state.dataPreTransforms!);
         })
       );
     }
-
-    // this._rawDataSubject.next({ state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() });
-    // this._rawDataSubject.next({ state: LoadingState.Done, series: [], timeRange: getDefaultTimeRange() });
 
     if (this.shouldRunQueriesOnActivate()) {
       this.runQueries();

--- a/src/querying/transformations.ts
+++ b/src/querying/transformations.ts
@@ -4,6 +4,7 @@ import { SceneDataNodeState } from '../core/SceneDataNode';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { CustomTransformOperator, SceneQueryRunnerInterface } from '../core/types';
+import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 
 export interface QueryRunnerWithTransformationsState extends SceneDataNodeState {
   // Array of standard transformation configs and custom transform operators
@@ -15,7 +16,11 @@ export class QueryRunnerWithTransformations
   extends SceneObjectBase<QueryRunnerWithTransformationsState>
   implements SceneQueryRunnerInterface
 {
-  // TODO add variable dependency config
+  protected _variableDependency: VariableDependencyConfig<QueryRunnerWithTransformationsState> =
+    new VariableDependencyConfig(this, {
+      statePaths: ['transformations'],
+      onReferencedVariableValueChanged: () => this.reprocessTransformations(),
+    });
 
   private _transformSub?: Unsubscribable;
 

--- a/src/querying/transformations.ts
+++ b/src/querying/transformations.ts
@@ -1,0 +1,43 @@
+import { BusEventBase, DataTransformerConfig, PanelData, transformDataFrame } from '@grafana/data';
+import { map, Observable, of } from 'rxjs';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { CustomTransformOperator, SceneObject, SceneObjectStatePlain } from '../core/types';
+
+export interface SceneQueryRunnerDataTransformer extends SceneObject {
+  transform(data: PanelData): Observable<PanelData>;
+}
+
+export class ReprocessTransformationsEvent extends BusEventBase {
+  public static readonly type = 'reprocess-transformations';
+}
+
+export interface DefaultQueryRunnerDataTransformerState extends SceneObjectStatePlain {
+  // Array of standard transformation configs and custom transform operators
+  transformations?: Array<DataTransformerConfig | CustomTransformOperator>;
+}
+
+export class DefaultQueryRunnerDataTransformer
+  extends SceneObjectBase<DefaultQueryRunnerDataTransformerState>
+  implements SceneQueryRunnerDataTransformer
+{
+  // TODO add variable dependency config
+
+  // Should this automatically trigger ReprocessTransformationsEvent on state change?
+
+  public transform(data: PanelData): Observable<PanelData> {
+    const transformations = this.state.transformations || [];
+
+    if (transformations.length === 0) {
+      return of(data);
+    }
+
+    const ctx = {
+      interpolate: (value: string) => {
+        return sceneGraph.interpolate(this, value, data.request?.scopedVars);
+      },
+    };
+
+    return transformDataFrame(transformations, data.series, ctx).pipe(map((series) => ({ ...data, series })));
+  }
+}


### PR DESCRIPTION
This is an alternative to https://github.com/grafana/scenes/pull/50 that explores a more compositional approach.

* Separate query runner and transformations so we can re-process transformations without query
* Now SceneQueryRunner is more simple and does not know or care about transformations 

The downside with this is that it's going to be a bit more complex for components that interact with the query runners, they might have to check if is it a normal query runner or a QueryRunnerWithTransforms.

Like updating queries state from panel edit could be more complex, also when adding new transforms it would mean changing and adding this new wrapping query runner. But it does keep the SceneQueryRunner itself simpler. 
