### PR TITLE
Types: depend on SubscriptionLike rather than Subscription directly 

### DIFF
--- a/src/core/SceneObjectBase.tsx
+++ b/src/core/SceneObjectBase.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Observer, Subject, Subscription, Unsubscribable } from 'rxjs';
+import { Observer, Subject, Subscription, SubscriptionLike, Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BusEvent, BusEventHandler, BusEventType, EventBusSrv } from '@grafana/data';
@@ -82,7 +82,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   /**
    * Subscribe to the scene state subject
    **/
-  public subscribeToState(observerOrNext?: Partial<Observer<TState>>): Subscription {
+  public subscribeToState(observerOrNext?: Partial<Observer<TState>>): SubscriptionLike {
     return this._subject.subscribe(observerOrNext);
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MonoTypeOperatorFunction, Observer, Subscription, Unsubscribable } from 'rxjs';
+import { MonoTypeOperatorFunction, Observer, SubscriptionLike, Unsubscribable } from 'rxjs';
 
 import {
   BusEvent,
@@ -69,7 +69,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   readonly urlSync?: SceneObjectUrlSyncHandler<TState>;
 
   /** Subscribe to state changes */
-  subscribeToState(observer?: Partial<Observer<TState>>): Subscription;
+  subscribeToState(observer?: Partial<Observer<TState>>): SubscriptionLike;
 
   /** Subscribe to a scene event */
   subscribeToEvent<T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable;


### PR DESCRIPTION
In general nicer to have the simple interfaces as core constraints rather than the full class hierarchy.