### PR TITLE
SceneFlexLayout: Fix issue with layout children being able to extrend their bounds

### DIFF
--- a/src/components/layout/SceneFlexLayout.tsx
+++ b/src/components/layout/SceneFlexLayout.tsx
@@ -43,6 +43,7 @@ function FlexLayoutRenderer({ model, isEditing }: SceneComponentProps<SceneFlexL
     gap: '8px',
     flexWrap: wrap,
     alignContent: 'baseline',
+    minHeight: 0,
   };
 
   return (


### PR DESCRIPTION
This fixes an issue where the layout child could not say "Use height 100%, overflow: auto", they would just extend their parent bounds beyond what it actually had.
For some reason it works with absolute positioned divs (in inner layout children), which is why it works for VizPanelRenderer.

This css fix makes it possible to have layout child components likke this.

```css
<div style={{ height: '100%', width: '100%', overflow: 'auto' }}>
      <Stack direction="column">
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
        <div style={{ background: 'red', height: '80px' }}>asd</div>
      </Stack>
</div>
```
