### PR TITLE
Fix logo in README

### DIFF
--- a/packages/scenes/README.md
+++ b/packages/scenes/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img
-    src="../../docs/img/grafana_icon.svg"
+    src="https://raw.githubusercontent.com/grafana/scenes/main/docs/img/grafana_icon.svg"
     alt="Grafana Logo"
     width="100px"
     padding="40px"


### PR DESCRIPTION
npm is not able to pull image due to relative path. So changing this to fixed url.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/153843/225316272-59399c94-af49-40f9-ba3e-5eee9894fbc3.png">
