### PR TITLE
SceneObjectBase: Expose previous state in state subscription

### DIFF
--- a/packages/scenes/src/components/SceneByFrameRepeater.tsx
+++ b/packages/scenes/src/components/SceneByFrameRepeater.tsx
@@ -23,9 +23,9 @@ export class SceneByFrameRepeater extends SceneObjectBase<RepeatOptions> {
 
     this._subs.add(
       sceneGraph.getData(this).subscribeToState({
-        next: (data) => {
-          if (data.data?.state === LoadingState.Done) {
-            this.performRepeat(data.data);
+        next: (state) => {
+          if (state.current.data?.state === LoadingState.Done) {
+            this.performRepeat(state.current.data);
           }
         },
       })

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -148,4 +148,84 @@ describe('SceneObject', () => {
       expect(scene.state.$variables!.isActive).toBe(false);
     });
   });
+
+  describe('state subscription', () => {
+    describe('emits previous and current value', () => {
+      const jestPrevSpy = jest.fn();
+      const jestCurrentSpy = jest.fn();
+
+      afterEach(() => {
+        jestPrevSpy.mockClear();
+        jestCurrentSpy.mockClear();
+      });
+
+      it('when no initial state value', async () => {
+        const scene = new TestScene({
+          $data: new SceneDataNode({}),
+          $variables: new SceneVariableSet({ variables: [] }),
+        });
+
+        scene.activate();
+
+        scene.subscribeToState({
+          next: ({ previous, current }) => {
+            jestPrevSpy(previous.name);
+            jestCurrentSpy(current.name);
+          },
+        });
+        scene.setState({ name: 'new name' });
+        expect(jestPrevSpy).toHaveBeenLastCalledWith(undefined);
+        expect(jestCurrentSpy).toHaveBeenLastCalledWith('new name');
+
+        scene.setState({ name: 'next name' });
+        expect(jestPrevSpy).toHaveBeenLastCalledWith('new name');
+        expect(jestCurrentSpy).toHaveBeenLastCalledWith('next name');
+      });
+      it('when initial state value defined', async () => {
+        const scene = new TestScene({
+          $data: new SceneDataNode({}),
+          $variables: new SceneVariableSet({ variables: [] }),
+          name: 'initial name',
+        });
+
+        scene.activate();
+
+        scene.subscribeToState({
+          next: ({ previous, current }) => {
+            jestPrevSpy(previous.name);
+            jestCurrentSpy(current.name);
+          },
+        });
+        scene.setState({ name: 'new name' });
+        expect(jestPrevSpy).toHaveBeenLastCalledWith('initial name');
+        expect(jestCurrentSpy).toHaveBeenLastCalledWith('new name');
+
+        scene.setState({ name: 'next name' });
+        expect(jestPrevSpy).toHaveBeenLastCalledWith('new name');
+        expect(jestCurrentSpy).toHaveBeenLastCalledWith('next name');
+      });
+
+      it('when subscribed to state after state changes', async () => {
+        const scene = new TestScene({
+          $data: new SceneDataNode({}),
+          $variables: new SceneVariableSet({ variables: [] }),
+          name: 'initial name',
+        });
+
+        scene.activate();
+        scene.setState({ name: 'new name' });
+
+        scene.subscribeToState({
+          next: ({ previous, current }) => {
+            jestPrevSpy(previous.name);
+            jestCurrentSpy(current.name);
+          },
+        });
+
+        scene.setState({ name: 'next name' });
+        expect(jestPrevSpy).toHaveBeenLastCalledWith('new name');
+        expect(jestCurrentSpy).toHaveBeenLastCalledWith('next name');
+      });
+    });
+  });
 });

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -69,7 +69,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   readonly urlSync?: SceneObjectUrlSyncHandler<TState>;
 
   /** Subscribe to state changes */
-  subscribeToState(observer?: Partial<Observer<TState>>): SubscriptionLike;
+  subscribeToState(observer?: Partial<Observer<{ previous: TState; current: TState }>>): SubscriptionLike;
 
   /** Subscribe to a scene event */
   subscribeToEvent<T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable;

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -39,7 +39,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
     this._subs.add(
       sourceData.subscribeToState({
-        next: (state) => this.transform(state.data),
+        next: (state) => this.transform(state.current.data),
       })
     );
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -66,7 +66,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     this._subs.add(
       timeRange.subscribeToState({
         next: (timeRange) => {
-          this.runWithTimeRange(timeRange.value);
+          this.runWithTimeRange(timeRange.current.value);
         },
       })
     );


### PR DESCRIPTION
Changes API of `SceneObject.subscribeToState` to expose previously recorded state.

```ts
subscribeToState(observer?: Partial<Observer<{ previous: TState; current: TState }>>): SubscriptionLike;
```