### PR TITLE
SceneObject: subscribeToState signature change and implementation change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,38 @@
+# 0.21 (2023-03-15)
+
+**SceneObject subscribeToState parameter change**
+
+Signature change. Now the parameter to this function expects a simple function that takes two args (newState, prevState).
+
+Before:
+
+```ts
+ this._subs.add(
+  sourceData.subscribeToState({
+    next: (state) => this.transform(state.data),
+  })
+);
+```
+
+Becomes:
+
+```ts
+ this._subs.add(
+  sourceData.subscribeToState((state) => this.transform(state.data))
+);
+```
+
+# 0.20 (2023-03-15)
+
+**AppScenePage**
+
+The getScene for drilldowns now expect the parent property to be of type AppScenePageLike (interface).
+
 # 0.19 (2023-03-15)
 
 **SceneQueryRunner no longer has transformations**
 
-Instead you have to use SceneDataTransformer and set its internal $data property to the SceneQueryRunner to get the same effect. 
+Instead you have to use SceneDataTransformer and set its internal $data property to the SceneQueryRunner to get the same effect.
 
 Example:
 
@@ -20,10 +50,10 @@ Example:
   }),
 ```
 
-SceneDataTransformer can still be used to transform parent scoped data, it will look for this if there is no $data property set. 
+SceneDataTransformer can still be used to transform parent scoped data, it will look for this if there is no $data property set.
 
 The reasons for this change it to have more control over when only transformations should be re-processed (to not issue query again when only a dependency on the transforms changed).
-It also removes some duplication between SceneQueryRunner and SceneDataTransformer. There is also a new interface SceneDataProvider. 
+It also removes some duplication between SceneQueryRunner and SceneDataTransformer. There is also a new interface SceneDataProvider.
 
 ```ts
 

--- a/packages/scenes/src/components/SceneByFrameRepeater.tsx
+++ b/packages/scenes/src/components/SceneByFrameRepeater.tsx
@@ -22,12 +22,10 @@ export class SceneByFrameRepeater extends SceneObjectBase<RepeatOptions> {
     super.activate();
 
     this._subs.add(
-      sceneGraph.getData(this).subscribeToState({
-        next: (data) => {
-          if (data.data?.state === LoadingState.Done) {
-            this.performRepeat(data.data);
-          }
-        },
+      sceneGraph.getData(this).subscribeToState((data) => {
+        if (data.data?.state === LoadingState.Done) {
+          this.performRepeat(data.data);
+        }
       })
     );
   }

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -126,13 +126,13 @@ describe('SceneObject', () => {
     scene.activate();
 
     // Subscribe to state change and to event
-    const stateSub = scene.subscribeToState({ next: () => {} });
+    const stateSub = scene.subscribeToState(() => {});
     const eventSub = scene.subscribeToEvent(SceneObjectStateChangedEvent, () => {});
 
     scene.deactivate();
 
     it('Should close subscriptions', () => {
-      expect(stateSub.closed).toBe(true);
+      expect((stateSub as any).closed).toBe(true);
       expect((eventSub as any).closed).toBe(true);
     });
 

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -3,7 +3,13 @@ import { Observer, Subject, Subscription, SubscriptionLike, Unsubscribable } fro
 import { v4 as uuidv4 } from 'uuid';
 
 import { BusEvent, BusEventHandler, BusEventType, EventBusSrv } from '@grafana/data';
-import { SceneObject, SceneComponent, SceneObjectState, SceneObjectUrlSyncHandler } from './types';
+import {
+  SceneObject,
+  SceneComponent,
+  SceneObjectState,
+  SceneObjectUrlSyncHandler,
+  SceneStateChangedHandler,
+} from './types';
 import { useForceUpdate } from '@grafana/ui';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
@@ -15,7 +21,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   implements SceneObject<TState>
 {
   private _isActive = false;
-  private _subject = new Subject<TState>();
   private _state: TState;
   private _events = new EventBusSrv();
 
@@ -31,7 +36,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
     }
 
     this._state = Object.freeze(state);
-    this._subject.next(state);
     this.setParent();
   }
 
@@ -82,8 +86,12 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   /**
    * Subscribe to the scene state subject
    **/
-  public subscribeToState(observerOrNext?: Partial<Observer<TState>>): SubscriptionLike {
-    return this._subject.subscribe(observerOrNext);
+  public subscribeToState(handler: SceneStateChangedHandler<TState>): Unsubscribable {
+    return this._events.subscribe(SceneObjectStateChangedEvent, (event) => {
+      if (event.payload.changedObject === this) {
+        handler(event.payload.newState as TState, event.payload.prevState as TState);
+      }
+    });
   }
 
   /**
@@ -103,7 +111,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
     this._state = Object.freeze(newState);
 
     this.setParent();
-    this._subject.next(newState);
 
     // Bubble state change event. This is event is subscribed to by UrlSyncManager and UndoManager
     this.publishEvent(
@@ -176,9 +183,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
     this._events.removeAllListeners();
     this._subs.unsubscribe();
     this._subs = new Subscription();
-
-    this._subject.complete();
-    this._subject = new Subject<TState>();
   }
 
   /**
@@ -210,7 +214,7 @@ function useSceneObjectState<TState extends SceneObjectState>(model: SceneObject
   const forceUpdate = useForceUpdate();
 
   useEffect(() => {
-    const s = model.subscribeToState({ next: forceUpdate });
+    const s = model.subscribeToState(forceUpdate);
     return () => s.unsubscribe();
   }, [model, forceUpdate]);
 

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Observer, Subject, Subscription, SubscriptionLike, Unsubscribable } from 'rxjs';
+import { Subscription, Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BusEvent, BusEventHandler, BusEventType, EventBusSrv } from '@grafana/data';

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -13,6 +13,7 @@ import {
 } from '@grafana/data';
 
 import { SceneVariableDependencyConfigLike, SceneVariables } from '../variables/types';
+import { SceneObjectStateChangedEvent } from './events';
 
 export interface SceneObjectStatePlain {
   key?: string;
@@ -69,7 +70,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   readonly urlSync?: SceneObjectUrlSyncHandler<TState>;
 
   /** Subscribe to state changes */
-  subscribeToState(observer?: Partial<Observer<TState>>): SubscriptionLike;
+  subscribeToState(handler: SceneStateChangedHandler<TState>): Unsubscribable;
 
   /** Subscribe to a scene event */
   subscribeToEvent<T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable;
@@ -171,6 +172,7 @@ export type SceneObjectUrlValue = string | string[] | undefined | null;
 export type SceneObjectUrlValues = Record<string, SceneObjectUrlValue>;
 
 export type CustomTransformOperator = (context: DataTransformContext) => MonoTypeOperatorFunction<DataFrame[]>;
+export type SceneStateChangedHandler<TState> = (newState: TState, prevState: TState) => void;
 
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MonoTypeOperatorFunction, Observer, SubscriptionLike, Unsubscribable } from 'rxjs';
+import { MonoTypeOperatorFunction, Unsubscribable } from 'rxjs';
 
 import {
   BusEvent,
@@ -13,7 +13,6 @@ import {
 } from '@grafana/data';
 
 import { SceneVariableDependencyConfigLike, SceneVariables } from '../variables/types';
-import { SceneObjectStateChangedEvent } from './events';
 
 export interface SceneObjectStatePlain {
   key?: string;

--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -472,9 +472,7 @@ describe('SceneDataTransformer', () => {
         });
 
         // This could potentially be done by QueryRunnerWithTransformations if we passed it "dependencies" (object it should subscribe to and re-run transformations on change)
-        someObject.subscribeToState({
-          next: () => queryRunner.reprocessTransformations(),
-        });
+        someObject.subscribeToState(() => queryRunner.reprocessTransformations());
 
         queryRunner.activate();
 

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -37,11 +37,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
     const sourceData = this.getSourceData();
 
-    this._subs.add(
-      sourceData.subscribeToState({
-        next: (state) => this.transform(state.data),
-      })
-    );
+    this._subs.add(sourceData.subscribeToState((state) => this.transform(state.data)));
 
     if (sourceData.state.data) {
       this.transform(sourceData.state.data);

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -64,10 +64,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     const timeRange = sceneGraph.getTimeRange(this);
 
     this._subs.add(
-      timeRange.subscribeToState({
-        next: (timeRange) => {
-          this.runWithTimeRange(timeRange.value);
-        },
+      timeRange.subscribeToState((timeRange) => {
+        this.runWithTimeRange(timeRange.value);
       })
     );
 

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -65,10 +65,8 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
     if (this.state.refresh === VariableRefresh.onTimeRangeChanged) {
       this._subs.add(
-        timeRange.subscribeToState({
-          next: () => {
-            this.updateSubscription = this.validateAndUpdate().subscribe();
-          },
+        timeRange.subscribeToState(() => {
+          this.updateSubscription = this.validateAndUpdate().subscribe();
         })
       );
     }


### PR DESCRIPTION
Alternative to https://github.com/grafana/scenes/pull/66
Closes #66 

* Add prevState to subscribeToState handler
* Simplify subscribeToState argument to be a handler callback to just receive state (and prevState) as separate args
* Reuse the existing event and eventbus instead of having separate subject
