### PR TITLE
SceneQueryRunner: support empty/missing queries

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -26,7 +26,6 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
   const plugin = model.getPlugin();
-  const { data } = sceneGraph.getData(model).useState();
   const parentLayout = sceneGraph.getLayout(model);
 
   // If parent has enabled dragging and we have not explicitly disabled it then dragging is enabled
@@ -39,6 +38,9 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   // Not sure we need to subscribe to this state
   const timeZone = sceneGraph.getTimeRange(model).state.timeZone;
+
+  // Subscribe to data and apply field overrides
+  const { data } = sceneGraph.getData(model).useState();
   const dataWithOverrides = useFieldOverrides(plugin, fieldConfig, data, timeZone, theme, model.interpolate);
 
   if (pluginLoadError) {

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -329,5 +329,38 @@ describe('SceneQueryRunner', () => {
       // Should execute query a second time
       expect(runRequestMock.mock.calls.length).toBe(2);
     });
+
+    it('Should set data and loadingState to Done when there are no queries', async () => {
+      const queryRunner = new SceneQueryRunner({
+        queries: [],
+      });
+
+      const scene = new SceneFlexLayout({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        children: [],
+      });
+
+      scene.activate();
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+    });
+
+    it('if datasource not set check queries for datasource', async () => {
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A', datasource: { uid: 'Muuu' } }],
+      });
+
+      const scene = new SceneFlexLayout({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        children: [],
+      });
+
+      scene.activate();
+
+      const getDataSourceCall = getDataSourceMock.mock.calls[0];
+      expect(getDataSourceCall[0]).toEqual({ uid: 'Muuu' });
+    });
   });
 });

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -174,12 +174,11 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
     // Simple path when no queries exist
     if (!queries?.length) {
-      this._querySub = of({
+      this.onDataReceived({
         state: LoadingState.Done,
         series: [],
         timeRange,
-      }).subscribe(this.onDataReceived);
-      return;
+      });
     }
 
     const request: DataQueryRequest = {


### PR DESCRIPTION
Text panels do not have queries (and a few others), but still hit the query runner path.

This lets the panels load rather than sitting with a "no data" message.  We may also want to bypass the query runner entirely, but it seems better to complete normally than to not show anything.

With these change https://github.com/grafana/grafana/pull/64936 now shows more panels OK:
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/705951/225824004-847010ea-cc9f-4d49-9318-82019fb07fcb.png">

Still failing with "-- Dashboard --" datasource... but this is progress!