### PR TITLE
SceneInterpolator: Support "__all_variables"

### DIFF
--- a/packages/scenes/src/variables/lookupVariable.ts
+++ b/packages/scenes/src/variables/lookupVariable.ts
@@ -23,3 +23,17 @@ export function lookupVariable(name: string, sceneObject: SceneObject): SceneVar
 
   return null;
 }
+
+export function lookupAllVariables(sceneObject: SceneObject): Record<string, SceneVariable> {
+  const result: Record<string, SceneVariable> = Object.fromEntries(
+    sceneObject.state.$variables?.state.variables.map((v) => [v.state.name, v]) ?? []
+  )
+
+  if (sceneObject.parent) {
+    return {
+      ...lookupAllVariables(sceneObject.parent),
+      ...result,
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
While working on app-o11y traces view I released we need `__all_variables` support for table data links, to presverve selected data sources. I doodles this, does it make sense?