### PR TITLE
UrlSyncManager: Improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# vNext
+
+* UrlSync: SceneObject that implement url sync _urlSync property will now see a change to how updateFromUrl is called. It is now called with null values when url query parameters are removed. Before the UrlSyncManager would remember the initial state and pass that to updateFromUrl, but now if you want to preserve your current state or set to some initial state you have to handle that logic inside updateFromUrl.
+
 # v0.0.28 (Tue Mar 21 2023)
 
 * Removal of isEditing from SceneComponentProps (also $editor from SceneObjectState, and sceneGraph.getSceneEditor)

--- a/packages/scenes/src/components/EmbeddedScene.tsx
+++ b/packages/scenes/src/components/EmbeddedScene.tsx
@@ -23,17 +23,16 @@ export class EmbeddedScene extends SceneObjectBase<EmbeddedSceneState> {
 
   private urlSyncManager?: UrlSyncManager;
 
-  public constructor(state: EmbeddedSceneState) {
-    super(state);
-  }
-
   /**
    * initUrlSync should be called before the scene is rendered to ensure that objects are in sync
    * before they get activated. This saves some unnecessary re-renders and makes sure variables
    * queries are issued as needed.
    */
   public initUrlSync() {
-    this.urlSyncManager = new UrlSyncManager(this);
+    if (!this.urlSyncManager) {
+      this.urlSyncManager = new UrlSyncManager(this);
+    }
+
     this.urlSyncManager.initSync();
   }
 }

--- a/packages/scenes/src/components/EmbeddedScene.tsx
+++ b/packages/scenes/src/components/EmbeddedScene.tsx
@@ -25,15 +25,6 @@ export class EmbeddedScene extends SceneObjectBase<EmbeddedSceneState> {
 
   public constructor(state: EmbeddedSceneState) {
     super(state);
-
-    this.addActivationHandler(() => {
-      // Clean up url sync when the scene is deactivated
-      return () => {
-        if (this.urlSyncManager) {
-          this.urlSyncManager!.cleanUp();
-        }
-      };
-    });
   }
 
   /**

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -44,9 +44,14 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    const update: Partial<SceneTimeRangeState> = {};
+    // ignore if both are missing
+    if (!values.to && !values.from) {
+      return;
+    }
 
+    const update: Partial<SceneTimeRangeState> = {};
     const from = parseUrlParam(values.from);
+
     if (from) {
       update.from = from;
     }

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -5,22 +5,23 @@ import { locationService } from '@grafana/runtime';
 import { SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneTimeRange } from '../core/SceneTimeRange';
-import { SceneLayoutChildState, SceneObjectUrlValues } from '../core/types';
+import { SceneLayoutChildState, SceneObject, SceneObjectUrlValues } from '../core/types';
 
 import { SceneObjectUrlSyncConfig } from './SceneObjectUrlSyncConfig';
 import { isUrlValueEqual, UrlSyncManager } from './UrlSyncManager';
 
 interface TestObjectState extends SceneLayoutChildState {
   name: string;
+  optional?: string;
   array?: string[];
   other?: string;
 }
 
 class TestObj extends SceneObjectBase<TestObjectState> {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['name', 'array'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['name', 'array', 'optional'] });
 
   public getUrlState(state: TestObjectState) {
-    return { name: state.name, array: state.array };
+    return { name: state.name, array: state.array, optional: state.optional };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
@@ -30,6 +31,9 @@ class TestObj extends SceneObjectBase<TestObjectState> {
     if (Array.isArray(values.array)) {
       this.setState({ array: values.array });
     }
+    if (values.hasOwnProperty('optional')) {
+      this.setState({ optional: typeof values.optional === 'string' ? values.optional : undefined });
+    }
   }
 }
 
@@ -37,6 +41,7 @@ describe('UrlSyncManager', () => {
   let urlManager: UrlSyncManager;
   let locationUpdates: Location[] = [];
   let listenUnregister: () => void;
+  let scene: SceneObject;
 
   beforeEach(() => {
     locationUpdates = [];
@@ -46,7 +51,7 @@ describe('UrlSyncManager', () => {
   });
 
   afterEach(() => {
-    urlManager.cleanUp();
+    scene.deactivate();
     locationService.push('/');
     listenUnregister();
   });
@@ -54,11 +59,14 @@ describe('UrlSyncManager', () => {
   describe('When state changes', () => {
     it('should update url', () => {
       const obj = new TestObj({ name: 'test' });
-      const scene = new SceneFlexLayout({
+      scene = new SceneFlexLayout({
         children: [obj],
       });
 
       urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+
+      scene.activate();
 
       // When making state change
       obj.setState({ name: 'test2' });
@@ -79,11 +87,13 @@ describe('UrlSyncManager', () => {
     it('should update state', () => {
       const obj = new TestObj({ name: 'test' });
       const initialObjState = obj.state;
-      const scene = new SceneFlexLayout({
+      scene = new SceneFlexLayout({
         children: [obj],
       });
 
       urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+      scene.activate();
 
       // When non relevant key changes in url
       locationService.partial({ someOtherProp: 'test2' });
@@ -114,7 +124,7 @@ describe('UrlSyncManager', () => {
       const outerTimeRange = new SceneTimeRange();
       const innerTimeRange = new SceneTimeRange();
 
-      const scene = new SceneFlexLayout({
+      scene = new SceneFlexLayout({
         children: [
           new SceneFlexLayout({
             $timeRange: innerTimeRange,
@@ -125,6 +135,8 @@ describe('UrlSyncManager', () => {
       });
 
       urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+      scene.activate();
 
       // When making state changes for second object with same key
       innerTimeRange.setState({ from: 'now-10m' });
@@ -159,11 +171,13 @@ describe('UrlSyncManager', () => {
   describe('When updating array value', () => {
     it('Should update url correctly', () => {
       const obj = new TestObj({ name: 'test' });
-      const scene = new SceneFlexLayout({
+      scene = new SceneFlexLayout({
         children: [obj],
       });
 
       urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+      scene.activate();
 
       // When making state change
       obj.setState({ array: ['A', 'B'] });
@@ -182,6 +196,53 @@ describe('UrlSyncManager', () => {
       locationService.partial({ array: ['A', 'B', 'C'] });
       // Should update state
       expect(obj.state.array).toEqual(['A', 'B', 'C']);
+    });
+  });
+
+  describe('When initial state is undefined', () => {
+    it('Should update from url correctly', () => {
+      const obj = new TestObj({ name: 'test' });
+      scene = new SceneFlexLayout({
+        children: [obj],
+      });
+
+      urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+      scene.activate();
+
+      // When setting value via url
+      locationService.partial({ optional: 'handler' });
+
+      // Should update state
+      expect(obj.state.optional).toBe('handler');
+
+      // When updating via url and remove optional
+      locationService.partial({ optional: null });
+
+      // Should update state
+      expect(obj.state.optional).toBe(undefined);
+    });
+
+    it('Should update from state correctly', () => {
+      const obj = new TestObj({ name: 'test' });
+      scene = new SceneFlexLayout({
+        children: [obj],
+      });
+
+      urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+      scene.activate();
+
+      obj.setState({ optional: 'handler' });
+
+      // Should update url
+      expect(locationService.getSearchObject().optional).toEqual('handler');
+
+      // When updating via url and remove optional
+      locationService.partial({ optional: null });
+
+      // Should update state
+      expect(obj.state.optional).toBe(undefined);
     });
   });
 });

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -223,7 +223,7 @@ describe('UrlSyncManager', () => {
       expect(obj.state.optional).toBe(undefined);
     });
 
-    it('Should update from state correctly', () => {
+    it('When updating via state and removing from url', () => {
       const obj = new TestObj({ name: 'test' });
       scene = new SceneFlexLayout({
         children: [obj],
@@ -243,6 +243,25 @@ describe('UrlSyncManager', () => {
 
       // Should update state
       expect(obj.state.optional).toBe(undefined);
+    });
+
+    it('When removing optional state via state change', () => {
+      const obj = new TestObj({ name: 'test' });
+      scene = new SceneFlexLayout({
+        children: [obj],
+      });
+
+      urlManager = new UrlSyncManager(scene);
+      urlManager.initSync();
+      scene.activate();
+
+      obj.setState({ optional: 'handler' });
+
+      expect(locationService.getSearchObject().optional).toEqual('handler');
+
+      obj.setState({ optional: undefined });
+
+      expect(locationService.getSearchObject().optional).toEqual(undefined);
     });
   });
 });

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -105,11 +105,11 @@ describe('UrlSyncManager', () => {
       // Should update state
       expect(obj.state.name).toBe('test2');
 
-      // When relevant key is cleared (say go back)
-      locationService.getHistory().goBack();
+      // When relevant key is cleared
+      locationService.partial({ name: null });
 
       // Should revert to initial state
-      expect(obj.state.name).toBe('test');
+      // expect(obj.state.name).toBe('test');
 
       // When relevant key is set to current state
       const currentState = obj.state;


### PR DESCRIPTION
@domasx2 identified some issues with URL sync when it comes to clearing / restoring state (one of the more complex parts of url sync) 

* Restoring state if the initial state was undefined did not work 
* Coming back to a scene did not remember the initialStates (that is used to restore state when url does not contain the state), this required a change so that we do not new up a new UrlSyncManager every initUrlSync but instead preserve the same instance for as long as that scene exists.
* Also updated the tests to more accurately reflect usage (initUrlSync called, then scene is activated) 

