### PR TITLE
UrlSync: Simplify url sync interface

### DIFF
--- a/packages/scenes/src/components/layout/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/SceneGridRow.tsx
@@ -57,8 +57,8 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
     this.getGridLayout().toggleRow(this);
   };
 
-  public getUrlState(state: SceneGridRowState) {
-    return { rowc: state.isCollapsed ? '1' : '0' };
+  public getUrlState() {
+    return { rowc: this.state.isCollapsed ? '1' : '0' };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -32,7 +32,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   protected _subs = new Subscription();
 
   protected _variableDependency: SceneVariableDependencyConfigLike | undefined;
-  protected _urlSync: SceneObjectUrlSyncHandler<TState> | undefined;
+  protected _urlSync: SceneObjectUrlSyncHandler | undefined;
 
   public constructor(state: TState) {
     if (!state.key) {
@@ -64,7 +64,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   }
 
   /** Returns url sync config */
-  public get urlSync(): SceneObjectUrlSyncHandler<TState> | undefined {
+  public get urlSync(): SceneObjectUrlSyncHandler | undefined {
     return this._urlSync;
   }
 

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -17,7 +17,7 @@ describe('SceneTimeRange', () => {
 
   it('toUrlValues with relative range', () => {
     const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
-    expect(timeRange.urlSync?.getUrlState(timeRange.state)).toEqual({
+    expect(timeRange.urlSync?.getUrlState()).toEqual({
       from: 'now-1h',
       to: 'now',
     });

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -39,8 +39,8 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     this.setState({ value: evaluateTimeRange(this.state.from, this.state.to, this.state.timeZone) });
   };
 
-  public getUrlState(state: SceneTimeRangeState) {
-    return { from: state.from, to: state.to };
+  public getUrlState() {
+    return { from: this.state.from, to: this.state.to };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -70,7 +70,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   readonly variableDependency?: SceneVariableDependencyConfigLike;
 
   /** This abstraction declares URL sync dependencies of a scene object. **/
-  readonly urlSync?: SceneObjectUrlSyncHandler<TState>;
+  readonly urlSync?: SceneObjectUrlSyncHandler;
 
   /** Subscribe to state changes */
   subscribeToState(handler: SceneStateChangedHandler<TState>): Unsubscribable;
@@ -153,14 +153,14 @@ export function isSceneObject(obj: any): obj is SceneObject {
   return obj.useState !== undefined;
 }
 
-export interface SceneObjectWithUrlSync<TState> extends SceneObject {
-  getUrlState(state: TState): SceneObjectUrlValues;
+export interface SceneObjectWithUrlSync extends SceneObject {
+  getUrlState(): SceneObjectUrlValues;
   updateFromUrl(values: SceneObjectUrlValues): void;
 }
 
-export interface SceneObjectUrlSyncHandler<TState> {
+export interface SceneObjectUrlSyncHandler {
   getKeys(): string[];
-  getUrlState(state: TState): SceneObjectUrlValues;
+  getUrlState(): SceneObjectUrlValues;
   updateFromUrl(values: SceneObjectUrlValues): void;
 }
 

--- a/packages/scenes/src/services/SceneObjectUrlSyncConfig.ts
+++ b/packages/scenes/src/services/SceneObjectUrlSyncConfig.ts
@@ -1,18 +1,13 @@
-import {
-  SceneObjectState,
-  SceneObjectUrlSyncHandler,
-  SceneObjectWithUrlSync,
-  SceneObjectUrlValues,
-} from '../core/types';
+import { SceneObjectUrlSyncHandler, SceneObjectWithUrlSync, SceneObjectUrlValues } from '../core/types';
 
 interface SceneObjectUrlSyncConfigOptions {
   keys: string[];
 }
 
-export class SceneObjectUrlSyncConfig<TState extends SceneObjectState> implements SceneObjectUrlSyncHandler<TState> {
+export class SceneObjectUrlSyncConfig implements SceneObjectUrlSyncHandler {
   private _keys: string[];
 
-  public constructor(private _sceneObject: SceneObjectWithUrlSync<TState>, _options: SceneObjectUrlSyncConfigOptions) {
+  public constructor(private _sceneObject: SceneObjectWithUrlSync, _options: SceneObjectUrlSyncConfigOptions) {
     this._keys = _options.keys;
   }
 
@@ -20,8 +15,8 @@ export class SceneObjectUrlSyncConfig<TState extends SceneObjectState> implement
     return this._keys;
   }
 
-  public getUrlState(state: TState): SceneObjectUrlValues {
-    return this._sceneObject.getUrlState(state);
+  public getUrlState(): SceneObjectUrlValues {
+    return this._sceneObject.getUrlState();
   }
 
   public updateFromUrl(values: SceneObjectUrlValues): void {

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -20,8 +20,8 @@ interface TestObjectState extends SceneLayoutChildState {
 class TestObj extends SceneObjectBase<TestObjectState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['name', 'array', 'optional'] });
 
-  public getUrlState(state: TestObjectState) {
-    return { name: state.name, array: state.array, optional: state.optional };
+  public getUrlState() {
+    return { name: this.state.name, array: this.state.array, optional: this.state.optional };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {

--- a/packages/scenes/src/services/UrlSyncManager.ts
+++ b/packages/scenes/src/services/UrlSyncManager.ts
@@ -43,7 +43,7 @@ export class UrlSyncManager {
     const changedObject = payload.changedObject;
 
     if (changedObject.urlSync) {
-      const newUrlState = changedObject.urlSync.getUrlState(payload.newState);
+      const newUrlState = changedObject.urlSync.getUrlState();
 
       const searchParams = locationService.getSearch();
       const mappedUpdated: SceneObjectUrlValues = {};
@@ -68,7 +68,7 @@ export class UrlSyncManager {
   private syncSceneStateFromUrl(sceneObject: SceneObject, urlParams: URLSearchParams) {
     if (sceneObject.urlSync) {
       const urlState: SceneObjectUrlValues = {};
-      const currentState = sceneObject.urlSync.getUrlState(sceneObject.state);
+      const currentState = sceneObject.urlSync.getUrlState();
 
       for (const key of sceneObject.urlSync.getKeys()) {
         const uniqueKey = this.urlKeyMapper.getUniqueKey(key, sceneObject);

--- a/packages/scenes/src/variables/macros/UrlTimeRangeMacro.ts
+++ b/packages/scenes/src/variables/macros/UrlTimeRangeMacro.ts
@@ -15,7 +15,7 @@ export class UrlTimeRangeMacro implements FormatVariable {
 
   public getValue(): SkipFormattingValue {
     const timeRange = getTimeRange(this._sceneObject);
-    const urlState = timeRange.urlSync?.getUrlState(timeRange.state);
+    const urlState = timeRange.urlSync?.getUrlState();
     return new SkipFormattingValue(urlUtil.toUrlParams(urlState));
   }
 

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -333,7 +333,7 @@ describe('MultiValueVariable', () => {
         text: 'A',
       });
 
-      expect(variable.urlSync?.getUrlState(variable.state)).toEqual({ ['var-test']: '1' });
+      expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: '1' });
     });
 
     it('getUrlState should return string array if value is string array', async () => {
@@ -345,7 +345,7 @@ describe('MultiValueVariable', () => {
         text: ['A', 'B'],
       });
 
-      expect(variable.urlSync?.getUrlState(variable.state)).toEqual({ ['var-test']: ['1', '2'] });
+      expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: ['1', '2'] });
     });
 
     it('fromUrlState should update value for single value', async () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -37,7 +37,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
   extends SceneObjectBase<TState>
   implements SceneVariable<TState>
 {
-  protected _urlSync: SceneObjectUrlSyncHandler<TState> = new MultiValueUrlSyncHandler(this);
+  protected _urlSync: SceneObjectUrlSyncHandler = new MultiValueUrlSyncHandler(this);
 
   /**
    * The source of value options.
@@ -236,7 +236,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
 }
 
 export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = MultiValueVariableState>
-  implements SceneObjectUrlSyncHandler<TState>
+  implements SceneObjectUrlSyncHandler
 {
   public constructor(private _sceneObject: MultiValueVariable<TState>) {}
 
@@ -248,9 +248,9 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
     return [this.getKey()];
   }
 
-  public getUrlState(state: TState): SceneObjectUrlValues {
+  public getUrlState(): SceneObjectUrlValues {
     let urlValue: string | string[] | null = null;
-    let value = state.value;
+    let value = this._sceneObject.state.value;
 
     if (Array.isArray(value)) {
       urlValue = value.map(String);

--- a/packages/scenes/src/variables/variants/TextBoxVariable.tsx
+++ b/packages/scenes/src/variables/variants/TextBoxVariable.tsx
@@ -13,7 +13,7 @@ export class TextBoxVariable
   extends SceneObjectBase<TextBoxVariableState>
   implements SceneVariable<TextBoxVariableState>
 {
-  protected _urlSync: SceneObjectUrlSyncHandler<TextBoxVariableState>;
+  protected _urlSync: SceneObjectUrlSyncHandler;
 
   public constructor(initialState: Partial<TextBoxVariableState>) {
     super({
@@ -39,8 +39,8 @@ export class TextBoxVariable
     return `var-${this.state.name}`;
   }
 
-  public getUrlState(state: TextBoxVariableState) {
-    return { [this.getKey()]: state.value };
+  public getUrlState() {
+    return { [this.getKey()]: this.state.value };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {


### PR DESCRIPTION
After the changes in https://github.com/grafana/scenes/pull/96 there is now technically no need for the getUrlState function to pass in state, but it could instead always use current state. The reason for it passing in state was to be able to pass in old state so we could remember the initial state and restore it when url state was removed. 

Burt all of that is no longer needed, so I think it makes sense to simplify this interface and have get just be getUrlState. 

There is a small argument that this could potentially be useful at some point and adding it later could be painful 

## Release Notes

The  SceneObjectUrlSyncHandler interface has changed. The function `getUrlState` no longer takes state as parameter. The implementation needs to use the current scene object state instead. 

