### PR TITLE
DataLinks: DataValueMacro for __value.* evaluation

### DIFF
--- a/packages/scenes/src/variables/TestScene.ts
+++ b/packages/scenes/src/variables/TestScene.ts
@@ -1,0 +1,11 @@
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneObjectStatePlain } from '../core/types';
+
+/**
+ * Used in a couple of unit tests
+ */
+export interface TestSceneState extends SceneObjectStatePlain {
+  nested?: TestScene;
+}
+
+export class TestScene extends SceneObjectBase<TestSceneState> {}

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -48,7 +48,7 @@ function lookupFormatVariable(
   sceneObject: SceneObject
 ): FormatVariable | null {
   if (macrosIndex[name]) {
-    return new macrosIndex[name](name, sceneObject);
+    return new macrosIndex[name](name, sceneObject, scopedVars);
   }
 
   if (scopedVars && scopedVars[name]) {

--- a/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
+++ b/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
@@ -2,9 +2,9 @@ import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { ConstantVariable } from '../variants/ConstantVariable';
 import { ObjectVariable } from '../variants/ObjectVariable';
 import { TestVariable } from '../variants/TestVariable';
-import { TestScene } from '../interpolation/sceneInterpolator.test';
 import { AllVariablesMacro } from './AllVariablesMacro';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
+import { TestScene } from '../TestScene';
 
 describe('UrlVariables', () => {
   it('Should include variables from all levels', () => {

--- a/packages/scenes/src/variables/macros/DataValueMacro.test.ts
+++ b/packages/scenes/src/variables/macros/DataValueMacro.test.ts
@@ -1,0 +1,43 @@
+import { FieldType, toDataFrame } from '@grafana/data';
+import { DataContextScopedVar } from '../macros/DataValueMacro';
+import { sceneInterpolator } from '../interpolation/sceneInterpolator';
+import { TestScene } from '../TestScene';
+
+describe('DataValueMacro', () => {
+  it('Can use use ${__value.*} interpolation when dataContext exist', () => {
+    const scene = new TestScene({});
+    const data = toDataFrame({
+      name: 'A',
+      fields: [
+        {
+          name: 'number',
+          type: FieldType.number,
+          values: [5, 10],
+          display: (value: number) => {
+            return { text: value.toString(), numeric: value, suffix: '%' };
+          },
+        },
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [5000, 10000],
+        },
+      ],
+    });
+
+    const dataContext: DataContextScopedVar = {
+      value: {
+        field: data.fields[0],
+        timeField: data.fields[1],
+        valueRowIndex: 1,
+      },
+    };
+
+    const scopedVars = { __dataContext: dataContext };
+
+    expect(sceneInterpolator(scene, '${__value.raw}', scopedVars)).toBe('10');
+    expect(sceneInterpolator(scene, '${__value.numeric}', scopedVars)).toBe('10');
+    expect(sceneInterpolator(scene, '${__value}', scopedVars)).toBe('10%');
+    expect(sceneInterpolator(scene, '${__value.time}', scopedVars)).toBe('10000');
+  });
+});

--- a/packages/scenes/src/variables/macros/DataValueMacro.ts
+++ b/packages/scenes/src/variables/macros/DataValueMacro.ts
@@ -1,0 +1,63 @@
+import { Field, formattedValueToString, getDisplayProcessor, ScopedVars } from '@grafana/data';
+import { SceneObject } from '../../core/types';
+import { FormatVariable } from '../interpolation/formatRegistry';
+import { VariableValue } from '../types';
+
+export interface DataContextScopedVar {
+  value: {
+    field: Field;
+    timeField?: Field;
+    valueRowIndex?: number;
+  };
+}
+
+export class DataValueMacro implements FormatVariable {
+  public state: { name: string; type: string };
+  private _scopedVars: ScopedVars | undefined;
+
+  public constructor(name: string, sceneObject: SceneObject, scopedVars?: ScopedVars) {
+    this.state = { name, type: 'url_variable' };
+    this._scopedVars = scopedVars;
+  }
+
+  public getValue(fieldPath?: string): VariableValue {
+    const dataContext: DataContextScopedVar | undefined = this._scopedVars?.__dataContext;
+    if (!dataContext) {
+      return '';
+    }
+
+    const { field, valueRowIndex, timeField } = dataContext.value;
+
+    if (!valueRowIndex) {
+      return '';
+    }
+
+    if (fieldPath === 'time') {
+      return timeField ? timeField.values.get(valueRowIndex) : undefined;
+    }
+
+    const value = field.values.get(valueRowIndex);
+    if (fieldPath === 'raw') {
+      return value;
+    }
+
+    const displayProcessor = field.display ?? fallbackDisplayProcessor;
+    const result = displayProcessor(value);
+
+    switch (fieldPath) {
+      case 'text':
+        return result.text;
+      case 'numeric':
+        return result.numeric;
+      default:
+        console.log('formatting', result);
+        return formattedValueToString(result);
+    }
+  }
+
+  public getValueText?(): string {
+    return '';
+  }
+}
+
+const fallbackDisplayProcessor = getDisplayProcessor();

--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -2,8 +2,10 @@ import { DataLinkBuiltInVars } from '@grafana/data';
 import { MacroVariableConstructor } from './types';
 import { UrlTimeRangeMacro } from './UrlTimeRangeMacro';
 import { AllVariablesMacro } from './AllVariablesMacro';
+import { DataValueMacro } from './DataValueMacro';
 
 export const macrosIndex: Record<string, MacroVariableConstructor> = {
   [DataLinkBuiltInVars.includeVars]: AllVariablesMacro,
   [DataLinkBuiltInVars.keepTime]: UrlTimeRangeMacro,
+  ['__value']: DataValueMacro,
 };

--- a/packages/scenes/src/variables/macros/types.ts
+++ b/packages/scenes/src/variables/macros/types.ts
@@ -1,9 +1,10 @@
+import { ScopedVars } from '@grafana/data';
 import { SceneObject } from '../../core/types';
 import { FormatVariable } from '../interpolation/formatRegistry';
 import { CustomVariableValue } from '../types';
 
 export interface MacroVariableConstructor {
-  new (name: string, sceneObject: SceneObject): FormatVariable;
+  new (name: string, sceneObject: SceneObject, scopedVars?: ScopedVars): FormatVariable;
 }
 
 /**


### PR DESCRIPTION
Was so excited how the macros  __all_variables and __url_time_range can now be implemented AND lazily evaluated (instead of how they are ALWAYS evaluated for all data link string interpolations) https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/field/fieldOverrides.ts#L423

Was really excited to see how we could implemented the other data link variables there in a similar lazy way using the same abstraction, starting with the  

* $__value.raw
* $__value.numeric
* $__value.text
* $__value
* $__value.time

All these are also evaluated for every datalink interpolation and passed as scopedVars https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/field/fieldOverrides.ts#L392

Instead this PR propose that we instead pass DataContext via scopedVars 
* field: Field
* valueRowIndex?: number
* timeField?  (optional) 

with this we can implement all the above value "macros" and only evaluate exactly what we need depending on the expression being evaluated! 

This needs a small change in core to set this dataContext (and ignore setting the normal value scopedVars when in a scene context. that should be pretty straight forward)