### PR TITLE
Query: support listening to non-parent nodes for data

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -7,6 +7,8 @@ export { SceneTimeRange } from './core/SceneTimeRange';
 
 export { SceneQueryRunner, type QueryRunnerState } from './querying/SceneQueryRunner';
 export { SceneDataTransformer } from './querying/SceneDataTransformer';
+export { SharedDataListener } from './querying/SharedDataListener';
+
 
 export * from './variables/types';
 export { VariableDependencyConfig } from './variables/VariableDependencyConfig';

--- a/packages/scenes/src/querying/SharedDataListener.ts
+++ b/packages/scenes/src/querying/SharedDataListener.ts
@@ -1,0 +1,46 @@
+import { Unsubscribable } from 'rxjs';
+import { SceneDataNodeState } from '../core/SceneDataNode';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneDataProvider } from '../core/types';
+
+export interface SharedDataListenerState extends SceneDataNodeState {
+  // FUTURE?
+  // providerKey // key for the node we want to listen to?
+  // includeTransformations? // with or without transformation node?
+
+  // Where the data actually comes from
+  provider: SceneDataProvider;
+}
+
+/**
+ * This allows a node to listen for changes to data elsewhere in the tree.
+ */
+export class SharedDataListener extends SceneObjectBase<SharedDataListenerState> implements SceneDataProvider {
+  private _sub?: Unsubscribable; // ??? necessary
+
+  public constructor(state: SharedDataListenerState) {
+    super(state);
+
+    this.addActivationHandler(() => this.activationHandler());
+  }
+
+  private activationHandler() {
+    const sourceData = this.state.provider; // ??? 
+
+    if (!sourceData) {
+      throw new Error('SharedDataListener must have provider defined');
+    }
+
+    this._subs.add(sourceData.subscribeToState((state) => this.setState({data: state.data})));
+
+    return () => {
+      if (this._sub) {
+        this._sub.unsubscribe();
+      }
+    };
+  }
+
+  public setContainerWidth(width: number) {
+    // will use the upstream values
+  }
+}


### PR DESCRIPTION
Trying to implement the existing "Dashboard Query" pattern we have in dashboards -- we need to find another panel and subscribe to the changes from there.

See https://github.com/grafana/grafana/pull/64936

This is my most naive attempt -- feedback welcome!