### PR TITLE
App: Show errors in the landing page if system is not configured properly

### DIFF
--- a/packages/scenes-app/provisioning/datasources/default.yaml
+++ b/packages/scenes-app/provisioning/datasources/default.yaml
@@ -1,0 +1,6 @@
+apiVersion: 1
+
+datasources:
+  - name: gdev-testdata
+    isDefault: true
+    type: testdata

--- a/packages/scenes-app/provisioning/datasources/default.yaml
+++ b/packages/scenes-app/provisioning/datasources/default.yaml
@@ -1,6 +1,0 @@
-apiVersion: 1
-
-datasources:
-  - name: scenes-app-testdata
-    isDefault: true
-    type: testdata

--- a/packages/scenes-app/src/constants.ts
+++ b/packages/scenes-app/src/constants.ts
@@ -10,6 +10,6 @@ export enum ROUTES {
 }
 
 export const DATASOURCE_REF = {
-  uid: 'scenes-app-testdata',
+  uid: 'gdev-testdata',
   type: 'testdata',
 };

--- a/packages/scenes-app/src/pages/Home/Home.tsx
+++ b/packages/scenes-app/src/pages/Home/Home.tsx
@@ -2,7 +2,9 @@ import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import * as React from 'react';
 import { getBasicScene } from './scenes';
 import { prefixRoute } from '../../utils/utils.routing';
-import { ROUTES } from '../../constants';
+import { DATASOURCE_REF, ROUTES } from '../../constants';
+import { config } from '@grafana/runtime';
+import { Alert } from '@grafana/ui';
 
 const getScene = () => {
   return new SceneApp({
@@ -21,5 +23,17 @@ const getScene = () => {
 };
 export const HomePage = () => {
   const scene = getScene();
-  return <scene.Component model={scene} />;
+
+  return <>
+    {!config.featureToggles.topnav && <Alert title='Missing topnav feature toggle'>
+      Scenes are designed to work with the new navigation wrapper that will be standard in grafana 10
+    </Alert>}
+
+    {!config.datasources[DATASOURCE_REF.uid] && <Alert title={`Missing ${DATASOURCE_REF.uid} datasource`}>
+      These demos depend on <b>testdata</b> datasource: <code>{JSON.stringify(DATASOURCE_REF)}</code>.  
+      This can be provisioned using the attached datasource provisioning files.
+    </Alert>}
+
+    <scene.Component model={scene} />
+  </>;
 };

--- a/packages/scenes-app/src/pages/Home/Home.tsx
+++ b/packages/scenes-app/src/pages/Home/Home.tsx
@@ -31,7 +31,7 @@ export const HomePage = () => {
 
     {!config.datasources[DATASOURCE_REF.uid] && <Alert title={`Missing ${DATASOURCE_REF.uid} datasource`}>
       These demos depend on <b>testdata</b> datasource: <code>{JSON.stringify(DATASOURCE_REF)}</code>.  
-      This can be provisioned using the attached datasource provisioning files.
+      See <a href="https://github.com/grafana/grafana/tree/main/devenv#set-up-your-development-environment">https://github.com/grafana/grafana/tree/main/devenv#set-up-your-development-environment</a> for more details.
     </Alert>}
 
     <scene.Component model={scene} />


### PR DESCRIPTION
Adding a few warning messages that would have helped me (non-documentation reading 😬 ) figure out why things were not working faster.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/705951/228603740-cc8a3ac3-c058-40b0-afc7-905c3465d99f.png">
