### PR TITLE
LayoutTypes: Cleanup old types that are no longer needed 

### DIFF
--- a/packages/scenes/src/components/NestedScene.tsx
+++ b/packages/scenes/src/components/NestedScene.tsx
@@ -8,13 +8,13 @@ import { Button, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import {
   SceneObject,
-  SceneLayoutChildState,
   SceneComponentProps,
   SceneLayout,
   SceneLayoutItemState,
+  SceneObjectStatePlain,
 } from '../core/types';
 
-interface NestedSceneState extends SceneLayoutChildState {
+interface NestedSceneState extends SceneObjectStatePlain {
   title: string;
   isCollapsed?: boolean;
   canCollapse?: boolean;
@@ -33,10 +33,6 @@ export class NestedScene extends SceneObjectBase<NestedSceneState> {
   public onToggle = () => {
     this.setState({
       isCollapsed: !this.state.isCollapsed,
-      placement: {
-        ...this.state.placement,
-        ySizing: this.state.isCollapsed ? 'fill' : 'content',
-      },
     });
   };
 
@@ -45,7 +41,7 @@ export class NestedScene extends SceneObjectBase<NestedSceneState> {
     const parent = this.parent!;
     if ('children' in parent.state) {
       parent.setState({
-        children: parent.state.children.filter((x) => x !== this),
+        // children: parent.state.children.filter((x) => x !== this),
       });
     }
 

--- a/packages/scenes/src/components/NestedScene.tsx
+++ b/packages/scenes/src/components/NestedScene.tsx
@@ -39,11 +39,6 @@ export class NestedScene extends SceneObjectBase<NestedSceneState> {
   /** Removes itself from its parent's children array */
   public onRemove = () => {
     const parent = this.parent!;
-    if ('children' in parent.state) {
-      parent.setState({
-        // children: parent.state.children.filter((x) => x !== this),
-      });
-    }
 
     if (isSceneLayoutItem(parent)) {
       parent.setState({

--- a/packages/scenes/src/components/SceneByFrameRepeater.tsx
+++ b/packages/scenes/src/components/SceneByFrameRepeater.tsx
@@ -4,17 +4,12 @@ import { LoadingState, PanelData, DataFrame } from '@grafana/data';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import {
-  SceneComponentProps,
-  SceneObject,
-  SceneObjectStatePlain,
-  SceneLayoutState,
-  SceneLayoutChild,
-} from '../core/types';
+import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
+import { SceneFlexItem, SceneFlexLayout } from './layout/SceneFlexLayout';
 
 interface SceneByFrameRepeaterState extends SceneObjectStatePlain {
-  body: SceneObject<SceneLayoutState>;
-  getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneLayoutChild;
+  body: SceneFlexLayout;
+  getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneFlexItem;
 }
 
 export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterState> {
@@ -33,7 +28,7 @@ export class SceneByFrameRepeater extends SceneObjectBase<SceneByFrameRepeaterSt
   }
 
   private performRepeat(data: PanelData) {
-    const newChildren: SceneLayoutChild[] = [];
+    const newChildren: SceneFlexItem[] = [];
 
     for (let seriesIndex = 0; seriesIndex < data.series.length; seriesIndex++) {
       const layoutChild = this.state.getLayoutChild(data, data.series[seriesIndex], seriesIndex);

--- a/packages/scenes/src/components/SceneCanvasText.tsx
+++ b/packages/scenes/src/components/SceneCanvasText.tsx
@@ -1,13 +1,11 @@
 import React, { CSSProperties } from 'react';
 
-import { Field, Input } from '@grafana/ui';
-
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneLayoutChildState } from '../core/types';
+import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 
-export interface SceneCanvasTextState extends SceneLayoutChildState {
+export interface SceneCanvasTextState extends SceneObjectStatePlain {
   text: string;
   fontSize?: number;
   align?: 'left' | 'center' | 'right';
@@ -18,8 +16,6 @@ export interface SceneCanvasTextState extends SceneLayoutChildState {
  * @internal
  */
 export class SceneCanvasText extends SceneObjectBase<SceneCanvasTextState> {
-  public static Editor = Editor;
-
   protected _variableDependency = new VariableDependencyConfig(this, { statePaths: ['text'] });
 
   public static Component = ({ model }: SceneComponentProps<SceneCanvasText>) => {
@@ -40,18 +36,4 @@ export class SceneCanvasText extends SceneObjectBase<SceneCanvasTextState> {
       </div>
     );
   };
-}
-
-function Editor({ model }: SceneComponentProps<SceneCanvasText>) {
-  const { fontSize } = model.useState();
-
-  return (
-    <Field label="Font size">
-      <Input
-        type="number"
-        defaultValue={fontSize}
-        onBlur={(evt) => model.setState({ fontSize: parseInt(evt.currentTarget.value, 10) })}
-      />
-    </Field>
-  );
 }

--- a/packages/scenes/src/components/SceneReactObject.tsx
+++ b/packages/scenes/src/components/SceneReactObject.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneLayoutChildState } from '../core/types';
+import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
 
-export interface SceneReactObjectState<TProps = {}> extends SceneLayoutChildState {
+export interface SceneReactObjectState<TProps = {}> extends SceneObjectStatePlain {
   /**
    * React component to render
    */

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
-import { SceneComponentProps, SceneLayoutChildState } from '../../../core/types';
+import { SceneComponentProps, SceneObjectStatePlain } from '../../../core/types';
 import { EmbeddedScene } from '../../EmbeddedScene';
 
 import { SceneGridItem, SceneGridLayout } from './SceneGridLayout';
@@ -16,7 +16,7 @@ jest.mock(
       children({ height: 600, width: 600 })
 );
 
-class TestObject extends SceneObjectBase<SceneLayoutChildState> {
+class TestObject extends SceneObjectBase<SceneObjectStatePlain> {
   public static Component = (m: SceneComponentProps<TestObject>) => {
     return <div data-testid="test-object">TestObject</div>;
   };

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -3,13 +3,13 @@ import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
 import { SceneDataNode } from './SceneDataNode';
 import { SceneObjectBase } from './SceneObjectBase';
 import { SceneObjectStateChangedEvent } from './events';
-import { SceneLayoutChild, SceneObject, SceneObjectStatePlain } from './types';
+import { SceneObject, SceneObjectStatePlain } from './types';
 import { SceneTimeRange } from '../core/SceneTimeRange';
 
 interface TestSceneState extends SceneObjectStatePlain {
   name?: string;
   nested?: SceneObject<TestSceneState>;
-  children?: SceneLayoutChild[];
+  children?: TestScene[];
   actions?: SceneObject[];
 }
 

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -6,12 +6,12 @@ import { BusEvent, BusEventHandler, BusEventType, EventBusSrv } from '@grafana/d
 import {
   SceneObject,
   SceneComponent,
-  SceneObjectState,
   SceneObjectUrlSyncHandler,
   SceneStateChangedHandler,
   SceneActivationHandler,
   SceneDeactivationHandler,
   CancelActivationHandler,
+  SceneObjectStatePlain,
 } from './types';
 import { useForceUpdate } from '@grafana/ui';
 
@@ -20,7 +20,7 @@ import { SceneObjectStateChangedEvent } from './events';
 import { cloneSceneObject, forEachSceneObjectInState } from './utils';
 import { SceneVariableDependencyConfigLike } from '../variables/types';
 
-export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObjectState>
+export abstract class SceneObjectBase<TState extends SceneObjectStatePlain = SceneObjectStatePlain>
   implements SceneObject<TState>
 {
   private _isActive = false;
@@ -242,7 +242,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
  * This hook is always returning model.state instead of a useState that remembers the last state emitted on the subject
  * The reason for this is so that if the model instance change this function will always return the latest state.
  */
-function useSceneObjectState<TState extends SceneObjectState>(model: SceneObjectBase<TState>): TState {
+function useSceneObjectState<TState extends SceneObjectStatePlain>(model: SceneObjectBase<TState>): TState {
   const forceUpdate = useForceUpdate();
 
   useEffect(() => {

--- a/packages/scenes/src/core/events.ts
+++ b/packages/scenes/src/core/events.ts
@@ -1,12 +1,12 @@
 import { BusEventWithPayload } from '@grafana/data';
 
-import { SceneObject, SceneObjectState } from './types';
+import { SceneObject, SceneObjectStatePlain } from './types';
 
-export interface SceneObjectStateChangedPayload {
-  prevState: SceneObjectState;
-  newState: SceneObjectState;
-  partialUpdate: Partial<SceneObjectState>;
-  changedObject: SceneObject;
+export interface SceneObjectStateChangedPayload<TState extends SceneObjectStatePlain = SceneObjectStatePlain> {
+  prevState: TState;
+  newState: TState;
+  partialUpdate: Partial<TState>;
+  changedObject: SceneObject<TState>;
 }
 
 export class SceneObjectStateChangedEvent extends BusEventWithPayload<SceneObjectStateChangedPayload> {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -21,15 +21,9 @@ export interface SceneObjectStatePlain {
   $variables?: SceneVariables;
 }
 
-export interface SceneLayoutChildState extends SceneObjectStatePlain {
-  placement?: SceneLayoutChildOptions;
-}
-
 export interface SceneLayoutItemState extends SceneObjectStatePlain {
   body: SceneObject | undefined;
 }
-
-export type SceneObjectState = SceneObjectStatePlain | SceneLayoutState | SceneLayoutChildState;
 
 export interface SceneLayoutChildOptions {
   width?: number | string;
@@ -60,7 +54,7 @@ export interface SceneDataState extends SceneObjectStatePlain {
   data?: PanelData;
 }
 
-export interface SceneObject<TState extends SceneObjectState = SceneObjectState> {
+export interface SceneObject<TState extends SceneObjectStatePlain = SceneObjectStatePlain> {
   /** The current state */
   readonly state: TState;
 
@@ -124,9 +118,7 @@ export type SceneDeactivationHandler = () => void;
  **/
 export type CancelActivationHandler = () => void;
 
-export type SceneLayoutChild = SceneObject<SceneLayoutChildState | SceneLayoutState>;
-
-export interface SceneLayoutState extends SceneLayoutChildState {
+export interface SceneLayoutState extends SceneObjectStatePlain {
   children: SceneObject[];
 }
 

--- a/packages/scenes/src/core/utils.ts
+++ b/packages/scenes/src/core/utils.ts
@@ -1,4 +1,4 @@
-import { SceneObjectState, SceneObjectStatePlain } from './types';
+import { SceneObjectStatePlain } from './types';
 
 import { SceneObjectBase } from './SceneObjectBase';
 
@@ -24,7 +24,7 @@ export function forEachSceneObjectInState(state: SceneObjectStatePlain, callback
 /**
  * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned
  */
-export function cloneSceneObject<T extends SceneObjectBase<TState>, TState extends SceneObjectState>(
+export function cloneSceneObject<T extends SceneObjectBase<TState>, TState extends SceneObjectStatePlain>(
   sceneObject: SceneObjectBase<TState>,
   withState?: Partial<TState>
 ): T {

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -5,12 +5,12 @@ import { locationService } from '@grafana/runtime';
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneTimeRange } from '../core/SceneTimeRange';
-import { SceneLayoutChildState, SceneObject, SceneObjectUrlValues } from '../core/types';
+import { SceneObjectStatePlain, SceneObject, SceneObjectUrlValues } from '../core/types';
 
 import { SceneObjectUrlSyncConfig } from './SceneObjectUrlSyncConfig';
 import { isUrlValueEqual, UrlSyncManager } from './UrlSyncManager';
 
-interface TestObjectState extends SceneLayoutChildState {
+interface TestObjectState extends SceneObjectStatePlain {
   name: string;
   optional?: string;
   array?: string[];

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -1,9 +1,9 @@
-import { SceneObject, SceneObjectState } from '../core/types';
+import { SceneObject, SceneObjectStatePlain } from '../core/types';
 import { VARIABLE_REGEX } from './constants';
 
 import { SceneVariable, SceneVariableDependencyConfigLike } from './types';
 
-interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
+interface VariableDependencyConfigOptions<TState extends SceneObjectStatePlain> {
   /**
    * State paths to scan / extract variable dependencies from. Leave empty to scan all paths.
    */
@@ -20,7 +20,9 @@ interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
   onVariableUpdatesCompleted?: (changedVariables: Set<SceneVariable>, dependencyChanged: boolean) => void;
 }
 
-export class VariableDependencyConfig<TState extends SceneObjectState> implements SceneVariableDependencyConfigLike {
+export class VariableDependencyConfig<TState extends SceneObjectStatePlain>
+  implements SceneVariableDependencyConfigLike
+{
   private _state: TState | undefined;
   private _dependencies = new Set<string>();
   private _statePaths?: Array<keyof TState>;

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react-dom/test-utils';
 
 import { SceneFlexItem, SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneObjectStatePlain, SceneLayoutChildState, SceneObject, SceneComponentProps } from '../../core/types';
+import { SceneObjectStatePlain, SceneObject, SceneComponentProps } from '../../core/types';
 import { TestVariable } from '../variants/TestVariable';
 
 import { SceneVariableSet } from './SceneVariableSet';
@@ -430,7 +430,7 @@ describe('SceneVariableList', () => {
   });
 });
 
-interface TestSceneObjectState extends SceneLayoutChildState {
+interface TestSceneObjectState extends SceneObjectStatePlain {
   title: string;
   variableValueChanged: number;
 }


### PR DESCRIPTION
* Simplify types now that the union type SceneObjectState is no longer needed 
* Removes SceneLayoutChildState
