### PR TITLE
SceneObject: Rename SceneObjectStatePlain to SceneObjectState

### DIFF
--- a/packages/scenes-app/src/pages/Demos/scenes/flexLayout.tsx
+++ b/packages/scenes-app/src/pages/Demos/scenes/flexLayout.tsx
@@ -5,7 +5,7 @@ import {
   SceneFlexItem,
   SceneFlexLayout,
   SceneObjectBase,
-  SceneObjectStatePlain,
+  SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery } from '../utils';
@@ -109,7 +109,7 @@ export function getFlexLayoutTest() {
   });
 }
 
-class DebugItem extends SceneObjectBase<SceneObjectStatePlain> {
+class DebugItem extends SceneObjectBase<SceneObjectState> {
   public static Component = DebugItemRenderer;
 }
 

--- a/packages/scenes-app/src/pages/Home/CustomSceneObject.tsx
+++ b/packages/scenes-app/src/pages/Home/CustomSceneObject.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { SceneComponentProps, SceneObjectBase, SceneObjectStatePlain } from '@grafana/scenes';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 
-export interface CustomSceneObjectState extends SceneObjectStatePlain {
+export interface CustomSceneObjectState extends SceneObjectState {
   value?: string;
   onChange: (value: number) => void;
 }

--- a/packages/scenes/src/components/EmbeddedScene.tsx
+++ b/packages/scenes/src/components/EmbeddedScene.tsx
@@ -4,10 +4,10 @@ import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectStatePlain, SceneObject } from '../core/types';
+import { SceneComponentProps, SceneObjectState, SceneObject } from '../core/types';
 import { UrlSyncManager } from '../services/UrlSyncManager';
 
-export interface EmbeddedSceneState extends SceneObjectStatePlain {
+export interface EmbeddedSceneState extends SceneObjectState {
   /**
    * The main content of the scene (usually a SceneFlexLayout)
    */

--- a/packages/scenes/src/components/NestedScene.tsx
+++ b/packages/scenes/src/components/NestedScene.tsx
@@ -6,15 +6,9 @@ import { Stack } from '@grafana/experimental';
 import { Button, ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import {
-  SceneObject,
-  SceneComponentProps,
-  SceneLayout,
-  SceneLayoutItemState,
-  SceneObjectStatePlain,
-} from '../core/types';
+import { SceneObject, SceneComponentProps, SceneLayout, SceneLayoutItemState, SceneObjectState } from '../core/types';
 
-interface NestedSceneState extends SceneObjectStatePlain {
+interface NestedSceneState extends SceneObjectState {
   title: string;
   isCollapsed?: boolean;
   canCollapse?: boolean;

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -1,4 +1,4 @@
-import { SceneObject, SceneObjectStatePlain } from '../../core/types';
+import { SceneObject, SceneObjectState } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { IconName } from '@grafana/data';
 
@@ -9,7 +9,7 @@ export interface SceneRouteMatch<Params extends { [K in keyof Params]?: string }
   url: string;
 }
 
-export interface SceneAppState extends SceneObjectStatePlain {
+export interface SceneAppState extends SceneObjectState {
   // Array of SceneAppPage objects that are considered app's top level pages
   pages: SceneAppPageLike[];
 }
@@ -20,7 +20,7 @@ export interface SceneAppRoute {
   drilldown?: SceneAppDrilldownView;
 }
 
-export interface SceneAppPageState extends SceneObjectStatePlain {
+export interface SceneAppPageState extends SceneObjectState {
   /** Page title */
   title: string;
   /** Page subTitle */

--- a/packages/scenes/src/components/SceneByFrameRepeater.tsx
+++ b/packages/scenes/src/components/SceneByFrameRepeater.tsx
@@ -4,10 +4,10 @@ import { LoadingState, PanelData, DataFrame } from '@grafana/data';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
+import { SceneComponentProps, SceneObjectState } from '../core/types';
 import { SceneFlexItem, SceneFlexLayout } from './layout/SceneFlexLayout';
 
-interface SceneByFrameRepeaterState extends SceneObjectStatePlain {
+interface SceneByFrameRepeaterState extends SceneObjectState {
   body: SceneFlexLayout;
   getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneFlexItem;
 }

--- a/packages/scenes/src/components/SceneCanvasText.tsx
+++ b/packages/scenes/src/components/SceneCanvasText.tsx
@@ -2,10 +2,10 @@ import React, { CSSProperties } from 'react';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
+import { SceneComponentProps, SceneObjectState } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 
-export interface SceneCanvasTextState extends SceneObjectStatePlain {
+export interface SceneCanvasTextState extends SceneObjectState {
   text: string;
   fontSize?: number;
   align?: 'left' | 'center' | 'right';

--- a/packages/scenes/src/components/SceneReactObject.tsx
+++ b/packages/scenes/src/components/SceneReactObject.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
+import { SceneComponentProps, SceneObjectState } from '../core/types';
 
-export interface SceneReactObjectState<TProps = {}> extends SceneObjectStatePlain {
+export interface SceneReactObjectState<TProps = {}> extends SceneObjectState {
   /**
    * React component to render
    */

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -5,12 +5,12 @@ import { RefreshPicker } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneObjectStatePlain, SceneObjectUrlValues } from '../core/types';
+import { SceneComponentProps, SceneObjectState, SceneObjectUrlValues } from '../core/types';
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
 
 export const DEFAULT_INTERVALS = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
 
-export interface SceneRefreshPickerState extends SceneObjectStatePlain {
+export interface SceneRefreshPickerState extends SceneObjectState {
   // Refresh interval, e.g. 5s, 1m, 2h
   refresh: string;
   // List of allowed refresh intervals, e.g. ['5s', '1m']

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -4,9 +4,9 @@ import { TimeRangePicker } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
+import { SceneComponentProps, SceneObjectState } from '../core/types';
 
-export interface SceneTimePickerState extends SceneObjectStatePlain {
+export interface SceneTimePickerState extends SceneObjectState {
   hidePicker?: boolean;
   isOnCanvas?: boolean;
 }

--- a/packages/scenes/src/components/SceneToolbarButton.tsx
+++ b/packages/scenes/src/components/SceneToolbarButton.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { IconName, Input, ToolbarButton } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
+import { SceneComponentProps, SceneObjectState } from '../core/types';
 
-export interface ToolbarButtonState extends SceneObjectStatePlain {
+export interface ToolbarButtonState extends SceneObjectState {
   icon: IconName;
   onClick: () => void;
 }
@@ -18,7 +18,7 @@ export class SceneToolbarButton extends SceneObjectBase<ToolbarButtonState> {
   };
 }
 
-export interface SceneToolbarInputState extends SceneObjectStatePlain {
+export interface SceneToolbarInputState extends SceneObjectState {
   value?: string;
   onChange: (value: number) => void;
 }

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -11,14 +11,14 @@ import {
 import { config, getPluginImportUtils } from '@grafana/runtime';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { DeepPartial, SceneObjectStatePlain } from '../../core/types';
+import { DeepPartial, SceneObjectState } from '../../core/types';
 
 import { VizPanelRenderer } from './VizPanelRenderer';
 import { VizPanelMenu } from './VizPanelMenu';
 import { VariableDependencyConfig } from '../../variables/VariableDependencyConfig';
 import { VariableCustomFormatterFn } from '../../variables/types';
 
-export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectStatePlain {
+export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectState {
   title: string;
   description?: string;
   pluginId: string;

--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { PanelMenuItem } from '@grafana/data';
 import { Menu } from '@grafana/ui';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectStatePlain } from '../../core/types';
+import { SceneComponentProps, SceneObjectState } from '../../core/types';
 
-interface VizPanelMenuState extends SceneObjectStatePlain {
+interface VizPanelMenuState extends SceneObjectState {
   items?: PanelMenuItem[];
 }
 

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -4,14 +4,14 @@ import { SceneObjectBase } from '../../core/SceneObjectBase';
 import {
   SceneComponentProps,
   SceneLayout,
-  SceneObjectStatePlain,
+  SceneObjectState,
   SceneObject,
   SceneLayoutItemState,
 } from '../../core/types';
 
 export interface SceneFlexItemLike extends SceneObject<SceneFlexItemState> {}
 
-interface SceneFlexLayoutState extends SceneObjectStatePlain {
+interface SceneFlexLayoutState extends SceneObjectState {
   direction?: CSSProperties['flexDirection'];
   wrap?: CSSProperties['flexWrap'];
   children: SceneFlexItemLike[];

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectStatePlain } from '../../../core/types';
+import { SceneComponentProps, SceneObjectState } from '../../../core/types';
 import { EmbeddedScene } from '../../EmbeddedScene';
 
 import { SceneGridItem, SceneGridLayout } from './SceneGridLayout';
@@ -16,7 +16,7 @@ jest.mock(
       children({ height: 600, width: 600 })
 );
 
-class TestObject extends SceneObjectBase<SceneObjectStatePlain> {
+class TestObject extends SceneObjectBase<SceneObjectState> {
   public static Component = (m: SceneComponentProps<TestObject>) => {
     return <div data-testid="test-object">TestObject</div>;
   };

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -8,14 +8,14 @@ import {
   SceneLayout,
   SceneLayoutItemState,
   SceneObject,
-  SceneObjectStatePlain,
+  SceneObjectState,
 } from '../../../core/types';
 import { DEFAULT_PANEL_SPAN, GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from './constants';
 
 import { SceneGridRow } from './SceneGridRow';
 import { SceneGridItemLike, SceneGridItemPlacement, SceneGridItemStateLike } from './types';
 
-interface SceneGridLayoutState extends SceneObjectStatePlain {
+interface SceneGridLayoutState extends SceneObjectState {
   /**
    * Turn on or off dragging for all items. Indiviadual items can still disabled via isDraggable property
    **/

--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -1,4 +1,4 @@
-import { SceneObject, SceneObjectStatePlain } from '../../../core/types';
+import { SceneObject, SceneObjectState } from '../../../core/types';
 
 export interface SceneGridItemPlacement {
   x?: number;
@@ -7,7 +7,7 @@ export interface SceneGridItemPlacement {
   height?: number;
 }
 
-export interface SceneGridItemStateLike extends SceneGridItemPlacement, SceneObjectStatePlain {
+export interface SceneGridItemStateLike extends SceneGridItemPlacement, SceneObjectState {
   isResizable: boolean;
   isDraggable: boolean;
 }

--- a/packages/scenes/src/core/SceneDataNode.ts
+++ b/packages/scenes/src/core/SceneDataNode.ts
@@ -1,9 +1,9 @@
 import { PanelData } from '@grafana/data';
 
 import { SceneObjectBase } from './SceneObjectBase';
-import { SceneDataProvider, SceneObjectStatePlain } from './types';
+import { SceneDataProvider, SceneObjectState } from './types';
 
-export interface SceneDataNodeState extends SceneObjectStatePlain {
+export interface SceneDataNodeState extends SceneObjectState {
   data?: PanelData;
 }
 

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -3,10 +3,10 @@ import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
 import { SceneDataNode } from './SceneDataNode';
 import { SceneObjectBase } from './SceneObjectBase';
 import { SceneObjectStateChangedEvent } from './events';
-import { SceneObject, SceneObjectStatePlain } from './types';
+import { SceneObject, SceneObjectState } from './types';
 import { SceneTimeRange } from '../core/SceneTimeRange';
 
-interface TestSceneState extends SceneObjectStatePlain {
+interface TestSceneState extends SceneObjectState {
   name?: string;
   nested?: SceneObject<TestSceneState>;
   children?: TestScene[];

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -11,7 +11,7 @@ import {
   SceneActivationHandler,
   SceneDeactivationHandler,
   CancelActivationHandler,
-  SceneObjectStatePlain,
+  SceneObjectState,
 } from './types';
 import { useForceUpdate } from '@grafana/ui';
 
@@ -20,7 +20,7 @@ import { SceneObjectStateChangedEvent } from './events';
 import { cloneSceneObject } from './utils';
 import { SceneVariableDependencyConfigLike } from '../variables/types';
 
-export abstract class SceneObjectBase<TState extends SceneObjectStatePlain = SceneObjectStatePlain>
+export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObjectState>
   implements SceneObject<TState>
 {
   private _isActive = false;
@@ -262,7 +262,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectStatePlain = Sce
  * This hook is always returning model.state instead of a useState that remembers the last state emitted on the subject
  * The reason for this is so that if the model instance change this function will always return the latest state.
  */
-function useSceneObjectState<TState extends SceneObjectStatePlain>(model: SceneObjectBase<TState>): TState {
+function useSceneObjectState<TState extends SceneObjectState>(model: SceneObjectBase<TState>): TState {
   const forceUpdate = useForceUpdate();
 
   useEffect(() => {

--- a/packages/scenes/src/core/events.ts
+++ b/packages/scenes/src/core/events.ts
@@ -1,8 +1,8 @@
 import { BusEventWithPayload } from '@grafana/data';
 
-import { SceneObject, SceneObjectStatePlain } from './types';
+import { SceneObject, SceneObjectState } from './types';
 
-export interface SceneObjectStateChangedPayload<TState extends SceneObjectStatePlain = SceneObjectStatePlain> {
+export interface SceneObjectStateChangedPayload<TState extends SceneObjectState = SceneObjectState> {
   prevState: TState;
   newState: TState;
   partialUpdate: Partial<TState>;

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -14,14 +14,14 @@ import {
 
 import { SceneVariableDependencyConfigLike, SceneVariables } from '../variables/types';
 
-export interface SceneObjectStatePlain {
+export interface SceneObjectState {
   key?: string;
   $timeRange?: SceneTimeRangeLike;
   $data?: SceneDataProvider;
   $variables?: SceneVariables;
 }
 
-export interface SceneLayoutItemState extends SceneObjectStatePlain {
+export interface SceneLayoutItemState extends SceneObjectState {
   body: SceneObject | undefined;
 }
 
@@ -50,11 +50,11 @@ export interface SceneComponentWrapperProps {
 export type SceneComponent<TModel> = (props: SceneComponentProps<TModel>) => React.ReactElement | null;
 export type SceneComponentCustomWrapper = (props: SceneComponentWrapperProps) => React.ReactElement | null;
 
-export interface SceneDataState extends SceneObjectStatePlain {
+export interface SceneDataState extends SceneObjectState {
   data?: PanelData;
 }
 
-export interface SceneObject<TState extends SceneObjectStatePlain = SceneObjectStatePlain> {
+export interface SceneObject<TState extends SceneObjectState = SceneObjectState> {
   /** The current state */
   readonly state: TState;
 
@@ -124,7 +124,7 @@ export type SceneDeactivationHandler = () => void;
  **/
 export type CancelActivationHandler = () => void;
 
-export interface SceneLayoutState extends SceneObjectStatePlain {
+export interface SceneLayoutState extends SceneObjectState {
   children: SceneObject[];
 }
 
@@ -134,7 +134,7 @@ export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> exte
   getDragClassCancel?(): string;
 }
 
-export interface SceneTimeRangeState extends SceneObjectStatePlain {
+export interface SceneTimeRangeState extends SceneObjectState {
   from: string;
   to: string;
   timeZone: TimeZone;

--- a/packages/scenes/src/core/utils.ts
+++ b/packages/scenes/src/core/utils.ts
@@ -1,11 +1,11 @@
-import { SceneObjectStatePlain } from './types';
+import { SceneObjectState } from './types';
 
 import { SceneObjectBase } from './SceneObjectBase';
 
 /**
  * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned
  */
-export function cloneSceneObject<T extends SceneObjectBase<TState>, TState extends SceneObjectStatePlain>(
+export function cloneSceneObject<T extends SceneObjectBase<TState>, TState extends SceneObjectState>(
   sceneObject: SceneObjectBase<TState>,
   withState?: Partial<TState>
 ): T {

--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -16,7 +16,7 @@ import { SceneDataNode } from '../core/SceneDataNode';
 import { SceneDataTransformer } from './SceneDataTransformer';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { CustomTransformOperator, SceneObjectStatePlain } from '../core/types';
+import { CustomTransformOperator, SceneObjectState } from '../core/types';
 import { mockTransformationsRegistry } from '../utils/mockTransformationsRegistry';
 import { SceneQueryRunner } from './SceneQueryRunner';
 import { SceneTimeRange } from '../core/SceneTimeRange';
@@ -490,7 +490,7 @@ describe('SceneDataTransformer', () => {
   });
 });
 
-export interface SceneObjectSearchBoxState extends SceneObjectStatePlain {
+export interface SceneObjectSearchBoxState extends SceneObjectState {
   value: string;
 }
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -18,7 +18,7 @@ import { getRunRequest } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { CustomTransformOperator, SceneDataProvider, SceneObject, SceneObjectStatePlain } from '../core/types';
+import { CustomTransformOperator, SceneDataProvider, SceneObject, SceneObjectState } from '../core/types';
 import { getDataSource } from '../utils/getDataSource';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 import { SceneVariable } from '../variables/types';
@@ -31,7 +31,7 @@ export function getNextRequestId() {
   return 'SQR' + counter++;
 }
 
-export interface QueryRunnerState extends SceneObjectStatePlain {
+export interface QueryRunnerState extends SceneObjectState {
   data?: PanelData;
   dataPreTransforms?: PanelData;
   queries: DataQueryExtended[];

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -5,12 +5,12 @@ import { locationService } from '@grafana/runtime';
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneTimeRange } from '../core/SceneTimeRange';
-import { SceneObjectStatePlain, SceneObject, SceneObjectUrlValues } from '../core/types';
+import { SceneObjectState, SceneObject, SceneObjectUrlValues } from '../core/types';
 
 import { SceneObjectUrlSyncConfig } from './SceneObjectUrlSyncConfig';
 import { isUrlValueEqual, UrlSyncManager } from './UrlSyncManager';
 
-interface TestObjectState extends SceneObjectStatePlain {
+interface TestObjectState extends SceneObjectState {
   name: string;
   optional?: string;
   array?: string[];

--- a/packages/scenes/src/variables/TestScene.ts
+++ b/packages/scenes/src/variables/TestScene.ts
@@ -1,10 +1,10 @@
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectStatePlain } from '../core/types';
+import { SceneObjectState } from '../core/types';
 
 /**
  * Used in a couple of unit tests
  */
-export interface TestSceneState extends SceneObjectStatePlain {
+export interface TestSceneState extends SceneObjectState {
   nested?: TestScene;
 }
 

--- a/packages/scenes/src/variables/VariableDependencyConfig.test.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.test.ts
@@ -1,10 +1,10 @@
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectStatePlain } from '../core/types';
+import { SceneObjectState } from '../core/types';
 
 import { VariableDependencyConfig } from './VariableDependencyConfig';
 import { ConstantVariable } from './variants/ConstantVariable';
 
-interface TestState extends SceneObjectStatePlain {
+interface TestState extends SceneObjectState {
   query: string;
   otherProp: string;
   nested: {

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -1,9 +1,9 @@
-import { SceneObject, SceneObjectStatePlain } from '../core/types';
+import { SceneObject, SceneObjectState } from '../core/types';
 import { VARIABLE_REGEX } from './constants';
 
 import { SceneVariable, SceneVariableDependencyConfigLike } from './types';
 
-interface VariableDependencyConfigOptions<TState extends SceneObjectStatePlain> {
+interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
   /**
    * State paths to scan / extract variable dependencies from. Leave empty to scan all paths.
    */
@@ -20,9 +20,7 @@ interface VariableDependencyConfigOptions<TState extends SceneObjectStatePlain> 
   onVariableUpdatesCompleted?: (changedVariables: Set<SceneVariable>, dependencyChanged: boolean) => void;
 }
 
-export class VariableDependencyConfig<TState extends SceneObjectStatePlain>
-  implements SceneVariableDependencyConfigLike
-{
+export class VariableDependencyConfig<TState extends SceneObjectState> implements SceneVariableDependencyConfigLike {
   private _state: TState | undefined;
   private _dependencies = new Set<string>();
   private _statePaths?: Array<keyof TState>;

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -6,11 +6,11 @@ import { Tooltip, useStyles2 } from '@grafana/ui';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { SceneComponentProps, SceneObject, SceneObjectStatePlain } from '../../core/types';
+import { SceneComponentProps, SceneObject, SceneObjectState } from '../../core/types';
 import { SceneVariableState } from '../types';
 import { css } from '@emotion/css';
 
-export class VariableValueSelectors extends SceneObjectBase<SceneObjectStatePlain> {
+export class VariableValueSelectors extends SceneObjectBase<SceneObjectState> {
   public static Component = VariableValueSelectorsRenderer;
 }
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react-dom/test-utils';
 
 import { SceneFlexItem, SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneObjectStatePlain, SceneObject, SceneComponentProps } from '../../core/types';
+import { SceneObjectState, SceneObject, SceneComponentProps } from '../../core/types';
 import { TestVariable } from '../variants/TestVariable';
 
 import { SceneVariableSet } from './SceneVariableSet';
@@ -12,7 +12,7 @@ import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { sceneGraph } from '../../core/sceneGraph';
 
-interface TestSceneState extends SceneObjectStatePlain {
+interface TestSceneState extends SceneObjectState {
   nested?: SceneObject;
   /** To test logic for inactive scene objects  */
   hidden?: SceneObject;
@@ -20,7 +20,7 @@ interface TestSceneState extends SceneObjectStatePlain {
 
 class TestScene extends SceneObjectBase<TestSceneState> {}
 
-interface SceneTextItemState extends SceneObjectStatePlain {
+interface SceneTextItemState extends SceneObjectState {
   text: string;
 }
 
@@ -430,7 +430,7 @@ describe('SceneVariableList', () => {
   });
 });
 
-interface TestSceneObjectState extends SceneObjectStatePlain {
+interface TestSceneObjectState extends SceneObjectState {
   title: string;
   variableValueChanged: number;
 }

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -3,9 +3,9 @@ import { Observable } from 'rxjs';
 import { BusEventWithPayload } from '@grafana/data';
 import { VariableType, VariableHide } from '@grafana/schema';
 
-import { SceneObject, SceneObjectStatePlain } from '../core/types';
+import { SceneObject, SceneObjectState } from '../core/types';
 
-export interface SceneVariableState extends SceneObjectStatePlain {
+export interface SceneVariableState extends SceneObjectState {
   type: VariableType;
   name: string;
   label?: string;
@@ -56,7 +56,7 @@ export interface VariableValueOption {
   value: VariableValueSingle;
 }
 
-export interface SceneVariableSetState extends SceneObjectStatePlain {
+export interface SceneVariableSetState extends SceneObjectState {
   variables: SceneVariable[];
 }
 


### PR DESCRIPTION
## Release notes

`SceneObjectStatePlain` is now named `SceneObjectState`. So if you have custom scene objects that extends `SceneObjectStatePlain` just do a search and replace for `SceneObjectStatePlain` and replace with`SceneObjectState`. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.0--canary.122.4597129830.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.3.0--canary.122.4597129830.0
  # or 
  yarn add @grafana/scenes@0.3.0--canary.122.4597129830.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
