### PR TITLE
ValueMacro: Fixes so __value works for rowIndex 0

### DIFF
--- a/packages/scenes/src/variables/macros/DataValueMacro.test.ts
+++ b/packages/scenes/src/variables/macros/DataValueMacro.test.ts
@@ -41,6 +41,20 @@ describe('DataValueMacro', () => {
     expect(sceneInterpolator(scene, '${__value.time}', scopedVars)).toBe('10000');
   });
 
+  it('Can use use ${__value.*} when rowIndex is 0', () => {
+    const scene = new TestScene({});
+    const dataContext: DataContextScopedVar = {
+      value: {
+        frame: data,
+        field: data.fields[0],
+        rowIndex: 0,
+      },
+    };
+
+    const scopedVars = { __dataContext: dataContext };
+    expect(sceneInterpolator(scene, '${__value.raw}', scopedVars)).toBe('5');
+  });
+
   it('Can use use ${__value.*} with calculatedValue', () => {
     const scene = new TestScene({});
     const dataContext: DataContextScopedVar = {

--- a/packages/scenes/src/variables/macros/DataValueMacro.ts
+++ b/packages/scenes/src/variables/macros/DataValueMacro.ts
@@ -43,7 +43,7 @@ export class DataValueMacro implements FormatVariable {
       }
     }
 
-    if (!rowIndex) {
+    if (rowIndex == null) {
       return this._match;
     }
 


### PR DESCRIPTION
Stupid javascript or stupid developer (me)? Answer: both!
