### PR TITLE
SceneVariableSet: Refresh variables that depend on time range

### DIFF
--- a/packages/scenes-app/src/pages/Demos/getDemos.ts
+++ b/packages/scenes-app/src/pages/Demos/getDemos.ts
@@ -5,6 +5,7 @@ import { getGridWithRowLayoutTest } from './scenes/gridWithRow';
 import { getNestedScene } from './scenes/nestedScene';
 import { getPanelMenuTest } from './scenes/panelMenu';
 import { getPanelRepeaterTest } from './scenes/panelRepeater';
+import { getVariablesDemo } from './scenes/variables';
 
 interface SceneDef {
   title: string;
@@ -19,6 +20,7 @@ export function getDemos(): SceneDef[] {
     { title: 'Grid layout', getScene: getGridLayoutTest },
     { title: 'Grid layout with rows', getScene: getGridWithRowLayoutTest },
     { title: 'Nested scene', getScene: getNestedScene },
+    { title: 'Variables', getScene: getVariablesDemo },
   ];
 }
 

--- a/packages/scenes-app/src/pages/Demos/scenes/variables.tsx
+++ b/packages/scenes-app/src/pages/Demos/scenes/variables.tsx
@@ -15,7 +15,6 @@ import {
   NestedScene,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery } from '../utils';
-// import { getQueryRunnerWithRandomWalkQuery } from '../utils';
 
 export function getVariablesDemo(): EmbeddedScene {
   return new EmbeddedScene({

--- a/packages/scenes-app/src/pages/Demos/scenes/variables.tsx
+++ b/packages/scenes-app/src/pages/Demos/scenes/variables.tsx
@@ -1,0 +1,136 @@
+import { VariableRefresh } from '@grafana/data';
+import {
+  SceneTimePicker,
+  SceneFlexLayout,
+  SceneTimeRange,
+  VariableValueSelectors,
+  SceneVariableSet,
+  TestVariable,
+  EmbeddedScene,
+  SceneControlsSpacer,
+  SceneRefreshPicker,
+  SceneFlexItem,
+  VizPanel,
+  SceneCanvasText,
+  NestedScene,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery } from '../utils';
+// import { getQueryRunnerWithRandomWalkQuery } from '../utils';
+
+export function getVariablesDemo(): EmbeddedScene {
+  return new EmbeddedScene({
+    $variables: new SceneVariableSet({
+      variables: [
+        new TestVariable({
+          name: 'server',
+          query: 'A.*',
+          value: 'server',
+          text: '',
+          delayMs: 1000,
+          options: [],
+          refresh: VariableRefresh.onTimeRangeChanged,
+        }),
+        new TestVariable({
+          name: 'pod',
+          query: 'A.$server.*',
+          value: 'pod',
+          delayMs: 1000,
+          isMulti: true,
+          text: '',
+          options: [],
+        }),
+
+        new TestVariable({
+          name: 'handler',
+          query: 'A.$server.$pod.*',
+          value: 'pod',
+          delayMs: 1000,
+          isMulti: true,
+          text: '',
+          options: [],
+          refresh: VariableRefresh.onTimeRangeChanged,
+        }),
+        new TestVariable({
+          name: 'lonelyOne',
+          query: 'B.*',
+          value: '',
+          delayMs: 1000,
+          isMulti: true,
+          text: '',
+          options: [],
+          // refresh: VariableRefresh.onTimeRangeChanged,
+        }),
+      ],
+    }),
+    body: new SceneFlexLayout({
+      direction: 'row',
+      children: [
+        new SceneFlexItem({
+          body: new SceneFlexLayout({
+            direction: 'column',
+            children: [
+              new SceneFlexItem({
+                body: new SceneFlexLayout({
+                  children: [
+                    new SceneFlexItem({
+                      body: new VizPanel({
+                        pluginId: 'timeseries',
+                        title: 'handler: $handler',
+                        $data: getQueryRunnerWithRandomWalkQuery({
+                          alias: 'handler: $handler',
+                        }),
+                      }),
+                    }),
+                    new SceneFlexItem({
+                      body: new SceneCanvasText({
+                        text: 'Text: ${textbox}',
+                        fontSize: 20,
+                        align: 'center',
+                      }),
+                    }),
+                    new SceneFlexItem({
+                      width: '40%',
+                      body: new SceneCanvasText({
+                        text: 'server: ${server} pod:${pod}',
+                        fontSize: 20,
+                        align: 'center',
+                      }),
+                    }),
+                  ],
+                }),
+              }),
+              new SceneFlexItem({
+                body: new NestedScene({
+                  title: 'Collapsable inner scene',
+                  canCollapse: true,
+                  body: new SceneFlexLayout({
+                    direction: 'row',
+                    children: [
+                      new SceneFlexItem({
+                        body: new VizPanel({
+                          pluginId: 'timeseries',
+                          title: 'handler: $handler',
+                          $data: getQueryRunnerWithRandomWalkQuery({
+                            alias: 'handler: $handler',
+                          }),
+                        }),
+                      }),
+                    ],
+                  }),
+                }),
+              }),
+            ],
+          }),
+        }),
+      ],
+    }),
+    $timeRange: new SceneTimeRange(),
+
+    controls: [
+      new VariableValueSelectors({}),
+      new SceneControlsSpacer(),
+      new SceneTimePicker({ isOnCanvas: true }),
+      new SceneRefreshPicker({ isOnCanvas: true }),
+    ],
+  });
+}

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { VariableRefresh } from '@grafana/data';
 
 import { SceneFlexItem, SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
@@ -11,6 +12,7 @@ import { SceneVariableSet } from './SceneVariableSet';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { sceneGraph } from '../../core/sceneGraph';
+import { SceneTimeRange } from '../../core/SceneTimeRange';
 
 interface TestSceneState extends SceneObjectStatePlain {
   nested?: SceneObject;
@@ -426,6 +428,59 @@ describe('SceneVariableList', () => {
 
       // Depenedent scene object notified of change
       expect(nestedObj.state.variableValueChanged).toBe(1);
+    });
+  });
+
+  describe('Refreshing time range dependant variables', () => {
+    it('updates variables in order', () => {
+      const A = new TestVariable({
+        name: 'A',
+        query: 'A.*',
+        value: '',
+        text: '',
+        options: [],
+        refresh: VariableRefresh.onTimeRangeChanged,
+      });
+      const B = new TestVariable({ name: 'B', query: 'A.$A', value: '', text: '', options: [] });
+      const C = new TestVariable({
+        name: 'C',
+        query: 'A.$A.$B.*',
+        value: '',
+        text: '',
+        options: [],
+        refresh: VariableRefresh.onTimeRangeChanged,
+      });
+
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [C, B, A] }),
+        $timeRange: timeRange,
+      });
+
+      scene.activate();
+      A.signalUpdateCompleted();
+      B.signalUpdateCompleted();
+      C.signalUpdateCompleted();
+
+      expect(A.state.loading).toBe(false);
+      expect(B.state.loading).toBe(false);
+      expect(C.state.loading).toBe(false);
+
+      timeRange.setState({ from: 'now-2h', to: 'now' });
+
+      expect(A.state.loading).toBe(true);
+      expect(B.state.loading).toBe(false);
+      expect(C.state.loading).toBe(false);
+
+      A.signalUpdateCompleted();
+      expect(A.state.loading).toBe(false);
+      expect(B.state.loading).toBe(false);
+      expect(C.state.loading).toBe(true);
+
+      C.signalUpdateCompleted();
+      expect(A.state.loading).toBe(false);
+      expect(B.state.loading).toBe(false);
+      expect(C.state.loading).toBe(false);
     });
   });
 });

--- a/packages/scenes/src/variables/variants/TestVariable.tsx
+++ b/packages/scenes/src/variables/variants/TestVariable.tsx
@@ -8,11 +8,13 @@ import { renderSelectForVariable } from '../components/VariableValueSelect';
 import { VariableValueOption } from '../types';
 
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from './MultiValueVariable';
+import { VariableRefresh } from '@grafana/data';
 
 export interface TestVariableState extends MultiValueVariableState {
   query: string;
   delayMs?: number;
   issuedQuery?: string;
+  refresh?: VariableRefresh;
 }
 
 /**
@@ -35,6 +37,7 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
       text: 'Text',
       query: 'Query',
       options: [],
+      refresh: VariableRefresh.onDashboardLoad,
       ...initialState,
     });
   }

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -16,10 +16,7 @@ import {
   VariableRefresh,
   VariableSupportType,
 } from '@grafana/data';
-import { SceneFlexLayout } from '../../../components/layout/SceneFlexLayout';
 import { SceneTimeRange } from '../../../core/SceneTimeRange';
-
-import { SceneVariableSet } from '../../sets/SceneVariableSet';
 
 import { QueryVariable } from './QueryVariable';
 import { QueryRunner, RunnerArgs, setCreateQueryVariableRunnerFactory } from './createQueryVariableRunner';
@@ -230,73 +227,6 @@ describe('QueryVariable', () => {
         await Promise.resolve();
 
         expect(runRequestMock).toBeCalledTimes(1);
-      });
-    });
-
-    describe('when refresh on time range change set', () => {
-      it('Should issue variable query with closes time range if refresh on time range change set', async () => {
-        const variable = new QueryVariable({
-          name: 'test',
-          datasource: { uid: 'fake-std', type: 'fake-std' },
-          query: 'query',
-          refresh: VariableRefresh.onTimeRangeChanged,
-        });
-
-        // @ts-expect-error
-        const scene = new SceneFlexLayout({
-          $timeRange: new SceneTimeRange({ from: 'now-1h', to: 'now' }),
-          $variables: new SceneVariableSet({
-            variables: [variable],
-          }),
-          children: [],
-        });
-
-        await lastValueFrom(variable.validateAndUpdate());
-
-        expect(runRequestMock).toBeCalledTimes(1);
-        const call = runRequestMock.mock.calls[0];
-
-        expect(call[1].range.raw).toEqual({
-          from: 'now-1h',
-          to: 'now',
-        });
-      });
-
-      it('Should issue variable query when time range changes if refresh on time range change is set', async () => {
-        const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
-        const variable = new QueryVariable({
-          name: 'test',
-          datasource: { uid: 'fake-std', type: 'fake-std' },
-          query: 'query',
-          refresh: VariableRefresh.onTimeRangeChanged,
-          $timeRange: timeRange,
-        });
-
-        variable.activate();
-
-        await lastValueFrom(variable.validateAndUpdate());
-
-        expect(runRequestMock).toBeCalledTimes(1);
-        const call1 = runRequestMock.mock.calls[0];
-        expect(call1[1].range.raw).toEqual({
-          from: 'now-1h',
-          to: 'now',
-        });
-
-        timeRange.onTimeRangeChange({
-          from: toUtc('2020-01-01'),
-          to: toUtc('2020-01-02'),
-          raw: { from: toUtc('2020-01-01'), to: toUtc('2020-01-02') },
-        });
-
-        await new Promise((r) => setTimeout(r, 1));
-
-        expect(runRequestMock).toBeCalledTimes(2);
-        const call2 = runRequestMock.mock.calls[1];
-        expect(call2[1].range.raw).toEqual({
-          from: '2020-01-01T00:00:00.000Z',
-          to: '2020-01-02T00:00:00.000Z',
-        });
       });
     });
   });

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Observable, of, Unsubscribable, filter, take, mergeMap, catchError, throwError, from } from 'rxjs';
+import { Observable, of, filter, take, mergeMap, catchError, throwError, from } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -37,8 +37,6 @@ export interface QueryVariableState extends MultiValueVariableState {
 }
 
 export class QueryVariable extends MultiValueVariable<QueryVariableState> {
-  private updateSubscription?: Unsubscribable;
-
   protected _variableDependency = new VariableDependencyConfig(this, {
     statePaths: ['regex', 'query', 'datasource'],
   });
@@ -57,26 +55,6 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       sort: VariableSort.alphabeticalAsc,
       ...initialState,
     });
-
-    this.addActivationHandler(() => this._onActivate());
-  }
-
-  private _onActivate() {
-    const timeRange = sceneGraph.getTimeRange(this);
-
-    if (this.state.refresh === VariableRefresh.onTimeRangeChanged) {
-      this._subs.add(
-        timeRange.subscribeToState(() => {
-          this.updateSubscription = this.validateAndUpdate().subscribe();
-        })
-      );
-    }
-
-    return () => {
-      if (this.updateSubscription) {
-        this.updateSubscription.unsubscribe();
-      }
-    };
   }
 
   public getValueOptions(args: VariableGetOptionsArgs): Observable<VariableValueOption[]> {


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/65832
Closes https://github.com/grafana/scenes/issues/29

First approach to refreshing variables that are dependant on time range.


1. Removed time range dependency from QueryVariable
2. Implemented logic in SceneVariableSet that will add all time range dependant variables to the update queue. My understanding is that doing this and calling `_updateNextBatch` is sufficient to trigger the chain of variable updates.