### PR TITLE
PackageJson: Simple scripts to run app dev from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "precommit": "yarn run lint-staged",
     "prepare": "husky install",
     "packages:publish": "lerna exec --no-private -- npm publish",
-    "test:scenes": "lerna run test --scope '@grafana/scenes' --"
+    "test:lib": "lerna run test --scope '@grafana/scenes' --",
+    "dev:lib": "lerna run dev --scope '@grafana/scenes' --",
+    "dev:app": "lerna run dev --scope 'scenes-app' --"
   },
   "resolutions": {
     "@types/react": "17.0.42"


### PR DESCRIPTION
After having been frustrated with having to cd into packages/scenes-app and running yarn dev there, and then not being able to run root yarn commands etc. I think
having these root scripts makes sense.
