### PR TITLE
FlexLayout: Allow SceneFlexLayout to be child of another flex layout

### DIFF
--- a/packages/scenes-app/src/demos/flexLayout.tsx
+++ b/packages/scenes-app/src/demos/flexLayout.tsx
@@ -81,6 +81,7 @@ export function getFlexLayoutTest() {
 
             new SceneFlexLayout({
               direction: 'row',
+              maxWidth: '50%',
               children: [
                 new SceneFlexItem({
                   width: 50,

--- a/packages/scenes-app/src/demos/flexLayout.tsx
+++ b/packages/scenes-app/src/demos/flexLayout.tsx
@@ -23,94 +23,86 @@ export function getFlexLayoutTest() {
         body: new SceneFlexLayout({
           direction: 'column',
           children: [
-            new SceneFlexItem({
-              ySizing: 'fill',
-              xSizing: 'fill',
-              body: new SceneFlexLayout({
-                direction: 'row',
-                children: [
-                  new SceneFlexItem({
-                    minWidth: '70%',
-                    body: new VizPanel({
-                      pluginId: 'timeseries',
-                      title: 'Dynamic height and width',
-                      $data: getQueryRunnerWithRandomWalkQuery({}, { maxDataPointsFromWidth: true }),
-                    }),
+            new SceneFlexLayout({
+              direction: 'row',
+              children: [
+                new SceneFlexItem({
+                  minWidth: '70%',
+                  body: new VizPanel({
+                    pluginId: 'timeseries',
+                    title: 'Dynamic height and width',
+                    $data: getQueryRunnerWithRandomWalkQuery({}, { maxDataPointsFromWidth: true }),
                   }),
-                  new SceneFlexItem({
-                    body: new SceneFlexLayout({
-                      $data: getQueryRunnerWithRandomWalkQuery(),
-                      direction: 'column',
-                      children: [
-                        new SceneFlexItem({
-                          body: new VizPanel({
-                            pluginId: 'timeseries',
-                            title: 'Fill height',
-                            options: {},
-                            fieldConfig: {
-                              defaults: {
-                                custom: {
-                                  fillOpacity: 20,
-                                },
-                              },
-                              overrides: [],
+                }),
+                new SceneFlexLayout({
+                  $data: getQueryRunnerWithRandomWalkQuery(),
+                  direction: 'column',
+                  children: [
+                    new SceneFlexItem({
+                      body: new VizPanel({
+                        pluginId: 'timeseries',
+                        title: 'Fill height',
+                        options: {},
+                        fieldConfig: {
+                          defaults: {
+                            custom: {
+                              fillOpacity: 20,
                             },
-                          }),
-                        }),
-                        new SceneFlexItem({
-                          body: new VizPanel({
-                            pluginId: 'timeseries',
-                            title: 'Fill height',
-                          }),
-                        }),
-                        new SceneFlexItem({
-                          ySizing: 'content',
-                          body: new SceneCanvasText({
-                            text: 'Size to content',
-                            fontSize: 20,
-                            align: 'center',
-                          }),
-                        }),
-                        new SceneFlexItem({
-                          height: 300,
-                          body: new VizPanel({
-                            pluginId: 'timeseries',
-                            title: 'Fixed height',
-                          }),
-                        }),
-                      ],
+                          },
+                          overrides: [],
+                        },
+                      }),
                     }),
-                  }),
-                ],
-              }),
+                    new SceneFlexItem({
+                      body: new VizPanel({
+                        pluginId: 'timeseries',
+                        title: 'Fill height',
+                      }),
+                    }),
+                    new SceneFlexItem({
+                      ySizing: 'content',
+                      body: new SceneCanvasText({
+                        text: 'Size to content',
+                        fontSize: 20,
+                        align: 'center',
+                      }),
+                    }),
+                    new SceneFlexItem({
+                      height: 300,
+                      body: new VizPanel({
+                        pluginId: 'timeseries',
+                        title: 'Fixed height',
+                      }),
+                    }),
+                  ],
+                }),
+              ],
             }),
-            new SceneFlexItem({
-              xSizing: 'fill',
-              body: new SceneFlexLayout({
-                direction: 'row',
-                children: [
-                  new SceneFlexItem({
-                    width: 50,
-                    height: 50,
-                    body: new DebugItem({}),
+
+            new SceneFlexLayout({
+              direction: 'row',
+              children: [
+                new SceneFlexItem({
+                  width: 50,
+                  height: 50,
+                  body: new DebugItem({}),
+                }),
+                new SceneFlexItem({
+                  xSizing: 'fill',
+                  ySizing: 'fill',
+                  maxHeight: 200,
+                  body: new VizPanel({
+                    title: 'Panel 1',
+                    pluginId: 'timeseries',
+                    $data: getQueryRunnerWithRandomWalkQuery(),
                   }),
-                  new SceneFlexItem({
-                    xSizing: 'fill',
-                    ySizing: 'fill',
-                    maxHeight: 200,
-                    body: new VizPanel({
-                      title: 'Panel 1',
-                      pluginId: 'timeseries',
-                      $data: getQueryRunnerWithRandomWalkQuery(),
-                    }),
-                  }),
-                  new SceneFlexItem({
-                    width: '10%',
-                    ySizing: 'fill',
-                    body: new DebugItem({}),
-                  }),
-                ],
-              }),
+                }),
+                new SceneFlexItem({
+                  width: '10%',
+                  ySizing: 'fill',
+                  body: new DebugItem({}),
+                }),
+              ],
             }),
           ],
         }),

--- a/packages/scenes/src/components/NestedScene.tsx
+++ b/packages/scenes/src/components/NestedScene.tsx
@@ -6,7 +6,7 @@ import { Stack } from '@grafana/experimental';
 import { Button, ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObject, SceneComponentProps, SceneLayout, SceneLayoutItemState, SceneObjectState } from '../core/types';
+import { SceneObject, SceneComponentProps, SceneLayout, SceneObjectState } from '../core/types';
 
 interface NestedSceneState extends SceneObjectState {
   title: string;
@@ -113,6 +113,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-function isSceneLayoutItem(x: SceneObject): x is SceneObject<SceneLayoutItemState> {
+function isSceneLayoutItem(x: SceneObject): x is SceneObject<SceneObjectState & { body: SceneObject | undefined }> {
   return 'body' in x.state;
 }

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -3,9 +3,11 @@ import React, { CSSProperties } from 'react';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps, SceneLayout, SceneObjectState, SceneObject } from '../../core/types';
 
-export interface SceneFlexItemLike extends SceneObject<SceneFlexItemSizeState> {}
+export interface SceneFlexItemStateLike extends SceneFlexItemPlacement, SceneObjectState {}
 
-interface SceneFlexLayoutState extends SceneObjectState, SceneFlexItemSizeState {
+export interface SceneFlexItemLike extends SceneObject<SceneFlexItemStateLike> {}
+
+interface SceneFlexLayoutState extends SceneObjectState, SceneFlexItemPlacement {
   direction?: CSSProperties['flexDirection'];
   wrap?: CSSProperties['flexWrap'];
   children: SceneFlexItemLike[];
@@ -54,7 +56,7 @@ function SceneFlexLayoutRenderer({ model }: SceneComponentProps<SceneFlexLayout>
   );
 }
 
-interface SceneFlexItemSizeState extends SceneObjectState {
+interface SceneFlexItemPlacement {
   flexGrow?: CSSProperties['flexGrow'];
   alignSelf?: CSSProperties['alignSelf'];
   width?: CSSProperties['width'];
@@ -67,9 +69,9 @@ interface SceneFlexItemSizeState extends SceneObjectState {
   ySizing?: 'fill' | 'content';
 }
 
-type SceneFlexItemState = SceneFlexItemSizeState & {
+interface SceneFlexItemState extends SceneFlexItemPlacement, SceneObjectState {
   body: SceneObject | undefined;
-};
+}
 
 export class SceneFlexItem extends SceneObjectBase<SceneFlexItemState> {
   public static Component = SceneFlexItemRenderer;

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -40,7 +40,7 @@ function SceneFlexLayoutRenderer({ model }: SceneComponentProps<SceneFlexLayout>
     minHeight: 0,
   };
 
-  if (parent && isSceneFlexLayout(parent)) {
+  if (parent && parent instanceof SceneFlexLayout) {
     style = {
       ...getFlexItemItemStyles(parent.state.direction || 'row', model),
       ...style,
@@ -82,7 +82,7 @@ function SceneFlexItemRenderer({ model }: SceneComponentProps<SceneFlexItem>) {
   const parent = model.parent;
   let style: CSSProperties = {};
 
-  if (parent && isSceneFlexLayout(parent)) {
+  if (parent && parent instanceof SceneFlexLayout) {
     style = getFlexItemItemStyles(parent.state.direction || 'row', model);
   } else {
     throw new Error('SceneFlexItem must be a child of SceneFlexLayout');
@@ -138,8 +138,4 @@ function getFlexItemItemStyles(direction: CSSProperties['flexDirection'], item: 
   }
 
   return style;
-}
-
-function isSceneFlexLayout(model: SceneObject): model is SceneFlexLayout {
-  return model instanceof SceneFlexLayout;
 }

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -14,7 +14,7 @@ export interface SceneFlexItemLike extends SceneObject<SceneFlexItemState> {}
 interface SceneFlexLayoutState extends SceneObjectState {
   direction?: CSSProperties['flexDirection'];
   wrap?: CSSProperties['flexWrap'];
-  children: SceneFlexItemLike[];
+  children: Array<SceneFlexItemLike | SceneFlexLayout>;
 }
 
 export class SceneFlexLayout extends SceneObjectBase<SceneFlexLayoutState> implements SceneLayout {
@@ -45,9 +45,12 @@ function SceneFlexLayoutRenderer({ model }: SceneComponentProps<SceneFlexLayout>
 
   return (
     <div style={style}>
-      {children.map((item) => (
-        <item.Component key={item.state.key} model={item} />
-      ))}
+      {children.map((item) => {
+        if (isSceneFlexLayout(item)) {
+          return <item.Component key={item.state.key} model={item} />;
+        }
+        return <item.Component key={item.state.key} model={item} />;
+      })}
     </div>
   );
 }

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -3,13 +3,7 @@ import ReactGridLayout from 'react-grid-layout';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
-import {
-  SceneComponentProps,
-  SceneLayout,
-  SceneLayoutItemState,
-  SceneObject,
-  SceneObjectState,
-} from '../../../core/types';
+import { SceneComponentProps, SceneLayout, SceneObject, SceneObjectState } from '../../../core/types';
 import { DEFAULT_PANEL_SPAN, GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from './constants';
 
 import { SceneGridRow } from './SceneGridRow';
@@ -378,7 +372,9 @@ function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>
   );
 }
 
-interface SceneGridItemState extends SceneGridItemStateLike, SceneLayoutItemState {}
+interface SceneGridItemState extends SceneGridItemStateLike {
+  body: SceneObject | undefined;
+}
 
 export class SceneGridItem extends SceneObjectBase<SceneGridItemState> implements SceneGridItemLike {
   static Component = SceneGridItemRenderer;

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -21,10 +21,6 @@ export interface SceneObjectState {
   $variables?: SceneVariables;
 }
 
-export interface SceneLayoutItemState extends SceneObjectState {
-  body: SceneObject | undefined;
-}
-
 export interface SceneLayoutChildOptions {
   width?: number | string;
   height?: number | string;


### PR DESCRIPTION
This allows SceneFlexLayout to be used as a child of another SceneFlexLayout, without the need for wrapping it with SceneFlexItem. Tried to make SceneFlexLayout to implement SceneFlexItemLike interface, but it's quite tricky since the primarily because the `body` and `children` differentiation.
