### PR TITLE
SceneApp: Correctly build demo pages with getParentPage 

### DIFF
--- a/packages/scenes-app/src/demos/dynamicPage.tsx
+++ b/packages/scenes-app/src/demos/dynamicPage.tsx
@@ -14,7 +14,6 @@ import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
 export function getDynamicPageDemo(defaults: SceneAppPageState): SceneAppPage {
   const defaultTabs = [getSceneAppPage('/tab1', 'Temperature')];
-  console.log('get dynamic page demo');
 
   const page = new SceneAppPage({
     ...defaults,

--- a/packages/scenes-app/src/demos/dynamicPage.tsx
+++ b/packages/scenes-app/src/demos/dynamicPage.tsx
@@ -7,17 +7,17 @@ import {
   SceneFlexItem,
   SceneAppPage,
   SceneRefreshPicker,
+  SceneAppPageState,
 } from '@grafana/scenes';
 import { demoUrl } from '../utils/utils.routing';
 import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getDynamicPageDemo(): SceneAppPage {
+export function getDynamicPageDemo(defaults: SceneAppPageState): SceneAppPage {
   const defaultTabs = [getSceneAppPage('/tab1', 'Temperature')];
 
   const page = new SceneAppPage({
-    title: 'Dynamic page',
+    ...defaults,
     subTitle: 'Dynamic tabs, and drilldowns. Adds a tab with drilldown after 2 seconds.',
-    url: `${demoUrl('dynamic-page')}`,
     $timeRange: new SceneTimeRange(),
     controls: [new SceneTimePicker({ isOnCanvas: true }), new SceneRefreshPicker({ isOnCanvas: true })],
     tabs: defaultTabs,

--- a/packages/scenes-app/src/demos/dynamicPage.tsx
+++ b/packages/scenes-app/src/demos/dynamicPage.tsx
@@ -14,6 +14,7 @@ import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
 export function getDynamicPageDemo(defaults: SceneAppPageState): SceneAppPage {
   const defaultTabs = [getSceneAppPage('/tab1', 'Temperature')];
+  console.log('get dynamic page demo');
 
   const page = new SceneAppPage({
     ...defaults,

--- a/packages/scenes-app/src/demos/flexLayout.tsx
+++ b/packages/scenes-app/src/demos/flexLayout.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import {
   EmbeddedScene,
   SceneAppPage,
+  SceneAppPageState,
   SceneCanvasText,
   SceneFlexItem,
   SceneFlexLayout,
@@ -10,13 +11,11 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
-import { demoUrl } from '../utils/utils.routing';
 
-export function getFlexLayoutTest() {
+export function getFlexLayoutTest(defaults: SceneAppPageState) {
   return new SceneAppPage({
-    title: 'Flex layout',
+    ...defaults,
     subTitle: 'A simple demo of different flex layout options',
-    url: `${demoUrl('flex-layout')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -6,15 +6,14 @@ import {
   SceneFlexItem,
   SceneAppPage,
   EmbeddedScene,
+  SceneAppPageState,
 } from '@grafana/scenes';
-import { demoUrl } from '../utils/utils.routing';
 import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
 
-export function getGridLayoutTest(): SceneAppPage {
+export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
   return new SceneAppPage({
-    title: 'Grid layout ',
+    ...defaults,
     subTitle: 'Demo of the SceneGridLayout',
-    url: `${demoUrl('grid-layout')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/gridWithRow.tsx
+++ b/packages/scenes-app/src/demos/gridWithRow.tsx
@@ -1,12 +1,18 @@
-import { VizPanel, SceneGridLayout, SceneGridRow, SceneGridItem, SceneAppPage, EmbeddedScene } from '@grafana/scenes';
-import { demoUrl } from '../utils/utils.routing';
+import {
+  VizPanel,
+  SceneGridLayout,
+  SceneGridRow,
+  SceneGridItem,
+  SceneAppPage,
+  EmbeddedScene,
+  SceneAppPageState,
+} from '@grafana/scenes';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getGridWithRowLayoutTest(): SceneAppPage {
+export function getGridWithRowLayoutTest(defaults: SceneAppPageState): SceneAppPage {
   return new SceneAppPage({
-    title: 'Grid with rows',
+    ...defaults,
     subTitle: 'SceneGridLayout demo with collapsible rows',
-    url: `${demoUrl('grid-layout-with-rows')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -1,4 +1,4 @@
-import { SceneAppPage } from '@grafana/scenes';
+import { SceneAppPage, SceneAppPageState } from '@grafana/scenes';
 import { getDynamicPageDemo } from './dynamicPage';
 import { getFlexLayoutTest } from './flexLayout';
 import { getGridLayoutTest } from './grid';
@@ -11,18 +11,23 @@ import { getQueryEditorDemo } from './queryEditor';
 import { getVariablesDemo } from './variables';
 import { getDrilldownsAppPageScene } from './withDrilldown/WithDrilldown';
 
-export function getDemos(): SceneAppPage[] {
+export interface DemoDescriptor {
+  title: string;
+  getPage: (defaults: SceneAppPageState) => SceneAppPage;
+}
+
+export function getDemos(): DemoDescriptor[] {
   return [
-    getFlexLayoutTest(),
-    getPanelMenuTest(),
-    getPanelContextDemoScene(),
-    getPanelRepeaterTest(),
-    getGridLayoutTest(),
-    getGridWithRowLayoutTest(),
-    getVariablesDemo(),
-    getNestedScene(),
-    getDrilldownsAppPageScene(),
-    getQueryEditorDemo(),
-    getDynamicPageDemo(),
+    { title: 'Flex layout', getPage: getFlexLayoutTest },
+    { title: 'Panel menu', getPage: getPanelMenuTest },
+    { title: 'Panel context', getPage: getPanelContextDemoScene },
+    { title: 'Repeat layout by series', getPage: getPanelRepeaterTest },
+    { title: 'Grid layout', getPage: getGridLayoutTest },
+    { title: 'Grid with rows', getPage: getGridWithRowLayoutTest },
+    { title: 'Variables', getPage: getVariablesDemo },
+    { title: 'Nested scene', getPage: getNestedScene },
+    { title: 'With drilldowns', getPage: getDrilldownsAppPageScene },
+    // getQueryEditorDemo(),
+    // getDynamicPageDemo(),
   ];
 }

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -27,7 +27,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Variables', getPage: getVariablesDemo },
     { title: 'Nested scene', getPage: getNestedScene },
     { title: 'With drilldowns', getPage: getDrilldownsAppPageScene },
-    // getQueryEditorDemo(),
-    // getDynamicPageDemo(),
+    { title: 'Query editor', getPage: getQueryEditorDemo },
+    { title: 'Dynamic page', getPage: getDynamicPageDemo },
   ];
 }

--- a/packages/scenes-app/src/demos/nestedScene.tsx
+++ b/packages/scenes-app/src/demos/nestedScene.tsx
@@ -7,15 +7,14 @@ import {
   SceneFlexItem,
   SceneAppPage,
   EmbeddedScene,
+  SceneAppPageState,
 } from '@grafana/scenes';
-import { demoUrl } from '../utils/utils.routing';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getNestedScene(): SceneAppPage {
+export function getNestedScene(defaults: SceneAppPageState): SceneAppPage {
   return new SceneAppPage({
-    title: 'Nested scene ',
+    ...defaults,
     subTitle: 'Example of a scene containing a NestedScene component.',
-    url: `${demoUrl('nested-scene')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/panelContext.tsx
+++ b/packages/scenes-app/src/demos/panelContext.tsx
@@ -5,16 +5,15 @@ import {
   SceneQueryRunner,
   SceneAppPage,
   EmbeddedScene,
+  SceneAppPageState,
 } from '@grafana/scenes';
 import { DATASOURCE_REF } from '../constants';
-import { demoUrl } from '../utils/utils.routing';
 import { getEmbeddedSceneDefaults } from './utils';
 
-export function getPanelContextDemoScene(): SceneAppPage {
+export function getPanelContextDemoScene(defaults: SceneAppPageState): SceneAppPage {
   return new SceneAppPage({
-    title: 'Panel context demo',
+    ...defaults,
     subTitle: 'Here you can test changing series color and toggle series visiblity. ',
-    url: `${demoUrl('panel-context')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/panelMenu.ts
+++ b/packages/scenes-app/src/demos/panelMenu.ts
@@ -1,8 +1,15 @@
-import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout, VizPanel, VizPanelMenu } from '@grafana/scenes';
-import { demoUrl } from '../utils/utils.routing';
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneFlexItem,
+  SceneFlexLayout,
+  VizPanel,
+  VizPanelMenu,
+} from '@grafana/scenes';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getPanelMenuTest(): SceneAppPage {
+export function getPanelMenuTest(defaults: SceneAppPageState): SceneAppPage {
   const data = getQueryRunnerWithRandomWalkQuery();
   const menuItems = [
     {
@@ -90,9 +97,8 @@ export function getPanelMenuTest(): SceneAppPage {
   });
 
   return new SceneAppPage({
-    title: 'Panel menu demo',
+    ...defaults,
     subTitle: 'Different ways to use panel menu',
-    url: `${demoUrl('panel-menui')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/panelRepeater.tsx
+++ b/packages/scenes-app/src/demos/panelRepeater.tsx
@@ -1,6 +1,7 @@
 import {
   EmbeddedScene,
   SceneAppPage,
+  SceneAppPageState,
   SceneByFrameRepeater,
   SceneDataNode,
   SceneFlexItem,
@@ -8,10 +9,9 @@ import {
   SceneToolbarInput,
   VizPanel,
 } from '@grafana/scenes';
-import { demoUrl } from '../utils/utils.routing';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getPanelRepeaterTest() {
+export function getPanelRepeaterTest(defaults: SceneAppPageState) {
   const queryRunner = getQueryRunnerWithRandomWalkQuery({
     seriesCount: 2,
     alias: '__server_names',
@@ -19,9 +19,8 @@ export function getPanelRepeaterTest() {
   });
 
   return new SceneAppPage({
-    title: 'Panel repeater',
+    ...defaults,
     subTitle: 'Here we use the SceneByFrameRepeater to dynamically build a layout for each frame',
-    url: `${demoUrl('panel-repeater')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/queryEditor.tsx
+++ b/packages/scenes-app/src/demos/queryEditor.tsx
@@ -1,13 +1,18 @@
-import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout, VizPanel } from '@grafana/scenes';
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneFlexItem,
+  SceneFlexLayout,
+  VizPanel,
+} from '@grafana/scenes';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 import { QueryEditor } from '../components/QueryEditor/QueryEditor';
-import { demoUrl } from '../utils/utils.routing';
 
-export function getQueryEditorDemo() {
+export function getQueryEditorDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
-    title: 'Query editor demo',
+    ...defaults,
     subTitle: 'Example of how to to build a component that uses the QueryEditor',
-    url: `${demoUrl('query-editor')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -11,15 +11,14 @@ import {
   SceneCanvasText,
   NestedScene,
   SceneAppPage,
+  SceneAppPageState,
 } from '@grafana/scenes';
-import { demoUrl } from '../utils/utils.routing';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getVariablesDemo() {
+export function getVariablesDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
-    title: 'Variables demo',
+    ...defaults,
     subTitle: 'Test of variable cascading updates and refresh on time range change',
-    url: `${demoUrl('variables')}`,
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),

--- a/packages/scenes-app/src/demos/withDrilldown/WithDrilldown.tsx
+++ b/packages/scenes-app/src/demos/withDrilldown/WithDrilldown.tsx
@@ -1,6 +1,12 @@
-import { demoUrl } from '../../utils/utils.routing';
 import { DATASOURCE_REF } from '../../constants';
-import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout, SceneQueryRunner } from '@grafana/scenes';
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneQueryRunner,
+} from '@grafana/scenes';
 import { getHumidityOverviewScene, getTemperatureOverviewScene } from './scenes';
 import { getRoomsTemperatureStats, getRoomsTemperatureTable } from './panels';
 import { getEmbeddedSceneDefaults } from '../utils';
@@ -38,32 +44,31 @@ const getScene = () =>
     }),
   });
 
-export function getDrilldownsAppPageScene() {
+export function getDrilldownsAppPageScene(defaults: SceneAppPageState) {
   return new SceneAppPage({
-    title: 'Page with drilldown',
+    ...defaults,
     subTitle: 'This scene showcases a basic drilldown functionality. Interact with room to see room details scene.',
-    url: demoUrl('with-drilldown'),
     getScene,
     drilldowns: [
       {
-        routePath: `${demoUrl('with-drilldown')}/room/:roomName`,
+        routePath: `${defaults.url}/room/:roomName`,
         getPage(routeMatch, parent) {
           const roomName = routeMatch.params.roomName;
 
           return new SceneAppPage({
-            url: `${demoUrl('with-drilldown')}/room/${roomName}/temperature`,
+            url: `${defaults.url}/room/${roomName}/temperature`,
             title: `${roomName} overview`,
             subTitle: 'This scene is a particular room drilldown. It implements two tabs to organise the data.',
             getParentPage: () => parent,
             tabs: [
               new SceneAppPage({
                 title: 'Temperature',
-                url: `${demoUrl('with-drilldown')}/room/${roomName}/temperature`,
+                url: `${defaults.url}/room/${roomName}/temperature`,
                 getScene: () => getTemperatureOverviewScene(roomName),
               }),
               new SceneAppPage({
                 title: 'Humidity',
-                url: `${demoUrl('with-drilldown')}/room/${roomName}/humidity`,
+                url: `${defaults.url}/room/${roomName}/humidity`,
                 getScene: () => getHumidityOverviewScene(roomName),
               }),
             ],

--- a/packages/scenes-app/src/demos/withDrilldown/panels.tsx
+++ b/packages/scenes-app/src/demos/withDrilldown/panels.tsx
@@ -110,7 +110,7 @@ export function getRoomsTemperatureTable() {
               value: [
                 {
                   title: 'Go to room overview',
-                  url: `${demoUrl('with-drilldown')}/room/\${__value.text}/temperature`,
+                  url: `${demoUrl('with-drilldowns')}/room/\${__value.text}/temperature`,
                 },
               ],
             },

--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -114,7 +114,7 @@ function slugify(title: string) {
   return encodeURIComponent(simplified);
 }
 
-function getDemoNotFoundPage(url: string): SceneAppPage {
+export function getDemoNotFoundPage(url: string): SceneAppPage {
   return new SceneAppPage({
     title: 'Demo not found',
     subTitle: 'So sorry sir but the demo cannot be found.',

--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -5,13 +5,12 @@ import {
   SceneFlexLayout,
   SceneFlexItem,
   SceneReactObject,
-  SceneAppPageLike,
 } from '@grafana/scenes';
 import { Stack } from '@grafana/experimental';
 import React, { useMemo } from 'react';
-import { prefixRoute } from '../utils/utils.routing';
+import { demoUrl, prefixRoute } from '../utils/utils.routing';
 import { DATASOURCE_REF, ROUTES } from '../constants';
-import { getDemos } from '../demos';
+import { DemoDescriptor, getDemos } from '../demos';
 import { Alert, Card } from '@grafana/ui';
 import { config } from '@grafana/runtime';
 
@@ -39,14 +38,25 @@ const getScene = () => {
             }),
           });
         },
-        drilldowns: demos.map((demo) => ({
-          routePath: demo.state.url,
-          getPage: (routeMatch, parent: SceneAppPageLike) => {
-            demo.setState({ getParentPage: () => parent });
+        drilldowns: [
+          {
+            routePath: `${demoUrl(':demo')}`,
+            getPage: (routeMatch, parent) => {
+              const demoSlug = decodeURIComponent(routeMatch.params.demo);
+              const demoInfo = demos.find((x) => slugify(x.title) === demoSlug);
 
-            return demo;
+              if (!demoInfo) {
+                return getDemoNotFoundPage(routeMatch.url);
+              }
+
+              return demoInfo.getPage({
+                title: demoInfo.title,
+                url: `${demoUrl(slugify(demoInfo.title))}`,
+                getParentPage: () => parent,
+              });
+            },
           },
-        })),
+        ],
       }),
     ],
   });
@@ -57,7 +67,7 @@ export const DemoListPage = () => {
   return <scene.Component model={scene} />;
 };
 
-function DemosList({ demos }: { demos: SceneAppPage[] }) {
+function DemosList({ demos }: { demos: DemoDescriptor[] }) {
   if (!config.featureToggles.topnav) {
     return (
       <Alert title="Missing topnav feature toggle">
@@ -82,11 +92,49 @@ function DemosList({ demos }: { demos: SceneAppPage[] }) {
     <Stack direction="column" gap={1} flexGrow={1}>
       <Stack direction="column" gap={0}>
         {demos.map((demo) => (
-          <Card key={demo.state.title} href={demo.state.url}>
-            <Card.Heading>{demo.state.title}</Card.Heading>
+          <Card key={demo.title} href={demoUrl(slugify(demo.title))}>
+            <Card.Heading>{demo.title}</Card.Heading>
           </Card>
         ))}
       </Stack>
     </Stack>
   );
+}
+
+function slugify(title: string) {
+  const simplified = title
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, '');
+
+  return encodeURIComponent(simplified);
+}
+
+function getDemoNotFoundPage(url: string): SceneAppPage {
+  return new SceneAppPage({
+    title: 'Demo not found',
+    subTitle: 'So sorry sir but the demo cannot be found.',
+    url: url,
+    getScene: () => {
+      return new EmbeddedScene({
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            new SceneFlexItem({
+              flexGrow: 1,
+              body: new SceneReactObject({
+                component: () => {
+                  return <div style={{ fontSize: 50 }}>😭</div>;
+                },
+              }),
+            }),
+          ],
+        }),
+      });
+    },
+  });
 }

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -5,8 +5,8 @@ import { SceneComponentProps } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
 import { SceneReactObject } from '../SceneReactObject';
-import { SceneAppPageView } from './SceneAppPageView';
-import { SceneAppDrilldownView, SceneAppPageLike, SceneAppPageState } from './types';
+import { SceneAppDrilldownViewRender, SceneAppPageView } from './SceneAppPageView';
+import { SceneAppPageLike, SceneAppPageState } from './types';
 import { renderSceneComponentWithRouteProps } from './utils';
 
 /**
@@ -114,17 +114,6 @@ function SceneAppPageRenderer({ model, routeProps }: SceneAppPageRendererProps) 
   routes.push(getFallbackRoute(model, routeProps));
 
   return <Switch>{routes}</Switch>;
-}
-
-export interface SceneAppDrilldownViewRenderProps {
-  drilldown: SceneAppDrilldownView;
-  parent: SceneAppPageLike;
-  routeProps: RouteComponentProps;
-}
-
-function SceneAppDrilldownViewRender({ drilldown, parent, routeProps }: SceneAppDrilldownViewRenderProps) {
-  const scene = drilldown.getPage(routeProps.match, parent);
-  return renderSceneComponentWithRouteProps(scene, routeProps);
 }
 
 function getFallbackRoute(page: SceneAppPage, routeProps: RouteComponentProps) {

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -3,8 +3,6 @@ import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
-import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
-import { SceneReactObject } from '../SceneReactObject';
 import { SceneAppDrilldownViewRender, SceneAppPageView } from './SceneAppPageView';
 import { SceneAppPageLike, SceneAppPageState } from './types';
 import { renderSceneComponentWithRouteProps } from './utils';
@@ -68,8 +66,6 @@ function SceneAppPageRenderer({ model, routeProps }: SceneAppPageRendererProps) 
       }
     }
 
-    routes.push(getFallbackRoute(model, routeProps));
-
     return <Switch>{routes}</Switch>;
   }
 
@@ -111,46 +107,5 @@ function SceneAppPageRenderer({ model, routeProps }: SceneAppPageRendererProps) 
     return page;
   }
 
-  routes.push(getFallbackRoute(model, routeProps));
-
   return <Switch>{routes}</Switch>;
-}
-
-function getFallbackRoute(page: SceneAppPage, routeProps: RouteComponentProps) {
-  return (
-    <Route
-      key={'fallback route'}
-      render={(props) => {
-        const fallbackPage = getDefaultFallbackPage();
-        return <SceneAppPageView page={fallbackPage} routeProps={routeProps} />;
-      }}
-    ></Route>
-  );
-}
-
-function getDefaultFallbackPage() {
-  return new SceneAppPage({
-    url: '',
-    title: 'Not found',
-    subTitle: 'The url did not match any page',
-    getScene: () => {
-      return new EmbeddedScene({
-        body: new SceneFlexLayout({
-          direction: 'column',
-          children: [
-            new SceneFlexItem({
-              flexGrow: 1,
-              body: new SceneReactObject({
-                component: () => {
-                  return (
-                    <div>If you found your way here using a link then there might be a bug in this application.</div>
-                  );
-                },
-              }),
-            }),
-          ],
-        }),
-      });
-    },
-  });
 }

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -3,6 +3,8 @@ import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
+import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
+import { SceneReactObject } from '../SceneReactObject';
 import { SceneAppPageView } from './SceneAppPageView';
 import { SceneAppDrilldownView, SceneAppPageLike, SceneAppPageState } from './types';
 import { renderSceneComponentWithRouteProps } from './utils';
@@ -66,6 +68,8 @@ function SceneAppPageRenderer({ model, routeProps }: SceneAppPageRendererProps) 
       }
     }
 
+    routes.push(getFallbackRoute(model, routeProps));
+
     return <Switch>{routes}</Switch>;
   }
 
@@ -107,6 +111,8 @@ function SceneAppPageRenderer({ model, routeProps }: SceneAppPageRendererProps) 
     return page;
   }
 
+  routes.push(getFallbackRoute(model, routeProps));
+
   return <Switch>{routes}</Switch>;
 }
 
@@ -119,4 +125,43 @@ export interface SceneAppDrilldownViewRenderProps {
 function SceneAppDrilldownViewRender({ drilldown, parent, routeProps }: SceneAppDrilldownViewRenderProps) {
   const scene = drilldown.getPage(routeProps.match, parent);
   return renderSceneComponentWithRouteProps(scene, routeProps);
+}
+
+function getFallbackRoute(page: SceneAppPage, routeProps: RouteComponentProps) {
+  return (
+    <Route
+      key={'fallback route'}
+      render={(props) => {
+        const fallbackPage = getDefaultFallbackPage();
+        return <SceneAppPageView page={fallbackPage} routeProps={routeProps} />;
+      }}
+    ></Route>
+  );
+}
+
+function getDefaultFallbackPage() {
+  return new SceneAppPage({
+    url: '',
+    title: 'Not found',
+    subTitle: 'The url did not match any page',
+    getScene: () => {
+      return new EmbeddedScene({
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            new SceneFlexItem({
+              flexGrow: 1,
+              body: new SceneReactObject({
+                component: () => {
+                  return (
+                    <div>If you found your way here using a link then there might be a bug in this application.</div>
+                  );
+                },
+              }),
+            }),
+          ],
+        }),
+      });
+    },
+  });
 }

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -60,7 +60,6 @@ export interface SceneAppPageLike extends SceneObject<SceneAppPageState> {
 export interface SceneAppDrilldownView {
   // Use to provide parametrized drilldown URL, i.e. /app/clusters/:clusterId
   routePath: string;
-  defaultRoute?: boolean;
   // Function that returns a page object for a given drilldown route match. Use parent to configure drilldown view parent SceneAppPage via getParentPage method.
   getPage: (routeMatch: SceneRouteMatch<any>, parent: SceneAppPageLike) => SceneAppPageLike;
 }

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -60,6 +60,7 @@ export interface SceneAppPageLike extends SceneObject<SceneAppPageState> {
 export interface SceneAppDrilldownView {
   // Use to provide parametrized drilldown URL, i.e. /app/clusters/:clusterId
   routePath: string;
+  defaultRoute?: boolean;
   // Function that returns a page object for a given drilldown route match. Use parent to configure drilldown view parent SceneAppPage via getParentPage method.
   getPage: (routeMatch: SceneRouteMatch<any>, parent: SceneAppPageLike) => SceneAppPageLike;
 }


### PR DESCRIPTION
I used a bit of a hack before to connect the demo page it's parent by doing this

```
 getPage: (routeMatch, parent: SceneAppPageLike) => {
            demo.setState({ getParentPage: () => parent });
``` 

Setting state inside getPage is not allowed as this is called in the React render path (and was a bit hacky either way). So this refactors the demos to be generated inside the getPage instead. To not duplicate the demo title and url I changed the signature a bit so that the demo getPage call get's passed in SceneAppState which already includes the title & url and getParentPage 

* Also adds a cache for drilldown pages 
* Will need to be reworked a bit, have a follow-up PR for this that refactors SceneAppPage a bit to add support for fallback routes 
