### PR TITLE
Annotations: Super early basic poc 

### DIFF
--- a/packages/scenes-app/src/demos/annotations.tsx
+++ b/packages/scenes-app/src/demos/annotations.tsx
@@ -20,16 +20,15 @@ export function getAnnotationsDemo(defaults: SceneAppPageState) {
           direction: 'column',
           children: [
             new SceneFlexItem({
-              minWidth: '70%',
               body: new VizPanel({
                 pluginId: 'timeseries',
-                title: 'Dynamic height and width',
+                title: 'Time series',
                 $data: getQueryRunnerWithRandomWalkQuery({}),
               }),
             }),
             new SceneFlexItem({
               body: new VizPanel({
-                title: 'Panel 1',
+                title: 'Time series',
                 pluginId: 'timeseries',
                 $data: getQueryRunnerWithRandomWalkQuery(),
               }),

--- a/packages/scenes-app/src/demos/annotations.tsx
+++ b/packages/scenes-app/src/demos/annotations.tsx
@@ -1,4 +1,5 @@
 import {
+  AnnotationsQueryRunner,
   EmbeddedScene,
   SceneAppPage,
   SceneAppPageState,
@@ -6,16 +7,29 @@ import {
   SceneFlexLayout,
   VizPanel,
 } from '@grafana/scenes';
+import { DATASOURCE_REF } from '../constants';
 import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
 
 export function getAnnotationsDemo(defaults: SceneAppPageState) {
+  const annotationsProviderKey = 'APK1';
+
   return new SceneAppPage({
     ...defaults,
     subTitle: 'Annotation queries on the dashboard level',
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),
-
+        $data: new AnnotationsQueryRunner({
+          key: annotationsProviderKey,
+          queries: [
+            {
+              name: 'errors',
+              datasource: DATASOURCE_REF,
+              iconColor: 'red',
+              enable: true,
+            },
+          ],
+        }),
         body: new SceneFlexLayout({
           direction: 'column',
           children: [
@@ -23,14 +37,14 @@ export function getAnnotationsDemo(defaults: SceneAppPageState) {
               body: new VizPanel({
                 pluginId: 'timeseries',
                 title: 'Time series',
-                $data: getQueryRunnerWithRandomWalkQuery({}),
+                $data: getQueryRunnerWithRandomWalkQuery({}, { annotationsProviderKey }),
               }),
             }),
             new SceneFlexItem({
               body: new VizPanel({
                 title: 'Time series',
                 pluginId: 'timeseries',
-                $data: getQueryRunnerWithRandomWalkQuery(),
+                $data: getQueryRunnerWithRandomWalkQuery({}, { annotationsProviderKey }),
               }),
             }),
           ],

--- a/packages/scenes-app/src/demos/annotations.tsx
+++ b/packages/scenes-app/src/demos/annotations.tsx
@@ -1,0 +1,42 @@
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneFlexItem,
+  SceneFlexLayout,
+  VizPanel,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
+
+export function getAnnotationsDemo(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Annotation queries on the dashboard level',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            new SceneFlexItem({
+              minWidth: '70%',
+              body: new VizPanel({
+                pluginId: 'timeseries',
+                title: 'Dynamic height and width',
+                $data: getQueryRunnerWithRandomWalkQuery({}),
+              }),
+            }),
+            new SceneFlexItem({
+              body: new VizPanel({
+                title: 'Panel 1',
+                pluginId: 'timeseries',
+                $data: getQueryRunnerWithRandomWalkQuery(),
+              }),
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -1,4 +1,5 @@
 import { SceneAppPage, SceneAppPageState } from '@grafana/scenes';
+import { getAnnotationsDemo } from './annotations';
 import { getDynamicPageDemo } from './dynamicPage';
 import { getFlexLayoutTest } from './flexLayout';
 import { getGridLayoutTest } from './grid';
@@ -27,6 +28,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Grid with rows', getPage: getGridWithRowLayoutTest },
     { title: 'Lazy load', getPage: getLazyLoadDemo },
     { title: 'Variables', getPage: getVariablesDemo },
+    { title: 'Annotations', getPage: getAnnotationsDemo },
     { title: 'Nested scene', getPage: getNestedScene },
     { title: 'With drilldowns', getPage: getDrilldownsAppPageScene },
     { title: 'Query editor', getPage: getQueryEditorDemo },

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -7,6 +7,7 @@ export { SceneTimeRange } from './core/SceneTimeRange';
 
 export { SceneQueryRunner, type QueryRunnerState } from './querying/SceneQueryRunner';
 export { SceneDataTransformer } from './querying/SceneDataTransformer';
+export { AnnotationsQueryRunner } from './querying/AnnotationsQueryRunner';
 
 export * from './variables/types';
 export { VariableDependencyConfig } from './variables/VariableDependencyConfig';

--- a/packages/scenes/src/querying/AnnotationsQueryRunner.ts
+++ b/packages/scenes/src/querying/AnnotationsQueryRunner.ts
@@ -1,0 +1,120 @@
+import { mergeMap, Unsubscribable, map, from, merge, ReplaySubject, mergeAll, reduce, Observable } from 'rxjs';
+
+import { AnnotationQuery, DataQuery, DataSourceRef } from '@grafana/schema';
+
+import { TimeRange } from '@grafana/data';
+
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneDataProvider, SceneObjectState } from '../core/types';
+import { getDataSource } from '../utils/getDataSource';
+import { executeAnnotationQuery } from './executeAnnotationQuery';
+import { AnnotationQueryResult } from './types';
+
+let counter = 100;
+
+export function getNextRequestId() {
+  return 'SQR' + counter++;
+}
+
+export interface AnnotationsQueryRunnerState extends SceneObjectState {
+  queries: AnnotationQuery[];
+  data?: any;
+}
+
+export class AnnotationsQueryRunner extends SceneObjectBase<AnnotationsQueryRunnerState> implements SceneDataProvider {
+  private _querySub?: Unsubscribable;
+  private _results = new ReplaySubject<AnnotationQueryResult>();
+
+  public constructor(initialState: AnnotationsQueryRunnerState) {
+    super(initialState);
+
+    this.addActivationHandler(() => this._onActivate());
+  }
+
+  private _onActivate() {
+    const timeRange = sceneGraph.getTimeRange(this);
+
+    this._subs.add(
+      timeRange.subscribeToState((timeRange) => {
+        this.runWithTimeRange(timeRange.value);
+      })
+    );
+
+    if (this.shouldRunQueriesOnActivate()) {
+      this.runQueries();
+    }
+
+    return () => this._onDeactivate();
+  }
+
+  private shouldRunQueriesOnActivate() {
+    if (this.state.data) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private _onDeactivate(): void {
+    if (this._querySub) {
+      this._querySub.unsubscribe();
+      this._querySub = undefined;
+    }
+  }
+
+  public runQueries() {
+    const timeRange = sceneGraph.getTimeRange(this);
+    this.runWithTimeRange(timeRange.state.value);
+  }
+
+  private async runWithTimeRange(timeRange: TimeRange) {
+    const { queries } = this.state;
+
+    // Simple path when no queries exist
+    if (!queries?.length) {
+      // TODO set empty state
+      return;
+    }
+
+    const observables = queries.map((query) => {
+      // TODO pass scopedVars
+      return from(getDataSource(query.datasource ?? null, {})).pipe(
+        mergeMap((ds) => executeAnnotationQuery(ds, timeRange, query)),
+        map((data) => {
+          const result: AnnotationQueryResult = {
+            annotations: data.events ?? [],
+            alertStates: [],
+          };
+          return result;
+        })
+      );
+    });
+
+    this._querySub = merge(observables)
+      .pipe(
+        mergeAll(),
+        reduce((acc: AnnotationQueryResult, value: AnnotationQueryResult) => {
+          // console.log({ acc: acc.annotations.length, value: value.annotations.length });
+          // should we use scan or reduce here
+          // reduce will only emit when all observables are completed
+          // scan will emit when any observable is completed
+          // choosing reduce to minimize re-renders
+          acc.annotations = acc.annotations.concat(value.annotations);
+          acc.alertStates = acc.alertStates.concat(value.alertStates);
+          return acc;
+        })
+      )
+      .subscribe((result) => {
+        this._results.next(result);
+      });
+  }
+
+  public getAnnotationsStream(): Observable<AnnotationQueryResult> {
+    return this._results;
+  }
+}
+
+export function findFirstDatasource(targets: DataQuery[]): DataSourceRef | undefined {
+  return targets.find((t) => t.datasource !== null)?.datasource ?? undefined;
+}

--- a/packages/scenes/src/querying/AnnotationsQueryRunner.ts
+++ b/packages/scenes/src/querying/AnnotationsQueryRunner.ts
@@ -1,8 +1,6 @@
 import { mergeMap, Unsubscribable, map, from, merge, ReplaySubject, mergeAll, reduce, Observable } from 'rxjs';
 
-import { AnnotationQuery, DataQuery, DataSourceRef } from '@grafana/schema';
-
-import { TimeRange } from '@grafana/data';
+import { AnnotationQuery, PanelData, TimeRange } from '@grafana/data';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
@@ -19,7 +17,7 @@ export function getNextRequestId() {
 
 export interface AnnotationsQueryRunnerState extends SceneObjectState {
   queries: AnnotationQuery[];
-  data?: any;
+  data?: PanelData;
 }
 
 export class AnnotationsQueryRunner extends SceneObjectBase<AnnotationsQueryRunnerState> implements SceneDataProvider {
@@ -110,11 +108,7 @@ export class AnnotationsQueryRunner extends SceneObjectBase<AnnotationsQueryRunn
       });
   }
 
-  public getAnnotationsStream(): Observable<AnnotationQueryResult> {
+  public getResultStream(): Observable<AnnotationQueryResult> {
     return this._results;
   }
-}
-
-export function findFirstDatasource(targets: DataQuery[]): DataSourceRef | undefined {
-  return targets.find((t) => t.datasource !== null)?.datasource ?? undefined;
 }

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -188,6 +188,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     const request: DataQueryRequest = {
       app: CoreApp.Dashboard,
       requestId: getNextRequestId(),
+      // TODO pass correct timezone
       timezone: 'browser',
       panelId: 1,
       dashboardId: 1,

--- a/packages/scenes/src/querying/annotationUtils.ts
+++ b/packages/scenes/src/querying/annotationUtils.ts
@@ -1,0 +1,10 @@
+import { AnnotationEvent } from '@grafana/data';
+
+export function getAnnotationsByPanelId(annotations: AnnotationEvent[], panelId?: number) {
+  return annotations.filter((item) => {
+    if (panelId !== undefined && item.panelId && item.source?.type === 'dashboard') {
+      return item.panelId === panelId;
+    }
+    return true;
+  });
+}

--- a/packages/scenes/src/querying/executeAnnotationQuery.ts
+++ b/packages/scenes/src/querying/executeAnnotationQuery.ts
@@ -1,0 +1,85 @@
+import { Observable, of } from 'rxjs';
+import { map, mergeMap } from 'rxjs/operators';
+
+import { CoreApp, DataQueryRequest, DataSourceApi, rangeUtil, ScopedVars, TimeRange } from '@grafana/data';
+
+import { standardAnnotationSupport } from './standardAnnotationSupport';
+import { AnnotationQueryResponse } from './types';
+import { getRunRequest } from '@grafana/runtime';
+import { AnnotationQuery } from '@grafana/schema';
+
+let counter = 100;
+function getNextRequestId() {
+  return 'AQ' + counter++;
+}
+
+export function executeAnnotationQuery(
+  datasource: DataSourceApi,
+  timeRange: TimeRange,
+  annotationQuery: AnnotationQuery
+): Observable<AnnotationQueryResponse> {
+  const processor = {
+    ...standardAnnotationSupport,
+    ...datasource.annotations,
+  };
+
+  const annotationWithDefaults = {
+    ...processor.getDefaultQuery?.(),
+    ...annotationQuery,
+  };
+
+  const annotation = processor.prepareAnnotation!(annotationWithDefaults);
+  if (!annotation) {
+    return of({});
+  }
+
+  const query = processor.prepareQuery!(annotation);
+  if (!query) {
+    return of({});
+  }
+
+  // No more points than pixels
+  const maxDataPoints = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
+
+  // Add interval to annotation queries
+  const interval = rangeUtil.calculateInterval(timeRange, maxDataPoints, datasource.interval);
+
+  const scopedVars: ScopedVars = {
+    __interval: { text: interval.interval, value: interval.interval },
+    __interval_ms: { text: interval.intervalMs.toString(), value: interval.intervalMs },
+    __annotation: { text: annotation.name, value: annotation },
+  };
+
+  const queryRequest: DataQueryRequest = {
+    startTime: Date.now(),
+    requestId: getNextRequestId(),
+    range: timeRange,
+    maxDataPoints,
+    scopedVars,
+    ...interval,
+    app: CoreApp.Dashboard,
+    // TODO
+    //publicDashboardAccessToken: options.dashboard.meta.publicDashboardAccessToken,
+    // TODO pass correct timezone
+    timezone: 'browser',
+    targets: [
+      {
+        ...query,
+        refId: 'Anno',
+      },
+    ],
+  };
+
+  const runRequest = getRunRequest();
+
+  return runRequest(datasource, queryRequest).pipe(
+    mergeMap((panelData) => {
+      // Some annotations set the topic already
+      const data = panelData?.series.length ? panelData.series : panelData.annotations;
+      if (!data?.length) {
+        return of({ panelData, events: [] });
+      }
+      return processor.processEvents!(annotation, data).pipe(map((events) => ({ panelData, events })));
+    })
+  );
+}

--- a/packages/scenes/src/querying/standardAnnotationSupport.test.ts
+++ b/packages/scenes/src/querying/standardAnnotationSupport.test.ts
@@ -1,0 +1,160 @@
+import { FieldType, toDataFrame } from '@grafana/data';
+
+import { getAnnotationsFromData } from './standardAnnotationSupport';
+
+describe('DataFrame to annotations', () => {
+  test('simple conversion', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { type: FieldType.time, values: [1, 2, 3, 4, 5] },
+        { name: 'first string field', values: ['t1', 't2', 't3', null, undefined] },
+        { name: 'tags', values: ['aaa,bbb', 'bbb,ccc', 'zyz', null, undefined] },
+      ],
+    });
+
+    await expect(getAnnotationsFromData([frame])).toEmitValues([
+      [
+        {
+          color: 'red',
+          tags: ['aaa', 'bbb'],
+          text: 't1',
+          time: 1,
+          type: 'default',
+        },
+        {
+          color: 'red',
+          tags: ['bbb', 'ccc'],
+          text: 't2',
+          time: 2,
+          type: 'default',
+        },
+        {
+          color: 'red',
+          tags: ['zyz'],
+          text: 't3',
+          time: 3,
+          type: 'default',
+        },
+        {
+          color: 'red',
+          time: 4,
+          type: 'default',
+        },
+        {
+          color: 'red',
+          time: 5,
+          type: 'default',
+        },
+      ],
+    ]);
+  });
+
+  test('explicit mappings', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'time1', values: [111, 222, 333] },
+        { name: 'time2', values: [100, 200, 300] },
+        { name: 'aaaaa', values: ['a1', 'a2', 'a3'] },
+        { name: 'bbbbb', values: ['b1', 'b2', 'b3'] },
+      ],
+    });
+
+    const observable = getAnnotationsFromData([frame], {
+      text: { value: 'bbbbb' },
+      time: { value: 'time2' },
+      timeEnd: { value: 'time1' },
+      title: { value: 'aaaaa' },
+    });
+
+    await expect(observable).toEmitValues([
+      [
+        {
+          color: 'red',
+          text: 'b1',
+          time: 100,
+          timeEnd: 111,
+          title: 'a1',
+          type: 'default',
+        },
+        {
+          color: 'red',
+          text: 'b2',
+          time: 200,
+          timeEnd: 222,
+          title: 'a2',
+          type: 'default',
+        },
+        {
+          color: 'red',
+          text: 'b3',
+          time: 300,
+          timeEnd: 333,
+          title: 'a3',
+          type: 'default',
+        },
+      ],
+    ]);
+  });
+
+  it('all valid key names should be included in the output result', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'time', values: [100] },
+        { name: 'timeEnd', values: [200] },
+        { name: 'title', values: ['title'] },
+        { name: 'text', values: ['text'] },
+        { name: 'tags', values: ['t1,t2,t3'] },
+        { name: 'id', values: [1] },
+        { name: 'userId', values: ['Admin'] },
+        { name: 'login', values: ['admin'] },
+        { name: 'email', values: ['admin@unknown.us'] },
+        { name: 'prevState', values: ['normal'] },
+        { name: 'newState', values: ['alerting'] },
+        { name: 'data', values: [{ text: 'a', value: 'A' }] },
+        { name: 'panelId', values: [4] },
+        { name: 'alertId', values: [0] },
+      ],
+    });
+
+    const observable = getAnnotationsFromData([frame]);
+
+    await expect(observable).toEmitValues([
+      [
+        {
+          color: 'red',
+          data: { text: 'a', value: 'A' },
+          email: 'admin@unknown.us',
+          id: 1,
+          login: 'admin',
+          newState: 'alerting',
+          panelId: 4,
+          prevState: 'normal',
+          tags: ['t1', 't2', 't3'],
+          text: 'text',
+          time: 100,
+          timeEnd: 200,
+          title: 'title',
+          type: 'default',
+          userId: 'Admin',
+          alertId: 0,
+        },
+      ],
+    ]);
+  });
+
+  it('key names that are not valid should be excluded in the output result', async () => {
+    const frame = toDataFrame({
+      fields: [
+        { name: 'time', values: [100] },
+        { name: 'text', values: ['text'] },
+        { name: 'someData', values: [{ value: 'bar' }] },
+        { name: 'panelSource', values: ['100'] },
+        { name: 'timeStart', values: [100] },
+      ],
+    });
+
+    const observable = getAnnotationsFromData([frame]);
+
+    await expect(observable).toEmitValues([[{ color: 'red', text: 'text', time: 100, type: 'default' }]]);
+  });
+});

--- a/packages/scenes/src/querying/standardAnnotationSupport.ts
+++ b/packages/scenes/src/querying/standardAnnotationSupport.ts
@@ -275,5 +275,5 @@ export function shouldUseMappingUI(datasource: DataSourceApi): boolean {
  */
 export function shouldUseLegacyRunner(datasource: DataSourceApi): boolean {
   const { type } = datasource;
-  return legacyRunner.includes(type);
+  return !datasource.annotations || legacyRunner.includes(type);
 }

--- a/packages/scenes/src/querying/standardAnnotationSupport.ts
+++ b/packages/scenes/src/querying/standardAnnotationSupport.ts
@@ -1,0 +1,279 @@
+import { isString } from 'lodash';
+import { Observable, of, OperatorFunction } from 'rxjs';
+import { map, mergeMap } from 'rxjs/operators';
+
+import {
+  AnnotationEvent,
+  AnnotationEventFieldSource,
+  AnnotationEventMappings,
+  AnnotationQuery,
+  AnnotationSupport,
+  DataFrame,
+  DataSourceApi,
+  DataTransformContext,
+  Field,
+  FieldType,
+  getFieldDisplayName,
+  KeyValue,
+  standardTransformers,
+} from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+export const standardAnnotationSupport: AnnotationSupport = {
+  /**
+   * Assume the stored value is standard model.
+   */
+  prepareAnnotation: (json: any) => {
+    if (isString(json?.query)) {
+      const { query, ...rest } = json;
+      return {
+        ...rest,
+        target: {
+          refId: 'annotation_query',
+          query,
+        },
+        mappings: {},
+      };
+    }
+    return json as AnnotationQuery;
+  },
+
+  /**
+   * Default will just return target from the annotation.
+   */
+  prepareQuery: (anno: AnnotationQuery) => anno.target,
+
+  /**
+   * Provides default processing from dataFrame to annotation events.
+   */
+  processEvents: (anno: AnnotationQuery, data: DataFrame[]) => {
+    return getAnnotationsFromData(data, anno.mappings);
+  },
+};
+
+/**
+ * Flatten all frames into a single frame with mergeTransformer.
+ */
+
+export function singleFrameFromPanelData(): OperatorFunction<DataFrame[], DataFrame | undefined> {
+  return (source) =>
+    source.pipe(
+      mergeMap((data) => {
+        if (!data?.length) {
+          return of(undefined);
+        }
+
+        if (data.length === 1) {
+          return of(data[0]);
+        }
+
+        const ctx: DataTransformContext = {
+          interpolate: (v: string) => v,
+        };
+
+        return of(data).pipe(
+          standardTransformers.mergeTransformer.operator({}, ctx),
+          map((d) => d[0])
+        );
+      })
+    );
+}
+
+interface AnnotationEventFieldSetter {
+  key: keyof AnnotationEvent;
+  field?: Field;
+  text?: string;
+  regex?: RegExp;
+  split?: string; // for tags
+}
+
+export interface AnnotationFieldInfo {
+  key: keyof AnnotationEvent;
+
+  split?: string;
+  field?: (frame: DataFrame) => Field | undefined;
+  placeholder?: string;
+  help?: string;
+}
+
+// These fields get added to the standard UI
+export const annotationEventNames: AnnotationFieldInfo[] = [
+  {
+    key: 'time',
+    field: (frame: DataFrame) => frame.fields.find((f) => f.type === FieldType.time),
+    placeholder: 'time, or the first time field',
+  },
+  { key: 'timeEnd', help: 'When this field is defined, the annotation will be treated as a range' },
+  {
+    key: 'title',
+  },
+  {
+    key: 'text',
+    field: (frame: DataFrame) => frame.fields.find((f) => f.type === FieldType.string),
+    placeholder: 'text, or the first text field',
+  },
+  { key: 'tags', split: ',', help: 'The results will be split on comma (,)' },
+  {
+    key: 'id',
+  },
+];
+
+export const publicDashboardEventNames: AnnotationFieldInfo[] = [
+  {
+    key: 'color',
+  },
+  {
+    key: 'isRegion',
+  },
+  {
+    key: 'source',
+  },
+];
+
+// Given legacy infrastructure, alert events are passed though the same annotation
+// pipeline, but include fields that should not be exposed generally
+const alertEventAndAnnotationFields: AnnotationFieldInfo[] = [
+  ...(config.isPublicDashboardView ? publicDashboardEventNames : []),
+  ...annotationEventNames,
+  { key: 'userId' },
+  { key: 'login' },
+  { key: 'email' },
+  { key: 'prevState' },
+  { key: 'newState' },
+  { key: 'data' as any },
+  { key: 'panelId' },
+  { key: 'alertId' },
+  { key: 'dashboardId' },
+  { key: 'dashboardUID' },
+];
+
+export function getAnnotationsFromData(
+  data: DataFrame[],
+  options?: AnnotationEventMappings
+): Observable<AnnotationEvent[]> {
+  return of(data).pipe(
+    singleFrameFromPanelData(),
+    map((frame) => {
+      if (!frame?.length) {
+        return [];
+      }
+
+      let hasTime = false;
+      let hasText = false;
+      const byName: KeyValue<Field> = {};
+
+      for (const f of frame.fields) {
+        const name = getFieldDisplayName(f, frame);
+        byName[name.toLowerCase()] = f;
+      }
+
+      if (!options) {
+        options = {};
+      }
+
+      const fields: AnnotationEventFieldSetter[] = [];
+
+      for (const evts of alertEventAndAnnotationFields) {
+        const opt = options[evts.key] || {}; //AnnotationEventFieldMapping
+
+        if (opt.source === AnnotationEventFieldSource.Skip) {
+          continue;
+        }
+
+        const setter: AnnotationEventFieldSetter = { key: evts.key, split: evts.split };
+
+        if (opt.source === AnnotationEventFieldSource.Text) {
+          setter.text = opt.value;
+        } else {
+          const lower = (opt.value || evts.key).toLowerCase();
+          setter.field = byName[lower];
+
+          if (!setter.field && evts.field) {
+            setter.field = evts.field(frame);
+          }
+        }
+
+        if (setter.field || setter.text) {
+          fields.push(setter);
+          if (setter.key === 'time') {
+            hasTime = true;
+          } else if (setter.key === 'text') {
+            hasText = true;
+          }
+        }
+      }
+
+      if (!hasTime || !hasText) {
+        console.error('Cannot process annotation fields. No time or text present.');
+        return [];
+      }
+
+      // Add each value to the string
+      const events: AnnotationEvent[] = [];
+
+      for (let i = 0; i < frame.length; i++) {
+        const anno: AnnotationEvent = {
+          type: 'default',
+          color: 'red',
+        };
+
+        for (const f of fields) {
+          let v: any = undefined;
+
+          if (f.text) {
+            v = f.text; // TODO support templates!
+          } else if (f.field) {
+            v = f.field.values.get(i);
+            if (v !== undefined && f.regex) {
+              const match = f.regex.exec(v);
+              if (match) {
+                v = match[1] ? match[1] : match[0];
+              }
+            }
+          }
+
+          if (v !== null && v !== undefined) {
+            if (f.split && typeof v === 'string') {
+              v = v.split(',');
+            }
+            (anno as any)[f.key] = v;
+          }
+        }
+
+        events.push(anno);
+      }
+
+      return events;
+    })
+  );
+}
+
+// These opt outs are here only for quicker and easier migration to react based annotations editors and because
+// annotation support API needs some work to support less "standard" editors like prometheus and here it is not
+// polluting public API.
+
+const legacyRunner = [
+  'prometheus',
+  'loki',
+  'elasticsearch',
+  'grafana-opensearch-datasource', // external
+];
+
+/**
+ * Opt out of using the default mapping functionality on frontend.
+ */
+export function shouldUseMappingUI(datasource: DataSourceApi): boolean {
+  const { type } = datasource;
+  return !(
+    type === 'datasource' || //  ODD behavior for "-- Grafana --" datasource
+    legacyRunner.includes(type)
+  );
+}
+
+/**
+ * Use legacy runner. Used only as an escape hatch for easier transition to React based annotation editor.
+ */
+export function shouldUseLegacyRunner(datasource: DataSourceApi): boolean {
+  const { type } = datasource;
+  return legacyRunner.includes(type);
+}

--- a/packages/scenes/src/querying/types.ts
+++ b/packages/scenes/src/querying/types.ts
@@ -1,5 +1,12 @@
-import { AlertStateInfo, AnnotationEvent, PanelData, PanelModel, TimeRange } from '@grafana/data';
-import { Dashboard } from '@grafana/schema';
+import { AlertStateInfo, AnnotationEvent, PanelData, TimeRange } from '@grafana/data';
+
+/**
+ * Filtered by panel id result
+ */
+export interface DashboardQueryRunnerResult {
+  annotations: AnnotationEvent[];
+  alertState?: AlertStateInfo;
+}
 
 export interface AnnotationQueryResult {
   annotations: AnnotationEvent[];
@@ -7,8 +14,8 @@ export interface AnnotationQueryResult {
 }
 
 export interface AnnotationQueryOptions {
-  dashboard: Dashboard;
-  panel: PanelModel;
+  //dashboard: Dashboard;
+  //panel: PanelModel;
   range: TimeRange;
 }
 

--- a/packages/scenes/src/querying/types.ts
+++ b/packages/scenes/src/querying/types.ts
@@ -1,0 +1,42 @@
+import { AlertStateInfo, AnnotationEvent, PanelData, PanelModel, TimeRange } from '@grafana/data';
+import { Dashboard } from '@grafana/schema';
+
+export interface AnnotationQueryResult {
+  annotations: AnnotationEvent[];
+  alertStates: AlertStateInfo[];
+}
+
+export interface AnnotationQueryOptions {
+  dashboard: Dashboard;
+  panel: PanelModel;
+  range: TimeRange;
+}
+
+export interface AnnotationQueryResponse {
+  /**
+   * The processed annotation events
+   */
+  events?: AnnotationEvent[];
+
+  /**
+   * The original panel response
+   */
+  panelData?: PanelData;
+}
+
+export interface AnnotationTag {
+  /**
+   * The tag name
+   */
+  tag: string;
+  /**
+   * The number of occurrences of that tag
+   */
+  count: number;
+}
+
+export interface AnnotationTagsResponse {
+  result: {
+    tags: AnnotationTag[];
+  };
+}

--- a/packages/scenes/src/utils/getDataSource.ts
+++ b/packages/scenes/src/utils/getDataSource.ts
@@ -3,7 +3,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 
 export async function getDataSource(
-  datasource: DataSourceRef | undefined,
+  datasource: DataSourceRef | undefined | null,
   scopedVars: ScopedVars
 ): Promise<DataSourceApi> {
   if (datasource && (datasource as any).query) {


### PR DESCRIPTION
This looks a bit trickier than I hoped. So much old legacy crap in how annotations work and the model. Also the heavy reliance on panelId as number. 

Really unsure on how to hookup and merge the annotations query stream with the local data. In this PR I explored an easy way that is very similar to how it works in core.

* SceneQueryRunner will look up an AnnotationsQueryRunner using a key 
* will get the AnnotationsQueryRunners observable and subscribe and merge it with its own. We cannot rely on the simple ScenePanelData interface here as we need direct access to the observable in order to wait for it. 

Problems
* Messy type shuffling, The AnnotationsQueryRunner does not really implement SceneDataProvider as it provides a stream of AnnotationEvents . But we later turn the AnnotationEvents into data frames so we do a strange dance of turning DataFrames into AnnotationEvents then back to dataframes
* How much of this implementation should be in scenes, vs runtime or main app?
* If you have multiple annotation queries we wait for all to complete.  (We do the same in core app)

Things ignored but we need to solve
* Visualisations can control if they care about annotations and alert state or not, so we need to in SceneQueryRunner find the local visualization plugin and check its dataSupport options. This is a bit more tricky than it sounds as the plugin might not have loaded yet so we need to use rxjs magic here to wait for it to load. 

Biggest question for me:
How important are annotations support for the plugins use case? Maybe this is something we should de-prioritize until after G10. I don't think adding support for Annotations looks to require any big breaking model changes. 



