### PR TITLE
SceneObjectBase: Activate parents before children

### DIFF
--- a/packages/scenes/src/core/SceneComponentWrapper.tsx
+++ b/packages/scenes/src/core/SceneComponentWrapper.tsx
@@ -4,8 +4,19 @@ import { SceneComponentProps, SceneObject } from './types';
 
 function SceneComponentWrapperWithoutMemo<T extends SceneObject>({ model, ...otherProps }: SceneComponentProps<T>) {
   const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
+  const [activated, setActivated] = React.useState(false);
 
-  useEffect(() => model.activate(), [model]);
+  useEffect(() => {
+    setActivated(true);
+    return model.activate();
+  }, [model]);
+
+  // By not rendering the component until the model is actiavted we make sure that parent models get activated before child models
+  // Otherwise child models would be activated before parents as that is the order of React mount effects.
+  // This also enables static logic to happen inside activate that can change state before the first render.
+  if (!activated) {
+    return null;
+  }
 
   return <Component {...otherProps} model={model} />;
 }


### PR DESCRIPTION
* Wait with rendering scene objects' real component until after activation is completed 

Enables
* Activation logic can now happen before the first rendering of the SceneObject Component 
* Behaviors can run before children are activated (and set isHidden for example to prevent children from activating/rendering) 

 