### PR TITLE
VizPanel: Support runtime registered panel plugins  

### DIFF
--- a/docusaurus/docs/visualizations.md
+++ b/docusaurus/docs/visualizations.md
@@ -1,0 +1,89 @@
+---
+id: visualizations
+title: Visualizations
+---
+
+# Visualizations
+
+You can add visualizations to your scene by using the scene object class `VizPanel`.
+
+## Simple VizPanel example
+
+```ts
+new VizPanel({
+    pluginId: 'timeseries',
+    title: 'Time series',
+    options: {
+        legend: {
+            showLegend: false,
+        }
+    },
+    fieldConfig: {
+        defaults: {
+            unit: 'bytes',
+            min: 0,
+            custom: { lineWidth: 2 fillOpacity: 6 },
+        },
+        overrides: [],
+    }
+})
+```
+
+The pluginId `timeseries` used above refers to the core Grafana panel plugin which is the standard graph visualization for time indexed data. The `options` and `fieldConfig` are the same options you would see
+in your normal dashboard panels when you view `Panel JSON` from the panel inspect drawer. You find the panel inspect drawer in the panel menu under the name `Inspect`.
+
+## Data
+
+VizPanel will use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that it will use `$data` set on it's own level or share data with other siblings and scene objects if  `$data` is set on any parent level.
+
+## Custom visualizations
+
+If you want to visualize data yourself in your Grafana app plugin you can do that in two ways. You always have the option to create a custom SceneObject. But then you will not get the PanelChrome with loading state and other features
+that VizPanel provides. If you want a custom visualization inside a panel frame that should look like the other panels in your scene then it's best to register a runtime panel plugin.
+
+
+Start by defining your panel options and field config.
+
+```ts
+interface CustomVizOptions {
+  mode: string;
+}
+
+interface CustomVizFieldOptions {
+  numericOption: number;
+}
+
+interface Props extends PanelProps<CustomVizOptions> {}
+
+```
+
+Then you can define the react component that renders your custom PanelPlugin.
+
+```ts
+export function CustomVizPanel(props: Props) {
+  const { options, data } = props;
+
+  return (
+    <div>
+      <h4>CustomVizPanel {options.mode}</h4>
+      <div>FieldConfig: {JSON.stringify(data.series[0]?.fields[0]?.config)}</div>
+    </div>
+  );
+}
+```
+
+Now your ready to create your PanelPlugin instance and register it with the scenes library.
+
+```ts
+const myCustomPanel = new PanelPlugin<MyCustomOptions, MyCustomFieldOptions>(CustomVizPanel);
+
+registerRuntimePanelPlugin({ pluginId: 'my-scene-app-my-custom-viz', plugin: myCustomPanel });
+```
+
+You can now use this pluginId in any `VizPanel`. Make sure you specify a pluginId that includes your scene app name and is unlikely to conflict with other scene apps.
+
+For more information read the offical [tutorial on building panel plugins](https://grafana.com/tutorials/build-a-panel-plugin). Just remember that for scene runtime panel plugins
+you do not need a plugin.json file for the panel plugin. It will not be a standalone plugin that you can use in dashboards. it will only be something that can be referenced inside your scene app.
+
+
+

--- a/docusaurus/website/sidebars.js
+++ b/docusaurus/website/sidebars.js
@@ -18,6 +18,7 @@ const sidebars = {
 
   docs: {
     'Getting started': ['getting-started', 'core-concepts'],
+    'Learn Scenes': ['visualizations'],
     // Section: [],
 
     // Distribution: [],

--- a/packages/scenes-app/src/demos/customPanelPlugin.tsx
+++ b/packages/scenes-app/src/demos/customPanelPlugin.tsx
@@ -1,0 +1,90 @@
+import { PanelPlugin, PanelProps } from '@grafana/data';
+import {
+  SceneFlexLayout,
+  SceneTimeRange,
+  SceneTimePicker,
+  SceneFlexItem,
+  EmbeddedScene,
+  VizPanel,
+  SceneRefreshPicker,
+  SceneAppPageState,
+  SceneAppPage,
+  registerRuntimePanelPlugin,
+} from '@grafana/scenes';
+import React from 'react';
+import { getQueryRunnerWithRandomWalkQuery } from './utils';
+
+export function getCustomPanelPluginScene(defaults: SceneAppPageState): SceneAppPage {
+  registerRuntimePanelPlugin({ pluginId: 'custom-viz-panel', plugin: getCustomVizPlugin() });
+
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Demo of the SceneGridLayout',
+    getScene: () => {
+      return new EmbeddedScene({
+        body: new SceneFlexLayout({
+          direction: 'column',
+          $data: getQueryRunnerWithRandomWalkQuery(),
+          children: [
+            new SceneFlexItem({
+              body: new VizPanel({
+                title: 'Custom visualization panel plugin',
+                pluginId: 'custom-viz-panel',
+                fieldConfig: {
+                  defaults: {
+                    displayName: '${__field.labels.cluster}',
+                  },
+                  overrides: [],
+                },
+              }),
+            }),
+          ],
+        }),
+        $timeRange: new SceneTimeRange(),
+        controls: [new SceneTimePicker({}), new SceneRefreshPicker({})],
+      });
+    },
+  });
+}
+
+interface CustomVizOptions {
+  mode: string;
+}
+
+interface CustomVizFieldOptions {
+  numericOption: number;
+}
+
+function getCustomVizPlugin() {
+  return new PanelPlugin<CustomVizOptions, CustomVizFieldOptions>(CustomVizPanel)
+    .setPanelOptions((builder) => {
+      builder.addTextInput({
+        path: 'mode',
+        name: 'Mode',
+        defaultValue: 'modeA',
+      });
+    })
+    .useFieldConfig({
+      useCustomConfig: (builder) => {
+        builder.addNumberInput({
+          path: 'numericOption',
+          name: 'Option editor',
+          description: 'Option editor description',
+          defaultValue: 10,
+        });
+      },
+    });
+}
+
+export interface Props extends PanelProps<CustomVizOptions> {}
+
+export function CustomVizPanel(props: Props) {
+  const { options, data } = props;
+
+  return (
+    <div>
+      <h4>CustomVizPanel {options.mode}</h4>
+      <div>FieldConfig: {JSON.stringify(data.series[0]?.fields[0]?.config?.custom)}</div>
+    </div>
+  );
+}

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -1,5 +1,5 @@
 import { SceneAppPage, SceneAppPageState } from '@grafana/scenes';
-import { getCustomPanelPluginScene } from './customPanelPlugin';
+import { getRuntimePanelPluginDemo } from './runtimePanelPlugin';
 import { getDynamicPageDemo } from './dynamicPage';
 import { getFlexLayoutTest } from './flexLayout';
 import { getGridLayoutTest } from './grid';
@@ -32,6 +32,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'With drilldowns', getPage: getDrilldownsAppPageScene },
     { title: 'Query editor', getPage: getQueryEditorDemo },
     { title: 'Dynamic page', getPage: getDynamicPageDemo },
-    { title: 'Custom visualization panel plugin', getPage: getCustomPanelPluginScene },
+    { title: 'Runtime panel plugin', getPage: getRuntimePanelPluginDemo },
   ];
 }

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -1,4 +1,5 @@
 import { SceneAppPage, SceneAppPageState } from '@grafana/scenes';
+import { getCustomPanelPluginScene } from './customPanelPlugin';
 import { getDynamicPageDemo } from './dynamicPage';
 import { getFlexLayoutTest } from './flexLayout';
 import { getGridLayoutTest } from './grid';
@@ -31,5 +32,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'With drilldowns', getPage: getDrilldownsAppPageScene },
     { title: 'Query editor', getPage: getQueryEditorDemo },
     { title: 'Dynamic page', getPage: getDynamicPageDemo },
+    { title: 'Custom visualization panel plugin', getPage: getCustomPanelPluginScene },
   ];
 }

--- a/packages/scenes-app/src/demos/runtimePanelPlugin.tsx
+++ b/packages/scenes-app/src/demos/runtimePanelPlugin.tsx
@@ -1,20 +1,17 @@
 import { PanelPlugin, PanelProps } from '@grafana/data';
 import {
   SceneFlexLayout,
-  SceneTimeRange,
-  SceneTimePicker,
   SceneFlexItem,
   EmbeddedScene,
   VizPanel,
-  SceneRefreshPicker,
   SceneAppPageState,
   SceneAppPage,
   registerRuntimePanelPlugin,
 } from '@grafana/scenes';
 import React from 'react';
-import { getQueryRunnerWithRandomWalkQuery } from './utils';
+import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
-export function getCustomPanelPluginScene(defaults: SceneAppPageState): SceneAppPage {
+export function getRuntimePanelPluginDemo(defaults: SceneAppPageState): SceneAppPage {
   registerRuntimePanelPlugin({ pluginId: 'custom-viz-panel', plugin: getCustomVizPlugin() });
 
   return new SceneAppPage({
@@ -23,25 +20,22 @@ export function getCustomPanelPluginScene(defaults: SceneAppPageState): SceneApp
     getScene: () => {
       return new EmbeddedScene({
         body: new SceneFlexLayout({
+          ...getEmbeddedSceneDefaults(),
           direction: 'column',
-          $data: getQueryRunnerWithRandomWalkQuery(),
           children: [
             new SceneFlexItem({
               body: new VizPanel({
                 title: 'Custom visualization panel plugin',
                 pluginId: 'custom-viz-panel',
+                $data: getQueryRunnerWithRandomWalkQuery(),
                 fieldConfig: {
-                  defaults: {
-                    displayName: '${__field.labels.cluster}',
-                  },
+                  defaults: {},
                   overrides: [],
                 },
               }),
             }),
           ],
         }),
-        $timeRange: new SceneTimeRange(),
-        controls: [new SceneTimePicker({}), new SceneRefreshPicker({})],
       });
     },
   });

--- a/packages/scenes-app/src/demos/runtimePanelPlugin.tsx
+++ b/packages/scenes-app/src/demos/runtimePanelPlugin.tsx
@@ -16,7 +16,7 @@ export function getRuntimePanelPluginDemo(defaults: SceneAppPageState): SceneApp
 
   return new SceneAppPage({
     ...defaults,
-    subTitle: 'Demo of the SceneGridLayout',
+    subTitle: 'Demo of a runtime registered panel plugin',
     getScene: () => {
       return new EmbeddedScene({
         body: new SceneFlexLayout({

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -11,19 +11,8 @@ import { SceneComponentProps } from '../../core/types';
 import { VizPanel } from './VizPanel';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
-  const {
-    title,
-    description,
-    options,
-    fieldConfig,
-    pluginId,
-    pluginLoadError,
-    $data,
-    displayMode,
-    hoverHeader,
-    menu,
-    ...state
-  } = model.useState();
+  const { title, description, options, fieldConfig, pluginLoadError, $data, displayMode, hoverHeader, menu, ...state } =
+    model.useState();
   const [ref, { width, height }] = useMeasure();
   const plugin = model.getPlugin();
   const parentLayout = sceneGraph.getLayout(model);
@@ -45,7 +34,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     return <div>Failed to load plugin: {pluginLoadError}</div>;
   }
 
-  if (!plugin || !plugin.hasPluginId(pluginId)) {
+  if (!plugin) {
     return <div>Loading plugin panel...</div>;
   }
 

--- a/packages/scenes/src/components/VizPanel/registerRuntimePanelPlugin.ts
+++ b/packages/scenes/src/components/VizPanel/registerRuntimePanelPlugin.ts
@@ -4,11 +4,22 @@ import { getPluginImportUtils } from '@grafana/runtime';
 export const runtimePanelPlugins = new Map<string, PanelPlugin>();
 
 export interface RuntimePanelPluginOptions {
+  /**
+   * Please specify a pluginId that is unlikely to collide with other plugins.
+   */
   pluginId: string;
   plugin: PanelPlugin;
 }
 
+/**
+ * Provides a way to register runtime panel plugins.
+ * Please use a pluginId that is unlikely to collide with other plugins.
+ */
 export function registerRuntimePanelPlugin({ pluginId, plugin }: RuntimePanelPluginOptions) {
+  if (runtimePanelPlugins.has(pluginId)) {
+    throw new Error(`A runtime panel plugin with id ${pluginId} has already been registered`);
+  }
+
   plugin.meta = {
     ...plugin.meta,
     id: pluginId,
@@ -37,5 +48,5 @@ export function registerRuntimePanelPlugin({ pluginId, plugin }: RuntimePanelPlu
 export function loadPanelPluginSync(pluginId: string) {
   const { getPanelPluginFromCache } = getPluginImportUtils();
 
-  return runtimePanelPlugins.get(pluginId) ?? getPanelPluginFromCache(pluginId);
+  return getPanelPluginFromCache(pluginId) ?? runtimePanelPlugins.get(pluginId);
 }

--- a/packages/scenes/src/components/VizPanel/registerRuntimePanelPlugin.ts
+++ b/packages/scenes/src/components/VizPanel/registerRuntimePanelPlugin.ts
@@ -1,0 +1,41 @@
+import { PanelPlugin, PluginMetaInfo } from '@grafana/data';
+import { getPluginImportUtils } from '@grafana/runtime';
+
+export const runtimePanelPlugins = new Map<string, PanelPlugin>();
+
+export interface RuntimePanelPluginOptions {
+  pluginId: string;
+  plugin: PanelPlugin;
+}
+
+export function registerRuntimePanelPlugin({ pluginId, plugin }: RuntimePanelPluginOptions) {
+  plugin.meta = {
+    ...plugin.meta,
+    id: pluginId,
+    name: pluginId,
+    module: 'runtime plugin',
+    baseUrl: 'runtime plugin',
+    info: {
+      author: {
+        name: 'Runtime plugin ' + pluginId,
+      },
+      description: '',
+      links: [],
+      logos: {
+        large: '',
+        small: '',
+      },
+      screenshots: [],
+      updated: '',
+      version: '',
+    } as PluginMetaInfo,
+  };
+
+  runtimePanelPlugins.set(pluginId, plugin);
+}
+
+export function loadPanelPluginSync(pluginId: string) {
+  const { getPanelPluginFromCache } = getPluginImportUtils();
+
+  return runtimePanelPlugins.get(pluginId) ?? getPanelPluginFromCache(pluginId);
+}

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -25,6 +25,7 @@ export { SceneObjectUrlSyncConfig } from './services/SceneObjectUrlSyncConfig';
 
 export { EmbeddedScene, type EmbeddedSceneState } from './components/EmbeddedScene';
 export { VizPanel, type VizPanelState } from './components/VizPanel/VizPanel';
+export { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
 export { VizPanelMenu } from './components/VizPanel/VizPanelMenu';
 export { NestedScene } from './components/NestedScene';
 export { SceneCanvasText } from './components/SceneCanvasText';


### PR DESCRIPTION
This PR makes it possible for scene app plugins to include custom visualizations without those visualizations having to be defined as standalone panel plugins. 

This can in a way already be accomplished via a custom SceneObject but requires plugins using PanelChrome directly and there is quire a bit of complexity in using that and setting the correct loading state and props for PanelChrome. 

Only problem with this implementation that I can think of right now
* The id of the runtime registered panel plugin could conflict with other plugins. This is not a problem right now as each scene app plugin get's it's own version of scenes so they get their own version of the runtimePanelPlugin registry. But if we where to switch to federated modules in the future then this could become a problem.

## Release notes 

It's now easier for scene app plugins to include custom visualizations in their scenes. By registering a runtime-defined PanelPlugin via the function `registerRuntimePanelPlugin` a scene app plugin can now take advantage of the full VizPanel logic that creates a PanelChrome with panel title, description, loading state, menu as well as the logic for applying panel option defaults and applying field config. 

