### PR TITLE
FormatRegistry: New format added

### DIFF
--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -68,5 +68,9 @@ describe('formatRegistry', () => {
     expect(formatValue(VariableFormatID.Date, 1594671549254, 'text', ['YYYY-MM'])).toBe('2020-07');
     expect(formatValue(VariableFormatID.Date, 1594671549254, 'text', ['YYYY-MM', 'ss'])).toBe('2020-07:09');
     expect(formatValue(VariableFormatID.Date, 1594671549254, 'text', ['YYYY', 'MM', 'DD'])).toBe('2020:07:13');
+
+    expect(formatValue(VariableFormatID.UriEncode, '/any-path/any-second-path?query=foo()bar BAZ')).toBe(
+      '/any-path/any-second-path?query=foo%28%29bar%20BAZ'
+    );
   });
 });

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -295,6 +295,18 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
         return formatQueryParameter(variable.state.name, value);
       },
     },
+    {
+      id: VariableFormatID.UriEncode,
+      name: 'Percent encode as URI',
+      description: 'Useful for URL escaping values, taking into URI syntax characters',
+      formatter: (value: VariableValue) => {
+        if (isArray(value)) {
+          return encodeURIStrict('{' + value.join(',') + '}');
+        }
+
+        return encodeURIStrict(value);
+      },
+    },
   ];
 
   return formats;
@@ -318,10 +330,15 @@ function encodeURIComponentStrict(str: VariableValueSingle) {
     str = String(str);
   }
 
-  return encodeURIComponent(str).replace(/[!'()*]/g, (c) => {
-    return '%' + c.charCodeAt(0).toString(16).toUpperCase();
-  });
+  return replaceSpecialCharactersToASCII(encodeURIComponent(str));
 }
+
+const encodeURIStrict = (str: VariableValueSingle): string =>
+  replaceSpecialCharactersToASCII(encodeURI(String(str)));
+
+const replaceSpecialCharactersToASCII = (value: string): string => value.replace(/[!'()*]/g, (c) => {
+  return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+});
 
 function formatQueryParameter(name: string, value: VariableValueSingle): string {
   return `var-${name}=${encodeURIComponentStrict(value)}`;


### PR DESCRIPTION
It adds a new format for [this issue](https://github.com/grafana/support-escalations/issues/5536)

Not to merge until [this PR](https://github.com/grafana/grafana/pull/66793/files) is merged and we've got the new VariableFormatId value