### PR TITLE
FlexLayout: Responsive breakpoints

### DIFF
--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -67,8 +67,8 @@ Both `ScenFlexLayout` and `SceneFlexItem` object types accept the following conf
   md?: SceneFlexItemPlacement;
 ```
 
-We really recommend setting a minHeight on all children of layout that use `column` direction. This will make sure that they don't get squashed to much on smaller screens. If you set minHeight or height on a SceneFlexLayout you do not need
-to set it on each child as they will inherit this constraint.
+We really recommend setting a minHeight on all children of layout that use `column` direction. This will make sure that they don't get squashed too much on smaller screens. If you set minHeight or height on a SceneFlexLayout you do not need
+to set it on each child as they will inherit these constraints.
 
 ### Step 4. Add panels to flex layout items
 
@@ -144,7 +144,7 @@ For `SceneFlexItems` that contain a `VizPanel`, it's usually a good idea to set 
 
 ### Responsive flex layouts
 
-By default SceneFlexLayout has some responsive behaviors for smaller screens. These kick in for screens that match the media query of theme.breakpoints.down('md').
+By default SceneFlexLayout has some responsive behaviors for smaller screens. These kick in for screens that match the media query of Grafana's theme.breakpoints.down('md').
 
 * SceneFlexLayout direction will change from row to column.
 * SceneFlexLayout maxWidth, maxHeight, height or width constraints are removed.

--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -45,7 +45,7 @@ Create scene with two, equally sized layout items in a column:
 const myScene = new EmbeddedScene({
   body: new SceneFlexLayout({
     direction: 'column',
-    children: [new SceneFlexItem({}), new SceneFlexItem({})],
+    children: [new SceneFlexItem({ minHeight: 200 }), new SceneFlexItem({ minHeight: 300})],
   }),
 });
 ```
@@ -66,6 +66,9 @@ Both `ScenFlexLayout` and `SceneFlexItem` object types accept the following conf
   // For sizing constaints on smaller screens
   md?: SceneFlexItemPlacement;
 ```
+
+We really recommend setting a minHeight on all children of layout that use `column` direction. This will make sure that they don't get squashed to much on smaller screens. If you set minHeight or height on a SceneFlexLayout you do not need
+to set it on each child as they will inherit this constraint.
 
 ### Step 4. Add panels to flex layout items
 
@@ -148,6 +151,22 @@ By default SceneFlexLayout has some responsive behaviors for smaller screens. Th
 * SceneFlexLayout and SceneFlexItem will use the minHeight or height set on the parent layout (unless specified on it directly). This is to make a height or minHeight constraint set on a SceneFlexLayout with direction row also apply to it's children so that when the responsive media query that changes direction to column kicks in these constaints are still acting on the children.
 
 You can override these behaviors and set custom direction and size constraints using the `md` property that exist on both SceneFlexLayout and SceneFlexItem.
+
+Example:
+
+```ts
+new SceneFlexLayout({
+  direction: 'row',
+  minHeight: 200,
+  md: {
+    minHeight: 100,
+    direction: 'row',
+  },
+  children: [getStatPanel({}), getStatPanel({})],
+}),
+```
+
+In the above example we use the `md` property to override the default responsive behavior that changes a `row` layout to a `column` layout. We also apply a tighter minHeight constraint.
 
 ## Grid layout
 

--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -63,6 +63,8 @@ Both `ScenFlexLayout` and `SceneFlexItem` object types accept the following conf
   maxHeight?: CSSProperties['maxHeight'];
   xSizing?: 'fill' | 'content';
   ySizing?: 'fill' | 'content';
+  // For sizing constaints on smaller screens
+  md?: SceneFlexItemPlacement;
 ```
 
 ### Step 4. Add panels to flex layout items
@@ -136,6 +138,16 @@ The above example will render two panels, a Timeseries and a Table panel.
 :::note
 For `SceneFlexItems` that contain a `VizPanel`, it's usually a good idea to set `minHeight` or `minWidth` constraints so they don't get squashed too small by limited screen space.
 :::
+
+### Responsive flex layouts
+
+By default SceneFlexLayout has some responsive behaviors for smaller screens. These kick in for screens that match the media query of theme.breakpoints.down('md').
+
+* SceneFlexLayout direction will change from row to column.
+* SceneFlexLayout maxWidth, maxHeight, height or width constraints are removed.
+* SceneFlexLayout and SceneFlexItem will use the minHeight or height set on the parent layout (unless specified on it directly). This is to make a height or minHeight constraint set on a SceneFlexLayout with direction row also apply to it's children so that when the responsive media query that changes direction to column kicks in these constaints are still acting on the children.
+
+You can override these behaviors and set custom direction and size constraints using the `md` property that exist on both SceneFlexLayout and SceneFlexItem.
 
 ## Grid layout
 

--- a/packages/scenes-app/src/demos/flexLayout.tsx
+++ b/packages/scenes-app/src/demos/flexLayout.tsx
@@ -39,9 +39,10 @@ export function getFlexLayoutTest(defaults: SceneAppPageState) {
                   direction: 'column',
                   children: [
                     new SceneFlexItem({
+                      minHeight: 200,
                       body: new VizPanel({
                         pluginId: 'timeseries',
-                        title: 'Fill height',
+                        title: 'Fill height with minHeight 200',
                         options: {},
                         fieldConfig: {
                           defaults: {
@@ -51,12 +52,6 @@ export function getFlexLayoutTest(defaults: SceneAppPageState) {
                           },
                           overrides: [],
                         },
-                      }),
-                    }),
-                    new SceneFlexItem({
-                      body: new VizPanel({
-                        pluginId: 'timeseries',
-                        title: 'Fill height',
                       }),
                     }),
                     new SceneFlexItem({

--- a/packages/scenes-app/src/demos/flexLayout.tsx
+++ b/packages/scenes-app/src/demos/flexLayout.tsx
@@ -39,10 +39,9 @@ export function getFlexLayoutTest(defaults: SceneAppPageState) {
                   direction: 'column',
                   children: [
                     new SceneFlexItem({
-                      minHeight: 200,
                       body: new VizPanel({
                         pluginId: 'timeseries',
-                        title: 'Fill height with minHeight 200',
+                        title: 'Fill height',
                         options: {},
                         fieldConfig: {
                           defaults: {
@@ -52,6 +51,12 @@ export function getFlexLayoutTest(defaults: SceneAppPageState) {
                           },
                           overrides: [],
                         },
+                      }),
+                    }),
+                    new SceneFlexItem({
+                      body: new VizPanel({
+                        pluginId: 'timeseries',
+                        title: 'Fill height',
                       }),
                     }),
                     new SceneFlexItem({

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -10,6 +10,7 @@ import { getPanelContextDemoScene } from './panelContext';
 import { getPanelMenuTest } from './panelMenu';
 import { getPanelRepeaterTest } from './panelRepeater';
 import { getQueryEditorDemo } from './queryEditor';
+import { getResponsiveLayoutDemo } from './responsiveLayout';
 import { getVariablesDemo } from './variables';
 import { getDrilldownsAppPageScene } from './withDrilldown/WithDrilldown';
 
@@ -21,6 +22,7 @@ export interface DemoDescriptor {
 export function getDemos(): DemoDescriptor[] {
   return [
     { title: 'Flex layout', getPage: getFlexLayoutTest },
+    { title: 'Responsive layout', getPage: getResponsiveLayoutDemo },
     { title: 'Panel menu', getPage: getPanelMenuTest },
     { title: 'Panel context', getPage: getPanelContextDemoScene },
     { title: 'Repeat layout by series', getPage: getPanelRepeaterTest },

--- a/packages/scenes-app/src/demos/responsiveLayout.tsx
+++ b/packages/scenes-app/src/demos/responsiveLayout.tsx
@@ -22,7 +22,7 @@ export function getResponsiveLayoutDemo(defaults: SceneAppPageState) {
           direction: 'column',
           children: [
             getRowWithText(
-              'Row with height 150, Default responsive behavior of switching to column layout and removing height constraint. '
+              'Row with height 150, Default responsive behavior of switching to column layout and removing height constraint on layout. Height constraints are automatically also applied to children so they work when the media query switches the flex direction to column'
             ),
             new SceneFlexLayout({
               direction: 'row',

--- a/packages/scenes-app/src/demos/responsiveLayout.tsx
+++ b/packages/scenes-app/src/demos/responsiveLayout.tsx
@@ -28,10 +28,10 @@ export function getResponsiveLayoutDemo(defaults: SceneAppPageState) {
               direction: 'row',
               maxHeight: 150,
               minHeight: 150,
-              children: [getStatPanel({}), getStatPanel({})],
-              screenSmall: {
+              md: {
                 direction: 'row',
               },
+              children: [getStatPanel({}), getStatPanel({})],
             }),
             getRowWithText(
               'Row with maxHeight 150,and minHeight 150. Default responsive behavior of switching to column layout and removing maxHeight constraint'

--- a/packages/scenes-app/src/demos/responsiveLayout.tsx
+++ b/packages/scenes-app/src/demos/responsiveLayout.tsx
@@ -1,0 +1,88 @@
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneCanvasText,
+  SceneFlexItem,
+  SceneFlexItemState,
+  SceneFlexLayout,
+  VizPanel,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
+
+export function getResponsiveLayoutDemo(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Show casing the default and custom responsive options of SceneFlexLayout',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        $data: getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 40 }),
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            getRowWithText(
+              'Row with maxHeight 150, and minHeight 150. Overriding default responsive rule to maintain row layout even on smaller screens'
+            ),
+            new SceneFlexLayout({
+              direction: 'row',
+              maxHeight: 150,
+              minHeight: 150,
+              children: [getStatPanel({}), getStatPanel({})],
+              screenSmall: {
+                direction: 'row',
+              },
+            }),
+            getRowWithText(
+              'Row with maxHeight 150,and minHeight 150. Default responsive behavior of switching to column layout and removing maxHeight constraint'
+            ),
+            new SceneFlexLayout({
+              direction: 'row',
+              maxHeight: 150,
+              minHeight: 150,
+              children: [getStatPanel({ minHeight: 100 }), getStatPanel({}), getStatPanel({})],
+            }),
+            getRowWithText(
+              'Row with minHeight 200, and width constraints. The responsive style will remove the maxWidth by default'
+            ),
+            new SceneFlexLayout({
+              direction: 'row',
+              minHeight: 200,
+              children: [getTimeSeries({}, 'No constraints'), getTimeSeries({ maxWidth: 300 }, 'maxWidth 300')],
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}
+
+function getRowWithText(text: string) {
+  return new SceneFlexItem({
+    ySizing: 'content',
+    body: new SceneCanvasText({
+      text,
+      fontSize: 12,
+    }),
+  });
+}
+
+function getStatPanel(overrides?: Partial<SceneFlexItemState>) {
+  return new SceneFlexItem({
+    ...overrides,
+    body: new VizPanel({
+      pluginId: 'stat',
+      title: 'Stat',
+    }),
+  });
+}
+
+function getTimeSeries(overrides?: Partial<SceneFlexItemState>, title?: string) {
+  return new SceneFlexItem({
+    ...overrides,
+    body: new VizPanel({
+      pluginId: 'timeseries',
+      title: title ?? 'Panel',
+    }),
+  });
+}

--- a/packages/scenes-app/src/demos/responsiveLayout.tsx
+++ b/packages/scenes-app/src/demos/responsiveLayout.tsx
@@ -22,33 +22,39 @@ export function getResponsiveLayoutDemo(defaults: SceneAppPageState) {
           direction: 'column',
           children: [
             getRowWithText(
-              'Row with maxHeight 150, and minHeight 150. Overriding default responsive rule to maintain row layout even on smaller screens'
+              'Row with height 150, Default responsive behavior of switching to column layout and removing height constraint. '
             ),
             new SceneFlexLayout({
               direction: 'row',
-              maxHeight: 150,
-              minHeight: 150,
+              height: 150,
+              children: [getStatPanel({}), getStatPanel({}), getStatPanel({})],
+            }),
+            getRowWithText(
+              'Row with height 20, Overriding default responsive rule to maintain row layout even on smaller screens but with only 100px height'
+            ),
+            new SceneFlexLayout({
+              direction: 'row',
+              height: 200,
               md: {
+                height: 100,
                 direction: 'row',
               },
               children: [getStatPanel({}), getStatPanel({})],
             }),
             getRowWithText(
-              'Row with maxHeight 150,and minHeight 150. Default responsive behavior of switching to column layout and removing maxHeight constraint'
+              'Row with minHeight 300, and item with width constraint. The responsive style will remove the maxWidth by default'
             ),
             new SceneFlexLayout({
               direction: 'row',
-              maxHeight: 150,
-              minHeight: 150,
-              children: [getStatPanel({ minHeight: 100 }), getStatPanel({}), getStatPanel({})],
-            }),
-            getRowWithText(
-              'Row with minHeight 200, and width constraints. The responsive style will remove the maxWidth by default'
-            ),
-            new SceneFlexLayout({
-              direction: 'row',
-              minHeight: 200,
-              children: [getTimeSeries({}, 'No constraints'), getTimeSeries({ maxWidth: 300 }, 'maxWidth 300')],
+              minHeight: 300,
+              children: [
+                getTimeSeries({}, 'No constraints'),
+                new SceneFlexLayout({
+                  direction: 'column',
+                  maxWidth: 300,
+                  children: [getTimeSeries({}, 'maxWidth 300'), getTimeSeries({}, 'maxWidth 300')],
+                }),
+              ],
             }),
           ],
         }),

--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -31,7 +31,6 @@ const getScene = () => {
               direction: 'column',
               children: [
                 new SceneFlexItem({
-                  flexGrow: 1,
                   body: new SceneReactObject({
                     component: () => <DemosList demos={demos} />,
                   }),
@@ -127,7 +126,6 @@ export function getDemoNotFoundPage(url: string): SceneAppPage {
           direction: 'column',
           children: [
             new SceneFlexItem({
-              flexGrow: 1,
               body: new SceneReactObject({
                 component: () => {
                   return <div style={{ fontSize: 50 }}>😭</div>;

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -180,7 +180,6 @@ function getDefaultFallbackPage() {
           direction: 'column',
           children: [
             new SceneFlexItem({
-              flexGrow: 1,
               body: new SceneReactObject({
                 component: () => {
                   return (

--- a/packages/scenes/src/components/SceneCanvasText.tsx
+++ b/packages/scenes/src/components/SceneCanvasText.tsx
@@ -1,14 +1,17 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneObjectState } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
+import { useTheme2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 export interface SceneCanvasTextState extends SceneObjectState {
   text: string;
   fontSize?: number;
   align?: 'left' | 'center' | 'right';
+  spacing?: number;
 }
 
 /**
@@ -19,19 +22,20 @@ export class SceneCanvasText extends SceneObjectBase<SceneCanvasTextState> {
   protected _variableDependency = new VariableDependencyConfig(this, { statePaths: ['text'] });
 
   public static Component = ({ model }: SceneComponentProps<SceneCanvasText>) => {
-    const { text, fontSize = 20, align = 'left', key } = model.useState();
+    const { text, fontSize = 20, align = 'left', key, spacing } = model.useState();
+    const theme = useTheme2();
 
-    const style: CSSProperties = {
+    const style = css({
       fontSize: fontSize,
       display: 'flex',
       flexGrow: 1,
       alignItems: 'center',
-      padding: 16,
+      padding: spacing ? theme.spacing(spacing, 0) : undefined,
       justifyContent: align,
-    };
+    });
 
     return (
-      <div style={style} data-testid={key}>
+      <div className={style} data-testid={key}>
         {sceneGraph.interpolate(model, text)}
       </div>
     );

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -179,17 +179,17 @@ function useLayoutStyle(state: SceneFlexLayoutState, parentDirection?: CSSProper
 
     if (parentDirection) {
       applyItemStyles(style, state, parentDirection);
+    } else {
+      style.display = 'flex';
+      style.flexGrow = 1;
     }
 
-    //style.flexGrow = 1;
-    style.display = 'flex';
     style.flexDirection = direction;
     style.gap = '8px';
-    style.flexGrow = 1;
     style.flexWrap = wrap || 'nowrap';
     style.alignContent = 'baseline';
 
-    if (state.minHeight === undefined) {
+    if (style.minHeight === undefined) {
       style.minHeight = 0;
     } else {
       // Have minHeight also apply to children so that this height also works for responsive layouts

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -13,11 +13,13 @@ export interface SceneFlexItemResponsiveProps {
   direction?: CSSProperties['flexDirection'];
   maxWidth?: CSSProperties['maxWidth'];
   maxHeight?: CSSProperties['minHeight'];
-  width?: CSSProperties['width'];
-  height?: CSSProperties['height'];
 }
 
 interface SceneFlexLayoutState extends SceneObjectState, SceneFlexItemPlacement {
+  /**
+   * The flexDirection for the layout. By default the there will be a media query that changes the
+   * direction to column layout using theme.breakpoints.down('md')
+   */
   direction?: CSSProperties['flexDirection'];
   wrap?: CSSProperties['flexWrap'];
   children: SceneFlexItemLike[];
@@ -25,7 +27,7 @@ interface SceneFlexLayoutState extends SceneObjectState, SceneFlexItemPlacement 
    * Set direction for smaller screens. This defaults to column.
    * This equals media query theme.breakpoints.down('md')
    */
-  screenSmall?: SceneFlexItemResponsiveProps;
+  md?: SceneFlexItemResponsiveProps;
 }
 
 export class SceneFlexLayout extends SceneObjectBase<SceneFlexLayoutState> implements SceneLayout {
@@ -200,9 +202,9 @@ function useLayoutStyle(state: SceneFlexLayoutState, parentDirection?: CSSProper
     }
 
     style[theme.breakpoints.down('md')] = {
-      flexDirection: state.screenSmall?.direction ?? 'column',
-      maxWidth: state.screenSmall?.maxWidth ?? 'unset',
-      maxHeight: state.screenSmall?.maxHeight ?? 'unset',
+      flexDirection: state.md?.direction ?? 'column',
+      maxWidth: state.md?.maxWidth ?? 'unset',
+      maxHeight: state.md?.maxHeight ?? 'unset',
     };
 
     return css(style);

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -33,7 +33,7 @@ export { SceneTimePicker } from './components/SceneTimePicker';
 export { SceneRefreshPicker } from './components/SceneRefreshPicker';
 export { SceneByFrameRepeater } from './components/SceneByFrameRepeater';
 export { SceneControlsSpacer } from './components/SceneControlsSpacer';
-export { SceneFlexLayout, SceneFlexItem } from './components/layout/SceneFlexLayout';
+export { SceneFlexLayout, SceneFlexItem, type SceneFlexItemState } from './components/layout/SceneFlexLayout';
 export { SceneGridLayout, SceneGridItem } from './components/layout/grid/SceneGridLayout';
 export { SceneGridRow } from './components/layout/grid/SceneGridRow';
 export {


### PR DESCRIPTION
Just started exploring this, opening a draft so no one else starts on it and get some early feedback.

I noticed that this is actually pretty tricky as all constraints you put change when you change flex direction. Say you have a row of stat panels and the row has a maxHeight of 150px, if we have a responsive rule to change the direction of that row to column then all those panels would be also constrained to 150px. So every responsive rule would also have to change / remove the height (and potentially width constraints).

I am trying to make SceneFlexLayout responsive by default as well, in order for this to not require too much work for every scene. What I think is required is minHeight constraints (either on row or visualization level).

* [x] Automatically change direction to column when media query match is lower than breakpoint md, or manual direction is set in screenSmall prop 
* [x] Automatically clear maxHeight constraints for media query (so that rows that become column layouts don't have each item constrained to the same height as the row layout had)
* [x] Automatically clear maxWidth constraints for meda query (unless specified in screenSmall)
* [x] Automatically set minHeight on children if minHeight set on layout level. This makes it so you do not have to set minHeight on all children and it's enough to set it on the parent layout (row). Why is this needed? Well, otherwise you ALWAYS have to set minHeight on basically all children. Because when the responsive rule kicks in and a row layout is changed to a column the minHeight constraint needs to be on the child level, not the parent level. 

[Responsive-layout---Demos---Scenes-Test-App---Apps---Grafana.webm](https://user-images.githubusercontent.com/10999/233094376-fd972afd-c525-4f29-893d-04d873c230c7.webm)


