### PR TITLE
Scenes App: Fix scenes dependency

### DIFF
--- a/packages/scenes-app/package.json
+++ b/packages/scenes-app/package.json
@@ -62,7 +62,7 @@
     "@emotion/css": "^11.1.3",
     "@grafana/data": "canary",
     "@grafana/runtime": "canary",
-    "@grafana/scenes": "workspace:*",
+    "@grafana/scenes": "canary",
     "@grafana/schema": "canary",
     "@grafana/ui": "canary",
     "@types/lodash": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,7 +3109,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/scenes@workspace:*, @grafana/scenes@workspace:packages/scenes":
+"@grafana/scenes@npm:canary":
+  version: 0.5.0--canary.155.4752430785.0
+  resolution: "@grafana/scenes@npm:0.5.0--canary.155.4752430785.0"
+  dependencies:
+    "@grafana/e2e-selectors": canary
+    "@grafana/experimental": 1.0.1
+    react-grid-layout: 1.3.4
+    react-use: 17.4.0
+    react-virtualized-auto-sizer: 1.0.7
+    uuid: ^9.0.0
+  checksum: 6f18401e4e565d054d1b517a9c1912c534c1f081da10afe1bd403688e262c316199e1dfb57ad86db1245bb5b4ca554050c83d9b084cc54e4e1c345e721b6eba2
+  languageName: node
+  linkType: hard
+
+"@grafana/scenes@workspace:packages/scenes":
   version: 0.0.0-use.local
   resolution: "@grafana/scenes@workspace:packages/scenes"
   dependencies:
@@ -23516,7 +23530,7 @@ __metadata:
     "@grafana/e2e-selectors": canary
     "@grafana/eslint-config": 5.0.0
     "@grafana/runtime": canary
-    "@grafana/scenes": "workspace:*"
+    "@grafana/scenes": canary
     "@grafana/schema": canary
     "@grafana/tsconfig": 1.2.0-rc1
     "@grafana/ui": canary


### PR DESCRIPTION
I followed the demo-app instructions and stumbed upon a bunch of errors telling ` Error: Can't resolve '@grafana/scenes' in '/Users/matyax/Apps/scenes/packages/scenes-app/src/pages'`.

Changing the dependency version fixed them and I was able to see the demo app.