### PR TITLE
Scenes app: add script step to build scenes

### DIFF
--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -6,6 +6,10 @@ scenesapppath=$(pwd)/packages/scenes-app
 
 yarn install
 
+cd $scenespath
+yarn install
+yarn build
+
 cd $scenesapppath
 docker compose up -d --build
 


### PR DESCRIPTION
Follow up to a previous PR https://github.com/grafana/scenes/pull/162 where there was a missing script step to build the Scenes library.

Adding it now.