### PR TITLE
SceneAppPage: Add support for custom title

### DIFF
--- a/packages/scenes-app/src/demos/dynamicPage.tsx
+++ b/packages/scenes-app/src/demos/dynamicPage.tsx
@@ -9,6 +9,7 @@ import {
   SceneRefreshPicker,
   SceneAppPageState,
 } from '@grafana/scenes';
+import React from 'react';
 import { demoUrl } from '../utils/utils.routing';
 import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
@@ -28,6 +29,7 @@ export function getDynamicPageDemo(defaults: SceneAppPageState): SceneAppPage {
       const cancel = setTimeout(() => {
         page.setState({
           tabs: [...defaultTabs, getSceneAppPage('/tab2', 'Humidity')],
+          renderTitle: renderTitleWithImageSuffix,
         });
       }, 2000);
       return () => clearTimeout(cancel);
@@ -62,4 +64,13 @@ function getSceneAppPage(url: string, name: string) {
     },
     drilldowns: [],
   });
+}
+
+function renderTitleWithImageSuffix(title: string) {
+  return (
+    <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+      <h1>{title}</h1>
+      <img src="public/img/online.svg" style={{ width: '24px', height: '24px' }} />
+    </div>
+  );
 }

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -65,7 +65,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   }
 
   return (
-    <PluginPage pageNav={pageNav} actions={pageActions}>
+    <PluginPage pageNav={pageNav} actions={pageActions} renderTitle={containerState.renderTitle}>
       <scene.Component model={scene} />
     </PluginPage>
   );

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -25,6 +25,11 @@ export interface SceneAppPageState extends SceneObjectState {
   title: string;
   /** Page subTitle */
   subTitle?: string;
+  /**
+   * Customize title rendering.
+   * Please return an unstyled h1 tag here + any additional elements you need.
+   **/
+  renderTitle?: (title: string) => React.ReactNode;
   /** For an image before title */
   titleImg?: string;
   /** For an icon before title */


### PR DESCRIPTION
Why: 
App observability app needs to show multiple images after title. 

I am torn on how best to expose it
 * Just use the plain renderTitle that Page/PluginPage expose 
 * Use `React.ComponentType<{page: SceneAppPage}>`  component (this way you can define a title component that can be passed the page model).
 * Or titleObject, a full scene object handling title rendering. 
 
