### PR TITLE
VizPanel: Support adding header actions to top right corner of PanelChrome 

### DIFF
--- a/docusaurus/docs/visualizations.md
+++ b/docusaurus/docs/visualizations.md
@@ -38,6 +38,29 @@ in your normal dashboard panels when you view `Panel JSON` from the panel inspec
 
 VizPanel will use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that it will use `$data` set on it's own level or share data with other siblings and scene objects if `$data` is set on any parent level.
 
+
+## Header actions
+
+VizPanel has a property named `headerActions` that can be either a `React.ReactNode` or a custom `SceneObject`. This property is useful if you want to place links or buttons in the top right corner of the panel header. Example:
+
+```ts
+new VizPanel({
+    pluginId: 'timeseries',
+    title: 'Time series',
+    headerActions: (
+      <LinkButton size="sm" variant="secondary" href="scene/sdrilldown/url">Drilldown</LinkButton>
+    )
+})
+```
+
+Placing buttons in the top right corner of the panel header could be used for:
+
+* Links to other scenes
+* Buttons that change the current scene (add drilldown view for example)
+* RadioButtonGroup that changes the visualization settings
+
+For LinkButton, Button and RadioButtonGroup please use size="sm" when placed in the panel header.
+
 ## Custom visualizations
 
 If you want to visualize data yourself in your Grafana app plugin you can do that in two ways. You always have the option to create a custom SceneObject. But then you will not get the PanelChrome with loading state and other features

--- a/packages/scenes-app/src/demos/responsiveLayout.tsx
+++ b/packages/scenes-app/src/demos/responsiveLayout.tsx
@@ -2,13 +2,12 @@ import {
   EmbeddedScene,
   SceneAppPage,
   SceneAppPageState,
-  SceneCanvasText,
   SceneFlexItem,
   SceneFlexItemState,
   SceneFlexLayout,
   VizPanel,
 } from '@grafana/scenes';
-import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
+import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults, getRowWithText } from './utils';
 
 export function getResponsiveLayoutDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
@@ -60,16 +59,6 @@ export function getResponsiveLayoutDemo(defaults: SceneAppPageState) {
         }),
       });
     },
-  });
-}
-
-function getRowWithText(text: string) {
-  return new SceneFlexItem({
-    ySizing: 'content',
-    body: new SceneCanvasText({
-      text,
-      fontSize: 12,
-    }),
   });
 }
 

--- a/packages/scenes-app/src/demos/utils.ts
+++ b/packages/scenes-app/src/demos/utils.ts
@@ -1,6 +1,8 @@
 import {
   QueryRunnerState,
+  SceneCanvasText,
   SceneControlsSpacer,
+  SceneFlexItem,
   SceneQueryRunner,
   SceneRefreshPicker,
   SceneTimePicker,
@@ -34,4 +36,14 @@ export function getEmbeddedSceneDefaults() {
       new SceneRefreshPicker({ isOnCanvas: true }),
     ],
   };
+}
+
+export function getRowWithText(text: string) {
+  return new SceneFlexItem({
+    ySizing: 'content',
+    body: new SceneCanvasText({
+      text,
+      fontSize: 12,
+    }),
+  });
 }

--- a/packages/scenes-app/src/demos/withDrilldown/WithDrilldown.tsx
+++ b/packages/scenes-app/src/demos/withDrilldown/WithDrilldown.tsx
@@ -7,7 +7,7 @@ import {
   SceneFlexLayout,
   SceneQueryRunner,
 } from '@grafana/scenes';
-import { getHumidityOverviewScene, getTemperatureOverviewScene } from './scenes';
+import { getHumidityOverviewScene, getRoomDrilldownScene } from './scenes';
 import { getRoomsTemperatureStats, getRoomsTemperatureTable } from './panels';
 import { getEmbeddedSceneDefaults } from '../utils';
 
@@ -57,14 +57,14 @@ export function getDrilldownsAppPageScene(defaults: SceneAppPageState) {
 
           return new SceneAppPage({
             url: `${defaults.url}/room/${roomName}/temperature`,
-            title: `${roomName} overview`,
+            title: `${roomName}`,
             subTitle: 'This scene is a particular room drilldown. It implements two tabs to organise the data.',
             getParentPage: () => parent,
             tabs: [
               new SceneAppPage({
                 title: 'Temperature',
                 url: `${defaults.url}/room/${roomName}/temperature`,
-                getScene: () => getTemperatureOverviewScene(roomName),
+                getScene: () => getRoomDrilldownScene(roomName),
               }),
               new SceneAppPage({
                 title: 'Humidity',

--- a/packages/scenes-app/src/demos/withDrilldown/scenes.tsx
+++ b/packages/scenes-app/src/demos/withDrilldown/scenes.tsx
@@ -4,7 +4,7 @@ import { DATASOURCE_REF } from '../../constants';
 import { getEmbeddedSceneDefaults } from '../utils';
 import { getRoomTemperatureStatPanel } from './panels';
 
-export function getTemperatureOverviewScene(roomName: string) {
+export function getRoomDrilldownScene(roomName: string) {
   return new EmbeddedScene({
     $data: new SceneQueryRunner({
       datasource: DATASOURCE_REF,

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -18,7 +18,7 @@ import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@gra
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { DeepPartial, SceneObjectState } from '../../core/types';
+import { DeepPartial, SceneObject, SceneObjectState } from '../../core/types';
 
 import { VizPanelRenderer } from './VizPanelRenderer';
 import { VizPanelMenu } from './VizPanelMenu';
@@ -45,6 +45,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   menu?: VizPanelMenu;
   isDraggable?: boolean;
   isResizable?: boolean;
+  headerActions?: React.ReactNode | SceneObject;
   // internal state
   pluginLoadError?: string;
   pluginInstanceState?: any;

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -6,13 +6,24 @@ import { getAppEvents } from '@grafana/runtime';
 import { PanelChrome, ErrorBoundaryAlert, PanelContextProvider } from '@grafana/ui';
 
 import { sceneGraph } from '../../core/sceneGraph';
-import { SceneComponentProps } from '../../core/types';
+import { isSceneObject, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
-  const { title, description, options, fieldConfig, pluginLoadError, $data, displayMode, hoverHeader, menu, ...state } =
-    model.useState();
+  const {
+    title,
+    description,
+    options,
+    fieldConfig,
+    pluginLoadError,
+    $data,
+    displayMode,
+    hoverHeader,
+    menu,
+    headerActions,
+    ...state
+  } = model.useState();
   const [ref, { width, height }] = useMeasure();
   const plugin = model.getPlugin();
   const parentLayout = sceneGraph.getLayout(model);
@@ -61,6 +72,16 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     panelMenu = <menu.Component model={menu} />;
   }
 
+  let actionsElement: React.ReactNode | undefined;
+
+  if (headerActions) {
+    if (isSceneObject(headerActions)) {
+      actionsElement = <headerActions.Component model={headerActions} />;
+    } else {
+      actionsElement = headerActions;
+    }
+  }
+
   // Data is always returned. For non-data panels, empty PanelData is returned.
   const data = dataWithFieldConfig!;
 
@@ -78,6 +99,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           hoverHeader={hoverHeader}
           titleItems={titleItems}
           dragClass={dragClass}
+          actions={actionsElement}
           dragClassCancel={dragClassCancel}
           padding={plugin.noPadding ? 'none' : 'md'}
           menu={panelMenu}


### PR DESCRIPTION
Want to polish up the Grafana monitoring scene to use for demos during GrafanaCon, so needed actions.

Think this is a pretty straight forward way to expose it.

Allow either react nodes or a scene object.

React node should be useful for links to other places while a scene object
could be more useful if it's a button that changes state on current scene.
