### PR TITLE
Docs: Getting started section copy edit

### DIFF
--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -5,17 +5,17 @@ title: Core concepts
 
 ## Scene
 
-Scene is a collection of objects, called scene objects. These objects represent different aspects of the Scene: data, time ranges, variables, layout, visualizations. Combined together, scene objects form an object tree.
+A scene is a collection of objects, called _scene objects_. These objects represent different aspects of the scene: data, time ranges, variables, layout, and visualizations. Together, scene objects form an _object tree_:
 
 ![Scene objects tree](../docs/assets/sceneTree.png)
 
-Scene allows to group and nest object. Things like data, time range or variables can be added to any object in the tree, making them accessible to that object and all descendant objects. Thanks to this, Scene allows to create dashboards that have multiple time ranges, queries that can be shared and transformed, or nested variables.
+Scenes allow you to group and nest object. Things like data, time ranges, or variables can be added to any object in the tree, making them accessible to that object and all descendant objects. Because of this, scenes allow you to create dashboards that have multiple time ranges, queries that can be shared and transformed, or nested variables.
 
-@grafana/scenes comes with multiple objects to solve common problems, like `SceneQueryRunner`, `SceneFlexLayout`, `VizPanel` and more. But you can also create your own scene objects to extend the functionality.
+@grafana/scenes comes with multiple objects&#151;like `SceneQueryRunner`, `SceneFlexLayout`, `VizPanel` and more&#151;to solve common problems. However, you can also create your own scene objects to extend functionality.
 
 ## Scene object
 
-Scene is built from atomic objects called scene objects. Here's an example of a simple Counter scene object:
+Each scene is built from atomic objects called scene objects. Here's an example of a simple `Counter` scene object:
 
 ```tsx
 import React from 'react';
@@ -58,7 +58,7 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 
 ## State
 
-Scene object can have a state. The shape of object's state is expressed via an interface that _must_ extend `SceneObjectState` interface:
+A scene object can have a state. The shape of the object's state is expressed through an interface that _must_ extend the `SceneObjectState` interface:
 
 ```tsx
 interface CounterState extends SceneObjectState {
@@ -66,9 +66,9 @@ interface CounterState extends SceneObjectState {
 }
 ```
 
-### Subscribing to state changes
+### Subscribe to state changes
 
-The component can read the state from scene object by using `model` prop that it receives when rendered. To subscribe to state changes, call `model.useState` method.
+A component can read the state from a scene object by using the `model` property that it receives when rendered. To subscribe to state changes, call the `model.useState` method:
 
 ```tsx
 function CounterRenderer({ model }: SceneComponentProps<Counter>) {
@@ -78,11 +78,11 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 }
 ```
 
-Subscribing to object's state using `model.useState()` will make the component reactive to state changes. Every change to the scene object state is immutable and will cause a re-render of the component.
+Subscribing to an object's state using `model.useState()` will make the component reactive to state changes. Every change to the scene object state is immutable and will cause a re-render of the component.
 
-### Modifying state
+### Modify state
 
-To change the state of the scene object, use `setState` method that each scene object has. This can be done directly from the component:
+To change the state of the scene object, use the `setState` method that each scene object has. This can be done directly from the component:
 
 ```tsx
 function CounterRenderer({ model }: SceneComponentProps<Counter>) {
@@ -93,7 +93,7 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 }
 ```
 
-Or in the scene object class:
+This can also be done the scene object class:
 
 ```tsx
 export class Counter extends SceneObjectBase<CounterState> {
@@ -118,12 +118,12 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 ```
 
 :::note
-We suggest to implement the state-modifying methods in the scene object rather than component to separate the model complexity from the component.
+We suggest that you implement the state-modifying methods in the scene object rather than in the component to separate the model complexity from the component.
 :::
 
 ## Data and time range
 
-Use `$data` property to add data coming from Grafana data sources to a Scene. Queries are configured via `SceneQueryRunner` scene object.
+Use the `$data` property to add data coming from Grafana data sources to a scene. Queries are configured using the `SceneQueryRunner` scene object:
 
 ```tsx
 import { SceneQueryRunner } from '@grafana/scenes';
@@ -143,10 +143,10 @@ const queryRunner = new SceneQueryRunner({
 ```
 
 :::info
-Keep in mind that your Grafana instance must have specified data source configured.
+Keep in mind that your Grafana instance must have a specified data source configured.
 :::
 
-For `SceneQueryRunner` to work, a time range has to be added to a Scene. Each scene object has `$timeRange` property to which `SceneTimeRange` scene object can be added. To specify time range for the query runner created in previous example, add `$timeRange` property in the object passed to the constructor:
+For `SceneQueryRunner` to work, a time range has to be added to a scene. Each scene object has a `$timeRange` property to which the `SceneTimeRange` scene object can be added. To specify a time range for the query runner created in the previous example, add the `$timeRange` property in the object passed to the constructor:
 
 ```tsx
 import { SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
@@ -166,7 +166,7 @@ const queryRunner = new SceneQueryRunner({
 });
 ```
 
-Add created `queryRunner` to your scene. Each object in the scene will now be able to access the provided data:
+Add the created `queryRunner` to your scene. Each object in the scene will now be able to access the provided data:
 
 ```ts
 const scene = new EmbeddedScene({
@@ -175,9 +175,9 @@ const scene = new EmbeddedScene({
 })
 ```
 
-Each scene object has `$data` and `$timeRange` property that can be configured. Given that Scene is a objects tree, data provided via `SceneQueryRunner` and time range configured via `SceneTimeRange` is accessible to the object those are added to _and_ all descendant objects.
+Each scene object has a `$data` and `$timeRange` property that can be configured. Because a scene is an object tree, the data and time range configured through `SceneQueryRunner` and `SceneTimeRange` respectively are accessible to the objects they're  added to _and_ all descendant objects.
 
-In the following example, each `VizPanel` use different data. Panel A uses data defined on the `EmbeddedScene`, while Panel B has it's own data and time range configured:
+In the following example, each `VizPanel` uses different data. Panel "A" uses data defined on the `EmbeddedScene`, while Panel "B" has it's own data and time range configured:
 
 ```tsx
 // Scene data, used by Panel A

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -3,7 +3,7 @@ id: core-concepts
 title: Core concepts
 ---
 
-This page explains the core concepts of Scenes and how to use them in creating your own scene.
+This topic explains the core concepts of Scenes and how to use them in creating your own scene.
 
 ## Scene
 

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -3,6 +3,8 @@ id: core-concepts
 title: Core concepts
 ---
 
+This page explains the core concepts of Scenes and how to use them in creating your own scene.
+
 ## Scene
 
 A scene is a collection of objects, called _scene objects_. These objects represent different aspects of the scene: data, time ranges, variables, layout, and visualizations. Together, scene objects form an _object tree_:
@@ -11,7 +13,7 @@ A scene is a collection of objects, called _scene objects_. These objects repres
 
 Scenes allow you to group and nest object. Things like data, time ranges, or variables can be added to any object in the tree, making them accessible to that object and all descendant objects. Because of this, scenes allow you to create dashboards that have multiple time ranges, queries that can be shared and transformed, or nested variables.
 
-@grafana/scenes comes with multiple objects&#151;like `SceneQueryRunner`, `SceneFlexLayout`, `VizPanel` and more&#151;to solve common problems. However, you can also create your own scene objects to extend functionality.
+@grafana/scenes comes with multiple objects&#151;like `SceneQueryRunner`, `SceneFlexLayout`, `VizPanel`, and more&#151;to solve common problems. However, you can also create your own scene objects to extend functionality.
 
 ## Scene object
 
@@ -143,10 +145,10 @@ const queryRunner = new SceneQueryRunner({
 ```
 
 :::info
-Keep in mind that your Grafana instance must have a specified data source configured.
+Your Grafana instance must have a specified data source configured.
 :::
 
-For `SceneQueryRunner` to work, a time range has to be added to a scene. Each scene object has a `$timeRange` property to which the `SceneTimeRange` scene object can be added. To specify a time range for the query runner created in the previous example, add the `$timeRange` property in the object passed to the constructor:
+For `SceneQueryRunner` to work, you must add a time range to a scene. Each scene object has a `$timeRange` property to which the `SceneTimeRange` scene object can be added. To specify a time range for the query runner created in the previous example, add the `$timeRange` property in the object passed to the constructor:
 
 ```tsx
 import { SceneQueryRunner, SceneTimeRange } from '@grafana/scenes';
@@ -177,7 +179,7 @@ const scene = new EmbeddedScene({
 
 Each scene object has a `$data` and `$timeRange` property that can be configured. Because a scene is an object tree, the data and time range configured through `SceneQueryRunner` and `SceneTimeRange` respectively are accessible to the objects they're  added to _and_ all descendant objects.
 
-In the following example, each `VizPanel` uses different data. Panel "A" uses data defined on the `EmbeddedScene`, while Panel "B" has it's own data and time range configured:
+In the following example, each `VizPanel` uses different data. "Panel A" uses data defined on the `EmbeddedScene`, while "Panel B" has its own data and time range configured:
 
 ```tsx
 // Scene data, used by Panel A

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -11,13 +11,15 @@ Add @grafana/scenes to your Grafana App Plugin by running the following command 
 yarn add @grafana/scenes
 ```
 
-Or use Scene App template to start from scratch: [Create new Scene App](https://github.com/grafana/scenes-app-template/generate)
+Conversely, use the [Scenes app template](https://github.com/grafana/scenes-app-template/generate) to start from scratch.
 
-## Hello World Scene
+## Hello World scene
 
-### Creating Scene
+The following instructions show you how to set up the "Hello World" scene.
 
-Create your first Scene using the snippet below. The following code will create a Scene that contains Grafana Text panel within a flex layout.
+### 1. Create a scene
+
+Create your first Scene using the snippet below. The following code will create a scene that contains a Grafana Text panel within a flex layout:
 
 ```ts
 // helloWorldScene.ts
@@ -45,9 +47,9 @@ function getScene() {
 }
 ```
 
-### Rendering Scene
+### 2. Render a scene
 
-Use the following code in your Grafana App Plugin page to render the Hello World scene:
+Use the following code in your Grafana App Plugin page to render the "Hello World" scene:
 
 ```tsx
 import React from 'react';

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -3,7 +3,9 @@ id: getting-started
 title: Set up Scenes
 ---
 
-### Installation
+This page shows you how to install Scenes and create your first "Hello World" scene.
+
+## Installation
 
 Add @grafana/scenes to your Grafana App Plugin by running the following command in your project:
 
@@ -19,7 +21,7 @@ The following instructions show you how to set up the "Hello World" scene.
 
 ### 1. Create a scene
 
-Create your first Scene using the snippet below. The following code will create a scene that contains a Grafana Text panel within a flex layout:
+Create your first scene using the snippet below. The following code will create a scene that contains a Grafana Text panel within a flex layout:
 
 ```ts
 // helloWorldScene.ts

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -3,7 +3,7 @@ id: getting-started
 title: Set up Scenes
 ---
 
-This page shows you how to install Scenes and create your first "Hello World" scene.
+This topic describes how to install Scenes and create your first "Hello World" scene.
 
 ## Installation
 
@@ -17,7 +17,7 @@ Conversely, use the [Scenes app template](https://github.com/grafana/scenes-app-
 
 ## Hello World scene
 
-The following instructions show you how to set up the "Hello World" scene.
+The following instructions describe how to set up the "Hello World" scene.
 
 ### 1. Create a scene
 

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -7,7 +7,7 @@ This page shows you how to install Scenes and create your first "Hello World" sc
 
 ## Installation
 
-Add @grafana/scenes to your Grafana App Plugin by running the following command in your project:
+Add @grafana/scenes to your Grafana app plugin by running the following command in your project:
 
 ```bash
 yarn add @grafana/scenes
@@ -51,7 +51,7 @@ function getScene() {
 
 ### 2. Render a scene
 
-Use the following code in your Grafana App Plugin page to render the "Hello World" scene:
+Use the following code in your Grafana app plugin page to render the "Hello World" scene:
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Style/wording/grammar edits for topics `getting-started.md` and `core-concepts.md`
Also adds some intro text to avoid stacked headings.

@dprokop I've left a couple questions in the text