### PR TITLE
Docs: Advanced usage section copy edit

### DIFF
--- a/docusaurus/docs/advanced-activation-handlers.md
+++ b/docusaurus/docs/advanced-activation-handlers.md
@@ -5,11 +5,13 @@ title: Activation handlers
 
 Activation handlers are useful tool for providing external behaviors to scene objects. When a scene object is mounted, activation handlers are called.
 
-Activation handlers, similar to React's `useEffect`, return a `function(deactivation handler)` that should be used to clean up all behaviors added in an activation handler. A deactivation handler is called when a scene object is unmounted.
+Similarly to React's `useEffect`, activation handlers return a `function(deactivation handler)` that should be used to clean up all behaviors added in an activation handler. A deactivation handler is called when a scene object is unmounted.
 
 :::info
 Activation handlers are especially useful if you want to add external behaviors to core scene objects. They reduce the need for implementing custom scene objects that would handle scene object connections.
 :::
+
+This topic describes how to create and use activation handlers.
 
 ## Add activation handlers
 

--- a/docusaurus/docs/advanced-activation-handlers.md
+++ b/docusaurus/docs/advanced-activation-handlers.md
@@ -5,17 +5,19 @@ title: Activation handlers
 
 Activation handlers are useful tool for providing external behaviors to scene objects. When a scene object is mounted, activation handlers are called.
 
-Activation handlers, similar to React's `useEffect`, return a function(deactivation handler), that should be used to clean up all behaviors added in activation handler. Deactivation handler is called when a scene object is unmounted.
+Activation handlers, similar to React's `useEffect`, return a `function(deactivation handler)` that should be used to clean up all behaviors added in an activation handler. A deactivation handler is called when a scene object is unmounted.
 
 :::info
-Activation handlers are especially usefull if you want to add external behaviors to core scene objects. They reduce a need for implementing custom scene objects that would handle scene objects connections.
+Activation handlers are especially useful if you want to add external behaviors to core scene objects. They reduce the need for implementing custom scene objects that would handle scene object connections.
 :::
 
-## Adding activation handler
+## Add activation handlers
+
+Follow these steps to create an activation handler.
 
 ### Step 1. Create a scene
 
-Start with creating a scene that renders a single timeseries panel:
+Start by creating a scene that renders a single time series panel:
 
 ```ts
 const queryRunner = new SceneQueryRunner({
@@ -52,9 +54,9 @@ const scene = new EmbeddedScene({
 });
 ```
 
-### Step 2. Add activation handler
+### Step 2. Add an activation handler
 
-Add activation handler to SceneQueryRunner that subscribe to state changes and log current state. Keep in mind that subscription to state will not be created until SceneQueryRunner is activated:
+Add an activation handler to `SceneQueryRunner` that subscribes to state changes and logs the current state. Keep in mind that a subscription to state won't be created until `SceneQueryRunner` is activated:
 
 ```ts
 queryRunner.addActivationHandler(() => {
@@ -64,9 +66,9 @@ queryRunner.addActivationHandler(() => {
 });
 ```
 
-### Step 3. Return deactivation handler
+### Step 3. Return a deactivation handler
 
-From the activation handler, return a function that will unsubscribe from `queryRunner` state changes when object is de-activated:
+From the activation handler, return a function that will unsubscribe from `queryRunner` state changes when the object is deactivated:
 
 ```ts
 queryRunner.addActivationHandler(() => {

--- a/docusaurus/docs/advanced-custom-scene-objects.md
+++ b/docusaurus/docs/advanced-custom-scene-objects.md
@@ -3,13 +3,15 @@ id: advanced-custom-scene-objects
 title: Custom scene objects
 ---
 
-Scenes comes with extensibility in mind. On top of the library primitives you can build your own custom scene objects that extend basic functionality of the library.
+Scenes comes with extensibility in mind. In addition to the library primitives, you can build your own custom scene objects that extend the basic functionality of the library. This topic describes how to create a custom object.
 
-## Create custom scene object
+## Create a custom scene object
 
-### Step 1. Define state type of the custom object
+Follow these steps to create a custom scene object.
 
-Start with defining the state type for your custom object. This interface must extend `SceneObjectState` interface:
+### Step 1. Define the state type of the custom object
+
+Start by defining the state type for your custom object. This interface must extend the `SceneObjectState` interface:
 
 ```ts
 interface CounterState extends SceneObjectState {
@@ -17,9 +19,9 @@ interface CounterState extends SceneObjectState {
 }
 ```
 
-### Step 2. Implement custom object class
+### Step 2. Implement a custom object class
 
-Implement class for custom scene object. This class must extend `SceneObjectBase` class:
+Implement a class for the custom scene object. This class must extend the `SceneObjectBase` class:
 
 ```ts
 export class Counter extends SceneObjectBase<CounterState> {
@@ -29,9 +31,9 @@ export class Counter extends SceneObjectBase<CounterState> {
 }
 ```
 
-### Step 3. Implement custom object renderer
+### Step 3. Implement a custom object renderer
 
-Implement React component that will be shown when custom object is used in scene. This component must use `SceneComponentProps<T extends SceneObjectBase>` type for props:
+Implement a React component that will be shown when the custom object is used in a scene. This component must use the `SceneComponentProps<T extends SceneObjectBase>` type for props:
 
 ```ts
 function CounterRenderer(props: SceneComponentProps<Counter>) {
@@ -39,7 +41,7 @@ function CounterRenderer(props: SceneComponentProps<Counter>) {
 }
 ```
 
-Set renderer for `Counter` custom object using `static Component` property:
+Set a renderer for the `Counter` custom object using the `static Component` property:
 
 ```ts
 export class Counter extends SceneObjectBase<CounterState> {
@@ -48,9 +50,9 @@ export class Counter extends SceneObjectBase<CounterState> {
 }
 ```
 
-### Step 4. Use custom object state in renderer
+### Step 4. Use a custom object state in the renderer
 
-Use `model` property passed to the component and subscribe to its state using `model.useState()` hook. Any changes to the object state will re-render the component:
+Use the `model` property passed to the component and subscribe to its state using the `model.useState()` hook. Any changes to the object state will re-render the component:
 
 ```ts
 function CounterRenderer({ model }: SceneComponentProps<Counter>) {
@@ -64,9 +66,9 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 }
 ```
 
-### Step 5. Modify state of custom object from component
+### Step 5. Modify the state of the custom object from the component
 
-Defined state-modifying method (`onIncrement`) in custom scene object:
+Define the state-modifying method (`onIncrement`) in the custom scene object:
 
 ```ts
 export class Counter extends SceneObjectBase<CounterState> {
@@ -79,7 +81,7 @@ export class Counter extends SceneObjectBase<CounterState> {
 }
 ```
 
-Use `onIncrement` method in the renderer:
+Use the `onIncrement` method in the renderer:
 
 ```ts
 function CounterRenderer({ model }: SceneComponentProps<Counter>) {
@@ -94,9 +96,9 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 }
 ```
 
-### Step 6. Use custom object in scene
+### Step 6. Use the custom object in a scene
 
-Now your custom scene object `Counter` is ready to be used in scene. Create a scene that uses it:
+Now your custom scene object, `Counter`, is ready to be used in a scene. Create a scene that uses it:
 
 ```ts
 const myScene = new EmbeddedScene({

--- a/docusaurus/docs/advanced-custom-scene-objects.md
+++ b/docusaurus/docs/advanced-custom-scene-objects.md
@@ -5,7 +5,7 @@ title: Custom scene objects
 
 Scenes comes with extensibility in mind. In addition to the library primitives, you can build your own custom scene objects that extend the basic functionality of the library. This topic describes how to create a custom object.
 
-## Create a custom scene object
+## Create custom scene objects
 
 Follow these steps to create a custom scene object.
 

--- a/docusaurus/docs/advanced-custom-scene-objects.md
+++ b/docusaurus/docs/advanced-custom-scene-objects.md
@@ -68,7 +68,7 @@ function CounterRenderer({ model }: SceneComponentProps<Counter>) {
 
 ### Step 5. Modify the state of the custom object from the component
 
-Define the state-modifying method (`onIncrement`) in the custom scene object:
+Define the state-modifying method, (`onIncrement`), in the custom scene object:
 
 ```ts
 export class Counter extends SceneObjectBase<CounterState> {

--- a/docusaurus/docs/advanced-data.md
+++ b/docusaurus/docs/advanced-data.md
@@ -3,15 +3,15 @@ id: advanced-data
 title: Data and time range in custom scene object
 ---
 
-Custom scene objects can use data and time range added to scene to perform additional operations. To read more about data and time range configuration please read [Data and time range](./core-concepts#data-and-time-range) first.
+Custom scene objects can use data and time range information added to a scene to perform additional operations. To read more about data and time range configuration, refer to [Data and time range](./core-concepts#data-and-time-range) first.
 
 ## Use data
 
-In custom scene object use `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that it will use `$data` set on it's own level or share data with other siblings and scene objects if `$data` is set on any parent level.
+In a custom scene object, use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that the custom object will use `$data` set on its own level or use shared data with other siblings and scene objects if `$data` is set on any parent level.
 
-### Use data in renderer
+### Use data in a renderer
 
-In your custom scene object renderer you can subscribe to the closest `SceneDataProvider` by using `sceneGraph.getData` utility:
+In your custom scene object renderer, you can subscribe to the closest `SceneDataProvider` by using the `sceneGraph.getData` utility:
 
 ```ts
 import { sceneGraph, SceneObjectState, SceneObjectBase, SceneComponentProps } from '@grafana/scenes';
@@ -31,9 +31,9 @@ function CustomObjectRenderer({ model }: SceneComponentProps<CustomObject>) {
 }
 ```
 
-### Use data in custom object class
+### Use data in a custom object class
 
-You can also use data in your custom object class. To do that use [activation handler](./advanced-activation-handlers.md). In the activation handler get the closest `SceneDataProvider` using `sceneGraph.getData(this)`. Then, subscribe to `SceneDataProvider` state changes using `subscribeToStata` method of the `SceneObjectBase`:
+You can also use data in your custom object class. To do so, use an [activation handler](./advanced-activation-handlers.md). In the activation handler, get the closest `SceneDataProvider` using `sceneGraph.getData(this)`. Then, subscribe to `SceneDataProvider` state changes using the `subscribeToState` method of the `SceneObjectBase`:
 
 ```ts
 class CustomObject extends SceneObjectBase<CustomObjectState> {
@@ -51,9 +51,9 @@ class CustomObject extends SceneObjectBase<CustomObjectState> {
 ```
 
 :::info
-Not that the subscription returned from `sourceData.subscribeToState` is added to `this._subs`. Thanks to that, you don't need to do any cleanup when the custom object is destroyed, as the library will take care of unsubscribing.
+Note that the subscription returned from `sourceData.subscribeToState` is added to `this._subs`. Because of this, you don't need to do any cleanup when the custom object is destroyed, as the library will take care of unsubscribing.
 :::
 
 ## Use time range
 
-Similarly to data, you can use the closest time range in custom scene object. Use `sceneGraph.getTimeRange(model)` to get the closest time range scene object. This method can be used both in the custom object class and rendere as describe in above in [Use data](#use-data) section
+Similarly to data, you can use the closest time range in a custom scene object. Use `sceneGraph.getTimeRange(model)` to get the closest time range scene object. This method can be used both in the custom object class and the renderer as described previously in the [Use data](#use-data) section.

--- a/docusaurus/docs/advanced-data.md
+++ b/docusaurus/docs/advanced-data.md
@@ -1,13 +1,15 @@
 ---
 id: advanced-data
-title: Data and time range in custom scene object
+title: Data and time range in custom scene objects
 ---
 
-Custom scene objects can use data and time range information added to a scene to perform additional operations. To read more about data and time range configuration, refer to [Data and time range](./core-concepts#data-and-time-range) first.
+Custom scene objects can use data and time range information added to a scene to perform additional operations. This topic describes how to use these properties in renderers and custom object classes. 
+
+To learn more about data and time range configuration, refer to [Data and time range](./core-concepts#data-and-time-range) first.
 
 ## Use data
 
-In a custom scene object, use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that the custom object will use `$data` set on its own level or use shared data with other siblings and scene objects if `$data` is set on any parent level.
+In a custom scene object, use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that the custom object will use the `$data` property set on its own level or use shared data with other siblings and scene objects if `$data` is set on any parent level.
 
 ### Use data in a renderer
 
@@ -51,9 +53,9 @@ class CustomObject extends SceneObjectBase<CustomObjectState> {
 ```
 
 :::info
-Note that the subscription returned from `sourceData.subscribeToState` is added to `this._subs`. Because of this, you don't need to do any cleanup when the custom object is destroyed, as the library will take care of unsubscribing.
+The subscription returned from `sourceData.subscribeToState` is added to `this._subs`. Because of this, you don't need to do any cleanup when the custom object is destroyed, as the library will take care of unsubscribing.
 :::
 
 ## Use time range
 
-Similarly to data, you can use the closest time range in a custom scene object. Use `sceneGraph.getTimeRange(model)` to get the closest time range scene object. This method can be used both in the custom object class and the renderer as described previously in the [Use data](#use-data) section.
+Similarly to data, you can use the closest time range in a custom scene object using `sceneGraph.getTimeRange(model)`. This method can be used both in the custom object class and the renderer, as described previously in the [Use data](#use-data) section.


### PR DESCRIPTION
Style/wording/grammar edits for topics `advanced-activation-handlers.md`, `advanced-custom-scene-objects.md`, and `advanced-data.md`.
Also adds some intro text to state what information is in the topic.