### PR TITLE
Docs: Scene objects section copy edit

### DIFF
--- a/docusaurus/docs/advanced-data.md
+++ b/docusaurus/docs/advanced-data.md
@@ -7,7 +7,7 @@ Custom scene objects can use data and time range added to scene to perform addit
 
 ## Use data
 
-In custom scene object use `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that it will use `$data` set on it's own level or share data with other siblings and scene objects if `$data` is set on any parent level.
+In custom scene object use `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. This means it uses `$data` set on its own level or shares data with other siblings and scene objects if `$data` is set on any parent level.
 
 ### Use data in renderer
 

--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -121,7 +121,7 @@ const tablePanel = new VizPanel({
 The above panel will have links for all values of the `handler` field. Clicking on a value will redirect to a particular endpoint drill-down URL that will show a "Not found page" error. We'll set up this page in the next step.
 
 :::note
-The `fieldConfig` options are the same options you would see in your normal dashboard panels when you view `Panel JSON` from the Table panel inspect drawer. To access panel inspect drawer, click **Inspect** in the panel edit menu.
+The `fieldConfig` options are the same options you would see in typical dashboard panels when you view **Panel JSON** from the Table panel inspect drawer. To access panel inspect drawer, click **Inspect** in the panel edit menu.
 :::
 
 :::info

--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -3,15 +3,15 @@ id: scene-layout
 title: Building a scene layout
 ---
 
-Scenes support two layout types: flex and grid layout. In this guide you will learn how to use and configure `SceneFlexLayout` and `SceneGridLayout`.
+Scenes support two layout types: flex and grid layout. In this guide, you'll learn how to use and configure `SceneFlexLayout` and `SceneGridLayout`.
 
 ## Flexbox layout
 
-`SceneFlexLayout` allows building flexible scenes with layout driven by browser's CSS flexbox layout. This allows for defining very dynamic layouts where panel widths and heights can adapt to the available space.
+`SceneFlexLayout` allows you to build flexible scenes with layouts driven by the browser's CSS flexbox layout. This lets you to define very dynamic layouts where panel widths and heights can adapt to the available space.
 
 ### Step 1. Create a scene
 
-Start using flexbox layout by creating a scene with `body` configured as `SceneFlexLayout`:
+Start using the flexbox layout by creating a scene with `body` configured as `SceneFlexLayout`:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -21,12 +21,12 @@ const myScene = new EmbeddedScene({
 
 ### Step 2. Configure flexbox layout
 
-`SceneFlexLayout` allows flexbox behavior configuration. You can configuere the following properties:
+`SceneFlexLayout` allows flexbox behavior configuration. You can configure the following properties:
 
-- `direction` - configure the main axis of flexbox layout. Children placed within the layout will follow it's direction.
-- `wrap` - configure behavior of layout children. By default, children will try to fit into one line.
+- `direction` - Configures the main axis of flexbox layout. Children placed within the layout follow its direction.
+- `wrap` - Configures the behavior of layout children. By default, children try to fit into one line.
 
-By default SceneFlexLayout uses `row` direction. To create colum layout, try the following code:
+By default, `SceneFlexLayout` uses `row` direction. To create a column layout, use the following code:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -38,8 +38,8 @@ const myScene = new EmbeddedScene({
 
 ### Step 3. Add layout children
 
-`SceneFlexLayout` has `children` property. It accepts an array of `SceneFlexItem` or `SceneFlexLayout` objects.
-Create scene with two, equally sized layout items in a column:
+`SceneFlexLayout` has a `children` property. It accepts an array of `SceneFlexItem` or `SceneFlexLayout` objects.
+Create a scene with two, equally sized layout items in a column:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -50,7 +50,7 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-Both `ScenFlexLayout` and `SceneFlexItem` object types accept the following configuration options that allow size constraints and behaviors:
+Both `SceneFlexLayout` and `SceneFlexItem` object types accept the following configuration options that allow size constraints and behaviors:
 
 ```ts
   flexGrow?: CSSProperties['flexGrow'];
@@ -67,12 +67,12 @@ Both `ScenFlexLayout` and `SceneFlexItem` object types accept the following conf
   md?: SceneFlexItemPlacement;
 ```
 
-We really recommend setting a minHeight on all children of layout that use `column` direction. This will make sure that they don't get squashed too much on smaller screens. If you set minHeight or height on a SceneFlexLayout you do not need
-to set it on each child as they will inherit these constraints.
+We strongly recommend setting a `minHeight` on all children of the layout that use `column` direction. This ensures that they aren't overly compressed on smaller screens. If you set `minHeight` or `height` on the `SceneFlexLayout` object, you don't need
+to set it on each child, as they will inherit these constraints.
 
 ### Step 4. Add panels to flex layout items
 
-The above example sets up layout for your scene. To visualize data, [configure `SceneQueryRunner`](./core-concepts.md#data-and-time-range) and add it to your scene first:
+The preceding example sets up a layout for your scene. To visualize data, [configure `SceneQueryRunner`](./core-concepts.md#data-and-time-range) and add it to your scene:
 
 ```ts
 const queryRunner = new SceneQueryRunner({
@@ -98,7 +98,7 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-Next, add `VizPanel` objects as `body` of layout items:
+Next, add `VizPanel` objects as the `body` of the layout items:
 
 ```ts
 const queryRunner = new SceneQueryRunner({
@@ -136,23 +136,23 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-The above example will render two panels, a Timeseries and a Table panel.
+This will render two panels, a Time series and a Table panel.
 
 :::note
-For `SceneFlexItems` that contain a `VizPanel`, it's usually a good idea to set `minHeight` or `minWidth` constraints so they don't get squashed too small by limited screen space.
+For `SceneFlexItems` that contain `VizPanel` objects, it's recommended that you set `minHeight` or `minWidth` constraints so the panels aren't overly compressed by limited screen space.
 :::
 
 ### Responsive flex layouts
 
-By default SceneFlexLayout has some responsive behaviors for smaller screens. These kick in for screens that match the media query of Grafana's theme.breakpoints.down('md').
+By default, `SceneFlexLayout` has some responsive behaviors for smaller screens:
 
-* SceneFlexLayout direction will change from row to column.
-* SceneFlexLayout maxWidth, maxHeight, height or width constraints are removed.
-* SceneFlexLayout and SceneFlexItem will use the minHeight or height set on the parent layout (unless specified on it directly). This is to make a height or minHeight constraint set on a SceneFlexLayout with direction row also apply to it's children so that when the responsive media query that changes direction to column kicks in these constaints are still acting on the children.
+* `SceneFlexLayout` direction changes from `row` to `column`.
+* `SceneFlexLayout` `maxWidth`, `maxHeight`, `height` or `width` constraints are removed.
+* `SceneFlexLayout` and `SceneFlexItem` uses the `minHeight` or `height` set on the parent layout (unless specified on it directly). This is to force a `height` or `minHeight` constraint set on a `SceneFlexLayout` with direction `row` to also apply to its children so that when the responsive media query that changes the direction to `column` is triggered, these constraints continue acting on the children.
 
-You can override these behaviors and set custom direction and size constraints using the `md` property that exist on both SceneFlexLayout and SceneFlexItem.
+These behaviors are triggered for screens that match the media query of Grafana's theme.breakpoints.down('md').
 
-Example:
+You can override these behaviors and set custom direction and size constraints using the `md` property that exists on both `SceneFlexLayout` and `SceneFlexItem`. For example:
 
 ```ts
 new SceneFlexLayout({
@@ -166,11 +166,11 @@ new SceneFlexLayout({
 }),
 ```
 
-In the above example we use the `md` property to override the default responsive behavior that changes a `row` layout to a `column` layout. We also apply a tighter minHeight constraint.
+In the preceding example, we use the `md` property to override the default responsive behavior that changes a row layout to a column layout. We also apply a tighter `minHeight` constraint.
 
 ## Grid layout
 
-`SceneGridLayout` allows building scenes as grids. This is the default behavior of Dashboards in Grafana, and grid layout enables adding a similar experience to your scene.
+`SceneGridLayout` allows you to build scenes as grids. This is the default behavior of Dashboards in Grafana, and grid layout lets you add a similar experience to your scene.
 
 ### Step 1. Create a scene
 
@@ -188,8 +188,8 @@ const myScene = new EmbeddedScene({
 
 You can configure the following properties:
 
-- `isDraggable` - configure whether or not grid items can be moved.
-- `isLazy` - configure whether or not grid items should be initialized when they are outside of the viewport.
+- `isDraggable` - Configures whether or not grid items can be moved.
+- `isLazy` - Configures whether or not grid items should be initialized when they are outside of the viewport.
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -202,8 +202,8 @@ const myScene = new EmbeddedScene({
 
 ### Step 3. Add layout children
 
-`SceneGridLayout` has `children` property. It accepts an array of `SceneGridItem` or `SceneGridRow` objects.
-Create scene with two grid item in a row:
+`SceneGridLayout` has a `children` property. It accepts an array of `SceneGridItem` or `SceneGridRow` objects.
+Create a scene with two grid items in a row:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -230,7 +230,7 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-`SceneGridItem` accepts the following configuration options. Options are expressed in 24 columns grid units.
+`SceneGridItem` accepts the following configuration options, which are expressed in 24 columnar grid units:
 
 ```ts
   x?: number;
@@ -241,7 +241,7 @@ const myScene = new EmbeddedScene({
 
 ### Step 4. Add panels to grid layout items
 
-[Similarily to flexbox layout](#step-4-add-panels-to-flex-layout-items), add `VizPanel` to `SceneGridItem` to show visualized data:
+Add `VizPanel` to `SceneGridItem` to show visualized data:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -279,10 +279,10 @@ const myScene = new EmbeddedScene({
 
 ### Step 5. Add a grid row
 
-Grid row is a layout item that groups other `SceneGridItems` into a collapsible row. Use `SceneGridRow` add a row to Scene:
+A grid row is a layout item that groups other `SceneGridItems` into a collapsible row. Use `SceneGridRow` to add a row to a scene:
 
 :::note
-In `SceneGridRow` the `x` and `y` coordinates are relative to the row.
+In `SceneGridRow`, the `x` and `y` coordinates are relative to the row.
 :::
 
 ```ts

--- a/docusaurus/docs/transformations.md
+++ b/docusaurus/docs/transformations.md
@@ -95,7 +95,7 @@ const transformedData = new SceneDataTransformer({
 ```
 
 :::note
-Objects used in `transformations` are the same transformation configuration objects you would see in your normal dashboard panels when you view `Panel JSON` from the panel inspect drawer. To access panel inspect drawer, click **Inspect** in the panel edit menu.
+Objects used in `transformations` are the same transformation configuration objects you would see in a typical dashboard panel when you view the **JSON** tab in the panel inspect drawer. To access this tab, click **Inspect > Panel JSON** in the panel edit menu.
 :::
 
 Use the newly created `transformedData` object in place of the previously used `SceneQueryRunner`:

--- a/docusaurus/docs/transformations.md
+++ b/docusaurus/docs/transformations.md
@@ -7,7 +7,7 @@ title: Transformations
 **Before you begin**: You must already know about [connecting data in Scenes apps](./core-concepts.md#data-and-time-range) before continuing with this guide.
 :::
 
-Transformations are a powerful way to manipulate data returned by `SceneQueryRunner` before Scenes renders a visualization. Using transformations, you can:
+Transformations are a powerful way to manipulate data returned by the `SceneQueryRunner` object before scenes render a visualization. Using transformations, you can:
 
 - Rename fields
 - Join time series data
@@ -57,7 +57,7 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-### Step 2. Configure data transformation
+### Step 2. Configure a data transformation
 
 The resulting table from the previous step will look similar to the one that follows:
 
@@ -72,7 +72,7 @@ The resulting table from the previous step will look similar to the one that fol
 | 2023-05-09 14:00:00.000 | /api/v1/series             | 0      |
 | 2023-05-09 14:00:00.000 | /api/v1/status/buildinfo   | 0      |
 
-Add the [_Organize fields_ transformation](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#organize-fields) to will hide the `Time` field:
+Add the [_Organize fields_ transformation](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#organize-fields) to hide the `Time` field:
 
 Create a `SceneDataTransformer` object:
 
@@ -132,7 +132,7 @@ The resulting table will look similar to the one that follows:
 
 ### Step 3. Configure multiple transformations
 
-`SceneDataTransformer` allows you to configure multiple transformations. They are executed in the same order as they are added to the `transformations` array.
+`SceneDataTransformer` allows you to configure multiple transformations. The transformations are executed in the same order as they are added to the `transformations` array.
 
 Modify the `transformedData` object and add [_Rename by regex_ transformations](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#rename-by-regex) to change the field names: `handler` to `Handler` and `Value` to `Average duration`:
 
@@ -183,9 +183,9 @@ The resulting table will look similar to the one that follows:
 
 ## Add custom transformations
 
-In addition to all the transformations available in Grafana, Scenes allows you to create custom transformations.
+In addition to all the transformations available in Grafana, scenes allow you to create custom transformations.
 
-`SceneDataTransformer ` accepts `CustomTransformOperator` as an item of the `transformations` array:
+`SceneDataTransformer` accepts `CustomTransformOperator` as an item of the `transformations` array:
 
 ```ts
   transformations: Array<DataTransformerConfig | CustomTransformOperator>;
@@ -201,9 +201,9 @@ type CustomTransformOperator = (context: DataTransformContext) => MonoTypeOperat
 Read more about RxJS operators in the [RxJS official documentation](https://rxjs.dev/guide/operators).
 :::
 
-### Step 1. Create custom transformation
+### Step 1. Create a custom transformation
 
-Create a custom transformation that will apply to the `handler` field and prefix all values with a URL.
+Create a custom transformation that will apply to the `handler` field and prefix all values with a URL:
 
 :::info
 Custom transformations depend heavily on manipulating internal Grafana data objects called _data frames_. Learn more about data frames in [the official Grafana documentation](https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/).
@@ -236,7 +236,7 @@ const prefixHandlerTransformation: CustomTransformOperator = () => (source: Obse
 };
 ```
 
-### Step 2. Use custom transformation
+### Step 2. Use a custom transformation
 
 Add a custom transformation to the previously created `transformedData` object:
 
@@ -292,6 +292,6 @@ The resulting table will look similar to the one that follows:
 
 ## Combine and filter
 
-One powerful thing you can do with transformations (custom and built-in) is share query results between panels in interesting ways. This allows you to place most of your queries in a single query runner that lives at the top of the scene. Then you can use a `SceneDataTransformer` objects on the `VizPanel` level to join and filter the resulting data in different ways. Some panels may need the result of two of the queries, and another needs the results of all of them.
+One powerful thing you can do with transformations (custom and built-in) is share query results between panels in interesting ways. This allows you to place most of your queries in a single query runner that lives at the top of the scene. Then you can use a `SceneDataTransformer` object on the `VizPanel` level to join and filter the resulting data in different ways. Some panels may need the result of two of the queries, and another may need the results of all of them.
 
 It's easy to filter the resulting `DataFrame` array by which query they came from using the `refId` property on `DataFrame`.

--- a/docusaurus/docs/variables.md
+++ b/docusaurus/docs/variables.md
@@ -3,23 +3,25 @@ id: variables
 title: Variables
 ---
 
-Variables are used to parametrize a scene. They are placeholders for a value that can be used in queries, panel titles and even custom scene objects. You can read more about Grafana template variables in [Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/variables/).
+Variables are used to parameterize a scene. They are placeholders for a value that can be used in queries, panel titles, and even custom scene objects. Learn more about Grafana template variables in [the official Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/variables/).
 
 ## Supported variable types
 
-Scenes support the following variable types
+Scenes support the following variable types:
 
 - Query variable (`QueryVariable`) - Query-generated list of values such as metric names, server names, sensor IDs, data centers, and so on.
-- Data source variable (`DataSourceVariable`) - Define list of data sources of a given type.
-- Custom variable (`CustomVariable`) - Define the variable options manually using a comma-separated list.
-- Constant variable (`ConstantVariable`) - Define a constant value variable.
-- Text box variable (`TextBoxVariable`) - Display a free text input field with an optional default value.
+- Data source variable (`DataSourceVariable`) - Defines the list of data sources of a given type.
+- Custom variable (`CustomVariable`) - Defines variable options manually, using a comma-separated list.
+- Constant variable (`ConstantVariable`) - Defines a constant value variable.
+- Text box variable (`TextBoxVariable`) - Displays a free text input field with an optional default value.
 
-## Add variables to scene
+## Add variables to scenes
 
-### Step 1. Create and customize variable object
+Follow these steps to add variables to a scene.
 
-Start with variable definition. The following code will create a variable that will retrieve all `handler` label values for `prometheus_http_requests_total` metric from Prometheus data source.
+### Step 1. Create and customize a variable object
+
+Start with a variable definition. The following code creates a variable that retrieves all `handler` label values for the `prometheus_http_requests_total` metric from the Prometheus data source:
 
 ```ts
 const handler = new QueryVariable({
@@ -35,13 +37,13 @@ const handler = new QueryVariable({
 ```
 
 :::note
-The `datasource` used above refers to the core Grafana Prometheus datasource plugin. Make sure your Grafana instance has this plugin installed and configured. The `query` property is the same that you would see
-in your normal dashboard template variables when you view dashboard JSON in Dashboard settings.
+The `datasource` used in the preceding code block refers to the core Grafana Prometheus data source plugin. Make sure your Grafana stack has this plugin installed and configured. The `query` property is the same one that you would see
+in typical dashboard template variables when you view the dashboard JSON in the dashboard settings.
 :::
 
-### Step 2. Configure scene to use variables
+### Step 2. Configure a scene to use variables
 
-Define `$variables` property for your scene using `SceneVariableSet` object:
+Define a `$variables` property for your scene using the `SceneVariableSet` object:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -54,9 +56,9 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-### Step 3. Show variables picker in scene
+### Step 3. Show a variables picker in the scene
 
-Use `controls` property of `EmbeddedScene` to show variable value pickers on top of the scene:
+Use the `controls` property of `EmbeddedScene` to show variable value pickers on top of the scene:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -70,11 +72,11 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-This will result with the select shown on top of the scene, that will allow changing the variable value.
+A selector that allows you to change the variable value is now shown on top of the scene.
 
-### Step 4. Use variable in a query
+### Step 4. Use the variable in a query
 
-Create `SceneQueryRunner` that will query Prometheus data source and use the configured variable in the query:
+Create `SceneQueryRunner`, which will query the Prometheus data source and use the configured variable in the query:
 
 ```ts
 const queryRunner = new SceneQueryRunner({
@@ -93,11 +95,11 @@ const queryRunner = new SceneQueryRunner({
 });
 ```
 
-Note the `expr` property of Prometheus query using `$handler` variable. Learn more about Grafana's variable syntax in [Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/).
+Note, the `expr` property of the Prometheus query uses the `$handler` variable. Learn more about Grafana's variable syntax in [the official Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/).
 
-### Step 5. Add data to scene
+### Step 5. Add data to the scene
 
-Connect `queryRunner` created in previous step with scene:
+Connect `queryRunner`, which was created in the previous step, with the scene:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -112,9 +114,9 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-### Step 6. Add visualization to scene
+### Step 6. Add a visualization to the scene
 
-To show the results of the query using `handler` variable, add a Time series visualization to scene using the `VizPanel` class.
+To show the results of the query using the `handler` variable, add a time series visualization to the scene using the `VizPanel` class:
 
 ```ts
 const myScene = new EmbeddedScene({
@@ -135,9 +137,9 @@ const myScene = new EmbeddedScene({
 });
 ```
 
-Change variable value using the select on top of the scene to see updated data in your visualization.
+Change the variable value using the selector on top of the scene to see updated data in your visualization.
 
-Below you will find the complete code of a scene using `QueryVariable`:
+Following, you'll find the complete code of a scene using `QueryVariable`:
 
 ```ts
 const labels = new QueryVariable({

--- a/docusaurus/docs/visualizations.md
+++ b/docusaurus/docs/visualizations.md
@@ -7,7 +7,7 @@ title: Visualizations
 
 You can add visualizations to your scene by using the scene object class `VizPanel`.
 
-## Simple VizPanel example
+## Simple `VizPanel` example
 
 ```ts
 new VizPanel({
@@ -30,18 +30,17 @@ new VizPanel({
 ```
 
 :::note
-The pluginId `timeseries` used above refers to the core Grafana panel plugin which is the standard graph visualization for time indexed data. The `options` and `fieldConfig` are the same options you would see
-in your normal dashboard panels when you view `Panel JSON` from the panel inspect drawer. You find the panel inspect drawer in the panel menu under the name `Inspect`.
+The pluginId, `timeseries`, used in the preceding example refers to the core Grafana panel plugin, which is the standard graph visualization for time indexed data. The `options` and `fieldConfig` are the same options you would see
+in a typical dashboard panel when you view the **JSON** tab in the panel inspect drawer. To access this tab, click **Inspect > Panel JSON** in the panel edit menu.
 :::
 
 ## Data
 
-VizPanel will use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that it will use `$data` set on it's own level or share data with other siblings and scene objects if `$data` is set on any parent level.
-
+`VizPanel` uses the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider` object. This means `VizPanel` uses `$data` set on its own level or shares data with other siblings and scene objects if `$data` is set on any parent level.
 
 ## Header actions
 
-VizPanel has a property named `headerActions` that can be either a `React.ReactNode` or a custom `SceneObject`. This property is useful if you want to place links or buttons in the top right corner of the panel header. Example:
+`VizPanel` has a property named `headerActions` that can be either `React.ReactNode` or a custom `SceneObject`. This property is useful if you want to place links or buttons in the top right corner of the panel header. For example:
 
 ```ts
 new VizPanel({
@@ -53,20 +52,20 @@ new VizPanel({
 })
 ```
 
-Placing buttons in the top right corner of the panel header could be used for:
+Buttons in the top right corner of the panel header can be used for:
 
 * Links to other scenes
-* Buttons that change the current scene (add drilldown view for example)
-* RadioButtonGroup that changes the visualization settings
+* Buttons that change the current scene (add a drill-down page, for example)
+* A `RadioButtonGroup` that changes the visualization settings
 
-For LinkButton, Button and RadioButtonGroup please use size="sm" when placed in the panel header.
+For `LinkButton`, `Button`, and `RadioButtonGroup`, use size="sm" when you place them in the panel header.
 
 ## Custom visualizations
 
-If you want to visualize data yourself in your Grafana app plugin you can do that in two ways. You always have the option to create a custom SceneObject. But then you will not get the PanelChrome with loading state and other features
-that VizPanel provides. If you want a custom visualization inside a panel frame that should look like the other panels in your scene then it's best to register a runtime panel plugin.
+If you want to determine how data is visualized in your Grafana app plugin, you can do so in two ways. You always have the option to create a custom `SceneObject`, but you won't get the `PanelChrome` with loading state and other features
+that `VizPanel` provides. If you want a custom visualization inside a panel frame that should look like the other panels in your scene, then it's best to register a runtime panel plugin.
 
-Start by defining your panel options and field config.
+Start by defining your panel options and field config:
 
 ```ts
 interface CustomVizOptions {
@@ -80,7 +79,7 @@ interface CustomVizFieldOptions {
 interface Props extends PanelProps<CustomVizOptions> {}
 ```
 
-Then you can define the react component that renders your custom PanelPlugin.
+Then you can define the react component that renders your custom `PanelPlugin`.
 
 ```ts
 export function CustomVizPanel(props: Props) {
@@ -95,7 +94,7 @@ export function CustomVizPanel(props: Props) {
 }
 ```
 
-Now your ready to create your PanelPlugin instance and register it with the scenes library.
+Now you're ready to create your `PanelPlugin` instance and register it with the Scenes library:
 
 ```ts
 const myCustomPanel = new PanelPlugin<MyCustomOptions, MyCustomFieldOptions>(CustomVizPanel);
@@ -103,7 +102,7 @@ const myCustomPanel = new PanelPlugin<MyCustomOptions, MyCustomFieldOptions>(Cus
 registerRuntimePanelPlugin({ pluginId: 'my-scene-app-my-custom-viz', plugin: myCustomPanel });
 ```
 
-You can now use this pluginId in any `VizPanel`. Make sure you specify a pluginId that includes your scene app name and is unlikely to conflict with other scene apps.
+You can now use this pluginId in any `VizPanel`. Make sure you specify a pluginId that includes your scene app name and is unlikely to conflict with other Scenes apps.
 
-For more information read the offical [tutorial on building panel plugins](https://grafana.com/tutorials/build-a-panel-plugin). Just remember that for scene runtime panel plugins
-you do not need a plugin.json file for the panel plugin. It will not be a standalone plugin that you can use in dashboards. it will only be something that can be referenced inside your scene app.
+For more information, refer to the official [tutorial on building panel plugins](https://grafana.com/tutorials/build-a-panel-plugin). Just remember that for Scenes runtime panel plugins,
+you don't need a plugin.json file for the panel plugin, as it won't be a standalone plugin that you can use in Dashboards. You'll only be able to reference the plugin inside your Scenes app.


### PR DESCRIPTION
- Style/wording/grammar edits for topics `scene-layout.md`, `visualizations.md`, and `variables.md`. 
- Minor edits to `transformations.md `to improve consistency with other topics in the section, specifically changing some instances of _Scenes_ (feature) to _scene_ (collection of scene objects) as this page is under the Scene objects section.
- Other minor edits to other topics for consistency of wording.