### PR TITLE
Docs: Scenes apps section copy edit

### DIFF
--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -7,21 +7,21 @@ Drill-down pages are a powerful tool for building complex, data-driven applicati
 
 ## Add drill-down pages to Scenes apps
 
-`SceneAppPage` comes with an API that allows creating deep, nested drilldown views.
+`SceneAppPage` comes with an API that allows you to create deep, nested drill-down pages.
 
 :::info
-This guide requires knowledge about React Router URL params, Grafana field configuration and data links.
+**Before you begin**: You must already know about React Router URL params, Grafana field configuration, and data links before continuing with this guide.
 :::
 
-To create a drilldown view for `SceneAppPage`, use `drilldown` property of the `SceneAppPage` object.
+To create a drill-down page for `SceneAppPage`, use the `drilldown` property of the `SceneAppPage` object.
 
 ### Step 1. Create a Scenes app
 
-Follow [Building apps with scenes guide](./scene-app.md) to build your app.
+Follow the [Building apps with Scenes guide](./scene-app.md) to build your app.
 
-### Step 2. Build top level drilldown page
+### Step 2. Build a top level drill-down page
 
-On this page, we'll show a summary of the average duration of HTTP requests for Prometheus API endpoints using Grafana's Table panel.
+Use the code that follows to build a page that shows a summary of the average duration of HTTP requests for Prometheus API endpoints, using Grafana's Table panel:
 
 ```ts
 function getOverviewScene() {
@@ -73,9 +73,9 @@ function getSceneApp() {
 }
 ```
 
-### Step 2. Set up drill-down navigation
+### Step 3. Set up drill-down navigation
 
-To show the drill-down page, we need to provide navigation. Configure Table panel data links (learn about data links in [official Grafana documentation](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/)). Then modify the Table panel configuration to set up a data link for the `handler` field.
+To show the drill-down page, you need to provide navigation. Configure Table panel data links (learn about data links in the [official Grafana documentation](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/)). Then modify the Table panel configuration to set up a data link for the `handler` field:
 
 ```tsx
 import { urlUtil } from '@grafana/data';
@@ -118,31 +118,31 @@ const tablePanel = new VizPanel({
 });
 ```
 
-The above panel will have links for all values of the `handler` field. Clicking on a value will redirect to a particular endpoint drill-down URL that will show a "Not found page" error. We'll set up this page in the next step.
+The resulting panel will have links for all values of the `handler` field. Clicking a value will redirect to a particular endpoint drill-down URL that will show a "Not found page" error. You'll set up this page in the next step.
 
 :::note
-The `fieldConfig` options are the same options you would see in your normal dashboard panels when you view `Panel JSON` from the Table panel inspect drawer. To access panel inspect drawer, click **Inspect** in the panel edit menu.
+The `fieldConfig` options are the same options you would see in a typical dashboard panel when you view the **JSON** tab in the panel inspect drawer. To access the tab, click **Inspect > Panel JSON** in the panel edit menu.
 :::
 
 :::info
-Using `locationService` and `urlUtil` comes handy if you want to preserve variables and time range query params.
+Using `locationService` and `urlUtil` is helpful if you want to preserve variables and time range query params.
 `${__value.text:percentencode}` is the percent-encoded value of the clicked table cell.
 :::
 
-### Step 3. Build drilldown page
+### Step 4. Build a drill-down page
 
-Modify the `getSceneApp` function to set up drilldown scenes. Use the `drilldowns` property of the `SceneAppPage` object. The `drilldowns` property accepts an array of `SceneAppDrilldownView` objects. It allows drilldown URL and page to be rendered configuration:
+Modify the `getSceneApp` function to set up drill-down scenes. Use the `drilldowns` property of the `SceneAppPage` object. The `drilldowns` property accepts an array of `SceneAppDrilldownView` objects. It allows a drill-down URL and page to be rendered configuration:
 
 ```ts
 export interface SceneAppDrilldownView {
-  /** Use to provide parametrized drilldown URL, i.e. /app/clusters/:clusterId **/
+  /** Use to provide parametrized drilldown URL, for example, /app/clusters/:clusterId **/
   routePath: string;
   /** Function that returns a page object for a given drilldown route match. Use parent to configure drilldown view parent SceneAppPage via getParentPage method. **/
   getPage: (routeMatch: SceneRouteMatch<any>, parent: SceneAppPageLike) => SceneAppPageLike;
 }
 ```
 
-Configure the API endpoint drilldown view:
+Configure the API endpoint drill-down view:
 
 ```tsx
 function getSceneApp() {
@@ -164,20 +164,20 @@ function getSceneApp() {
 }
 ```
 
-Define a function that will return a `SceneAppPage` for a drilldown view. This function receives two arguments:
+Define a function that returns a `SceneAppPage` for a drill-down view. This function receives two arguments:
 
-- `routeMatch` - contains information about URL params.
-- `parentPage` - contains reference to the parent `SceneAppPage` required to configure breadcrumbs correctly.
+- `routeMatch` - Contains information about URL params.
+- `parentPage` - Contains a reference to the parent `SceneAppPage` required to configure breadcrumbs correctly.
 
 ```ts
 function getHandlerDrilldownPage(routeMatch: SceneRouteMatch<{ handler: string }>, parent: SceneAppPageLike) {
-  // Retrieve handler from the URL params.
+  // Retrieve handler from the URL params
   const handler = decodeURIComponent(routeMatch.params.handler);
 
   return new SceneAppPage({
-    // Setup particular handler drilldown URL
+    // Set up a particular handler drill-down URL
     url: `/a/<PLUGIN_ID>/my-app/${encodeURIComponent(handler)}`,
-    // Important: setup this for breadcrumbs to be built
+    // Important: Set this up for breadcrumbs to be built
     getParentPage: () => parent,
     title: `${handler} endpoint overview`,
     getScene: () => getHandlerDrilldownScene(handler),
@@ -185,9 +185,9 @@ function getHandlerDrilldownPage(routeMatch: SceneRouteMatch<{ handler: string }
 }
 ```
 
-### Step 4. Build drilldown scene
+### Step 5. Build a drill-down scene
 
-Define a scene that will be rendered on the drilldown page:
+Define a scene that will be rendered on the drill-down page:
 
 ```ts
 function getHandlerDrilldownScene(handler: string) {
@@ -245,7 +245,7 @@ function getHandlerDrilldownScene(handler: string) {
 
 ### Complete example
 
-Below you will find the complete code for the scene app with drilldowns:
+Below you'll find the complete code for a Scenes app with drill-down pages:
 
 ```tsx
 import { urlUtil } from '@grafana/data';

--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -13,7 +13,7 @@ Drill-down pages are a powerful tool for building complex, data-driven applicati
 **Before you begin**: You must already know about React Router URL params, Grafana field configuration, and data links before continuing with this guide.
 :::
 
-To create a drill-down page for `SceneAppPage`, use the `drilldown` property of the `SceneAppPage` object.
+To create a drill-down page, use the `drilldown` property of the `SceneAppPage` object.
 
 ### Step 1. Create a Scenes app
 

--- a/docusaurus/docs/scene-app-tabs.md
+++ b/docusaurus/docs/scene-app-tabs.md
@@ -7,11 +7,11 @@ title: Tab navigation in Scenes apps
 
 ## Add tabs navigation to Scenes apps
 
-Defining tabs navigation for apps using scenes is a matter of utilizing `SceneAppPage` property `tabs`.
+Defining tabs navigation for apps using Scenes requires you to use the `SceneAppPage` property, `tabs`.
 
 ### Step 1. Create a Scenes app
 
-Follow the [Building apps with scenes guide](./scene-app.md) to build your app.
+Follow the [Building apps with Scenes guide](./scene-app.md) to build your app.
 
 ### Step 2. Create scenes for individual tabs
 
@@ -81,9 +81,9 @@ const getHandlersScene =() => {
 }
 ```
 
-### Step 3. Configure tabs for page
+### Step 3. Configure tabs for the page
 
-Tabs are instances of `SceneAppPage` objects. Similar to creating a scene page, you create tabs. To render tabs, use the `tabs` property of the `SceneAppPage` object.
+Tabs are instances of `SceneAppPage` objects. Similar to creating a scene page, you create tabs. To render tabs, use the `tabs` property of the `SceneAppPage` object:
 
 ```tsx
 
@@ -110,4 +110,4 @@ const myAppPage = new SceneAppPage({
 });
 ```
 
-Navigating to `https://your-grafana.url/a/<PLUGIN_ID>/my-app` will render a scene app with two tabs: **Overview** and **Handlers**. The **Overview** tab contains a time series panel with a Prometheus HTTP Requests summary. The **Handlers** tab contains a table panel with a Prometheus HTTP request average duration summary, per handler.
+Navigating to `https://your-grafana.url/a/<PLUGIN_ID>/my-app` will render a Scenes app with two tabs: **Overview** and **Handlers**. The **Overview** tab contains a time series panel with a Prometheus HTTP Requests summary. The **Handlers** tab contains a table panel with a Prometheus HTTP request average duration summary, per handler.

--- a/docusaurus/docs/scene-app.md
+++ b/docusaurus/docs/scene-app.md
@@ -4,7 +4,7 @@ title: Building apps with Scenes
 ---
 
 :::info
-This guide requires knowledge about building Grafana plugins. Learn more about building Grafana plugins in the [official plugins documentation](https://grafana.com/docs/grafana/latest/developers/plugins/).
+**Before you begin**: You must already know about building Grafana plugins before continuing with this guide. Learn more in the [official Grafana documentation](https://grafana.com/docs/grafana/latest/developers/plugins/).
 :::
 
 Scenes come with the following objects that make it easy to build highly interactive Grafana app plugins:
@@ -14,11 +14,11 @@ Scenes come with the following objects that make it easy to build highly interac
 
 ## SceneApp
 
-`SceneApp` is the root object you must use to take full advantage of Scenes and Grafana plugin integration. `SceneApp` provides support for routing of your Scenes app.
+`SceneApp` is the root object you must use to take full advantage of Scenes and Grafana plugin integration. `SceneApp` provides support for the routing of your Scenes app.
 
 ### Step 1. Create a Scenes app
 
-Define a new scene app using the `SceneApp` object :
+Define a new Scenes app using the `SceneApp` object :
 
 ```tsx
 const getSceneApp = () =>
@@ -27,9 +27,9 @@ const getSceneApp = () =>
   });
 ```
 
-### Step 2. Render scene app in plugin
+### Step 2. Render the Scenes app in a plugin
 
-Define a component that will render the scene app:
+Define a component that will render the Scenes app:
 
 ```tsx
 function MyApp() {
@@ -43,7 +43,7 @@ function MyApp() {
 Memoize `SceneApp` using `React.useMemo` to avoid unnecessary re-renders.
 :::
 
-In app plugin render scene app:
+In the app plugin, render the Scenes app:
 
 ```tsx
 export class App extends React.PureComponent<AppRootProps> {
@@ -58,17 +58,17 @@ export class App extends React.PureComponent<AppRootProps> {
 ```
 
 :::note
-The example above will render a blank page because the `pages` property in the `SceneApp` constructor is empty. Use the `SceneAppPage` object to render scenes in your app.
+The preceding example will render a blank page because the `pages` property in the `SceneApp` constructor is empty. Use the `SceneAppPage` object to render scenes in your app.
 :::
 
 ## SceneAppPage
 
-The `SceneAppPage` object allows for rendering scenes in app plugins easily. In addition to rendering scenes, it provides support for:
+The `SceneAppPage` object allows you to render scenes in app plugins easily. In addition to rendering scenes, it provides support for:
 
 - Routing
 - Grafana breadcrumbs integration
 - [Tabs navigation](./scene-app-tabs.md)
-- [Drilldowns](./scene-app-drilldown.md)
+- [Drill-down pages](./scene-app-drilldown.md)
 
 Use `SceneAppPage` to build your app pages. It accepts the following properties:
 
@@ -141,7 +141,7 @@ const getScene = () => {
 
 ### Step 2. Create `SceneAppPage`
 
-Use the `SceneAppPage` object to configure app page:
+Use the `SceneAppPage` object to configure an app page:
 
 ```tsx
 const myAppPage = new SceneAppPage({
@@ -151,7 +151,7 @@ const myAppPage = new SceneAppPage({
 });
 ```
 
-### Step 3. Add page to `SceneApp`
+### Step 3. Add a page to `SceneApp`
 
 ```tsx
 const getSceneApp = () =>
@@ -160,4 +160,4 @@ const getSceneApp = () =>
   });
 ```
 
-Navigating to `https://your-grafana.url/a/<PLUGIN_ID>` will render a scene app with a page containing Time series panel that visualizes number of Prometheus HTTP requests.
+Navigating to `https://your-grafana.url/a/<PLUGIN_ID>` will render a Scenes app with a page containing a Time series panel that visualizes the number of Prometheus HTTP requests.

--- a/docusaurus/website/sidebars.js
+++ b/docusaurus/website/sidebars.js
@@ -33,7 +33,7 @@ const sidebars = {
         'transformations',
         {
           type: 'category',
-          label: 'Scene apps',
+          label: 'Scenes apps',
           collapsible: true,
           collapsed: false,
           items: [


### PR DESCRIPTION
- Style/wording/grammar edits for topics `scene-app-drilldown.md`, `scene-app-tabs.md`, and `scene-app.md` based on Scenes glossary.
- Fixed step numbering.
- Updated sidebar heading from **Scene apps** to **Scenes apps** per glossary.
