### PR TITLE
Scene utils: Expose helper for building drilldown links

### DIFF
--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -78,8 +78,7 @@ function getSceneApp() {
 To show the drill-down page, you need to provide navigation. Configure Table panel data links (learn about data links in the [official Grafana documentation](https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/)). Then modify the Table panel configuration to set up a data link for the `handler` field:
 
 ```tsx
-import { urlUtil } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { sceneUtils } from '@grafana/scenes';
 
 // ...
 
@@ -101,12 +100,11 @@ const tablePanel = new VizPanel({
             value: [
               {
                 title: 'Go to handler overview',
-                onBuildUrl: () => {
-                  // Use @grafana/runtime location service to get current query params
-                  const params = locationService.getSearchObject();
-
-                  // Use @grafana/data urlUtil to render drilldown URL with query params.
-                  return urlUtil.renderUrl('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}', params);
+                onBuildUrl: ({ replaceVariables }: { replaceVariables: InterpolateFunction }) => {
+                  return sceneUtils.getLinkUrlWithAppUrlState(
+                    replaceVariables('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}'),
+                    params
+                  );
                 },
               },
             ],
@@ -125,8 +123,7 @@ The `fieldConfig` options are the same options you would see in a typical dashbo
 :::
 
 :::info
-Using `locationService` and `urlUtil` is helpful if you want to preserve variables and time range query params.
-`${__value.text:percentencode}` is the percent-encoded value of the clicked table cell.
+`${__value.text:percentencode}` is the percent-encoded value of the clicked table cell. When using variables in drilldown links make sure to call `replaceVariables` available via argument of `onBuildUrl` function, before passing the URL to `sceneUtils.getLinkUrlWithAppUrlState` helper.
 :::
 
 ### Step 4. Build a drill-down page
@@ -248,9 +245,6 @@ function getHandlerDrilldownScene(handler: string) {
 Below you'll find the complete code for a Scenes app with drill-down pages:
 
 ```tsx
-import { urlUtil } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
-
 function getOverviewScene() {
   const queryRunner = new SceneQueryRunner({
     $timeRange: new SceneTimeRange(),
@@ -286,12 +280,11 @@ function getOverviewScene() {
               value: [
                 {
                   title: 'Go to handler overview',
-                  onBuildUrl: () => {
-                    // Use @grafana/runtime location service to get current query params
-                    const params = locationService.getSearchObject();
-
-                    // Use @grafana/data urlUtil to render drilldown URL with query params.
-                    return urlUtil.renderUrl('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}', params);
+                  onBuildUrl: ({ replaceVariables }: { replaceVariables: InterpolateFunction }) => {
+                    return sceneUtils.getLinkUrlWithAppUrlState(
+                      replaceVariables('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}'),
+                      params
+                    );
                   },
                 },
               ],

--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -101,7 +101,7 @@ const tablePanel = new VizPanel({
               {
                 title: 'Go to handler overview',
                 onBuildUrl: ({ replaceVariables }: { replaceVariables: InterpolateFunction }) => {
-                  return sceneUtils.getLinkUrlWithAppUrlState(
+                  return sceneUtils.getLinkWithAppState(
                     replaceVariables('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}'),
                     params
                   );
@@ -123,7 +123,7 @@ The `fieldConfig` options are the same options you would see in a typical dashbo
 :::
 
 :::info
-`${__value.text:percentencode}` is the percent-encoded value of the clicked table cell. When using variables in drilldown links make sure to call `replaceVariables` available via argument of `onBuildUrl` function, before passing the URL to `sceneUtils.getLinkUrlWithAppUrlState` helper.
+`${__value.text:percentencode}` is the percent-encoded value of the clicked table cell. When using variables in drilldown links make sure to call `replaceVariables` available via argument of `onBuildUrl` function, before passing the URL to `sceneUtils.getLinkWithAppState` helper.
 :::
 
 ### Step 4. Build a drill-down page
@@ -281,7 +281,7 @@ function getOverviewScene() {
                 {
                   title: 'Go to handler overview',
                   onBuildUrl: ({ replaceVariables }: { replaceVariables: InterpolateFunction }) => {
-                    return sceneUtils.getLinkUrlWithAppUrlState(
+                    return sceneUtils.getLinkWithAppState(
                       replaceVariables('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}'),
                       params
                     );

--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -101,7 +101,7 @@ const tablePanel = new VizPanel({
               {
                 title: 'Go to handler overview',
                 onBuildUrl: ({ replaceVariables }: { replaceVariables: InterpolateFunction }) => {
-                  return sceneUtils.getLinkWithAppState(
+                  return sceneUtils.getUrlWithAppState(
                     replaceVariables('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}'),
                     params
                   );
@@ -123,7 +123,7 @@ The `fieldConfig` options are the same options you would see in a typical dashbo
 :::
 
 :::info
-`${__value.text:percentencode}` is the percent-encoded value of the clicked table cell. When using variables in drilldown links make sure to call `replaceVariables` available via argument of `onBuildUrl` function, before passing the URL to `sceneUtils.getLinkWithAppState` helper.
+`${__value.text:percentencode}` is the percent-encoded value of the clicked table cell. When using variables in drilldown links make sure to call `replaceVariables` available via argument of `onBuildUrl` function, before passing the URL to `sceneUtils.getUrlWithAppState` helper.
 :::
 
 ### Step 4. Build a drill-down page
@@ -281,7 +281,7 @@ function getOverviewScene() {
                 {
                   title: 'Go to handler overview',
                   onBuildUrl: ({ replaceVariables }: { replaceVariables: InterpolateFunction }) => {
-                    return sceneUtils.getLinkWithAppState(
+                    return sceneUtils.getUrlWithAppState(
                       replaceVariables('/a/<PLUGIN_ID>/my-app/${__value.text:percentencode}'),
                       params
                     );

--- a/docusaurus/docs/visualizations.md
+++ b/docusaurus/docs/visualizations.md
@@ -38,26 +38,27 @@ in your normal dashboard panels when you view `Panel JSON` from the panel inspec
 
 VizPanel will use the `sceneGraph.getData(model)` call to find and subscribe to the closest parent that has a `SceneDataProvider`. What this means is that it will use `$data` set on it's own level or share data with other siblings and scene objects if `$data` is set on any parent level.
 
-
 ## Header actions
 
 VizPanel has a property named `headerActions` that can be either a `React.ReactNode` or a custom `SceneObject`. This property is useful if you want to place links or buttons in the top right corner of the panel header. Example:
 
 ```ts
 new VizPanel({
-    pluginId: 'timeseries',
-    title: 'Time series',
-    headerActions: (
-      <LinkButton size="sm" variant="secondary" href="scene/sdrilldown/url">Drilldown</LinkButton>
-    )
-})
+  pluginId: 'timeseries',
+  title: 'Time series',
+  headerActions: (
+    <LinkButton size="sm" variant="secondary" href="scenes/drilldown/url">
+      Drilldown
+    </LinkButton>
+  ),
+});
 ```
 
 Placing buttons in the top right corner of the panel header could be used for:
 
-* Links to other scenes
-* Buttons that change the current scene (add drilldown view for example)
-* RadioButtonGroup that changes the visualization settings
+- Links to other scenes
+- Buttons that change the current scene (add drilldown view for example)
+- RadioButtonGroup that changes the visualization settings
 
 For LinkButton, Button and RadioButtonGroup please use size="sm" when placed in the panel header.
 
@@ -98,9 +99,11 @@ export function CustomVizPanel(props: Props) {
 Now your ready to create your PanelPlugin instance and register it with the scenes library.
 
 ```ts
+import { sceneUtils } from '@grafana/scenes';
+
 const myCustomPanel = new PanelPlugin<MyCustomOptions, MyCustomFieldOptions>(CustomVizPanel);
 
-registerRuntimePanelPlugin({ pluginId: 'my-scene-app-my-custom-viz', plugin: myCustomPanel });
+sceneUtils.registerRuntimePanelPlugin({ pluginId: 'my-scene-app-my-custom-viz', plugin: myCustomPanel });
 ```
 
 You can now use this pluginId in any `VizPanel`. Make sure you specify a pluginId that includes your scene app name and is unlikely to conflict with other scene apps.

--- a/packages/scenes-app/src/demos/runtimePanelPlugin.tsx
+++ b/packages/scenes-app/src/demos/runtimePanelPlugin.tsx
@@ -6,13 +6,13 @@ import {
   VizPanel,
   SceneAppPageState,
   SceneAppPage,
-  registerRuntimePanelPlugin,
+  sceneUtils,
 } from '@grafana/scenes';
 import React from 'react';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 
 export function getRuntimePanelPluginDemo(defaults: SceneAppPageState): SceneAppPage {
-  registerRuntimePanelPlugin({ pluginId: 'custom-viz-panel', plugin: getCustomVizPlugin() });
+  sceneUtils.registerRuntimePanelPlugin({ pluginId: 'custom-viz-panel', plugin: getCustomVizPlugin() });
 
   return new SceneAppPage({
     ...defaults,

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { SceneObject } from '../../core/types';
 import { SceneAppPage } from './SceneAppPage';
 import { SceneAppDrilldownView, SceneAppPageLike } from './types';
-import { getLinkUrlWithAppUrlState, renderSceneComponentWithRouteProps, useAppQueryParams } from './utils';
+import { getLinkWithAppState, renderSceneComponentWithRouteProps, useAppQueryParams } from './utils';
 
 export interface Props {
   page: SceneAppPageLike;
@@ -38,7 +38,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
     subTitle: containerState.subTitle,
     img: containerState.titleImg,
     icon: containerState.titleIcon,
-    url: getLinkUrlWithAppUrlState(containerState.url, containerState.preserveUrlKeys),
+    url: getLinkWithAppState(containerState.url, containerState.preserveUrlKeys),
     hideFromBreadcrumbs: containerState.hideFromBreadcrumbs,
     parentItem: getParentBreadcrumbs(
       containerState.getParentPage ? containerState.getParentPage() : containerPage.parent,
@@ -51,7 +51,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
       return {
         text: tab.state.title,
         active: page === tab,
-        url: getLinkUrlWithAppUrlState(tab.state.url, tab.state.preserveUrlKeys),
+        url: getLinkWithAppState(tab.state.url, tab.state.preserveUrlKeys),
         parentItem: pageNav,
       };
     });
@@ -86,7 +86,7 @@ function getParentBreadcrumbs(parent: SceneObject | undefined, params: UrlQueryM
   if (parent instanceof SceneAppPage) {
     return {
       text: parent.state.title,
-      url: getLinkUrlWithAppUrlState(parent.state.url, parent.state.preserveUrlKeys),
+      url: getLinkWithAppState(parent.state.url, parent.state.preserveUrlKeys),
       hideFromBreadcrumbs: parent.state.hideFromBreadcrumbs,
       parentItem: getParentBreadcrumbs(
         parent.state.getParentPage ? parent.state.getParentPage() : parent.parent,

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { SceneObject } from '../../core/types';
 import { SceneAppPage } from './SceneAppPage';
 import { SceneAppDrilldownView, SceneAppPageLike } from './types';
-import { getLinkWithAppState, renderSceneComponentWithRouteProps, useAppQueryParams } from './utils';
+import { getUrlWithAppState, renderSceneComponentWithRouteProps, useAppQueryParams } from './utils';
 
 export interface Props {
   page: SceneAppPageLike;
@@ -38,7 +38,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
     subTitle: containerState.subTitle,
     img: containerState.titleImg,
     icon: containerState.titleIcon,
-    url: getLinkWithAppState(containerState.url, containerState.preserveUrlKeys),
+    url: getUrlWithAppState(containerState.url, containerState.preserveUrlKeys),
     hideFromBreadcrumbs: containerState.hideFromBreadcrumbs,
     parentItem: getParentBreadcrumbs(
       containerState.getParentPage ? containerState.getParentPage() : containerPage.parent,
@@ -51,7 +51,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
       return {
         text: tab.state.title,
         active: page === tab,
-        url: getLinkWithAppState(tab.state.url, tab.state.preserveUrlKeys),
+        url: getUrlWithAppState(tab.state.url, tab.state.preserveUrlKeys),
         parentItem: pageNav,
       };
     });
@@ -86,7 +86,7 @@ function getParentBreadcrumbs(parent: SceneObject | undefined, params: UrlQueryM
   if (parent instanceof SceneAppPage) {
     return {
       text: parent.state.title,
-      url: getLinkWithAppState(parent.state.url, parent.state.preserveUrlKeys),
+      url: getUrlWithAppState(parent.state.url, parent.state.preserveUrlKeys),
       hideFromBreadcrumbs: parent.state.hideFromBreadcrumbs,
       parentItem: getParentBreadcrumbs(
         parent.state.getParentPage ? parent.state.getParentPage() : parent.parent,

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -38,7 +38,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
     subTitle: containerState.subTitle,
     img: containerState.titleImg,
     icon: containerState.titleIcon,
-    url: getLinkUrlWithAppUrlState(containerState.url, params, containerState.preserveUrlKeys),
+    url: getLinkUrlWithAppUrlState(containerState.url, containerState.preserveUrlKeys),
     hideFromBreadcrumbs: containerState.hideFromBreadcrumbs,
     parentItem: getParentBreadcrumbs(
       containerState.getParentPage ? containerState.getParentPage() : containerPage.parent,
@@ -51,7 +51,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
       return {
         text: tab.state.title,
         active: page === tab,
-        url: getLinkUrlWithAppUrlState(tab.state.url, params, tab.state.preserveUrlKeys),
+        url: getLinkUrlWithAppUrlState(tab.state.url, tab.state.preserveUrlKeys),
         parentItem: pageNav,
       };
     });
@@ -86,7 +86,7 @@ function getParentBreadcrumbs(parent: SceneObject | undefined, params: UrlQueryM
   if (parent instanceof SceneAppPage) {
     return {
       text: parent.state.title,
-      url: getLinkUrlWithAppUrlState(parent.state.url, params, parent.state.preserveUrlKeys),
+      url: getLinkUrlWithAppUrlState(parent.state.url, parent.state.preserveUrlKeys),
       hideFromBreadcrumbs: parent.state.hideFromBreadcrumbs,
       parentItem: getParentBreadcrumbs(
         parent.state.getParentPage ? parent.state.getParentPage() : parent.parent,

--- a/packages/scenes/src/components/SceneApp/utils.ts
+++ b/packages/scenes/src/components/SceneApp/utils.ts
@@ -15,7 +15,7 @@ export function useAppQueryParams(): UrlQueryMap {
  * @param preserveParams Query params to preserve
  * @returns Url with query params
  */
-export function getLinkUrlWithAppUrlState(path: string, preserveParams?: string[]): string {
+export function getLinkWithAppState(path: string, preserveParams?: string[]): string {
   // make a copy of params as the renderUrl function mutates the object
   const paramsCopy = { ...locationService.getSearchObject() };
 

--- a/packages/scenes/src/components/SceneApp/utils.ts
+++ b/packages/scenes/src/components/SceneApp/utils.ts
@@ -1,18 +1,23 @@
-import { RouteComponentProps, useLocation } from 'react-router-dom';
-
-import { UrlQueryMap, urlUtil } from '@grafana/data';
-import { locationSearchToObject } from '@grafana/runtime';
-import { SceneObject } from '../../core/types';
 import React from 'react';
+import { RouteComponentProps, useLocation } from 'react-router-dom';
+import { UrlQueryMap, urlUtil } from '@grafana/data';
+import { locationSearchToObject, locationService } from '@grafana/runtime';
+import { SceneObject } from '../../core/types';
 
 export function useAppQueryParams(): UrlQueryMap {
   const location = useLocation();
   return locationSearchToObject(location.search || '');
 }
 
-export function getLinkUrlWithAppUrlState(path: string, params: UrlQueryMap, preserveParams?: string[]): string {
+/**
+ *
+ * @param path Url to append query params to
+ * @param preserveParams Query params to preserve
+ * @returns Url with query params
+ */
+export function getLinkUrlWithAppUrlState(path: string, preserveParams?: string[]): string {
   // make a copy of params as the renderUrl function mutates the object
-  const paramsCopy = { ...params };
+  const paramsCopy = { ...locationService.getSearchObject() };
 
   if (preserveParams) {
     for (const key of Object.keys(paramsCopy)) {

--- a/packages/scenes/src/components/SceneApp/utils.ts
+++ b/packages/scenes/src/components/SceneApp/utils.ts
@@ -15,7 +15,7 @@ export function useAppQueryParams(): UrlQueryMap {
  * @param preserveParams Query params to preserve
  * @returns Url with query params
  */
-export function getLinkWithAppState(path: string, preserveParams?: string[]): string {
+export function getUrlWithAppState(path: string, preserveParams?: string[]): string {
   // make a copy of params as the renderUrl function mutates the object
   const paramsCopy = { ...locationService.getSearchObject() };
 

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -1,3 +1,6 @@
+import { getLinkUrlWithAppUrlState } from './components/SceneApp/utils';
+import { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
+
 export * from './core/types';
 export * from './core/events';
 export { sceneGraph } from './core/sceneGraph';
@@ -26,7 +29,6 @@ export { SceneObjectUrlSyncConfig } from './services/SceneObjectUrlSyncConfig';
 
 export { EmbeddedScene, type EmbeddedSceneState } from './components/EmbeddedScene';
 export { VizPanel, type VizPanelState } from './components/VizPanel/VizPanel';
-export { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
 export { VizPanelMenu } from './components/VizPanel/VizPanelMenu';
 export { NestedScene } from './components/NestedScene';
 export { SceneCanvasText } from './components/SceneCanvasText';
@@ -48,3 +50,8 @@ export {
 export { SceneApp } from './components/SceneApp/SceneApp';
 export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
+
+export const sceneUtils = {
+  getLinkUrlWithAppUrlState,
+  registerRuntimePanelPlugin,
+};

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -1,4 +1,4 @@
-import { getLinkWithAppState } from './components/SceneApp/utils';
+import { getUrlWithAppState } from './components/SceneApp/utils';
 import { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
 
 export * from './core/types';
@@ -52,6 +52,6 @@ export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
 
 export const sceneUtils = {
-  getLinkWithAppState,
+  getUrlWithAppState,
   registerRuntimePanelPlugin,
 };

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -1,4 +1,4 @@
-import { getLinkUrlWithAppUrlState } from './components/SceneApp/utils';
+import { getLinkWithAppState } from './components/SceneApp/utils';
 import { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
 
 export * from './core/types';
@@ -52,6 +52,6 @@ export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
 
 export const sceneUtils = {
-  getLinkUrlWithAppUrlState,
+  getLinkWithAppState,
   registerRuntimePanelPlugin,
 };


### PR DESCRIPTION
- Exposes `getLinkUrlWithAppUrlState` under `sceneUtils` object.
- Changes `getLinkUrlWithAppUrlState` not to require `params` as an argument. This now happens under the hood using runtime's `locationService`
- Moves `registerRuntimePanelPlugin` to `sceneUtils`

Ref https://github.com/grafana/scenes/issues/180
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.0--canary.193.5042913418.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.9.0--canary.193.5042913418.0
  # or 
  yarn add @grafana/scenes@0.9.0--canary.193.5042913418.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
