### PR TITLE
SceneDataTransformer: Correctly resolve isDataReadyToDisplay

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -75,10 +75,12 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
   }
 
   public isDataReadyToDisplay() {
-    if (this.state.$data && this.state.$data.isDataReadyToDisplay) {
-      return this.state.$data.isDataReadyToDisplay();
+    const dataObject = this.getSourceData();
+    if (dataObject.isDataReadyToDisplay) {
+      return dataObject.isDataReadyToDisplay();
     }
-    return false;
+
+    return true;
   }
 
   public reprocessTransformations() {


### PR DESCRIPTION
With https://github.com/grafana/scenes/pull/190 I forgot to handle the standalone `SceneDataTransformer` that doesn't have SQR attached to it. This caused panel not being rendered. This PR resolves data display readiness according to `SceneDataTransformer` data provider.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.8.1--canary.194.5016069301.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.8.1--canary.194.5016069301.0
  # or 
  yarn add @grafana/scenes@0.8.1--canary.194.5016069301.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
