### PR TITLE
SceneAppPage: Support react elements in subtitle

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -35,7 +35,6 @@ export function SceneAppPageView({ page, routeProps }: Props) {
 
   const pageNav: NavModelItem = {
     text: containerState.title,
-    subTitle: containerState.subTitle,
     img: containerState.titleImg,
     icon: containerState.titleIcon,
     url: getUrlWithAppState(containerState.url, containerState.preserveUrlKeys),
@@ -65,7 +64,12 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   }
 
   return (
-    <PluginPage pageNav={pageNav} actions={pageActions} renderTitle={containerState.renderTitle}>
+    <PluginPage
+      pageNav={pageNav}
+      actions={pageActions}
+      renderTitle={containerState.renderTitle}
+      subTitle={containerState.subTitle}
+    >
       <scene.Component model={scene} />
     </PluginPage>
   );

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -24,7 +24,7 @@ export interface SceneAppPageState extends SceneObjectState {
   /** Page title */
   title: string;
   /** Page subTitle */
-  subTitle?: string;
+  subTitle?: string | React.ReactNode;
   /**
    * Customize title rendering.
    * Please return an unstyled h1 tag here + any additional elements you need.


### PR DESCRIPTION
Closes #170
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.0--canary.196.5054162429.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.10.0--canary.196.5054162429.0
  # or 
  yarn add @grafana/scenes@0.10.0--canary.196.5054162429.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
