### PR TITLE
Refactor sceneGraph structure to avoid circular dependencies

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -16,7 +16,7 @@ import {
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
 import { SceneObjectStateChangedEvent } from './events';
-import { cloneSceneObject } from './utils';
+import { cloneSceneObject } from './sceneGraph/utils';
 import { SceneVariableDependencyConfigLike } from '../variables/types';
 
 export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObjectState>

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -5,7 +5,7 @@ import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
 
 import { SceneObjectBase } from './SceneObjectBase';
 import { SceneTimeRangeLike, SceneTimeRangeState, SceneObjectUrlValues, SceneObjectUrlValue } from './types';
-import { getClosest } from './utils';
+import { getClosest } from './sceneGraph/utils';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to'] });

--- a/packages/scenes/src/core/sceneGraph/getTimeRange.ts
+++ b/packages/scenes/src/core/sceneGraph/getTimeRange.ts
@@ -1,0 +1,10 @@
+import { DefaultTimeRange } from '../../variables/interpolation/defaults';
+import { SceneObject, SceneTimeRangeLike } from '../types';
+import { getClosest } from './utils';
+
+/**
+ * Will walk up the scene object graph to the closest $timeRange scene object
+ */
+export function getTimeRange(sceneObject: SceneObject): SceneTimeRangeLike {
+  return getClosest(sceneObject, (s) => s.state.$timeRange) ?? DefaultTimeRange;
+}

--- a/packages/scenes/src/core/sceneGraph/index.ts
+++ b/packages/scenes/src/core/sceneGraph/index.ts
@@ -1,0 +1,21 @@
+import { lookupVariable } from '../../variables/lookupVariable';
+import { getTimeRange } from './getTimeRange';
+import {
+  findObject,
+  getData,
+  getLayout,
+  getVariables,
+  hasVariableDependencyInLoadingState,
+  interpolate,
+} from './sceneGraph';
+
+export const sceneGraph = {
+  getVariables,
+  getData,
+  getTimeRange,
+  getLayout,
+  interpolate,
+  lookupVariable,
+  hasVariableDependencyInLoadingState,
+  findObject,
+};

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -1,11 +1,11 @@
 import { ScopedVars } from '@grafana/data';
-import { DefaultTimeRange, EmptyDataNode, EmptyVariableSet } from '../variables/interpolation/defaults';
+import { EmptyDataNode, EmptyVariableSet } from '../../variables/interpolation/defaults';
 
-import { sceneInterpolator } from '../variables/interpolation/sceneInterpolator';
-import { VariableCustomFormatterFn, SceneVariables } from '../variables/types';
+import { sceneInterpolator } from '../../variables/interpolation/sceneInterpolator';
+import { VariableCustomFormatterFn, SceneVariables } from '../../variables/types';
 
-import { SceneDataProvider, SceneLayout, SceneObject, SceneTimeRangeLike } from './types';
-import { lookupVariable } from '../variables/lookupVariable';
+import { SceneDataProvider, SceneLayout, SceneObject } from '../types';
+import { lookupVariable } from '../../variables/lookupVariable';
 import { getClosest } from './utils';
 
 /**
@@ -20,13 +20,6 @@ export function getVariables(sceneObject: SceneObject): SceneVariables {
  */
 export function getData(sceneObject: SceneObject): SceneDataProvider {
   return getClosest(sceneObject, (s) => s.state.$data) ?? EmptyDataNode;
-}
-
-/**
- * Will walk up the scene object graph to the closest $timeRange scene object
- */
-export function getTimeRange(sceneObject: SceneObject): SceneTimeRangeLike {
-  return getClosest(sceneObject, (s) => s.state.$timeRange) ?? DefaultTimeRange;
 }
 
 function isSceneLayout(s: SceneObject): s is SceneLayout {
@@ -122,14 +115,3 @@ function findObjectInternal(
 export function findObject(scene: SceneObject, check: (obj: SceneObject) => boolean): SceneObject | null {
   return findObjectInternal(scene, check, undefined, true);
 }
-
-export const sceneGraph = {
-  getVariables,
-  getData,
-  getTimeRange,
-  getLayout,
-  interpolate,
-  lookupVariable,
-  hasVariableDependencyInLoadingState,
-  findObject,
-};

--- a/packages/scenes/src/core/sceneGraph/utils.ts
+++ b/packages/scenes/src/core/sceneGraph/utils.ts
@@ -1,6 +1,6 @@
-import { SceneObject, SceneObjectState } from './types';
+import { SceneObject, SceneObjectState } from '../types';
 
-import { SceneObjectBase } from './SceneObjectBase';
+import { SceneObjectBase } from '../SceneObjectBase';
 
 /**
  * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -1,7 +1,7 @@
 import { dateTimeFormat, urlUtil } from '@grafana/data';
-import { SceneObject, SceneTimeRangeLike } from '../../core/types';
+import { getTimeRange } from '../../core/sceneGraph/getTimeRange';
+import { SceneObject } from '../../core/types';
 import { FormatVariable } from '../interpolation/formatRegistry';
-import { DefaultTimeRange } from '../interpolation/defaults';
 import { SkipFormattingValue } from './types';
 
 /**
@@ -56,17 +56,4 @@ export class TimeFromAndToMacro implements FormatVariable {
       return dateTimeFormat(timeRange.state.value.to, { timeZone: timeRange.getTimeZone() });
     }
   }
-}
-
-function getTimeRange(sceneObject: SceneObject): SceneTimeRangeLike {
-  const { $timeRange } = sceneObject.state;
-  if ($timeRange) {
-    return $timeRange;
-  }
-
-  if (sceneObject.parent) {
-    return getTimeRange(sceneObject.parent);
-  }
-
-  return DefaultTimeRange;
 }


### PR DESCRIPTION
Based on https://github.com/grafana/scenes/pull/197 

Wanted to get rid of duplicate implementation of `getTimeRange` in  https://github.com/grafana/scenes/blob/from-to-macros/packages/scenes/src/variables/macros/timeMacros.ts#L61 but this resulted in a circular dependency.

This PR slightly changes the structure of the `sceneGraph` utils so that we can refactor them in the future if more issues like this appear. Currently, the `getTimeRange` util is extracted to a separate file making it possible to re-use directly in code that uses it (`timeMacros`). 

The `sceneGraph` API remains unchanged.