### PR TITLE
Macros: Add __timezone macro

### DIFF
--- a/packages/scenes-app/src/demos/timeZones.tsx
+++ b/packages/scenes-app/src/demos/timeZones.tsx
@@ -23,19 +23,19 @@ export function getTimeZoneTest(defaults: SceneAppPageState) {
 
   const panel1 = new VizPanel({
     pluginId: 'timeseries',
-    title: 'Using global time range and time zone',
+    title: 'Using global time range and time zone (${__timezone})',
     description: 'This panel should show data within time zone and time range selected in the time picker.',
   });
 
   const panel2 = new VizPanel({
     pluginId: 'timeseries',
-    title: 'Using global time zone, local range',
+    title: 'Using local range and global time zone (${__timezone})',
     description: 'This panel should show data from the last 5 minutes, using time zone from the time picker',
   });
 
   const panel3 = new VizPanel({
     pluginId: 'timeseries',
-    title: 'Using global range, local time zone',
+    title: 'Using global range, local time zone (${__timezone})',
     description: 'This panel should show data using America/New_York time zone and time range from the time picker',
   });
 

--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -1,6 +1,6 @@
 import { DataLinkBuiltInVars } from '@grafana/data';
 import { MacroVariableConstructor } from './types';
-import { TimeFromAndToMacro, UrlTimeRangeMacro } from './timeMacros';
+import { TimeFromAndToMacro, TimezoneMacro, UrlTimeRangeMacro } from './timeMacros';
 import { AllVariablesMacro } from './AllVariablesMacro';
 import { DataMacro, FieldMacro, SeriesMacro, ValueMacro } from './dataMacros';
 
@@ -13,4 +13,5 @@ export const macrosIndex: Record<string, MacroVariableConstructor> = {
   ['__field']: FieldMacro,
   ['__from']: TimeFromAndToMacro,
   ['__to']: TimeFromAndToMacro,
+  ['__timezone']: TimezoneMacro,
 };

--- a/packages/scenes/src/variables/macros/timeMacros.test.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.test.ts
@@ -2,6 +2,7 @@ import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { TestScene } from '../TestScene';
 
 import { sceneInterpolator } from '../interpolation/sceneInterpolator';
+import { SceneTimeZoneOverride } from '../../core/SceneTimeZoneOverride';
 
 describe('timeMacros', () => {
   it('Can use use $__url_time_range', () => {
@@ -34,5 +35,28 @@ describe('timeMacros', () => {
 
     expect(sceneInterpolator(scene, '$__from', undefined, 'text')).toBe('2023-05-23 06:09:57');
     expect(sceneInterpolator(scene, '$__to', undefined, 'text')).toBe('2023-05-23 07:09:57');
+  });
+
+  it('Can use use $__timezone', () => {
+    const scene1 = new TestScene({
+      $timeRange: new SceneTimeRange({ from: '2023-05-23T06:09:57.073Z', to: '2023-05-23T07:09:57.073Z' }),
+    });
+
+    const nestedScene = new TestScene({});
+    const scene2 = new TestScene({
+      $timeRange: new SceneTimeRange({
+        from: '2023-05-23T06:09:57.073Z',
+        to: '2023-05-23T07:09:57.073Z',
+        timeZone: 'America/New_York',
+      }),
+      nested: new TestScene({
+        $timeRange: new SceneTimeZoneOverride({ timeZone: 'Africa/Abidjan' }),
+        nested: nestedScene,
+      }),
+    });
+
+    expect(sceneInterpolator(scene1, '$__timezone')).toBe('browser');
+    expect(sceneInterpolator(scene2, '$__timezone')).toBe('America/New_York');
+    expect(sceneInterpolator(nestedScene, '$__timezone')).toBe('Africa/Abidjan');
   });
 });

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -59,7 +59,7 @@ export class TimeFromAndToMacro implements FormatVariable {
 }
 
 /**
- * Handles expressions like $__from and $__to.
+ * Handles $__timezone expression.
  */
 export class TimezoneMacro implements FormatVariable {
   public state: { name: string; type: string };

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -76,7 +76,6 @@ export class TimezoneMacro implements FormatVariable {
   }
 
   public getValueText?(): string {
-    const timeRange = getTimeRange(this._sceneObject);
-    return timeRange.getTimeZone();
+    return this.getValue(); 
   }
 }

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -57,3 +57,26 @@ export class TimeFromAndToMacro implements FormatVariable {
     }
   }
 }
+
+/**
+ * Handles expressions like $__from and $__to.
+ */
+export class TimezoneMacro implements FormatVariable {
+  public state: { name: string; type: string };
+  private _sceneObject: SceneObject;
+
+  public constructor(name: string, sceneObject: SceneObject) {
+    this.state = { name: name, type: 'time_macro' };
+    this._sceneObject = sceneObject;
+  }
+
+  public getValue() {
+    const timeRange = getTimeRange(this._sceneObject);
+    return timeRange.getTimeZone();
+  }
+
+  public getValueText?(): string {
+    const timeRange = getTimeRange(this._sceneObject);
+    return timeRange.getTimeZone();
+  }
+}


### PR DESCRIPTION
Adds `__timezone` macro working with scene time range and timezone override.

Closes https://github.com/grafana/scenes/issues/166