### PR TITLE
VizPanel: Allow queries to be cancelled

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,8 @@
 {
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.15.0"
+  "version": "0.15.0",
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -15,6 +15,7 @@ import { getResponsiveLayoutDemo } from './responsiveLayout';
 import { getVariablesDemo } from './variables';
 import { getDrilldownsAppPageScene } from './withDrilldown/WithDrilldown';
 import { getTimeZoneTest } from './timeZones';
+import { getQueryCancellationTest } from './queryCancellation';
 
 export interface DemoDescriptor {
   title: string;
@@ -39,5 +40,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Runtime panel plugin', getPage: getRuntimePanelPluginDemo },
     { title: 'Behaviors demo', getPage: getBehaviorsDemo },
     { title: 'Time zones demo', getPage: getTimeZoneTest },
+    { title: 'Query cancellation', getPage: getQueryCancellationTest },
   ];
 }

--- a/packages/scenes-app/src/demos/queryCancellation.tsx
+++ b/packages/scenes-app/src/demos/queryCancellation.tsx
@@ -1,11 +1,11 @@
 import {
   EmbeddedScene,
+  PanelBuilders,
   SceneAppPage,
   SceneAppPageState,
   SceneDataTransformer,
   SceneFlexItem,
   SceneFlexLayout,
-  VizPanel,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
 
@@ -28,60 +28,87 @@ export function getQueryCancellationTest(defaults: SceneAppPageState) {
               direction: 'row',
               children: [
                 new SceneFlexItem({
-                  minWidth: '25%',
-                  body: new VizPanel({
-                    pluginId: 'timeseries',
-                    title: 'Global query',
-                  }),
+                  minWidth: '20%',
+                  body: PanelBuilders.timeseries().setTitle('Global query').build(),
                 }),
                 new SceneFlexItem({
-                  minWidth: '25%',
-                  body: new VizPanel({
-                    $data: getQueryRunnerWithRandomWalkQuery(
-                      { scenarioId: 'slow_query', stringInput: '15s' },
-                      { maxDataPointsFromWidth: false }
-                    ),
-                    pluginId: 'timeseries',
-                    title: 'Local query',
-                  }),
+                  minWidth: '20%',
+                  body: PanelBuilders.timeseries()
+                    .setTitle('Local query')
+                    .setData(
+                      getQueryRunnerWithRandomWalkQuery(
+                        { scenarioId: 'slow_query', stringInput: '10s' },
+                        { maxDataPointsFromWidth: false }
+                      )
+                    )
+                    .build(),
                 }),
                 new SceneFlexItem({
-                  minWidth: '25%',
-                  body: new VizPanel({
-                    pluginId: 'stat',
-                    title: 'Local query via transformation',
-                    $data: new SceneDataTransformer({
-                      $data: getQueryRunnerWithRandomWalkQuery(
-                        { scenarioId: 'slow_query', stringInput: '15s' },
-                        { maxDataPointsFromWidth: true }
-                      ),
-                      transformations: [
-                        {
-                          id: 'reduce',
-                          options: {
-                            reducers: ['mean'],
+                  minWidth: '20%',
+                  body: PanelBuilders.stat()
+                    .setTitle('Local query via transformation')
+                    .setData(
+                      new SceneDataTransformer({
+                        $data: getQueryRunnerWithRandomWalkQuery(
+                          { scenarioId: 'slow_query', stringInput: '15s' },
+                          { maxDataPointsFromWidth: true }
+                        ),
+                        transformations: [
+                          {
+                            id: 'reduce',
+                            options: {
+                              reducers: ['mean'],
+                            },
                           },
-                        },
-                      ],
-                    }),
-                  }),
+                        ],
+                      })
+                    )
+                    .build(),
                 }),
                 new SceneFlexItem({
-                  minWidth: '25%',
-                  body: new VizPanel({
-                    pluginId: 'stat',
-                    title: 'Global query via transformation',
-                    $data: new SceneDataTransformer({
-                      transformations: [
-                        {
-                          id: 'reduce',
-                          options: {
-                            reducers: ['mean'],
+                  minWidth: '20%',
+                  body: PanelBuilders.stat()
+                    .setTitle('Global query via transformation')
+                    .setData(
+                      new SceneDataTransformer({
+                        transformations: [
+                          {
+                            id: 'reduce',
+                            options: {
+                              reducers: ['mean'],
+                            },
                           },
-                        },
-                      ],
-                    }),
-                  }),
+                        ],
+                      })
+                    )
+                    .build(),
+                }),
+                new SceneFlexItem({
+                  minWidth: '20%',
+                  body: PanelBuilders.stat()
+                    .setTitle('Transformed transformation')
+                    .setData(
+                      new SceneDataTransformer({
+                        transformations: [
+                          {
+                            id: 'calculateField',
+                            options: {
+                              mode: 'binary',
+                              reduce: {
+                                reducer: 'sum',
+                              },
+                              binary: {
+                                left: 'A-series',
+                                reducer: 'sum',
+                                operator: '*',
+                                right: '2',
+                              },
+                            },
+                          },
+                        ],
+                      })
+                    )
+                    .build(),
                 }),
               ],
             }),

--- a/packages/scenes-app/src/demos/queryCancellation.tsx
+++ b/packages/scenes-app/src/demos/queryCancellation.tsx
@@ -18,7 +18,7 @@ export function getQueryCancellationTest(defaults: SceneAppPageState) {
         ...getEmbeddedSceneDefaults(),
         key: 'Flex layout embedded scene',
         $data: getQueryRunnerWithRandomWalkQuery(
-          { scenarioId: 'slow_query', stringInput: '15s' },
+          { scenarioId: 'slow_query', stringInput: '10s' },
           { maxDataPointsFromWidth: false }
         ),
         body: new SceneFlexLayout({

--- a/packages/scenes-app/src/demos/queryCancellation.tsx
+++ b/packages/scenes-app/src/demos/queryCancellation.tsx
@@ -1,0 +1,93 @@
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneDataTransformer,
+  SceneFlexItem,
+  SceneFlexLayout,
+  VizPanel,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
+
+export function getQueryCancellationTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Demo of query cancellation',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        key: 'Flex layout embedded scene',
+        $data: getQueryRunnerWithRandomWalkQuery(
+          { scenarioId: 'slow_query', stringInput: '15s' },
+          { maxDataPointsFromWidth: false }
+        ),
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            new SceneFlexLayout({
+              direction: 'row',
+              children: [
+                new SceneFlexItem({
+                  minWidth: '25%',
+                  body: new VizPanel({
+                    pluginId: 'timeseries',
+                    title: 'Global query',
+                  }),
+                }),
+                new SceneFlexItem({
+                  minWidth: '25%',
+                  body: new VizPanel({
+                    $data: getQueryRunnerWithRandomWalkQuery(
+                      { scenarioId: 'slow_query', stringInput: '15s' },
+                      { maxDataPointsFromWidth: false }
+                    ),
+                    pluginId: 'timeseries',
+                    title: 'Local query',
+                  }),
+                }),
+                new SceneFlexItem({
+                  minWidth: '25%',
+                  body: new VizPanel({
+                    pluginId: 'stat',
+                    title: 'Local query via transformation',
+                    $data: new SceneDataTransformer({
+                      $data: getQueryRunnerWithRandomWalkQuery(
+                        { scenarioId: 'slow_query', stringInput: '15s' },
+                        { maxDataPointsFromWidth: true }
+                      ),
+                      transformations: [
+                        {
+                          id: 'reduce',
+                          options: {
+                            reducers: ['mean'],
+                          },
+                        },
+                      ],
+                    }),
+                  }),
+                }),
+                new SceneFlexItem({
+                  minWidth: '25%',
+                  body: new VizPanel({
+                    pluginId: 'stat',
+                    title: 'Global query via transformation',
+                    $data: new SceneDataTransformer({
+                      transformations: [
+                        {
+                          id: 'reduce',
+                          options: {
+                            reducers: ['mean'],
+                          },
+                        },
+                      ],
+                    }),
+                  }),
+                }),
+              ],
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -232,7 +232,7 @@ export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<
 
   public onCancelQuery = () => {
     const data = sceneGraph.getData(this);
-    data.cancel?.();
+    data.cancelQuery?.();
   }
 
   /**

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -230,6 +230,11 @@ export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<
     return this._dataWithFieldConfig;
   }
 
+  public onCancelQuery = () => {
+    const data = sceneGraph.getData(this);
+    data.cancel?.();
+  }
+
   /**
    * Panel context functions
    */

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -9,8 +9,6 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { isSceneObject, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
-import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
-import { SceneDataTransformer } from '../../querying/SceneDataTransformer';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -88,7 +86,6 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   // Data is always returned. For non-data panels, empty PanelData is returned.
   const data = dataWithFieldConfig!;
   const isReadyToRender = dataObject.isDataReadyToDisplay ? dataObject.isDataReadyToDisplay() : true;
-  const canCancel = $data instanceof SceneQueryRunner || ($data instanceof SceneDataTransformer && $data.state.$data instanceof SceneQueryRunner);
 
   return (
     <div ref={ref as RefCallback<HTMLDivElement>} style={{ position: 'absolute', width: '100%', height: '100%' }}>
@@ -108,7 +105,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           dragClassCancel={dragClassCancel}
           padding={plugin.noPadding ? 'none' : 'md'}
           menu={panelMenu}
-          onCancelQuery={canCancel ? model.onCancelQuery : undefined}
+          onCancelQuery={model.onCancelQuery}
         >
           {(innerWidth, innerHeight) => (
             <>

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -9,8 +9,6 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { isSceneObject, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
-import { getClosest } from '../../core/sceneGraph/utils';
-import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -37,8 +35,6 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const dataObject = sceneGraph.getData(model);
   const rawData = dataObject.useState();
   const dataWithFieldConfig = model.applyFieldConfig(rawData.data!);
-  // maybe move this logic to VizPanel itself?
-  const queryRunner = getClosest(model, (s) => (s.state.$data instanceof SceneQueryRunner) ? s.state.$data : undefined);
 
   // Interpolate title
   const titleInterpolated = model.interpolate(title, undefined, 'text');
@@ -109,7 +105,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           dragClassCancel={dragClassCancel}
           padding={plugin.noPadding ? 'none' : 'md'}
           menu={panelMenu}
-          onCancelQuery={() => queryRunner?.cancelQuery()}
+          onCancelQuery={model.onCancelQuery}
         >
           {(innerWidth, innerHeight) => (
             <>

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -9,6 +9,8 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { isSceneObject, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
+import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
+import { SceneDataTransformer } from '../../querying/SceneDataTransformer';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -86,6 +88,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   // Data is always returned. For non-data panels, empty PanelData is returned.
   const data = dataWithFieldConfig!;
   const isReadyToRender = dataObject.isDataReadyToDisplay ? dataObject.isDataReadyToDisplay() : true;
+  const canCancel = $data instanceof SceneQueryRunner || ($data instanceof SceneDataTransformer && $data.state.$data instanceof SceneQueryRunner);
 
   return (
     <div ref={ref as RefCallback<HTMLDivElement>} style={{ position: 'absolute', width: '100%', height: '100%' }}>
@@ -105,7 +108,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           dragClassCancel={dragClassCancel}
           padding={plugin.noPadding ? 'none' : 'md'}
           menu={panelMenu}
-          onCancelQuery={model.onCancelQuery}
+          onCancelQuery={canCancel ? model.onCancelQuery : undefined}
         >
           {(innerWidth, innerHeight) => (
             <>

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -9,6 +9,8 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { isSceneObject, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
+import { getClosest } from '../../core/sceneGraph/utils';
+import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -35,6 +37,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const dataObject = sceneGraph.getData(model);
   const rawData = dataObject.useState();
   const dataWithFieldConfig = model.applyFieldConfig(rawData.data!);
+  // maybe move this logic to VizPanel itself?
+  const queryRunner = getClosest(model, (s) => (s.state.$data instanceof SceneQueryRunner) ? s.state.$data : undefined);
 
   // Interpolate title
   const titleInterpolated = model.interpolate(title, undefined, 'text');
@@ -105,6 +109,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           dragClassCancel={dragClassCancel}
           padding={plugin.noPadding ? 'none' : 'md'}
           menu={panelMenu}
+          onCancelQuery={() => queryRunner?.cancelQuery()}
         >
           {(innerWidth, innerHeight) => (
             <>

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -177,7 +177,7 @@ export type DeepPartial<T> = {
 export interface SceneDataProvider extends SceneObject<SceneDataState> {
   setContainerWidth?: (width: number) => void;
   isDataReadyToDisplay?: () => boolean;
-  cancel?: () => void;
+  cancelQuery?: () => void;
 }
 
 export type SceneStatelessBehavior = (sceneObject: SceneObject) => CancelActivationHandler | void;

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -177,6 +177,7 @@ export type DeepPartial<T> = {
 export interface SceneDataProvider extends SceneObject<SceneDataState> {
   setContainerWidth?: (width: number) => void;
   isDataReadyToDisplay?: () => boolean;
+  cancel?: () => void;
 }
 
 export type SceneStatelessBehavior = (sceneObject: SceneObject) => CancelActivationHandler | void;

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -88,9 +88,9 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
     this.transform(this.getSourceData().state.data);
   }
 
-  public cancel() {
+  public cancelQuery() {
     if (this.state.$data instanceof SceneQueryRunner) {
-        this.getSourceData().cancel?.();
+        this.getSourceData().cancelQuery?.();
     }
   }
 

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -89,8 +89,8 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
   }
 
   public cancelQuery() {
-    if (this.state.$data instanceof SceneQueryRunner) {
-        this.getSourceData().cancelQuery?.();
+    if (this.getSourceData() instanceof SceneQueryRunner) {
+      this.getSourceData().cancelQuery?.();
     }
   }
 

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -90,9 +90,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
   public cancel() {
     if (this.state.$data instanceof SceneQueryRunner) {
-      try {
         this.getSourceData().cancel?.();
-      } catch {}
     }
   }
 

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -87,6 +87,10 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
     this.transform(this.getSourceData().state.data);
   }
 
+  public cancel() {
+    this._transformSub?.unsubscribe();
+  }
+
   private transform(data: PanelData | undefined) {
     const transformations = this.state.transformations || [];
 

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -4,7 +4,6 @@ import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { CustomTransformOperator, SceneDataProvider, SceneDataState } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
-import { SceneQueryRunner } from './SceneQueryRunner';
 
 export interface SceneDataTransformerState extends SceneDataState {
   /**
@@ -89,9 +88,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
   }
 
   public cancelQuery() {
-    if (this.getSourceData() instanceof SceneQueryRunner) {
-      this.getSourceData().cancelQuery?.();
-    }
+    this.getSourceData().cancelQuery?.();
   }
 
   private transform(data: PanelData | undefined) {

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -4,6 +4,7 @@ import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { CustomTransformOperator, SceneDataProvider, SceneDataState } from '../core/types';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
+import { SceneQueryRunner } from './SceneQueryRunner';
 
 export interface SceneDataTransformerState extends SceneDataState {
   /**
@@ -88,7 +89,11 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
   }
 
   public cancel() {
-    this._transformSub?.unsubscribe();
+    if (this.state.$data instanceof SceneQueryRunner) {
+      try {
+        this.getSourceData().cancel?.();
+      } catch {}
+    }
   }
 
   private transform(data: PanelData | undefined) {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -153,6 +153,13 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     return this.state.maxDataPoints ?? this._containerWidth ?? 500;
   }
 
+  public cancelQuery() {
+    this._querySub?.unsubscribe();
+    this.setState({
+      data: { ...this.state.data!, state: LoadingState.Done },
+    });
+  }
+
   private async runWithTimeRange(timeRange: SceneTimeRangeLike) {
     // Skip executing queries if variable dependency is in loading state
     if (sceneGraph.hasVariableDependencyInLoadingState(this)) {
@@ -161,7 +168,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       return;
     }
 
-    // If we where waiting for variables clear that flag
+    // If we were waiting for variables, clear that flag
     if (this.state.isWaitingForVariables) {
       this.setState({ isWaitingForVariables: false });
     }

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -153,7 +153,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     return this.state.maxDataPoints ?? this._containerWidth ?? 500;
   }
 
-  public cancelQuery() {
+  public cancel() {
     this._querySub?.unsubscribe();
     this.setState({
       data: { ...this.state.data!, state: LoadingState.Done },

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -153,7 +153,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     return this.state.maxDataPoints ?? this._containerWidth ?? 500;
   }
 
-  public cancel() {
+  public cancelQuery() {
     this._querySub?.unsubscribe();
     this.setState({
       data: { ...this.state.data!, state: LoadingState.Done },


### PR DESCRIPTION
Not sure this is the right approach (specifically with how I'm getting the closest SceneQueryRunner), but it seems to work.

Part of #207
Will tackle query variable cancellation in another PR
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.17.0--canary.220.5309552119.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.17.0--canary.220.5309552119.0
  # or 
  yarn add @grafana/scenes@0.17.0--canary.220.5309552119.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
