### PR TITLE
SceneQueryRunner: Re-run queries onActivate when time range changed

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -367,4 +367,34 @@ describe('SceneQueryRunner', () => {
       expect(getDataSourceCall[0]).toEqual({ uid: 'Muuu' });
     });
   });
+
+  describe('when time range changed while in-active', () => {
+    it('It should re-issue new query', async () => {
+      const timeRange = new SceneTimeRange();
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        $timeRange: timeRange,
+      });
+
+      expect(queryRunner.state.data).toBeUndefined();
+
+      const deactivateQueryRunner = queryRunner.activate();
+
+      // When consumer viz is rendered with width 1000
+      await new Promise((r) => setTimeout(r, 1));
+      // Should query
+      expect(runRequestMock.mock.calls.length).toEqual(1);
+
+      deactivateQueryRunner();
+
+      timeRange.setState({ from: 'now-10m' });
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      // Should run new query
+      expect(runRequestMock.mock.calls.length).toEqual(2);
+    });
+  });
 });

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -100,12 +100,27 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       return true;
     }
 
-    // If we already have data, no need
-    // TODO validate that time range is similar and if not we should run queries again
-    if (this.state.data) {
+    // If we don't have any data we should run queries
+    if (!this.state.data) {
+      return true;
+    }
+
+    // If time range is stale / different we should run queries
+    if (this._isDataTimeRangeStale(this.state.data)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private _isDataTimeRangeStale(data: PanelData) {
+    const timeRange = sceneGraph.getTimeRange(this);
+
+    if (data.timeRange === timeRange.state.value) {
       return false;
     }
 
+    writeSceneLog('SceneQueryRunner', 'Data time range is stale');
     return true;
   }
 


### PR DESCRIPTION
Noticed that queries are not re-issued when moving between different tabs / drilldowns after changing the time range 