### PR TITLE
TimeRangePicker: Default to the "isOnCanvas" true look

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -108,7 +108,7 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       intervals={intervals}
       onRefresh={model.onRefresh}
       onIntervalChanged={model.onIntervalChanged}
-      isOnCanvas={isOnCanvas}
+      isOnCanvas={isOnCanvas ?? true}
     />
   );
 }

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -27,7 +27,7 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
 
   return (
     <TimeRangePicker
-      isOnCanvas={isOnCanvas}
+      isOnCanvas={isOnCanvas ?? true}
       value={timeRangeState.value}
       onChange={timeRange.onTimeRangeChange}
       timeZone={timeZone}


### PR DESCRIPTION
Seeing scene apps with this:
![image](https://github.com/grafana/scenes/assets/10999/08f0933c-5541-46aa-8740-add0ea04d1ec)
 

I think we should default to isOnCanvas true behavior, only core dashboards will have these in the nav toolbar (and not for long), all other use cases should use the canvas style