### PR TITLE
SceneQueryRunner: Only use containerWidth when maxDataPointsFromWidth is true

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -150,7 +150,11 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   }
 
   private getMaxDataPoints() {
-    return this.state.maxDataPoints ?? this._containerWidth ?? 500;
+    if (this.state.maxDataPoints) {
+      return this.state.maxDataPoints;
+    }
+
+    return this.state.maxDataPointsFromWidth ? this._containerWidth ?? 500 : 500;
   }
 
   private async runWithTimeRange(timeRange: SceneTimeRangeLike) {


### PR DESCRIPTION
Noticed a bug on https://ops.grafana-ops.net/a/grafana-app-observability-app/services/datadog-proxy-gateway/overview?var-prometheus=ops-cortex&var-loki=Loki-Ops&var-tempo=Tempo%20%28tempo-ops%29&from=now-6h&to=now 

where it issues the first request with the default 500 data points, second request it issues using containerWidth. 

containerWidth should only be used for maxDataPoints if maxDataPointsFromWidth is true. 

Not sure what the default behavior should be here. because SceneQueryRunner can be placed anywhere in the tree and it's only when it's on VizPanel and when there is a timeseries graph visualization that using containerWidth for maxDataPoints is actually good I figured it best to make it opt in.  