### PR TITLE
Docs: Unify admonition styles

### DIFF
--- a/docusaurus/docs/advanced-activation-handlers.md
+++ b/docusaurus/docs/advanced-activation-handlers.md
@@ -7,7 +7,7 @@ Activation handlers are useful tool for providing external behaviors to scene ob
 
 Similarly to React's `useEffect`, activation handlers return a `function(deactivation handler)` that should be used to clean up all behaviors added in an activation handler. A deactivation handler is called when a scene object is unmounted.
 
-:::info
+:::note
 Activation handlers are especially useful if you want to add external behaviors to core scene objects. They reduce the need for implementing custom scene objects that would handle scene object connections.
 :::
 

--- a/docusaurus/docs/advanced-data.md
+++ b/docusaurus/docs/advanced-data.md
@@ -52,7 +52,7 @@ class CustomObject extends SceneObjectBase<CustomObjectState> {
 }
 ```
 
-:::info
+:::note
 The subscription returned from `sourceData.subscribeToState` is added to `this._subs`. Because of this, you don't need to do any cleanup when the custom object is destroyed, as the library will take care of unsubscribing.
 :::
 

--- a/docusaurus/docs/advanced-variables.md
+++ b/docusaurus/docs/advanced-variables.md
@@ -123,7 +123,7 @@ class TextInterpolator extends SceneObjectBase<TextInterpolatorState> {
 - `statePaths` - Configures which properties of the object state can contain variables.
 - `onReferencedVariableValueChanged` - Configures a callback that will be executed when variable(s) that the object depends on are changed.
 
-:::info
+:::note
 If `onReferencedVariableValueChanged` is not specified for the `VariableDependencyConfig`, the object will re-render on variable change by default.
 :::
 

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -156,7 +156,7 @@ const queryRunner = new SceneQueryRunner({
 });
 ```
 
-:::info
+:::note
 Your Grafana instance must have a specified data source configured.
 :::
 

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -68,6 +68,6 @@ export const HelloWorldPluginPage = () => {
 };
 ```
 
-:::info
+:::note
 The rendered scene won't be rendered within Grafana plugin page. To integrate scenes with Grafana sidebar, navigation and plugin page follow [Scenes apps](./scene-app.md) guide.
 :::

--- a/docusaurus/docs/scene-app-drilldown.md
+++ b/docusaurus/docs/scene-app-drilldown.md
@@ -9,7 +9,7 @@ Drill-down pages are a powerful tool for building complex, data-driven applicati
 
 `SceneAppPage` comes with an API that allows you to create deep, nested drill-down pages.
 
-:::info
+:::note
 **Before you begin**: You must already know about React Router URL params, Grafana field configuration, and data links before continuing with this guide.
 :::
 

--- a/docusaurus/docs/scene-app.md
+++ b/docusaurus/docs/scene-app.md
@@ -3,7 +3,7 @@ id: scene-app
 title: Building apps with Scenes
 ---
 
-:::info
+:::note
 **Before you begin**: You must already know about building Grafana plugins before continuing with this guide. Learn more in the [official Grafana documentation](https://grafana.com/docs/grafana/latest/developers/plugins/).
 :::
 
@@ -39,7 +39,7 @@ function MyApp() {
 }
 ```
 
-:::info
+:::note
 Memoize `SceneApp` using `React.useMemo` to avoid unnecessary re-renders.
 :::
 

--- a/docusaurus/docs/transformations.md
+++ b/docusaurus/docs/transformations.md
@@ -3,7 +3,7 @@ id: transformations
 title: Transformations
 ---
 
-:::info
+:::note
 **Before you begin**: You must already know about [connecting data in Scenes apps](./core-concepts.md#data-and-time-range) before continuing with this guide.
 :::
 
@@ -197,7 +197,7 @@ In addition to all the transformations available in Grafana, scenes allow you to
 type CustomTransformOperator = (context: DataTransformContext) => MonoTypeOperatorFunction<DataFrame[]>;
 ```
 
-:::info
+:::note
 Read more about RxJS operators in the [RxJS official documentation](https://rxjs.dev/guide/operators).
 :::
 
@@ -205,7 +205,7 @@ Read more about RxJS operators in the [RxJS official documentation](https://rxjs
 
 Create a custom transformation that will apply to the `handler` field and prefix all values with a URL:
 
-:::info
+:::note
 Custom transformations depend heavily on manipulating internal Grafana data objects called _data frames_. Learn more about data frames in [the official Grafana documentation](https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/).
 :::
 


### PR DESCRIPTION
Reviewing the admonitions in the docs, there doesn't seem to be an underlying pattern for when we use `:::note` vs `:::info`. There should be a clear difference in why we use one admonition type vs another, so I've changed all the admonition types to `:::note` for consistency. 

Also, if this content should ever become part of the main Grafana doc set, this will make the move easier, since we don't use an `:::info` type admonition.

Another option is to make all the admonitions `:::info` style because those are rendered with a blue background rather than white (`:::note` admonitions are rendered in white) and stand out more in the docs. Code snippets are also rendered with a white background.