### PR TITLE
SplitLayout: Add Splitter and SplitLayout

### DIFF
--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -324,3 +324,53 @@ const myScene = new EmbeddedScene({
   }),
 });
 ```
+
+## Split layout
+
+`SplitLayout` allows you to build scenes as combinations of separate resizable panes, oriented either vertically or horizontally.
+
+### Step 1. Create a scene
+
+Start using the split layout by creating a scene with `body` configured as `SplitLayout`:
+
+```ts
+const myScene = new EmbeddedScene({
+  body: new SplitLayout({}),
+});
+```
+
+### Step 2. Configure split layout
+
+`SplitLayout` allows several configuration options:
+
+- `direction` - Configures whether panes are oriented by row or column.
+- `primary` - The first pane.
+- `secondary` - The second pane
+
+```ts
+const myScene = new EmbeddedScene({
+  body: new SplitLayout({
+    direction: 'column',
+  }),
+});
+```
+
+### Step 3. Provide `primary` and `secondary` objects
+
+`primary` and `secondary` both accept a `SceneFlexItemLike` object.
+
+```ts
+const myScene = new EmbeddedScene({
+  body: new SplitLayout({
+    direction: 'column',
+    primary: new VizPanel({
+      pluginId: 'timeseries',
+      title: 'Primary panel',
+    }),
+    secondary: new VizPanel({
+      pluginId: 'timeseries',
+      title: 'Secondary panel',
+    }),
+  }),
+});
+```

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -15,6 +15,7 @@ import { getResponsiveLayoutDemo } from './responsiveLayout';
 import { getVariablesDemo } from './variables';
 import { getDrilldownsAppPageScene } from './withDrilldown/WithDrilldown';
 import { getTimeZoneTest } from './timeZones';
+import { getSplitTest } from './split';
 
 export interface DemoDescriptor {
   title: string;
@@ -39,5 +40,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Runtime panel plugin', getPage: getRuntimePanelPluginDemo },
     { title: 'Behaviors demo', getPage: getBehaviorsDemo },
     { title: 'Time zones demo', getPage: getTimeZoneTest },
+    { title: 'Split layout', getPage: getSplitTest },
   ];
 }

--- a/packages/scenes-app/src/demos/split.tsx
+++ b/packages/scenes-app/src/demos/split.tsx
@@ -1,0 +1,44 @@
+import {
+  EmbeddedScene,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneCanvasText,
+  SplitLayout,
+  VizPanel,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
+
+export function getSplitTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'A simple demo of different flex layout options',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        key: 'Flex layout embedded scene',
+        body: new SplitLayout({
+          direction: 'row',
+          primary: new VizPanel({
+            pluginId: 'timeseries',
+            title: 'Dynamic height and width',
+            $data: getQueryRunnerWithRandomWalkQuery({}, { maxDataPointsFromWidth: true }),
+          }),
+          secondary: new SplitLayout({
+            ySizing: 'content',
+            direction: 'column',
+            primary: new SceneCanvasText({
+              text: 'Size to content',
+              fontSize: 20,
+              align: 'center',
+            }),
+            secondary: new SceneCanvasText({
+              text: 'Blah blah',
+              fontSize: 30,
+              align: 'center',
+            }),
+          }),
+        }),
+      });
+    },
+  });
+}

--- a/packages/scenes-app/src/demos/split.tsx
+++ b/packages/scenes-app/src/demos/split.tsx
@@ -5,6 +5,7 @@ import {
   SceneAppPageState,
   SceneCanvasText,
   SceneDataTransformer,
+  SceneFlexItem,
   SceneQueryRunner,
   SplitLayout,
   VizPanel,
@@ -62,10 +63,13 @@ const roomsTemperatureQuery = {
 };
 
 const getDynamicSplitScene = () => {
-  const defaultSecondary = new SceneCanvasText({
-    text: 'Select room to see details',
-    fontSize: 20,
-    align: 'center',
+  const defaultSecondary = new SceneFlexItem({
+    minWidth: 500,
+    body: new SceneCanvasText({
+      text: 'Select room to see details',
+      fontSize: 20,
+      align: 'center',
+    }),
   });
   const runner = new SceneQueryRunner({
     datasource: DATASOURCE_REF,
@@ -152,15 +156,18 @@ const getDynamicSplitScene = () => {
                   onClick: (e: DataLinkClickEvent) => {
                     const roomName = e.origin.field.values.get(e.origin.rowIndex);
                     splitter.setState({
-                      secondary: new VizPanel({
-                        title: `${roomName} temperature`,
-                        $data: new SceneQueryRunner({
-                          datasource: DATASOURCE_REF,
-                          queries: [getRoomTemperatureQuery(roomName)],
+                      secondary: new SceneFlexItem({
+                        minWidth: 500,
+                        body: new VizPanel({
+                          title: `${roomName} temperature`,
+                          $data: new SceneQueryRunner({
+                            datasource: DATASOURCE_REF,
+                            queries: [getRoomTemperatureQuery(roomName)],
+                          }),
+                          headerActions: (
+                            <IconButton name="x" onClick={() => splitter.setState({ secondary: defaultSecondary })} />
+                          ),
                         }),
-                        headerActions: (
-                          <IconButton name="x" onClick={() => splitter.setState({ secondary: defaultSecondary })} />
-                        ),
                       }),
                     });
                   },
@@ -179,7 +186,10 @@ const getDynamicSplitScene = () => {
 
   const splitter = new SplitLayout({
     direction: 'row',
-    primary: table,
+    primary: new SceneFlexItem({
+      body: table,
+      minWidth: 300,
+    }),
     secondary: defaultSecondary,
   });
 

--- a/packages/scenes-app/src/demos/split.tsx
+++ b/packages/scenes-app/src/demos/split.tsx
@@ -1,17 +1,26 @@
+import React from 'react';
 import {
   EmbeddedScene,
   SceneAppPage,
   SceneAppPageState,
   SceneCanvasText,
+  SceneDataTransformer,
+  SceneQueryRunner,
   SplitLayout,
   VizPanel,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
+import { demoUrl } from '../utils/utils.routing';
+import { DATASOURCE_REF } from '../constants';
+import { FieldColorModeId } from '@grafana/schema';
+import { DataLinkClickEvent } from '@grafana/data';
+import { getRoomTemperatureQuery } from './withDrilldown/scenes';
+import { IconButton } from '@grafana/ui';
 
-export function getSplitTest(defaults: SceneAppPageState) {
-  return new SceneAppPage({
-    ...defaults,
-    subTitle: 'A simple demo of different flex layout options',
+const basicDemo = () =>
+  new SceneAppPage({
+    title: 'Split layout test',
+    url: demoUrl('split-layout'),
     getScene: () => {
       return new EmbeddedScene({
         ...getEmbeddedSceneDefaults(),
@@ -40,5 +49,160 @@ export function getSplitTest(defaults: SceneAppPageState) {
         }),
       });
     },
+  });
+
+const roomsTemperatureQuery = {
+  refId: 'Rooms temperature',
+  datasource: DATASOURCE_REF,
+  scenarioId: 'random_walk',
+  seriesCount: 8,
+  alias: '__house_locations',
+  min: 10,
+  max: 27,
+};
+
+const getDynamicSplitScene = () => {
+  const defaultSecondary = new SceneCanvasText({
+    text: 'Select room to see details',
+    fontSize: 20,
+    align: 'center',
+  });
+  const runner = new SceneQueryRunner({
+    datasource: DATASOURCE_REF,
+    queries: [roomsTemperatureQuery],
+    maxDataPoints: 100,
+  });
+
+  const table = new VizPanel({
+    pluginId: 'table',
+    $data: new SceneDataTransformer({
+      transformations: [
+        {
+          id: 'reduce',
+          options: {
+            reducers: ['mean'],
+          },
+        },
+        {
+          id: 'organize',
+          options: {
+            excludeByName: {},
+            indexByName: {},
+            renameByName: {
+              Field: 'Room',
+              Mean: 'Average temperature',
+            },
+          },
+        },
+      ],
+    }),
+    title: 'Room temperature overview',
+    options: {
+      sortBy: ['Average temperature'],
+    },
+    fieldConfig: {
+      defaults: {
+        custom: {
+          align: 'auto',
+          cellOptions: {
+            type: 'auto',
+          },
+          inspect: false,
+        },
+        mappings: [],
+        color: {
+          mode: FieldColorModeId.ContinuousGrYlRd,
+        },
+      },
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Average temperature',
+          },
+          properties: [
+            {
+              id: 'unit',
+              value: 'celsius',
+            },
+            {
+              id: 'custom.cellOptions',
+              value: {
+                type: 'gauge',
+                mode: 'gradient',
+              },
+            },
+            {
+              id: 'custom.align',
+              value: 'center',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Room',
+          },
+          properties: [
+            {
+              id: 'links',
+              value: [
+                {
+                  title: 'Go to room overview',
+                  onClick: (e: DataLinkClickEvent) => {
+                    const roomName = e.origin.field.values.get(e.origin.rowIndex);
+                    splitter.setState({
+                      secondary: new VizPanel({
+                        title: `${roomName} temperature`,
+                        $data: new SceneQueryRunner({
+                          datasource: DATASOURCE_REF,
+                          queries: [getRoomTemperatureQuery(roomName)],
+                        }),
+                        headerActions: (
+                          <IconButton name="x" onClick={() => splitter.setState({ secondary: defaultSecondary })} />
+                        ),
+                      }),
+                    });
+                  },
+                },
+              ],
+            },
+            {
+              id: 'custom.width',
+              value: 250,
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  const splitter = new SplitLayout({
+    direction: 'row',
+    primary: table,
+    secondary: defaultSecondary,
+  });
+
+  return new EmbeddedScene({
+    ...getEmbeddedSceneDefaults(),
+    key: 'Flex layout embedded scene',
+    $data: runner,
+    body: splitter,
+  });
+};
+
+const dynamicSplitDemo = () =>
+  new SceneAppPage({
+    title: 'Dynamic split layout test',
+    url: demoUrl('split-layout/dynamic'),
+    getScene: getDynamicSplitScene,
+  });
+
+export function getSplitTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'A demo of split layout options',
+    url: demoUrl('split-layout'),
+    tabs: [basicDemo(), dynamicSplitDemo()],
   });
 }

--- a/packages/scenes-app/src/demos/withDrilldown/scenes.tsx
+++ b/packages/scenes-app/src/demos/withDrilldown/scenes.tsx
@@ -80,7 +80,7 @@ export function getHumidityOverviewScene(roomName: string) {
   });
 }
 
-function getRoomTemperatureQuery(roomName: string) {
+export function getRoomTemperatureQuery(roomName: string) {
   return {
     refId: 'Temp',
     datasource: DATASOURCE_REF,

--- a/packages/scenes/src/components/layout/Splitter.tsx
+++ b/packages/scenes/src/components/layout/Splitter.tsx
@@ -369,74 +369,74 @@ export function Splitter({
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    handle: css`
-      cursor: col-resize;
-      position: relative;
-      flex-shrink: 0;
-      user-select: none;
+    handle: css({
+      cursor: 'col-resize',
+      position: 'relative',
+      flexShrink: 0,
+      userSelect: 'none',
 
-      &::before {
-        content: '';
-        position: absolute;
-        background-color: ${theme.colors.primary.main};
-        left: 50%;
-        transform: translateX(-50%);
-        top: 0;
-        height: 100%;
-        width: 1px;
-        opacity: 0;
-        transition: opacity ease-in-out 0.2s;
-      }
+      '&::before': {
+        content: '""',
+        position: 'absolute',
+        backgroundColor: theme.colors.primary.main,
+        left: '50%',
+        transform: 'translate(-50%)',
+        top: 0,
+        height: '100%',
+        width: '1px',
+        opacity: 0,
+        transition: 'opacity ease-in-out 0.2s',
+      },
 
-      &::after {
-        content: '';
-        width: 4px;
-        border-radius: 4px;
-        background-color: ${theme.colors.border.weak};
-        transition: background-color ease-in-out 0.2s;
-        height: 50%;
-        top: calc(50% - (50%) / 2);
-        transform: translateX(-50%);
-        position: absolute;
-        left: 50%;
-      }
-      &:hover,
-      &:focus-visible {
-        outline: none;
-        &::before {
-          opacity: 1;
-        }
+      '&::after': {
+        content: '""',
+        width: '4px',
+        borderRadius: '4px',
+        backgroundColor: theme.colors.border.weak,
+        transition: 'background-color ease-in-out 0.2s',
+        height: '50%',
+        top: 'calc(50% - (50%) / 2)',
+        transform: 'translateX(-50%)',
+        position: 'absolute',
+        left: '50%',
+      },
 
-        &::after {
-          background-color: ${theme.v1.palette.blue95};
-        }
-      }
-    `,
-    handleHorizontal: css`
-      cursor: row-resize;
+      '&:hover, &:focus-visible': {
+        outline: 'none',
+        '&::before': {
+          opacity: 1,
+        },
 
-      &::before {
-        left: inherit;
-        transform: translateY(-50%);
-        top: 50%;
-        height: 1px;
-        width: 100%;
-      }
+        '&::after': {
+          backgroundColor: theme.colors.primary.main,
+        },
+      },
+    }),
+    handleHorizontal: css({
+      cursor: 'row-resize',
 
-      &::after {
-        width: 50%;
-        height: 4px;
-        top: 50%;
-        transform: translateY(-50%);
-        left: calc(50% - (50%) / 2);
-      }
-    `,
-    container: css`
-      display: flex;
-      width: 100%;
-      flex-grow: 1;
-      overflow: hidden;
-    `,
+      '&::before': {
+        left: 'inherit',
+        transform: 'translateY(-50%)',
+        top: '50%',
+        height: '1px',
+        width: '100%',
+      },
+
+      '&::after': {
+        width: '50%',
+        height: '4px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        left: 'calc(50% - (50%) / 2)',
+      },
+    }),
+    container: css({
+      display: 'flex',
+      width: '100%',
+      flexGrow: 1,
+      overflow: 'hidden',
+    }),
     panel: css({ display: 'flex', overflow: 'hidden', position: 'relative', flexBasis: 0 }),
   };
 }

--- a/packages/scenes/src/components/layout/Splitter.tsx
+++ b/packages/scenes/src/components/layout/Splitter.tsx
@@ -233,7 +233,7 @@ export function Splitter({
     [direction, handleSize, minDimProp, maxDimProp, measurementProp]
   );
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       if (savedPos.current === undefined) {
         savedPos.current = firstPaneRef.current!.style.flexGrow;
@@ -286,18 +286,18 @@ export function Splitter({
         window.requestAnimationFrame(handlePressedKeys);
       }
     }
-  };
+  }, [direction, handlePressedKeys, handleSize, maxDimProp, measurementProp, minDimProp]);
 
-  const onKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const onKeyUp = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if ((direction === 'row' && !HORIZONTAL_KEYS.has(e.key)) || (direction === 'column' && !VERTICAL_KEYS.has(e.key))) {
       return;
     }
 
     pressedKeys.current.delete(e.key);
     onDragFinished?.(parseFloat(firstPaneRef.current!.style.flexGrow));
-  };
+  }, [direction, onDragFinished]);
 
-  const onDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const onDoubleClick = useCallback(() => {
     firstPaneRef.current!.style.flexGrow = '0.5';
     secondPaneRef.current!.style.flexGrow = '0.5';
     const dim = measureElement(firstPaneRef.current!);
@@ -306,7 +306,7 @@ export function Splitter({
     splitterRef.current!.ariaValueNow = `${
       ((primarySizeRef.current - dim[minDimProp]) / (dim[maxDimProp] - dim[minDimProp])) * 100
     }`;
-  };
+  }, [maxDimProp, measurementProp, minDimProp]);
 
   const styles = useStyles2(getStyles);
   const id = useUniqueId();

--- a/packages/scenes/src/components/layout/Splitter.tsx
+++ b/packages/scenes/src/components/layout/Splitter.tsx
@@ -1,0 +1,531 @@
+import { css, cx } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import { clamp, throttle } from 'lodash';
+import React, { ComponentType, CSSProperties, useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { SceneComponentProps, SceneObjectState, SceneObject } from '../../core/types';
+import { useUniqueId } from './grid/LazyLoader';
+
+export interface SceneFlexItemStateLike extends SceneFlexItemPlacement, SceneObjectState {}
+
+export interface SceneFlexItemLike extends SceneObject<SceneFlexItemStateLike> {}
+
+interface SplitLayoutState extends SceneObjectState, SceneFlexItemPlacement {
+  primary: SceneFlexItemLike;
+  secondary: SceneFlexItemLike;
+  direction: 'row' | 'column';
+}
+
+export class SplitLayout extends SceneObjectBase<SplitLayoutState> {
+  public static Component = SceneFlexLayoutRenderer;
+
+  public toggleDirection() {
+    this.setState({
+      direction: this.state.direction === 'row' ? 'column' : 'row',
+    });
+  }
+
+  public isDraggable(): boolean {
+    return false;
+  }
+}
+
+function SceneFlexLayoutRenderer({ model, parentState }: SceneFlexItemRenderProps<SplitLayout>) {
+  const { primary, secondary, direction, isHidden } = model.useState();
+
+  if (isHidden) {
+    return null;
+  }
+
+  const Prim = primary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  const Sec = secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  return (
+
+    <Splitter direction={direction}>
+        <Prim key={primary.state.key} model={primary} parentState={model.state} />
+        <Sec key={secondary.state.key} model={secondary} parentState={model.state} />
+    </Splitter>
+  );
+}
+
+export interface SceneFlexItemPlacement {
+  wrap?: CSSProperties['flexWrap'];
+  direction?: CSSProperties['flexDirection'];
+  width?: CSSProperties['width'];
+  height?: CSSProperties['height'];
+  minWidth?: CSSProperties['minWidth'];
+  minHeight?: CSSProperties['minHeight'];
+  maxWidth?: CSSProperties['maxWidth'];
+  maxHeight?: CSSProperties['maxHeight'];
+  xSizing?: 'fill' | 'content';
+  ySizing?: 'fill' | 'content';
+  /**
+   * True when the item should rendered but not visible.
+   * Useful for conditional display of layout items
+   */
+  isHidden?: boolean;
+
+  /**
+   * Set direction for smaller screens. This defaults to column.
+   * This equals media query theme.breakpoints.down('md')
+   */
+  md?: SceneFlexItemPlacement;
+}
+
+export interface SceneFlexItemState extends SceneFlexItemPlacement, SceneObjectState {
+  body: SceneObject | undefined;
+}
+
+interface SceneFlexItemRenderProps<T> extends SceneComponentProps<T> {
+  parentState?: SceneFlexItemPlacement;
+}
+
+
+interface Props {
+  handleSize?: number;
+  initialSize?: number | 'auto';
+  direction?: 'row' | 'column';
+  primary?: 'first' | 'second';
+  collapsedDefault?: boolean;
+  firstPaneStyles?: React.CSSProperties;
+  secondPaneStyles?: React.CSSProperties;
+  onDragFinished?: (size: number) => void;
+  children: [React.ReactNode, React.ReactNode];
+}
+
+const PIXELS_PER_MS = 0.3 as const;
+const VERTICAL_KEYS = new Set(['ArrowUp', 'ArrowDown']);
+const HORIZONTAL_KEYS = new Set(['ArrowLeft', 'ArrowRight']);
+
+const propsForDirection = {
+  'row': {
+    dim: 'width',
+    axis: 'clientX',
+    min: 'minWidth',
+    max: 'maxWidth',
+  },
+  'column': {
+    dim: 'height',
+    axis: 'clientY',
+    min: 'minHeight',
+    max: 'maxHeight'
+  }
+} as const;
+
+export function Splitter({
+  direction = 'row',
+  handleSize = 32,
+  initialSize = 'auto',
+  firstPaneStyles,
+  secondPaneStyles,
+  onDragFinished,
+  children,
+}: Props) {
+  const kids = React.Children.toArray(children);
+
+  const splitterRef = useRef<HTMLDivElement | null>(null);
+  const firstPaneRef = useRef<HTMLDivElement | null>(null);
+  const secondPaneRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerSize = useRef<number | null>(null);
+  const primarySizeRef = useRef<'1fr' | number>('1fr');
+
+  const firstPaneMeasurements = useRef<ReturnType<typeof measureElement>>(undefined);
+  const savedPos = useRef<string | undefined>(undefined);
+
+  const measurementProp = propsForDirection[direction].dim;
+  const clientAxis = propsForDirection[direction].axis;
+  const minDimProp = propsForDirection[direction].min;
+  const maxDimProp = propsForDirection[direction].max;
+
+  // Using a resize observer here, as with content or screen based width/height the ratio between panes might
+  // change after a window resize, so ariaValueNow needs to be updated accordingly
+  useResizeObserver(
+    containerRef.current!,
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.target.isSameNode(containerRef.current)) {
+          return;
+        }
+
+        const curSize = firstPaneRef.current!.getBoundingClientRect()[measurementProp];
+        const newDims = measureElement(firstPaneRef.current!);
+        splitterRef.current!.ariaValueNow = `${clamp(
+          ((curSize - newDims[minDimProp]) / (newDims[maxDimProp] - newDims[minDimProp])) * 100,
+          0,
+          100
+        )}`;
+      }
+    },
+    500,
+    [maxDimProp, minDimProp, direction, measurementProp]
+  );
+
+  const dragStart = useRef<number | null>(null);
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // measure left-side width
+      primarySizeRef.current = firstPaneRef.current!.getBoundingClientRect()[measurementProp];
+      containerSize.current = containerRef.current!.getBoundingClientRect()[measurementProp];
+
+      // set position at start of drag
+      dragStart.current = e[clientAxis];
+      splitterRef.current!.setPointerCapture(e.pointerId);
+      firstPaneMeasurements.current = measureElement(firstPaneRef.current!);
+
+      savedPos.current = undefined;
+    },
+    [measurementProp, clientAxis]
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (dragStart.current !== null && primarySizeRef.current !== '1fr') {
+        const diff = e[clientAxis] - dragStart.current;
+        const dims = firstPaneMeasurements.current!;
+        const newSize = clamp(primarySizeRef.current + diff, dims[minDimProp], dims[maxDimProp]);
+        const newFlex = newSize / (containerSize.current! - handleSize);
+        firstPaneRef.current!.style.flexGrow = `${newFlex}`;
+        secondPaneRef.current!.style.flexGrow = `${1 - newFlex}`;
+        const ariaValueNow = clamp(
+          ((newSize - dims[minDimProp]) / (dims[maxDimProp] - dims[minDimProp])) * 100,
+          0,
+          100
+        );
+
+        splitterRef.current!.ariaValueNow = `${ariaValueNow}`;
+      }
+    },
+    [handleSize, clientAxis, minDimProp, maxDimProp]
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      splitterRef.current!.releasePointerCapture(e.pointerId);
+      dragStart.current = null;
+      onDragFinished?.(parseFloat(firstPaneRef.current!.style.flexGrow));
+    },
+    [onDragFinished]
+  );
+
+  const pressedKeys = useRef(new Set<string>());
+  const keysLastHandledAt = useRef<number | null>(null);
+  const handlePressedKeys = useCallback(
+    (time: number) => {
+      const nothingPressed = pressedKeys.current.size === 0;
+      if (nothingPressed) {
+        keysLastHandledAt.current = null;
+        return;
+      } else if (primarySizeRef.current === '1fr') {
+        return;
+      }
+
+      const dt = time - (keysLastHandledAt.current ?? time);
+      const dx = dt * PIXELS_PER_MS;
+      let sizeChange = 0;
+
+      if (direction === 'row') {
+        if (pressedKeys.current.has('ArrowLeft')) {
+          sizeChange -= dx;
+        }
+        if (pressedKeys.current.has('ArrowRight')) {
+          sizeChange += dx;
+        }
+      } else {
+        if (pressedKeys.current.has('ArrowUp')) {
+          sizeChange -= dx;
+        }
+        if (pressedKeys.current.has('ArrowDown')) {
+          sizeChange += dx;
+        }
+      }
+
+      const firstPaneDims = firstPaneMeasurements.current!;
+      const curSize = firstPaneRef.current!.getBoundingClientRect()[measurementProp];
+      const newSize = clamp(curSize + sizeChange, firstPaneDims[minDimProp], firstPaneDims[maxDimProp]);
+
+      const newFlex = newSize / (containerSize.current! - handleSize);
+
+      // primarySizeRef.current = newSize;
+      firstPaneRef.current!.style.flexGrow = `${newFlex}`;
+      secondPaneRef.current!.style.flexGrow = `${1 - newFlex}`;
+      const ariaValueNow =
+        ((newSize - firstPaneDims[minDimProp]) / (firstPaneDims[maxDimProp] - firstPaneDims[minDimProp])) * 100;
+      splitterRef.current!.ariaValueNow = `${clamp(ariaValueNow, 0, 100)}`;
+
+      keysLastHandledAt.current = time;
+      window.requestAnimationFrame(handlePressedKeys);
+    },
+    [direction, handleSize, minDimProp, maxDimProp, measurementProp]
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter') {
+      if (savedPos.current === undefined) {
+        savedPos.current = firstPaneRef.current!.style.flexGrow;
+        firstPaneRef.current!.style.flexGrow = '0';
+        secondPaneRef.current!.style.flexGrow = '1';
+      } else {
+        firstPaneRef.current!.style.flexGrow = savedPos.current;
+        secondPaneRef.current!.style.flexGrow = `${1 - parseFloat(savedPos.current)}`;
+        savedPos.current = undefined;
+      }
+      return;
+    } else if (e.key === 'Home') {
+      firstPaneMeasurements.current = measureElement(firstPaneRef.current!);
+      containerSize.current = containerRef.current!.getBoundingClientRect()[measurementProp];
+      const newFlex = firstPaneMeasurements.current[minDimProp] / (containerSize.current! - handleSize);
+      firstPaneRef.current!.style.flexGrow = `${newFlex}`;
+      secondPaneRef.current!.style.flexGrow = `${1 - newFlex}`;
+      splitterRef.current!.ariaValueNow = '0';
+      return;
+    } else if (e.key === 'End') {
+      firstPaneMeasurements.current = measureElement(firstPaneRef.current!);
+      containerSize.current = containerRef.current!.getBoundingClientRect()[measurementProp];
+      const newFlex = firstPaneMeasurements.current[maxDimProp] / (containerSize.current! - handleSize);
+      firstPaneRef.current!.style.flexGrow = `${newFlex}`;
+      secondPaneRef.current!.style.flexGrow = `${1 - newFlex}`;
+      splitterRef.current!.ariaValueNow = '100';
+      return;
+    }
+
+    if (
+      !((direction === 'column' && VERTICAL_KEYS.has(e.key)) || (direction === 'row' && HORIZONTAL_KEYS.has(e.key))) ||
+      pressedKeys.current.has(e.key)
+    ) {
+      return;
+    }
+
+    savedPos.current = undefined;
+    e.preventDefault();
+    e.stopPropagation();
+    primarySizeRef.current = firstPaneRef.current!.getBoundingClientRect()[measurementProp];
+    containerSize.current = containerRef.current!.getBoundingClientRect()[measurementProp];
+    firstPaneMeasurements.current = measureElement(firstPaneRef.current!);
+    const newKey = !pressedKeys.current.has(e.key);
+
+    if (newKey) {
+      const initiateAnimationLoop = pressedKeys.current.size === 0;
+      pressedKeys.current.add(e.key);
+
+      if (initiateAnimationLoop) {
+        window.requestAnimationFrame(handlePressedKeys);
+      }
+    }
+  };
+
+  const onKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      (direction === 'row' && !HORIZONTAL_KEYS.has(e.key)) ||
+      (direction === 'column' && !VERTICAL_KEYS.has(e.key))
+    ) {
+      return;
+    }
+
+    pressedKeys.current.delete(e.key);
+    onDragFinished?.(parseFloat(firstPaneRef.current!.style.flexGrow));
+  };
+
+  const onDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // firstPaneMeasurements.current = measureElement(firstPaneRef.current!);
+    // containerSize.current = containerRef.current!.getBoundingClientRect()[measurementProp];
+    // const midPoint = (firstPaneMeasurements.current[maxDimProp] - firstPaneMeasurements.current[minDimProp]) / 2;
+    // const newFlex = midPoint / (containerSize.current! - handleSize);
+    firstPaneRef.current!.style.flexGrow = '0.5';
+    secondPaneRef.current!.style.flexGrow = '0.5';
+    const dim = measureElement(firstPaneRef.current!);
+    firstPaneMeasurements.current = dim;
+    primarySizeRef.current = firstPaneRef.current!.getBoundingClientRect()[measurementProp];
+    splitterRef.current!.ariaValueNow = `${
+      ((primarySizeRef.current - dim[minDimProp]) / (dim[maxDimProp] - dim[minDimProp])) * 100
+    }`;
+  };
+
+  const styles = useStyles2(getStyles);
+  const id = useUniqueId();
+
+  return (
+    <div
+      ref={containerRef}
+      className={styles.container}
+      style={{
+        flexDirection: direction,
+      }}
+    >
+      <div
+        ref={firstPaneRef}
+        className={styles.panel}
+        style={{
+          flexGrow: initialSize === 'auto' ? 0.5 : clamp(initialSize, 0, 1),
+          [minDimProp]: 'min-content',
+          ...firstPaneStyles,
+        }}
+        id={`start-panel-${id}`}
+      >
+        {kids[0]}
+      </div>
+
+      <div
+        ref={splitterRef}
+        style={{ [measurementProp]: `${handleSize}px` }}
+        className={cx(styles.handle, { [styles.handleHorizontal]: direction === 'column' })}
+        onPointerUp={onPointerUp}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onDoubleClick={onDoubleClick}
+        role="separator"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={50}
+        aria-controls={`start-panel-${id}`}
+        aria-label="Pane resize widget"
+        tabIndex={0}
+      ></div>
+
+      <div
+        ref={secondPaneRef}
+        className={styles.panel}
+        style={{
+          flexGrow: initialSize === 'auto' ? 0.5 : clamp(1 - initialSize, 0, 1),
+          [minDimProp]: 'min-content',
+          ...secondPaneStyles,
+        }}
+        id={`end-panel-${id}`}
+      >
+        {kids[1]}
+      </div>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    handle: css`
+      cursor: col-resize;
+      position: relative;
+      flex-shrink: 0;
+      user-select: none;
+
+      &::before {
+        content: '';
+        position: absolute;
+        background-color: ${theme.v1.palette.blue95};
+        left: 50%;
+        transform: translateX(-50%);
+        top: 0;
+        height: 100%;
+        width: 1px;
+        opacity: 0;
+        transition: opacity ease-in-out 0.2s;
+      }
+
+      &::after {
+        content: '';
+        width: 4px;
+        border-radius: 4px;
+        background-color: ${theme.colors.border.weak};
+        transition: background-color ease-in-out 0.2s;
+        height: 50%;
+        top: calc(50% - (50%) / 2);
+        transform: translateX(-50%);
+        position: absolute;
+        left: 50%;
+      }
+      &:hover,
+      &:focus-visible {
+        outline: none;
+        &::before {
+          opacity: 1;
+        }
+
+        &::after {
+          background-color: ${theme.v1.palette.blue95};
+        }
+      }
+    `,
+    handleHorizontal: css`
+      cursor: row-resize;
+
+      &::before {
+        left: inherit;
+        transform: translateY(-50%);
+        top: 50%;
+        height: 1px;
+        width: 100%;
+      }
+
+      &::after {
+        width: 50%;
+        height: 4px;
+        top: 50%;
+        transform: translateY(-50%);
+        left: calc(50% - (50%) / 2);
+      }
+    `,
+    container: css`
+      display: flex;
+      width: 100%;
+      flex-grow: 1;
+      overflow: hidden;
+    `,
+    panel: css({ display: 'flex', overflow: 'hidden', position: 'relative', flexBasis: 0 }),
+  };
+}
+
+type MeasureR<T> = T extends HTMLElement
+  ? { minWidth: number; maxWidth: number; minHeight: number; maxHeight: number }
+  : T extends null
+  ? undefined
+  : never;
+type HTMLElementOrNull = HTMLElement | null;
+
+function measureElement<T extends HTMLElementOrNull>(ref: T): MeasureR<T> {
+  if (ref === null) {
+    return undefined as MeasureR<T>;
+  }
+
+  const savedBodyOverflow = document.body.style.overflow;
+  const savedWidth = ref.style.width;
+  const savedHeight = ref.style.height;
+  const savedFlex = ref.style.flexGrow;
+  document.body.style.overflow = 'hidden';
+  ref.style.flexGrow = '0';
+  const { width: minWidth, height: minHeight } = ref.getBoundingClientRect();
+
+  ref.style.flexGrow = '100';
+  const { width: maxWidth, height: maxHeight } = ref.getBoundingClientRect();
+
+  document.body.style.overflow = savedBodyOverflow;
+  ref.style.width = savedWidth;
+  ref.style.height = savedHeight;
+  ref.style.flexGrow = savedFlex;
+
+  return { minWidth, maxWidth, minHeight, maxHeight } as MeasureR<T>;
+}
+
+function useResizeObserver(
+  target: Element,
+  cb: (entries: ResizeObserverEntry[]) => void,
+  throttleWait = 0,
+  deps?: React.DependencyList
+) {
+  const throttledCallback = throttle(cb, throttleWait);
+
+  useLayoutEffect(() => {
+    if (!target) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(throttledCallback);
+
+    resizeObserver.observe(target, { box: 'device-pixel-content-box' });
+    return () => resizeObserver.disconnect();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/packages/scenes/src/components/layout/Splitter.tsx
+++ b/packages/scenes/src/components/layout/Splitter.tsx
@@ -378,7 +378,7 @@ function getStyles(theme: GrafanaTheme2) {
       &::before {
         content: '';
         position: absolute;
-        background-color: ${theme.v1.palette.blue95};
+        background-color: ${theme.colors.primary.main};
         left: 50%;
         transform: translateX(-50%);
         top: 0;

--- a/packages/scenes/src/components/layout/split/SplitLayout.ts
+++ b/packages/scenes/src/components/layout/split/SplitLayout.ts
@@ -1,0 +1,24 @@
+import { SceneObjectBase } from '../../../core/SceneObjectBase';
+import { SceneObjectState } from '../../../core/types';
+import { SceneFlexItemPlacement, SceneFlexItemLike } from '../SceneFlexLayout';
+import { SplitLayoutRenderer } from './SplitLayoutRenderer';
+
+interface SplitLayoutState extends SceneObjectState, SceneFlexItemPlacement {
+  primary: SceneFlexItemLike;
+  secondary: SceneFlexItemLike;
+  direction: 'row' | 'column';
+}
+
+export class SplitLayout extends SceneObjectBase<SplitLayoutState> {
+  public static Component = SplitLayoutRenderer;
+
+  public toggleDirection() {
+    this.setState({
+      direction: this.state.direction === 'row' ? 'column' : 'row',
+    });
+  }
+
+  public isDraggable(): boolean {
+    return false;
+  }
+}

--- a/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
@@ -1,0 +1,32 @@
+import React, { ComponentType } from 'react';
+
+import { SceneComponentProps, SceneObjectState, SceneObject } from '../../../core/types';
+import { SceneFlexItemPlacement } from '../SceneFlexLayout';
+import { SplitLayout } from './SplitLayout';
+import { Splitter } from './Splitter';
+
+
+export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLayout>) {
+  const { primary, secondary, direction, isHidden } = model.useState();
+
+  if (isHidden) {
+    return null;
+  }
+
+  const Prim = primary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  const Sec = secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  return (
+    <Splitter direction={direction}>
+      <Prim key={primary.state.key} model={primary} parentState={model.state} />
+      <Sec key={secondary.state.key} model={secondary} parentState={model.state} />
+    </Splitter>
+  );
+}
+
+export interface SceneFlexItemState extends SceneFlexItemPlacement, SceneObjectState {
+  body: SceneObject | undefined;
+}
+
+interface SceneFlexItemRenderProps<T> extends SceneComponentProps<T> {
+  parentState?: SceneFlexItemPlacement;
+}

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -42,7 +42,7 @@ export { SceneControlsSpacer } from './components/SceneControlsSpacer';
 export { SceneFlexLayout, SceneFlexItem, type SceneFlexItemState } from './components/layout/SceneFlexLayout';
 export { SceneGridLayout, SceneGridItem } from './components/layout/grid/SceneGridLayout';
 export { SceneGridRow } from './components/layout/grid/SceneGridRow';
-export { SplitLayout } from './components/layout/Splitter';
+export { SplitLayout } from './components/layout/split/SplitLayout';
 export {
   type SceneAppPageLike,
   type SceneRouteMatch,

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -42,6 +42,7 @@ export { SceneControlsSpacer } from './components/SceneControlsSpacer';
 export { SceneFlexLayout, SceneFlexItem, type SceneFlexItemState } from './components/layout/SceneFlexLayout';
 export { SceneGridLayout, SceneGridItem } from './components/layout/grid/SceneGridLayout';
 export { SceneGridRow } from './components/layout/grid/SceneGridRow';
+export { SplitLayout } from './components/layout/Splitter';
 export {
   type SceneAppPageLike,
   type SceneRouteMatch,


### PR DESCRIPTION
Adds a SplitLayout scene object.
I wanted to use the opportunity to write an accessible and robust Splitter component (possibly one we can add to grafana-ui). To this end it supports keyboard controls, shortcuts, aria values, and maintains proportions if a screen is resized. Min/max dimensions can also be set on splitter panes.

I think there's still room for refactoring and improvement, but it's a start.

Solves #176 