### PR TITLE
SceneQueryRunner: Support `liveStreaming`

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -28,6 +28,7 @@ export interface QueryRunnerState extends SceneObjectState {
   datasource?: DataSourceRef;
   minInterval?: string;
   maxDataPoints?: number;
+  liveStreaming?: boolean;
   // Non persisted state
   maxDataPointsFromWidth?: boolean;
   isWaitingForVariables?: boolean;
@@ -218,6 +219,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       maxDataPoints: this.getMaxDataPoints(),
       scopedVars: sceneObjectScopedVar,
       startTime: Date.now(),
+      liveStreaming: this.state.liveStreaming,
     };
 
     try {


### PR DESCRIPTION
Adds support for passing `liveStreaming` prop to data query request.

Closes #232
