### PR TITLE
SceneGridRow: Fix rows auto collapsing on load due to url sync

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -62,7 +62,7 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    if (values.rowc === undefined) {
+    if (values.rowc == null) {
       return;
     }
 

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -62,8 +62,11 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    const isCollapsed = values.rowc === '1';
-    if (isCollapsed !== this.state.isCollapsed) {
+    if (values.rowc === undefined) {
+      return;
+    }
+
+    if (values.rowc !== this.getUrlState().rowc) {
       this.onCollapseToggle();
     }
   }


### PR DESCRIPTION
- SceneGridRow: Fix url sync issues that collapses rows
- correct fix


Noticied that when loading dashboards some rows where collapsed when loaded in scenes runtime
