### PR TITLE
POC: Time comparison

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -18,6 +18,7 @@ import { getTimeZoneTest } from './timeZones';
 import { getSplitTest } from './split';
 import { getQueryCancellationTest } from './queryCancellation';
 import { getDocsExamples } from './docs-examples';
+import { getTimeRangeComparisonTest } from './timeRangeComparison';
 
 export interface DemoDescriptor {
   title: string;
@@ -44,6 +45,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Time zones demo', getPage: getTimeZoneTest },
     { title: 'Split layout', getPage: getSplitTest },
     { title: 'Query cancellation', getPage: getQueryCancellationTest },
+    { title: 'Time range comparison', getPage: getTimeRangeComparisonTest },
     { title: 'Docs examples', getPage: getDocsExamples },
   ];
 }

--- a/packages/scenes-app/src/demos/timeRangeComparison.tsx
+++ b/packages/scenes-app/src/demos/timeRangeComparison.tsx
@@ -1,0 +1,82 @@
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneControlsSpacer,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneRefreshPicker,
+  SceneTimePicker,
+  SceneTimeRange,
+  SceneTimeRangeComparePicker,
+  SceneTimeRangeWithComparison,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery } from './utils';
+
+export function getTimeRangeComparisonTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Time range comparison test',
+    getScene: () => {
+      return new EmbeddedScene({
+        $timeRange: new SceneTimeRangeWithComparison({
+          $timeRange: new SceneTimeRange({}),
+        }),
+        controls: [
+          new SceneControlsSpacer(),
+          new SceneTimePicker({}),
+          new SceneTimeRangeComparePicker({}),
+          new SceneRefreshPicker({}),
+        ],
+        key: 'Flex layout embedded scene',
+        body: new SceneFlexLayout({
+          direction: 'column',
+          children: [
+            new SceneFlexLayout({
+              direction: 'row',
+              children: [
+                new SceneFlexItem({
+                  body: PanelBuilders.timeseries()
+                    .setTitle('Should run two queries when compare option provided')
+                    .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPointsFromWidth: true }))
+                    .build(),
+                }),
+                // new SceneFlexLayout({
+                //   direction: 'column',
+                //   children: [
+                //     new SceneFlexItem({
+                //       ySizing: 'content',
+                //       body: new SceneCanvasText({
+                //         text: 'Panel below uses local compare options, reading from the global time range',
+                //       }),
+                //     }),
+                //     new SceneFlexItem({
+                //       body: new SceneFlexLayout({
+                //         direction: 'row',
+                //         $timeRange: new SceneTimeRangeWithComparison({}),
+                //         children: [
+                //           new SceneFlexItem({
+                //             body: PanelBuilders.timeseries()
+                //               .setTitle('Dynamic height and width')
+                //               .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPointsFromWidth: true }))
+                //               .build(),
+                //           }),
+                //           new SceneFlexItem({
+                //             body: new SceneTimeRangeComparePicker({}),
+                //             xSizing: 'content',
+                //             ySizing: 'content',
+                //           }),
+                //         ],
+                //       }),
+                //     }),
+                //   ],
+                // }),
+              ],
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}

--- a/packages/scenes/src/components/SceneTimeRangeComparePicker.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeComparePicker.tsx
@@ -1,0 +1,53 @@
+import { ButtonSelect, InlineField } from '@grafana/ui';
+import React from 'react';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneComponentProps } from '../core/types';
+import { isSceneTimeRangeWithComparison } from './SceneTimeRangeWithComparison';
+
+export class SceneTimeRangeComparePicker extends SceneObjectBase {
+  static Component = SceneTimeRangeComparePickerRenderer;
+
+  public getCompareOptions = () => {
+    const timeRange = sceneGraph.getTimeRange(this);
+
+    if (isSceneTimeRangeWithComparison(timeRange)) {
+      return timeRange.provideCompareOptions();
+    }
+
+    throw new Error('SceneTimeRangeComparePicker can only be used with SceneTimeRangeWithComparison');
+  };
+
+  public getTimeRange = () => {
+    const timeRange = sceneGraph.getTimeRange(this);
+    if (isSceneTimeRangeWithComparison(timeRange)) {
+      return timeRange;
+    }
+    throw new Error('SceneTimeRangeComparePicker can only be used with SceneTimeRangeWithComparison');
+  };
+
+  public onCompareWithChanged = (compareWith: string) => {
+    const timeRange = this.getTimeRange();
+    timeRange.onCompareChange(compareWith);
+  };
+}
+
+function SceneTimeRangeComparePickerRenderer({ model }: SceneComponentProps<SceneTimeRangeComparePicker>) {
+  const options = model.getCompareOptions();
+  const tr = model.getTimeRange().useState();
+  const value = options.find((o) => o.value === tr.compareTo);
+
+  return (
+    // UI here is temporary, just for the sake of testing the functionality
+    <InlineField label="Compare with:">
+      <ButtonSelect
+        value={value}
+        variant="canvas"
+        options={options}
+        onChange={(v) => {
+          model.onCompareWithChanged(v.value!);
+        }}
+      />
+    </InlineField>
+  );
+}

--- a/packages/scenes/src/components/SceneTimeRangeWithComparison.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeWithComparison.tsx
@@ -1,0 +1,137 @@
+import { dateTime, getTimeZone, rangeUtil, TimeRange } from '@grafana/data';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { evaluateTimeRange } from '../core/SceneTimeRange';
+import { SceneObjectUrlValues, SceneTimeRangeLike, SceneTimeRangeState } from '../core/types';
+import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
+
+interface SceneTimeRangeWithComparisonState extends SceneTimeRangeState {
+  compareTo?: string;
+}
+
+interface MultiTimeRangeProvider extends SceneTimeRangeLike {
+  getTimeRanges(): [TimeRange, TimeRange | undefined];
+}
+
+export class SceneTimeRangeWithComparison
+  extends SceneObjectBase<SceneTimeRangeWithComparisonState>
+  implements MultiTimeRangeProvider
+{
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['compareTo'] });
+
+  public constructor(state: Partial<SceneTimeRangeWithComparisonState>) {
+    super({
+      ...state,
+      // Fake time range, it's actually provided via closest time range object on activation
+      from: 'now-6h',
+      to: 'now',
+      value: evaluateTimeRange('now-6h', 'now', state.timeZone || getTimeZone()),
+    });
+
+    this.addActivationHandler(this._activationHandler);
+  }
+
+  public getUrlState() {
+    return { from: this.state.from, to: this.state.to };
+  }
+
+  public updateFromUrl(values: SceneObjectUrlValues) {
+    // TODO
+  }
+
+  private _activationHandler = () => {
+    const timeRangeObject = this.getTimeRangeObject();
+    const { from, to } = timeRangeObject.state;
+    this.setState({
+      from,
+      to,
+      value: evaluateTimeRange(from, to, timeRangeObject.getTimeZone()),
+    });
+
+    this._subs.add(
+      timeRangeObject.subscribeToState((n) => {
+        this.setState({
+          from: n.from,
+          to: n.to,
+          value: evaluateTimeRange(n.from, n.to, timeRangeObject.getTimeZone()),
+        });
+      })
+    );
+  };
+
+  public onTimeRangeChange = (timeRange: TimeRange) => {
+    const timeRangeObject = this.getTimeRangeObject();
+    timeRangeObject.onTimeRangeChange(timeRange);
+  };
+
+  public onTimeZoneChange = (timeZone: string) => {
+    const timeRangeObject = this.getTimeRangeObject();
+    timeRangeObject.onTimeZoneChange(timeZone);
+  };
+
+  public getTimeZone(): string {
+    const timeRangeObject = this.getTimeRangeObject();
+    return timeRangeObject.getTimeZone();
+  }
+
+  public onRefresh() {
+    const timeRangeObject = this.getTimeRangeObject();
+    timeRangeObject.onRefresh();
+  }
+
+  public onCompareChange = (compareTo: string) => {
+    this.setState({ compareTo });
+  };
+
+  private getTimeRangeObject = () => {
+    if (this.state.$timeRange) {
+      return this.state.$timeRange;
+    }
+
+    return sceneGraph.getTimeRange(this.parent!.parent!);
+  };
+
+  public getTimeRanges = (): [TimeRange, TimeRange | undefined] => {
+    const timeRangeObject = this.getTimeRangeObject();
+    const timeRange = timeRangeObject.state.value;
+
+    let compareTimeRange: TimeRange | undefined;
+    if (this.state.compareTo) {
+      const compareFrom = dateTime(timeRange.from!).subtract(rangeUtil.intervalToMs(this.state.compareTo));
+      const compareTo = dateTime(timeRange.to!).subtract(rangeUtil.intervalToMs(this.state.compareTo));
+
+      compareTimeRange = {
+        from: compareFrom,
+        to: compareTo,
+        raw: {
+          from: compareFrom,
+          to: compareTo,
+        },
+      };
+    }
+
+    return [timeRange, compareTimeRange];
+  };
+
+  public provideCompareOptions = () => {
+    // TODO - those options should be provided based on the selected time range, this is faking for now
+    return [
+      {
+        label: 'A day ago',
+        value: '24h',
+      },
+      {
+        label: 'A week ago',
+        value: '7d',
+      },
+    ];
+  };
+}
+
+export function isSceneTimeRangeWithComparison(obj: any): obj is SceneTimeRangeWithComparison {
+  return Object.prototype.hasOwnProperty.call(obj, 'provideCompareOptions');
+}
+
+export function isMultiTimeRangeProvider(obj: any): obj is MultiTimeRangeProvider {
+  return Object.prototype.hasOwnProperty.call(obj, 'getTimeRanges');
+}

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -130,7 +130,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   }
 }
 
-function parseUrlParam(value: SceneObjectUrlValue): string | null {
+export function parseUrlParam(value: SceneObjectUrlValue): string | null {
   if (typeof value !== 'string') {
     return null;
   }

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -37,6 +37,8 @@ export { SceneCanvasText } from './components/SceneCanvasText';
 export { SceneToolbarButton, SceneToolbarInput } from './components/SceneToolbarButton';
 export { SceneTimePicker } from './components/SceneTimePicker';
 export { SceneRefreshPicker } from './components/SceneRefreshPicker';
+export { SceneTimeRangeWithComparison } from './components/SceneTimeRangeWithComparison';
+export { SceneTimeRangeComparePicker } from './components/SceneTimeRangeComparePicker';
 export { SceneByFrameRepeater } from './components/SceneByFrameRepeater';
 export { SceneControlsSpacer } from './components/SceneControlsSpacer';
 export { SceneFlexLayout, SceneFlexItem, type SceneFlexItemState } from './components/layout/SceneFlexLayout';


### PR DESCRIPTION
POC for handling time-over-time comparison.

Introduces `SceneTimeRangeWithComparison` that behaves like a regular `SceneTimeRange` object but also implements `MultiTimeRangeProvider` interface for providing multiple time ranges to consumers. In this case the consumer is `SceneQueryRunner` which will detect whether or not its time range is multi time range provider, and run the queries accordingly. In case of SQR being in scope of `MultiTimeRangeProvider` it will execute two query requests with the corresponding time ranges. Later, when the data is received it will re-adjust compare series timestamps based on the comparison diff and also modify returned fields' field config in order to indicate the comparison series. 

Not sure this is the best approach, but seems to be working just fine :)