### PR TITLE
SceneGridLayout: Fixes issues with unmount on every re-render

### DIFF
--- a/packages/scenes-app/src/demos/lazyLoad.tsx
+++ b/packages/scenes-app/src/demos/lazyLoad.tsx
@@ -15,12 +15,10 @@ export function getLazyLoadDemo(defaults: SceneAppPageState) {
     getScene: () => {
       const panelIds = Array.from(Array(20).keys());
       const height = 6;
-      const panel = PanelBuilders.timeseries().setData(
-        getQueryRunnerWithRandomWalkQuery({ scenarioId: 'slow_query', stringInput: '5s' })
-      );
 
       return new EmbeddedScene({
         body: new SceneGridLayout({
+          isLazy: true,
           children: panelIds.map(
             (id) =>
               new SceneGridItem({
@@ -30,7 +28,10 @@ export function getLazyLoadDemo(defaults: SceneAppPageState) {
                 height: height,
                 isResizable: true,
                 isDraggable: true,
-                body: panel.setTitle(`Panel ${id}`).build(),
+                body: PanelBuilders.timeseries()
+                  .setTitle(`Panel ${id}`)
+                  .setData(getQueryRunnerWithRandomWalkQuery({ scenarioId: 'slow_query', stringInput: '5s' }))
+                  .build(),
               })
           ),
         }),

--- a/packages/scenes/src/components/layout/grid/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/grid/LazyLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { ForwardRefExoticComponent, useImperativeHandle, useRef, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { uniqueId } from 'lodash';
@@ -11,51 +11,61 @@ export function useUniqueId(): string {
 
 export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
   children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
-  width?: number;
-  height?: number;
+  key: string;
   onLoad?: () => void;
   onChange?: (isInView: boolean) => void;
 }
 
-export function LazyLoader({ children, width, height, onLoad, onChange, style, ...rest }: Props) {
-  const id = useUniqueId();
-  const [loaded, setLoaded] = useState(false);
-  const [isInView, setIsInView] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffectOnce(() => {
-    LazyLoader.addCallback(id, (entry) => {
-      if (!loaded && entry.isIntersecting) {
-        setLoaded(true);
-        onLoad?.();
-      }
-
-      setIsInView(entry.isIntersecting);
-      onChange?.(entry.isIntersecting);
-    });
-
-    const wrapperEl = wrapperRef.current;
-
-    if (wrapperEl) {
-      LazyLoader.observer.observe(wrapperEl);
-    }
-
-    return () => {
-      delete LazyLoader.callbacks[id];
-      wrapperEl && LazyLoader.observer.unobserve(wrapperEl);
-      if (Object.keys(LazyLoader.callbacks).length === 0) {
-        LazyLoader.observer.disconnect();
-      }
-    };
-  });
-
-  return (
-    <div id={id} ref={wrapperRef} style={{ ...style, width, height }} {...rest}>
-      {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
-    </div>
-  );
+export interface LazyLoaderType extends ForwardRefExoticComponent<Props> {
+  addCallback: (id: string, c: (e: IntersectionObserverEntry) => void) => void;
+  callbacks: Record<string, (e: IntersectionObserverEntry) => void>;
+  observer: IntersectionObserver;
 }
 
+export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props>(
+  ({ children, onLoad, onChange, ...rest }, ref) => {
+    const id = useUniqueId();
+    const [loaded, setLoaded] = useState(false);
+    const [isInView, setIsInView] = useState(false);
+    const innerRef = useRef<HTMLDivElement>(null);
+
+    useImperativeHandle(ref, () => innerRef.current!);
+
+    useEffectOnce(() => {
+      LazyLoader.addCallback(id, (entry) => {
+        if (!loaded && entry.isIntersecting) {
+          setLoaded(true);
+          onLoad?.();
+        }
+
+        setIsInView(entry.isIntersecting);
+        onChange?.(entry.isIntersecting);
+      });
+
+      const wrapperEl = innerRef.current;
+
+      if (wrapperEl) {
+        LazyLoader.observer.observe(wrapperEl);
+      }
+
+      return () => {
+        delete LazyLoader.callbacks[id];
+        wrapperEl && LazyLoader.observer.unobserve(wrapperEl);
+        if (Object.keys(LazyLoader.callbacks).length === 0) {
+          LazyLoader.observer.disconnect();
+        }
+      };
+    });
+
+    return (
+      <div id={id} ref={innerRef} {...rest}>
+        {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
+      </div>
+    );
+  }
+) as LazyLoaderType;
+
+LazyLoader.displayName = 'LazyLoader';
 LazyLoader.callbacks = {} as Record<string, (e: IntersectionObserverEntry) => void>;
 LazyLoader.addCallback = (id: string, c: (e: IntersectionObserverEntry) => void) => (LazyLoader.callbacks[id] = c);
 LazyLoader.observer = new IntersectionObserver(


### PR DESCRIPTION
When testing core dashboards loaded in scenes runtime I noticed that every panel grid resize change caused big flickering due to all panels unmounting and re-mounting. 

* Root cause was a new component instance LazyLoader was created on every render (when isLazy was false)
* But to fix I ended up refactoring the LazyLoader so to avoid the unnecessary wrapping div (it just needed forwardRef)
* Also fixed the lazy demo which had two issues:
** Lazy was not enabled!! :) 
** Was just not assigning any query on every panel so was just using same data  (this likely introduced in recent refactor to use PanelBuilders) 
 