### PR TITLE
GridLayout: Default isDraggable to false (unset)

### DIFF
--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -19,6 +19,7 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
         ...getEmbeddedSceneDefaults(),
         $data: getQueryRunnerWithRandomWalkQuery(),
         body: new SceneGridLayout({
+          isDraggable: true,
           children: [
             new SceneGridItem({
               x: 0,

--- a/packages/scenes-app/src/demos/gridWithRow.tsx
+++ b/packages/scenes-app/src/demos/gridWithRow.tsx
@@ -18,6 +18,7 @@ export function getGridWithRowLayoutTest(defaults: SceneAppPageState): SceneAppP
         ...getEmbeddedSceneDefaults(),
         $data: getQueryRunnerWithRandomWalkQuery(),
         body: new SceneGridLayout({
+          isDraggable: true,
           children: [
             new SceneGridRow({
               title: 'Row A',

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -26,7 +26,6 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
   public constructor(state: SceneGridLayoutState) {
     super({
       ...state,
-      isDraggable: true,
       children: sortChildrenByPosition(state.children),
     });
   }


### PR DESCRIPTION
Just think it makes more intuitive sense to default this to undefined (false) 