### PR TITLE
SceneGridItem: Makes isDraggable and isResizable optional 

### DIFF
--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -8,8 +8,8 @@ export interface SceneGridItemPlacement {
 }
 
 export interface SceneGridItemStateLike extends SceneGridItemPlacement, SceneObjectState {
-  isResizable: boolean;
-  isDraggable: boolean;
+  isResizable?: boolean;
+  isDraggable?: boolean;
 }
 
 export type SceneGridItemLike = SceneObject<SceneGridItemStateLike>;

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -180,4 +180,6 @@ export interface SceneDataProvider extends SceneObject<SceneDataState> {
   cancelQuery?: () => void;
 }
 
-export type SceneStatelessBehavior = (sceneObject: SceneObject) => CancelActivationHandler | void;
+export type SceneStatelessBehavior<T extends SceneObject = SceneObject> = (
+  sceneObject: T
+) => CancelActivationHandler | void;


### PR DESCRIPTION
* Makes the isDraggable and isResizable optional 
* Makes StatelessBehavior generic so you can define one with a typed scene object parametere 