### PR TITLE
SceneQueryRunner: Provide rangeRaw in request

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -68,6 +68,64 @@ describe('SceneQueryRunner', () => {
     getDataSourceMock.mockClear();
   });
 
+  describe('when running query', () => {
+    it('should build DataQueryRequest object', async () => {
+      Date.now = jest.fn(() => 1689063488000);
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        $timeRange: new SceneTimeRange(),
+      });
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(sentRequest).toBeDefined();
+      const { scopedVars, ...request } = sentRequest!;
+
+      expect(Object.keys(scopedVars)).toMatchInlineSnapshot(`
+        [
+          "__sceneObject",
+          "__interval",
+          "__interval_ms",
+        ]
+      `);
+      expect(request).toMatchInlineSnapshot(`
+        {
+          "app": "dashboard",
+          "interval": "30s",
+          "intervalMs": 30000,
+          "liveStreaming": undefined,
+          "maxDataPoints": 500,
+          "panelId": 1,
+          "range": {
+            "from": "2023-07-11T02:18:08.000Z",
+            "raw": {
+              "from": "now-6h",
+              "to": "now",
+            },
+            "to": "2023-07-11T08:18:08.000Z",
+          },
+          "rangeRaw": {
+            "from": "now-6h",
+            "to": "now",
+          },
+          "requestId": "SQR100",
+          "startTime": 1689063488000,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "test",
+              },
+              "refId": "A",
+            },
+          ],
+          "timezone": "browser",
+        }
+      `);
+    });
+  });
+
   describe('when activated and got no data', () => {
     it('should run queries', async () => {
       const queryRunner = new SceneQueryRunner({

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -220,6 +220,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       scopedVars: sceneObjectScopedVar,
       startTime: Date.now(),
       liveStreaming: this.state.liveStreaming,
+      rangeRaw: {
+        from: timeRange.state.from,
+        to: timeRange.state.to,
+      },
     };
 
     try {


### PR DESCRIPTION
Fixes #250 

When implementing `SceneQueryRunner` we missed `rangeRaw` on `DataQueryRequest`. This property is used by some of the Grafana data sources, i.e. Influx.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.19.0--canary.253.5517537976.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.19.0--canary.253.5517537976.0
  # or 
  yarn add @grafana/scenes@0.19.0--canary.253.5517537976.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
