### PR TITLE
Behaviors: Enabled type stateless behavior params

### DIFF
--- a/packages/scenes-app/src/demos/behaviors/behaviorsDemo.tsx
+++ b/packages/scenes-app/src/demos/behaviors/behaviorsDemo.tsx
@@ -104,7 +104,7 @@ export function getBehaviorsDemo(defaults: SceneAppPageState) {
   });
 }
 
-function logEventsBehavior(sceneObject: SceneObject) {
+function logEventsBehavior(sceneObject: SceneQueryRunner) {
   console.log(`[SceneObjectEvent]: ${sceneObject.constructor?.name} ${sceneObject.state.key} activated!`);
 
   sceneObject.subscribeToState((state) => {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -24,7 +24,7 @@ export interface SceneObjectState {
    * Can be used to add extra behaviors to a scene object.
    * These are activated when the their parent scene object is activated.
    */
-  $behaviors?: Array<SceneObject | SceneStatelessBehavior>;
+  $behaviors?: Array<SceneObject | SceneStatelessBehavior<any>>;
 }
 
 export interface SceneLayoutChildOptions {
@@ -180,6 +180,6 @@ export interface SceneDataProvider extends SceneObject<SceneDataState> {
   cancelQuery?: () => void;
 }
 
-export type SceneStatelessBehavior<T extends SceneObject = SceneObject> = (
-  sceneObject: T
-) => CancelActivationHandler | void;
+export interface SceneStatelessBehavior<T extends SceneObject = SceneObject> {
+  (sceneObject: T): CancelActivationHandler | void;
+}


### PR DESCRIPTION
I can't figure out any other way than add this any here to
make it possible to have behavior functions that take in a typed SceneObject
