### PR TITLE
FieldConfigOverridesBuilder: Simplify matchFieldsByValue API

### DIFF
--- a/packages/scenes/src/core/PanelBuilders/FieldConfigOverridesBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/FieldConfigOverridesBuilder.ts
@@ -1,11 +1,4 @@
-import {
-  BasicValueMatcherOptions,
-  FieldMatcherID,
-  FieldType,
-  RangeValueMatcherOptions,
-  ValueMatcherID,
-  ValueMatcherOptions,
-} from '@grafana/data';
+import { FieldMatcherID, FieldType, FieldValueMatcherConfig } from '@grafana/data';
 import { MatcherConfig } from '@grafana/schema';
 import { StandardFieldConfigOverridesBuilder } from './StandardFieldConfigBuilders';
 
@@ -62,13 +55,10 @@ export class FieldConfigOverridesBuilder<TFieldConfig> extends StandardFieldConf
     return this;
   }
 
-  public matchFieldsByValue(
-    id: ValueMatcherID,
-    options: ValueMatcherOptions | BasicValueMatcherOptions | RangeValueMatcherOptions
-  ): this {
+  public matchFieldsByValue(options: FieldValueMatcherConfig): this {
     this._overrides.push({
       matcher: {
-        id,
+        id: FieldMatcherID.byValue,
         options,
       },
       properties: [],


### PR DESCRIPTION
Closes #263
When implementing `FieldConfigOverridesBuilder` we exposed an API that's a superset to what's possible in overrides configuration when configuring by-value overrides. 

This PR simplifies the API of `matchFieldsByValue` to only allow relevant options configuration.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.21.0--canary.267.5584998646.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.21.0--canary.267.5584998646.0
  # or 
  yarn add @grafana/scenes@0.21.0--canary.267.5584998646.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
