### PR TITLE
PanelBuilder: Fix default options being mutated

### DIFF
--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
@@ -1,4 +1,4 @@
-import { MappingType, ThresholdsMode } from '@grafana/schema';
+import { BigValueGraphMode, MappingType, ThresholdsMode } from '@grafana/schema';
 import { PanelBuilders } from './index';
 import { VizPanelBuilder } from './VizPanelBuilder';
 
@@ -20,23 +20,26 @@ interface FieldConfigTest {
   };
 }
 
-const createDefaultOptions = (): OptionsTest => ({
+const defaultOption = {
   numeric: 1,
   text: 'text',
   complex: {
     a: 1,
     b: 'text',
   },
-});
+};
 
-const createDefaultFieldConfig = (): FieldConfigTest => ({
+const createDefaultOptions = (): OptionsTest => defaultOption;
+
+const defaultFieldConfig = {
   numeric: 1,
   text: 'text',
   complex: {
     a: 1,
     b: 'text',
   },
-});
+};
+const createDefaultFieldConfig = (): FieldConfigTest => defaultFieldConfig;
 
 const getTestBuilder = () =>
   new VizPanelBuilder<OptionsTest, FieldConfigTest>(
@@ -206,6 +209,32 @@ describe('VizPanelBuilder', () => {
         {
           "complex": {
             "a": 2,
+            "b": "text",
+          },
+          "numeric": 2,
+          "text": "text",
+        }
+      `);
+    });
+
+    it('allows multiple panels of the same type configuration', () => {
+      const p1 = getTestBuilder().setTitle('p1').build();
+      const p2 = getTestBuilder().setTitle('p2').setOption('numeric', 2).build();
+
+      expect(p1.state.options).toMatchInlineSnapshot(`
+        {
+          "complex": {
+            "a": 1,
+            "b": "text",
+          },
+          "numeric": 1,
+          "text": "text",
+        }
+      `);
+      expect(p2.state.options).toMatchInlineSnapshot(`
+        {
+          "complex": {
+            "a": 1,
             "b": "text",
           },
           "numeric": 2,

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -1,5 +1,5 @@
 import { FieldConfigSource } from '@grafana/data';
-import { merge } from 'lodash';
+import { merge, cloneDeep } from 'lodash';
 
 import { VizPanel, VizPanelState } from '../../components/VizPanel/VizPanel';
 import { DeepPartial } from '../types';
@@ -28,12 +28,12 @@ export class VizPanelBuilder<TOptions, TFieldConfig extends {}>
     this._state.pluginVersion = pluginVersion;
     const fieldConfig: FieldConfigSource<TFieldConfig> = {
       defaults: {
-        custom: defaultFieldConfig ? defaultFieldConfig() : ({} as TFieldConfig),
+        custom: defaultFieldConfig ? cloneDeep(defaultFieldConfig()) : ({} as TFieldConfig),
       }, // use field config factory that will provide default field config
       overrides: [],
     };
 
-    this._state.options = defaultOptions ? defaultOptions() : ({} as TOptions);
+    this._state.options = defaultOptions ? cloneDeep(defaultOptions()) : ({} as TOptions);
     this._state.fieldConfig = fieldConfig;
   }
 


### PR DESCRIPTION
As noticed by @tskarhed, building configuring multiple stat panels in a scene resulted in options being shared between all stat panel instances. This problem was occurring with all panels that have default options/fieldConfig provided from grafana/schema. 

The problem was caused by how the options were configured in VizPanelBuilder - we were basically using a reference to an object comming from schema, and mutating it when calling `setOptions`.

This PR makes sure this no longer happens by deep cloning the defaults in a sconstructor, when provided to a builder.