### PR TITLE
Adding developer portal dev workflow and config

### DIFF
--- a/.github/workflows/deploy-to-dev-portal-dev.yml
+++ b/.github/workflows/deploy-to-dev-portal-dev.yml
@@ -1,0 +1,50 @@
+name: Deploy to Developer Portal DEV Bucket
+
+on:
+    workflow_dispatch:
+      inputs:
+        branch:
+          description: "Which branch to use?"
+          default: "main"
+jobs:
+  deploy:
+    name: Deploy docs to Developer Portal Bucket
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+            ref: ${{ github.event.inputs.branch }}
+            fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        uses: ./.github/actions/yarn-nm-install
+      
+        #mac: sed -i '' 's/title: Set up Scenes/title: Set up Scenes\nslug:\ \//g' ./docusaurus/docs/getting-started.md
+        #linux: sed -i 's/title: Set up Scenes/title: Set up Scenes\nslug:\ \//g' ./docusaurus/docs/getting-started.md
+      - name: Make docs the homepage of this subsite
+        run: |
+          rm -f ./docusaurus/website/src/pages/index.tsx
+          sed -i 's/title: Set up Scenes/title: Set up Scenes\nslug:\ \//g' ./docusaurus/docs/getting-started.md
+          
+      - name: Build documentation website
+        env:
+          GTAG_CONTAINER_ID: ${{ secrets.GTAG_CONTAINER_ID }}
+        run: yarn docs:build --config docusaurus.config.devportal.js
+        
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
+      - name: Deploy to Developer Portal Bucket
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: './docusaurus/website/build/'
+          destination: 'staging-developer-portal/scenes'
+          parent: false

--- a/docusaurus/website/docusaurus.config.devportal.js
+++ b/docusaurus/website/docusaurus.config.devportal.js
@@ -1,0 +1,132 @@
+// @ts-check
+// Note: type annotations allow type checking and IDEs autocompletion
+
+const lightCodeTheme = require('prism-react-renderer/themes/github');
+const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const remark = require('remark');
+const stripHTML = require('remark-strip-html');
+
+/** @type {import('@docusaurus/types').Config} */
+const config = {
+  title: 'Grafana Scenes',
+  tagline: 'Build highly interactive Grafana apps with ease.',
+  url: 'https://devportal.grafana-dev.net/',
+  baseUrl: 'scenes/',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
+  favicon: 'img/favicon.png',
+
+  // GitHub pages deployment config.
+  // If you aren't using GitHub pages, you don't need these.
+  organizationName: 'grafana', // Usually your GitHub org/user name.
+  projectName: 'scenes', // Usually your repo name.
+
+  // Even if you don't use internalization, you can use this field to set useful
+  // metadata like html lang. For example, if your site is Chinese, you may want
+  // to replace "en" with "zh-Hans".
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en'],
+  },
+
+  plugins: [],
+
+  presets: [
+    [
+      'classic',
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
+        docs: {
+          path: '../docs',
+          sidebarPath: require.resolve('./sidebars.js'),
+          // Please change this to your repo.
+          // Remove this to remove the "edit this page" links.
+          editUrl: 'https://github.com/grafana/scenes/edit/main/docusaurus/website',
+          routeBasePath: '/',
+        },
+        blog: false,
+        theme: {
+          customCss: require.resolve('./src/css/custom.css'),
+        },
+        googleTagManager: {
+          containerId: process.env.GTAG_CONTAINER_ID || 'GOOGLE_TAG_MANAGER_ID',
+        },
+      }),
+    ],
+  ],
+
+  themeConfig:
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    ({
+      docs: {
+        sidebar: {
+          autoCollapseCategories: false,
+        },
+      },
+      navbar: {
+        title: 'Grafana Scenes',
+        logo: {
+          alt: 'Grafana Logo',
+          src: 'img/logo.svg',
+        },
+        items: [
+          {
+            type: 'doc',
+            docId: 'getting-started',
+            position: 'right',
+            label: 'Docs',
+          },
+          // TODO
+          // { href: 'https://community.grafana.com/c/plugin-development/30', label: 'Help', position: 'right' },
+          {
+            href: 'https://www.github.com/grafana/scenes',
+            label: 'GitHub',
+            position: 'right',
+          },
+        ],
+      },
+      footer: {
+        style: 'dark',
+        links: [
+          {
+            title: 'Docs',
+            items: [
+              {
+                label: 'Getting Started',
+                to: '/',
+              },
+            ],
+          },
+          {
+            title: 'Community',
+            items: [
+              {
+                label: 'Github Issues',
+                href: 'https://www.github.com/grafana/scenes/issues',
+              },
+              {
+                label: 'Grafana Community Forums',
+                href: 'https://community.grafana.com/c/plugin-development/30',
+              },
+            ],
+          },
+          {
+            title: 'Social',
+            items: [
+              {
+                label: 'GitHub',
+                href: 'https://www.github.com/grafana/scenes',
+              },
+            ],
+          },
+        ],
+        copyright: `Copyright © ${new Date().getFullYear()} Grafana Labs. Built with Docusaurus.`,
+      },
+      prism: {
+        theme: lightCodeTheme,
+        darkTheme: darkCodeTheme,
+      },
+    }),
+};
+
+module.exports = config;

--- a/docusaurus/website/docusaurus.config.devportal.js
+++ b/docusaurus/website/docusaurus.config.devportal.js
@@ -10,8 +10,8 @@ const stripHTML = require('remark-strip-html');
 const config = {
   title: 'Grafana Scenes',
   tagline: 'Build highly interactive Grafana apps with ease.',
-  url: 'https://devportal.grafana-dev.net/',
-  baseUrl: 'scenes/',
+  url: 'https://grafana-dev.com/',
+  baseUrl: 'developers/scenes/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',


### PR DESCRIPTION
This PR:

- Adds a github action that deploys dataplane docusaurus content into dev portal dev bucket, triggered manually
- Adds a docusaurus config necessary to remove the landing page so it can work from a subdirectory

We will simplify the docusaurus configs later once production deployment is in place