### PR TITLE
SceneObject: Warn if parent is already set to another SceneObject

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -81,6 +81,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
 
   private _setParent() {
     this.forEachChild((child) => {
+      // If we already have a parent and it's not this, then we likely have a bug
+      if (child._parent && child._parent !== this) {
+        console.warn(
+          'SceneObject already has a parent that is different from new parent. You cannot share the same instance in multiple scenes or in multiple different places in the same scene. Use SceneObject.clone() to duplicate a SceneObject or store a key reference to the scene object.',
+          child,
+          this
+        );
+      }
       child._parent = this;
     });
   }

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -84,7 +84,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
       // If we already have a parent and it's not this, then we likely have a bug
       if (child._parent && child._parent !== this) {
         console.warn(
-          'SceneObject already has a parent that is different from new parent. You cannot share the same instance in multiple scenes or in multiple different places in the same scene. Use SceneObject.clone() to duplicate a SceneObject or store a key reference to the scene object.',
+          'SceneObject already has a parent that is different from new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it.',
           child,
           this
         );

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -84,7 +84,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
       // If we already have a parent and it's not this, then we likely have a bug
       if (child._parent && child._parent !== this) {
         console.warn(
-          'SceneObject already has a parent that is different from new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it.',
+          'SceneObject already has a parent set that is different from the new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it.',
           child,
           this
         );


### PR DESCRIPTION
I think something like this is good to have as I found some bugs in scene apps related to reusing scene instances in multiple scenes.
