### PR TITLE
VariableValueSelectors: Don't wrap labels

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -99,6 +99,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     position: 'relative',
     // To make the border line up with the input border
     right: -1,
+    whiteSpace: 'nowrap',
   }),
 });
 


### PR DESCRIPTION
Closes https://github.com/grafana/scenes/issues/269


Nit to make sure labels are not wrapped.