### PR TITLE
VizPanel: Handle plugin not found scenario correctly

### DIFF
--- a/packages/scenes-app/src/demos/flexLayout.tsx
+++ b/packages/scenes-app/src/demos/flexLayout.tsx
@@ -27,8 +27,8 @@ export function getFlexLayoutTest(defaults: SceneAppPageState) {
                 new SceneFlexItem({
                   minWidth: '70%',
                   body: new VizPanel({
-                    title: 'Data coming from custom runtime registered data source',
-                    pluginId: 'table',
+                    title: 'Failing panel because of wrong panel id',
+                    pluginId: 'this-plugin-does-not-exist',
                     $data: getQueryRunnerWithRandomWalkQuery({}),
                   }),
                 }),

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -42,10 +42,6 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   // Not sure we need to subscribe to this state
   const timeZone = sceneGraph.getTimeRange(model).getTimeZone();
 
-  if (pluginLoadError) {
-    return <div>Failed to load plugin: {pluginLoadError}</div>;
-  }
-
   if (!plugin) {
     return <div>Loading plugin panel...</div>;
   }


### PR DESCRIPTION
I've noticed a runtime error appearing when there is plugin not found error comming from panel plugin import. That's because [an error thrown from `importPanelPlugin` is not wrapped in a promise](https://github.com/grafana/grafana/blob/dash-loaders-lib-panel/public/app/features/plugins/importPanelPlugin.ts#L20), hence we cannot rely on `Promise.catch` in VizPanel.

