### PR TITLE
SceneTimeRange: Don't update state if time range has not changed

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -1,3 +1,4 @@
+import { toUtc } from '@grafana/data';
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 import { PanelBuilders } from './PanelBuilders';
 import { SceneTimeRange } from './SceneTimeRange';
@@ -34,6 +35,25 @@ describe('SceneTimeRange', () => {
 
     expect(timeRange.state.from).toEqual('2021-01-01T10:00:00.000Z');
     expect(timeRange.state.value.from.valueOf()).toEqual(1609495200000);
+  });
+
+  it('should not update state when time range is not changed', () => {
+    const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+    const stateSpy = jest.spyOn(timeRange, 'setState');
+
+    timeRange.onTimeRangeChange({
+      from: toUtc('2020-01-01'),
+      to: toUtc('2020-01-02'),
+      raw: { from: toUtc('2020-01-01'), to: toUtc('2020-01-02') },
+    });
+    expect(stateSpy).toBeCalledTimes(1);
+
+    timeRange.onTimeRangeChange({
+      from: toUtc('2020-01-01'),
+      to: toUtc('2020-01-02'),
+      raw: { from: toUtc('2020-01-01'), to: toUtc('2020-01-02') },
+    });
+    expect(stateSpy).toBeCalledTimes(1);
   });
 
   describe('time zones', () => {

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -92,7 +92,11 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     }
 
     update.value = evaluateTimeRange(update.from, update.to, this.getTimeZone());
-    this.setState(update);
+
+    // Only update if time range actually changed
+    if (update.from !== this.state.from || update.to !== this.state.to) {
+      this.setState(update);
+    }
   };
 
   public onTimeZoneChange = (timeZone: TimeZone) => {


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/290

Did some digging and it seems like uPlot is executing the `setSelect` hooks across multiple instances when cursor sync is turned on. The `ZoomPlugin` relies on the `setSelect` hook definition (ref https://github.com/grafana/grafana/blob/dash-loaders-lib-panel/packages/grafana-ui/src/components/uPlot/plugins/ZoomPlugin.tsx#L18-L19) and is executing the zoom callback (basically time range update) multiple times, making the query runner perform queries multiple times unnecessarily.

This PR just makes sure that the updates to `SceneTimeRange` state happens only if the actual time range has changed. Otherwise, the state update is skipped.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.24.2--canary.291.5904086181.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.24.2--canary.291.5904086181.0
  # or 
  yarn add @grafana/scenes@0.24.2--canary.291.5904086181.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
