### PR TITLE
SceneObject: Typed extra props to SceneComponents

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -9,8 +9,9 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { isSceneObject, SceneComponentProps } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
+import { SceneGridItemExtraProps } from '../layout/grid/types';
 
-export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
+export function VizPanelRenderer({ model, isDraggable }: SceneComponentProps<VizPanel, SceneGridItemExtraProps>) {
   const {
     title,
     description,
@@ -22,14 +23,12 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     hoverHeader,
     menu,
     headerActions,
-    ...state
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
   const plugin = model.getPlugin();
   const parentLayout = sceneGraph.getLayout(model);
 
   // If parent has enabled dragging and we have not explicitly disabled it then dragging is enabled
-  const isDraggable = parentLayout.isDraggable() && (state.isDraggable ?? true);
   const dragClass = isDraggable && parentLayout.getDragClass ? parentLayout.getDragClass() : '';
   const dragClassCancel = isDraggable && parentLayout.getDragClassCancel ? parentLayout.getDragClassCancel() : '';
   const dataObject = sceneGraph.getData(model);

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -314,7 +314,7 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 }
 
 interface SceneGridItemState extends SceneGridItemStateLike {
-  body: SceneObject | undefined;
+  body: SceneObject<SceneObjectState, SceneGridItemExtraProps> | undefined;
 }
 
 export class SceneGridItem
@@ -325,7 +325,7 @@ export class SceneGridItem
 }
 
 function SceneGridItemRenderer({ model, isDraggable }: SceneComponentProps<SceneGridItem, SceneGridItemExtraProps>) {
-  const { body } = model.useState();
+  const { body, isDraggable: isDraggableLocal } = model.useState();
   const parent = model.parent;
 
   if (parent && !isSceneGridLayout(parent) && !isSceneGridRow(parent)) {
@@ -336,7 +336,7 @@ function SceneGridItemRenderer({ model, isDraggable }: SceneComponentProps<Scene
     return null;
   }
 
-  return <body.Component model={body} />;
+  return <body.Component model={body} isDraggable={isDraggable && (isDraggableLocal ?? true)} />;
 }
 
 function isItemSizeEqual(a: SceneGridItemPlacement, b: SceneGridItemPlacement) {

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_PANEL_SPAN } from './constants';
 import { SceneGridLayoutRenderer } from './SceneGridLayoutRenderer';
 
 import { SceneGridRow } from './SceneGridRow';
-import { SceneGridItemLike, SceneGridItemPlacement, SceneGridItemStateLike } from './types';
+import { SceneGridItemExtraProps, SceneGridItemLike, SceneGridItemPlacement, SceneGridItemStateLike } from './types';
 
 interface SceneGridLayoutState extends SceneObjectState {
   /**
@@ -316,11 +316,15 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 interface SceneGridItemState extends SceneGridItemStateLike {
   body: SceneObject | undefined;
 }
-export class SceneGridItem extends SceneObjectBase<SceneGridItemState> implements SceneGridItemLike {
+
+export class SceneGridItem
+  extends SceneObjectBase<SceneGridItemState, SceneGridItemExtraProps>
+  implements SceneGridItemLike
+{
   static Component = SceneGridItemRenderer;
 }
 
-function SceneGridItemRenderer({ model }: SceneComponentProps<SceneGridItem>) {
+function SceneGridItemRenderer({ model, isDraggable }: SceneComponentProps<SceneGridItem, SceneGridItemExtraProps>) {
   const { body } = model.useState();
   const parent = model.parent;
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -4,7 +4,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { SceneComponentProps } from '../../../core/types';
 import { GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, GRID_CELL_HEIGHT } from './constants';
 import { LazyLoader } from './LazyLoader';
-import { SceneGridItem, SceneGridLayout } from './SceneGridLayout';
+import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
 
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -4,7 +4,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { SceneComponentProps } from '../../../core/types';
 import { GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, GRID_CELL_HEIGHT } from './constants';
 import { LazyLoader } from './LazyLoader';
-import { SceneGridLayout } from './SceneGridLayout';
+import { SceneGridItem, SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
 
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
@@ -51,11 +51,11 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
               isBounded={false}
             >
               {layout.map((gridItem) => {
-                const sceneChild = model.getSceneLayoutChild(gridItem.i)!;
+                const sceneChild = model.getSceneLayoutChild(gridItem.i);
 
                 return isLazy ? (
                   <LazyLoader key={sceneChild.state.key!}>
-                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
+                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} isDraggable={true} />
                   </LazyLoader>
                 ) : (
                   <div key={sceneChild.state.key}>

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -55,11 +55,11 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
 
                 return isLazy ? (
                   <LazyLoader key={sceneChild.state.key!}>
-                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} isDraggable={true} />
+                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} isDraggable={isDraggable} />
                   </LazyLoader>
                 ) : (
                   <div key={sceneChild.state.key}>
-                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
+                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} isDraggable={isDraggable} />
                   </div>
                 );
               })}

--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -12,4 +12,8 @@ export interface SceneGridItemStateLike extends SceneGridItemPlacement, SceneObj
   isDraggable?: boolean;
 }
 
-export type SceneGridItemLike = SceneObject<SceneGridItemStateLike>;
+export interface SceneGridItemExtraProps {
+  isDraggable?: boolean;
+}
+
+export type SceneGridItemLike = SceneObject<SceneGridItemStateLike, SceneGridItemExtraProps>;

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -19,7 +19,7 @@ import { SceneObjectStateChangedEvent } from './events';
 import { cloneSceneObject } from './sceneGraph/utils';
 import { SceneVariableDependencyConfigLike } from '../variables/types';
 
-export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObjectState>
+export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObjectState, TExtra = {}>
   implements SceneObject<TState>
 {
   private _isActive = false;
@@ -75,7 +75,8 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
    * Used in render functions when rendering a SceneObject.
    * Wraps the component in an EditWrapper that handles edit mode
    */
-  public get Component(): SceneComponent<this> {
+  public get Component(): SceneComponent<this, TExtra> {
+    // @ts-ignore
     return SceneComponentWrapper;
   }
 
@@ -236,7 +237,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   /**
    * Utility hook to get and subscribe to state
    */
-  public useState() {
+  public useState(): TState {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useSceneObjectState(this);
   }
@@ -286,7 +287,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
  * This hook is always returning model.state instead of a useState that remembers the last state emitted on the subject
  * The reason for this is so that if the model instance change this function will always return the latest state.
  */
-function useSceneObjectState<TState extends SceneObjectState>(model: SceneObjectBase<TState>): TState {
+function useSceneObjectState<TState extends SceneObjectState, TExtra>(model: SceneObjectBase<TState, TExtra>): TState {
   const [_, setState] = useState<TState>(model.state);
   const stateAtFirstRender = model.state;
 

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -76,7 +76,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
    * Wraps the component in an EditWrapper that handles edit mode
    */
   public get Component(): SceneComponent<this, TExtra> {
-    // @ts-ignore
     return SceneComponentWrapper;
   }
 

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -81,6 +81,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
 
   private _setParent() {
     this.forEachChild((child) => {
+      // If we already have a parent and it's not this, then we likely have a bug
+      if (child._parent && child._parent !== this) {
+        console.warn(
+          'SceneObject already has a parent that is different from new parent. You cannot share the same instance in multiple scenes or in multiple different places in the same scene. Use SceneObject.clone() to duplicate a SceneObject or store a key reference to the scene object.',
+          child,
+          this
+        );
+      }
       child._parent = this;
     });
   }

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -84,7 +84,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
       // If we already have a parent and it's not this, then we likely have a bug
       if (child._parent && child._parent !== this) {
         console.warn(
-          'SceneObject already has a parent that is different from new parent. You cannot share the same instance in multiple scenes or in multiple different places in the same scene. Use SceneObject.clone() to duplicate a SceneObject or store a key reference to the scene object.',
+          'SceneObject already has a parent that is different from new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it.',
           child,
           this
         );

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -84,7 +84,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
       // If we already have a parent and it's not this, then we likely have a bug
       if (child._parent && child._parent !== this) {
         console.warn(
-          'SceneObject already has a parent that is different from new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it.',
+          'SceneObject already has a parent set that is different from the new parent. You cannot share the same SceneObject instance in multiple scenes or in multiple different places of the same scene graph. Use SceneObject.clone() to duplicate a SceneObject or store a state key reference and use sceneGraph.findObject to locate it.',
           child,
           this
         );

--- a/packages/scenes/src/core/sceneGraph/utils.ts
+++ b/packages/scenes/src/core/sceneGraph/utils.ts
@@ -5,8 +5,8 @@ import { SceneObjectBase } from '../SceneObjectBase';
 /**
  * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned
  */
-export function cloneSceneObject<T extends SceneObjectBase<TState>, TState extends SceneObjectState>(
-  sceneObject: SceneObjectBase<TState>,
+export function cloneSceneObject<TExtra, T extends SceneObjectBase<TState, TExtra>, TState extends SceneObjectState>(
+  sceneObject: SceneObjectBase<TState, TExtra>,
   withState?: Partial<TState>
 ): T {
   const clonedState = { ...sceneObject.state };

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -96,7 +96,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState,
   clone(state?: Partial<TState>): this;
 
   /** A React component to use for rendering the object */
-  Component(props: SceneComponentProps<SceneObject<TState, TExtra>, TExtra>): React.ReactElement | null;
+  Component(props: SceneComponentProps<ThisType<this>, TExtra>): React.ReactElement | null;
 
   /** Force a re-render, should only be needed when variable values change */
   forceRender(): void;

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -127,7 +127,6 @@ export interface SceneLayoutState extends SceneObjectState {
 }
 
 export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> extends SceneObject<T> {
-  isDraggable(): boolean;
   getDragClass?(): string;
   getDragClassCancel?(): string;
 }

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -40,17 +40,19 @@ export interface SceneLayoutChildOptions {
   isResizable?: boolean;
 }
 
-export interface SceneComponentProps<T> {
+export type SceneComponentProps<T, TExtra = {}> = TExtra & {
   model: T;
-}
+};
 
-export type SceneComponent<TModel> = (props: SceneComponentProps<TModel>) => React.ReactElement | null;
+export type SceneComponent<TModel, TExtra = {}> = (
+  props: SceneComponentProps<TModel, TExtra>
+) => React.ReactElement | null;
 
 export interface SceneDataState extends SceneObjectState {
   data?: PanelData;
 }
 
-export interface SceneObject<TState extends SceneObjectState = SceneObjectState> {
+export interface SceneObject<TState extends SceneObjectState = SceneObjectState, TExtra = {}> {
   /** The current state */
   readonly state: TState;
 
@@ -94,7 +96,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   clone(state?: Partial<TState>): this;
 
   /** A React component to use for rendering the object */
-  Component(props: SceneComponentProps<SceneObject<TState>>): React.ReactElement | null;
+  Component(props: SceneComponentProps<SceneObject<TState, TExtra>, TExtra>): React.ReactElement | null;
 
   /** Force a re-render, should only be needed when variable values change */
   forceRender(): void;


### PR DESCRIPTION
In some rare scenarios we have situations where a state change in a parent needs to trigger re-renders of children (that also care about this state change). 

Example here is isDraggable on SceneGridLayout, this property is something VizPanel cares about, and it can also be overriden by a state property on SceneGridItem level. So we need some system to cascade this state change down to VizPanel. 

Options
* We can manually force render layout children (Explored in https://github.com/grafana/scenes/pull/288) 
* We can pass untyped extra props to children via util function renderSceneComponentWithExtraProps, explored in https://github.com/grafana/scenes/pull/289 

This PR explores a third-typed approach to extra props. Sadly this complicated SceneObject, SceneObjectBase, SceneComponent, and SceneComponentProps types by requiring a second generic param. I don't like this extra type complexity for what should be a uncommon scenario, so really torn on the best approach here. 

