### PR TITLE
DO NOT MERGE: Use latest schema API

### DIFF
--- a/packages/scenes-app/package.json
+++ b/packages/scenes-app/package.json
@@ -60,11 +60,11 @@
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/data": "10.0.3",
-    "@grafana/runtime": "10.0.3",
+    "@grafana/data": "10.2.0-131492",
+    "@grafana/runtime": "10.2.0-131492",
     "@grafana/scenes": "workspace:*",
-    "@grafana/schema": "10.0.3",
-    "@grafana/ui": "10.0.3",
+    "@grafana/schema": "10.2.0-131492",
+    "@grafana/ui": "10.2.0-131492",
     "@types/lodash": "latest",
     "react-router-dom": "^5.2.0"
   },

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -44,10 +44,10 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@grafana/data": "10.0.3",
-    "@grafana/runtime": "10.0.3",
-    "@grafana/schema": "10.0.3",
-    "@grafana/ui": "10.0.3"
+    "@grafana/data": "10.2.0-131492",
+    "@grafana/runtime": "10.2.0-131492",
+    "@grafana/schema": "10.2.0-131492",
+    "@grafana/ui": "10.2.0-131492"
   },
   "devDependencies": {
     "@emotion/css": "11.10.5",

--- a/packages/scenes/src/core/PanelBuilders/index.ts
+++ b/packages/scenes/src/core/PanelBuilders/index.ts
@@ -79,7 +79,7 @@ import {
 import {
   Options as XYChartOptions,
   defaultOptions as defaultXYChartOptions,
-  defaultScatterFieldConfig as defaultXYChartFieldConfig,
+  defaultFieldConfig as defaultXYChartFieldConfig,
 } from '@grafana/schema/dist/esm/raw/composable/xychart/panelcfg/x/XYChartPanelCfg_types.gen';
 
 import { VizPanelBuilder } from './VizPanelBuilder';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,12 +2129,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.22.6
   resolution: "@babel/runtime@npm:7.22.6"
   dependencies:
     regenerator-runtime: ^0.13.11
   checksum: e585338287c4514a713babf4fdb8fc2a67adcebab3e7723a739fc62c79cfda875b314c90fd25f827afb150d781af97bc16c85bfdbfa2889f06053879a1ddb597
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.21.0":
+  version: 7.22.10
+  resolution: "@babel/runtime@npm:7.22.10"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 524d41517e68953dbc73a4f3616b8475e5813f64e28ba89ff5fca2c044d535c2ea1a3f310df1e5bb06162e1f0b401b5c4af73fe6e2519ca2450d9d8c44cf268d
   languageName: node
   linkType: hard
 
@@ -2816,7 +2825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.10.5, @emotion/babel-plugin@npm:^11.10.6, @emotion/babel-plugin@npm:^11.11.0":
+"@emotion/babel-plugin@npm:^11.10.5, @emotion/babel-plugin@npm:^11.11.0":
   version: 11.11.0
   resolution: "@emotion/babel-plugin@npm:11.11.0"
   dependencies:
@@ -2866,20 +2875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/css@npm:11.10.6":
-  version: 11.10.6
-  resolution: "@emotion/css@npm:11.10.6"
-  dependencies:
-    "@emotion/babel-plugin": ^11.10.6
-    "@emotion/cache": ^11.10.5
-    "@emotion/serialize": ^1.1.1
-    "@emotion/sheet": ^1.2.1
-    "@emotion/utils": ^1.2.0
-  checksum: 010ca5e1d0434923c431eab2c6f8226ab4415310a053ece6e4133011c7dc621de099469e57314b013e682c3b6ffd09a91cc6473538c185095d2afca79d81fb95
-  languageName: node
-  linkType: hard
-
-"@emotion/css@npm:^11.1.3":
+"@emotion/css@npm:11.11.2, @emotion/css@npm:^11.1.3":
   version: 11.11.2
   resolution: "@emotion/css@npm:11.11.2"
   dependencies:
@@ -2930,28 +2926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:11.10.6":
-  version: 11.10.6
-  resolution: "@emotion/react@npm:11.10.6"
-  dependencies:
-    "@babel/runtime": ^7.18.3
-    "@emotion/babel-plugin": ^11.10.6
-    "@emotion/cache": ^11.10.5
-    "@emotion/serialize": ^1.1.1
-    "@emotion/use-insertion-effect-with-fallbacks": ^1.0.0
-    "@emotion/utils": ^1.2.0
-    "@emotion/weak-memoize": ^0.3.0
-    hoist-non-react-statics: ^3.3.1
-  peerDependencies:
-    react: ">=16.8.0"
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 4762042e39126ffaffe76052dc65c9bb0ba6b8893013687ba3cc13ed4dd834c31597f1230684c3c078e90aecc13ab6cd0e3cde0dec8b7761affd2571f4d80019
-  languageName: node
-  linkType: hard
-
-"@emotion/react@npm:^11.8.1":
+"@emotion/react@npm:11.11.1, @emotion/react@npm:^11.8.1":
   version: 11.11.1
   resolution: "@emotion/react@npm:11.11.1"
   dependencies:
@@ -3224,38 +3199,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/data@npm:10.0.3":
-  version: 10.0.3
-  resolution: "@grafana/data@npm:10.0.3"
+"@grafana/data@npm:10.2.0-131492":
+  version: 10.2.0-131492
+  resolution: "@grafana/data@npm:10.2.0-131492"
   dependencies:
     "@braintree/sanitize-url": 6.0.2
-    "@grafana/schema": 10.0.3
+    "@grafana/schema": 10.2.0-131492
     "@types/d3-interpolate": ^3.0.0
     "@types/string-hash": 1.1.1
     d3-interpolate: 3.0.1
-    date-fns: 2.29.3
+    date-fns: 2.30.0
     dompurify: ^2.4.3
-    eventemitter3: 5.0.0
+    eventemitter3: 5.0.1
     fast_array_intersect: 1.1.0
     history: 4.10.1
     lodash: 4.17.21
-    marked: 4.2.12
+    marked: 5.1.1
+    marked-mangle: 1.1.0
     moment: 2.29.4
-    moment-timezone: 0.5.41
-    ol: 7.2.2
-    papaparse: 5.3.2
+    moment-timezone: 0.5.43
+    ol: 7.4.0
+    papaparse: 5.4.1
     react-use: 17.4.0
     regenerator-runtime: 0.13.11
-    rxjs: 7.8.0
+    rxjs: 7.8.1
     string-hash: ^1.1.3
     tinycolor2: 1.6.0
-    tslib: 2.5.0
+    tslib: 2.6.0
     uplot: 1.6.24
     xss: ^1.0.14
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 16864254311b4e696f11ff740d8b323e909bc336d7f62a8a9f1fd7c40b4221ecea7de45603c34c50ef51cf1f1cf25e980f0f6ccee030fced8011b19e3a0d3e88
+  checksum: a5afab0ae9c00f2ea375d92f2751ffc31c295cbe65095bb4a39515bb6f2edade47203c9ab76b798bac371744b4ed84274bddfa96f403047c7180e598c6b6202c
   languageName: node
   linkType: hard
 
@@ -3270,14 +3246,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/e2e-selectors@npm:10.0.3":
-  version: 10.0.3
-  resolution: "@grafana/e2e-selectors@npm:10.0.3"
+"@grafana/e2e-selectors@npm:10.2.0-131492":
+  version: 10.2.0-131492
+  resolution: "@grafana/e2e-selectors@npm:10.2.0-131492"
   dependencies:
     "@grafana/tsconfig": ^1.2.0-rc1
-    tslib: 2.5.0
+    tslib: 2.6.0
     typescript: 4.8.4
-  checksum: 259cb7c7acde7ba5d544dc6554f5b74431d65be214f0fb74b9bced46c8a72b2141921145d56a432480b64c1ccea89d6477e3467e3788f705c2e524f56590e5b8
+  checksum: 7d7744e79af538ede8669043101d10bf42b1fef14043b77ac36d215dcf6d09328c25b15bd34c6b8bb0febd8a25d1487f680e3d8aa3352b151aa50927d16a42e7
   languageName: node
   linkType: hard
 
@@ -3358,47 +3334,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-core@npm:^1.0.2":
-  version: 1.1.2
-  resolution: "@grafana/faro-core@npm:1.1.2"
+"@grafana/faro-core@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "@grafana/faro-core@npm:1.1.3"
   dependencies:
     "@opentelemetry/api": ^1.4.1
     "@opentelemetry/api-metrics": ^0.33.0
     "@opentelemetry/otlp-transformer": ^0.37.0
     murmurhash-js: ^1.0.0
-  checksum: 7d2b8343c28ba7e028fa918f4ee3c0ffbf0171b975d778402adb9a2bede169f854664f18bbd12f5c7c25c2d8b88af3fdfa40af598eae3a5d0c0e7e57c9414005
+  checksum: 8371a9f4ee3dc0d46b985f8b49350692ed08f9dc05edb365a88a304a3567d2d1a21cc1b591529dbab177132e1e09dbf17fd1ce00b0cdcece26f8f09dde66f8b3
   languageName: node
   linkType: hard
 
-"@grafana/faro-web-sdk@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@grafana/faro-web-sdk@npm:1.0.2"
+"@grafana/faro-web-sdk@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@grafana/faro-web-sdk@npm:1.1.2"
   dependencies:
-    "@grafana/faro-core": ^1.0.2
+    "@grafana/faro-core": ^1.1.2
     ua-parser-js: ^1.0.32
     web-vitals: ^3.1.1
-  checksum: ca04add8469778d73e1bc15f057d063d93a88b9d76325c79060848ad3211fa929e30b6a85365981f7bcef023704f9f92f67678311bfed13dd521399c0f00e92f
+  checksum: 7a2086c946a388590eb73d2d02f5e011db7cbeb9120ba67eab40b9824848cff99764bf76ea5cd168c749d4e0e3682aa79c89a4e84b1f0947326dbbdf1fd1d937
   languageName: node
   linkType: hard
 
-"@grafana/runtime@npm:10.0.3":
-  version: 10.0.3
-  resolution: "@grafana/runtime@npm:10.0.3"
+"@grafana/runtime@npm:10.2.0-131492":
+  version: 10.2.0-131492
+  resolution: "@grafana/runtime@npm:10.2.0-131492"
   dependencies:
-    "@grafana/data": 10.0.3
-    "@grafana/e2e-selectors": 10.0.3
-    "@grafana/faro-web-sdk": 1.0.2
-    "@grafana/ui": 10.0.3
-    "@sentry/browser": 6.19.7
+    "@grafana/data": 10.2.0-131492
+    "@grafana/e2e-selectors": 10.2.0-131492
+    "@grafana/faro-web-sdk": 1.1.2
+    "@grafana/ui": 10.2.0-131492
     history: 4.10.1
     lodash: 4.17.21
-    rxjs: 7.8.0
+    rxjs: 7.8.1
     systemjs: 0.20.19
-    tslib: 2.5.0
+    tslib: 2.6.0
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 383162a3d2af2ae2a0d43348b1c9727297d18e52c70e99439cc43a31c493d0ef49b6cd4fb11ccee0943974623183e55c960cd74298388d964475f390e6571292
+  checksum: 752f5797b564a3c9266836d985b25146141d26848afcf2e4375d3a8605b3840a70e8c851ac2895dfffa35336d098f475cd16cf20e156ccd3088f4d8a5406d619
   languageName: node
   linkType: hard
 
@@ -3467,19 +3442,19 @@ __metadata:
     typescript: 4.9.3
     uuid: ^9.0.0
   peerDependencies:
-    "@grafana/data": 10.0.3
-    "@grafana/runtime": 10.0.3
-    "@grafana/schema": 10.0.3
-    "@grafana/ui": 10.0.3
+    "@grafana/data": 10.2.0-131492
+    "@grafana/runtime": 10.2.0-131492
+    "@grafana/schema": 10.2.0-131492
+    "@grafana/ui": 10.2.0-131492
   languageName: unknown
   linkType: soft
 
-"@grafana/schema@npm:10.0.3":
-  version: 10.0.3
-  resolution: "@grafana/schema@npm:10.0.3"
+"@grafana/schema@npm:10.2.0-131492":
+  version: 10.2.0-131492
+  resolution: "@grafana/schema@npm:10.2.0-131492"
   dependencies:
-    tslib: 2.5.0
-  checksum: 1b0591456755cfc1ca8a022c037f4001becc4258d4e79fa0839cb971b3466e2b884196a4b626bbab2078bd3ee0996f48428be63f434ddb54345ff1ea652f5937
+    tslib: 2.6.0
+  checksum: 14aee42548e2d6d397b9b3363d9d6f60be148ecc5445a2e816ebf46a713d7f5be9f3f1f708d8313a5ae1360e4b221f54f410b2b0abc13b8e4c9b58e1ac712365
   languageName: node
   linkType: hard
 
@@ -3490,51 +3465,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/ui@npm:10.0.3":
-  version: 10.0.3
-  resolution: "@grafana/ui@npm:10.0.3"
+"@grafana/ui@npm:10.2.0-131492":
+  version: 10.2.0-131492
+  resolution: "@grafana/ui@npm:10.2.0-131492"
   dependencies:
-    "@emotion/css": 11.10.6
-    "@emotion/react": 11.10.6
-    "@grafana/data": 10.0.3
-    "@grafana/e2e-selectors": 10.0.3
-    "@grafana/faro-web-sdk": 1.0.2
-    "@grafana/schema": 10.0.3
-    "@leeoniya/ufuzzy": 1.0.6
-    "@monaco-editor/react": 4.4.6
-    "@popperjs/core": 2.11.6
-    "@react-aria/button": 3.6.1
-    "@react-aria/dialog": 3.3.1
-    "@react-aria/focus": 3.8.0
-    "@react-aria/menu": 3.6.1
-    "@react-aria/overlays": 3.10.1
-    "@react-aria/utils": 3.13.1
-    "@react-stately/menu": 3.4.1
-    "@sentry/browser": 6.19.7
+    "@emotion/css": 11.11.2
+    "@emotion/react": 11.11.1
+    "@grafana/data": 10.2.0-131492
+    "@grafana/e2e-selectors": 10.2.0-131492
+    "@grafana/faro-web-sdk": 1.1.2
+    "@grafana/schema": 10.2.0-131492
+    "@leeoniya/ufuzzy": 1.0.8
+    "@monaco-editor/react": 4.5.1
+    "@popperjs/core": 2.11.8
+    "@react-aria/button": 3.8.0
+    "@react-aria/dialog": 3.5.3
+    "@react-aria/focus": 3.13.0
+    "@react-aria/menu": 3.10.0
+    "@react-aria/overlays": 3.15.0
+    "@react-aria/utils": 3.18.0
+    "@react-stately/menu": 3.5.3
     ansicolor: 1.1.100
     calculate-size: 1.1.1
     classnames: 2.3.2
-    core-js: 3.28.0
-    d3: 7.8.2
-    date-fns: 2.29.3
+    core-js: 3.31.1
+    d3: 7.8.5
+    date-fns: 2.30.0
     hoist-non-react-statics: 3.3.2
     i18next: ^22.0.0
-    immutable: 4.2.4
+    i18next-browser-languagedetector: ^7.0.2
+    immutable: 4.3.1
     is-hotkey: 0.2.0
-    jquery: 3.6.3
+    jquery: 3.7.0
     lodash: 4.17.21
     memoize-one: 6.0.0
     moment: 2.29.4
     monaco-editor: 0.34.0
-    ol: 7.2.2
+    ol: 7.4.0
     prismjs: 1.29.0
-    rc-cascader: 3.10.2
-    rc-drawer: 6.1.3
-    rc-slider: 10.1.1
+    rc-cascader: 3.12.1
+    rc-drawer: 6.3.0
+    rc-slider: 10.2.1
     rc-time-picker: ^3.7.3
-    rc-tooltip: 5.3.1
+    rc-tooltip: 6.0.1
     react-beautiful-dnd: 13.1.1
-    react-calendar: 4.0.0
+    react-calendar: 4.3.0
     react-colorful: 5.6.1
     react-custom-scrollbars-2: 4.5.0
     react-dropzone: 14.2.3
@@ -3542,27 +3517,28 @@ __metadata:
     react-hook-form: 7.5.3
     react-i18next: ^12.0.0
     react-inlinesvg: 3.0.2
+    react-loading-skeleton: 3.3.1
     react-popper: 2.3.0
     react-popper-tooltip: 4.4.2
     react-router-dom: 5.3.3
-    react-select: 5.7.0
+    react-select: 5.7.4
     react-select-event: ^5.1.0
     react-table: 7.8.0
     react-transition-group: 4.4.5
     react-use: 17.4.0
-    react-window: 1.8.8
-    rxjs: 7.8.0
+    react-window: 1.8.9
+    rxjs: 7.8.1
     slate: 0.47.9
     slate-plain-serializer: 0.7.13
     slate-react: 0.22.10
     tinycolor2: 1.6.0
-    tslib: 2.5.0
+    tslib: 2.6.0
     uplot: 1.6.24
     uuid: 9.0.0
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: d3ba44c76568456427526427b0568d3a27e9b7daedcec9f6135ea79dc1a11f24e2245706cc74c0f81f2c0c20d9bc70bab84cf6eca911edde6320e3c616c03fb5
+  checksum: ec35165358340774e9c39800d119bbeea0272e070d19ff113d5498daecd1723730800b60dcfa1de1dab8702161e27e65f9a1545e520e722631e1c57fea9a730e
   languageName: node
   linkType: hard
 
@@ -3666,6 +3642,15 @@ __metadata:
   dependencies:
     "@swc/helpers": ^0.5.0
   checksum: f79f272f845b9adde73dfea396248114a545cacb1082c90c58115cffe386fc46984033f383c10a866dc02ebeac1cb8c1464a2e4dedb4f7fd95aaf15a2996a012
+  languageName: node
+  linkType: hard
+
+"@internationalized/date@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@internationalized/date@npm:3.4.0"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  checksum: 699cac3a7b4e6ccad027cb33e2682535af4287d6101d0d3a5267141209e9954cf779d0c148b6cb9ff92abd480b92b72315ff536328f8a0b55f5d2761774769aa
   languageName: node
   linkType: hard
 
@@ -4254,10 +4239,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@leeoniya/ufuzzy@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@leeoniya/ufuzzy@npm:1.0.6"
-  checksum: e09672848e094745726331feebe6744d42563ccf160b38796eed4d72105daa052838fdec1944d5b44a27e328fc74a00547d00b894710e2720aa692ed5d3d6e3b
+"@leeoniya/ufuzzy@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@leeoniya/ufuzzy@npm:1.0.8"
+  checksum: 899a9269fa72c773c4806ff6ca7277a9ed69a8e3e7f0e8db9d3f4c9aa9c23d1d5c1df1e5cbea47d720af85ae6aa2ad88822443cd18ef94631876b96d23f4d7e2
   languageName: node
   linkType: hard
 
@@ -4464,7 +4449,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monaco-editor/loader@npm:^1.3.2":
+"@monaco-editor/loader@npm:^1.3.3":
   version: 1.3.3
   resolution: "@monaco-editor/loader@npm:1.3.3"
   dependencies:
@@ -4475,17 +4460,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monaco-editor/react@npm:4.4.6":
-  version: 4.4.6
-  resolution: "@monaco-editor/react@npm:4.4.6"
+"@monaco-editor/react@npm:4.5.1":
+  version: 4.5.1
+  resolution: "@monaco-editor/react@npm:4.5.1"
   dependencies:
-    "@monaco-editor/loader": ^1.3.2
-    prop-types: ^15.7.2
+    "@monaco-editor/loader": ^1.3.3
   peerDependencies:
     monaco-editor: ">= 0.25.0 < 1"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: cb25b5ce153608c2a4291390456488e100c5e3ac48a913875c98182836e2a9f315d4f96e85cf6f7d4b1eadff8d08d13356e38891b472894155bcb2c4aeaf3b1c
+  checksum: 989b98f5750f0b0ad54dc1dd7da8e92c67fcab55e89e26465ab7312fae87b3795f2e4603e7979e9545b7ad5d00fbcb3f21d20144d9e7eafa6f6989a76ad78c3a
   languageName: node
   linkType: hard
 
@@ -5259,21 +5243,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@popperjs/core@npm:2.11.6":
-  version: 2.11.6
-  resolution: "@popperjs/core@npm:2.11.6"
-  checksum: 47fb328cec1924559d759b48235c78574f2d71a8a6c4c03edb6de5d7074078371633b91e39bbf3f901b32aa8af9b9d8f82834856d2f5737a23475036b16817f0
-  languageName: node
-  linkType: hard
-
-"@popperjs/core@npm:^2.11.5":
+"@popperjs/core@npm:2.11.8, @popperjs/core@npm:^2.11.5":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: e5c69fdebf52a4012f6a1f14817ca8e9599cb1be73dd1387e1785e2ed5e5f0862ff817f420a87c7fc532add1f88a12e25aeb010ffcbdc98eace3d55ce2139cf0
   languageName: node
   linkType: hard
 
-"@rc-component/portal@npm:^1.0.0-6, @rc-component/portal@npm:^1.1.0":
+"@rc-component/portal@npm:^1.1.0":
   version: 1.1.1
   resolution: "@rc-component/portal@npm:1.1.1"
   dependencies:
@@ -5284,6 +5261,38 @@ __metadata:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
   checksum: 4a2aef7cfd71a7614dc83b5ee5863ef49613e392b9aec0fa5913de4fb04ca6c9b13fd4ed183d8696475999d9c2bb945d707b245f7f28b7c0615a5f613416206a
+  languageName: node
+  linkType: hard
+
+"@rc-component/portal@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@rc-component/portal@npm:1.1.2"
+  dependencies:
+    "@babel/runtime": ^7.18.0
+    classnames: ^2.3.2
+    rc-util: ^5.24.4
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: bdb14f48d3d0d7391347a4da37e8de1b539ae7b0bc71005beb964036a1fd7874a242ce42d3e06a4979a26d22a12f965357d571c40966cd457736d3c430a5421f
+  languageName: node
+  linkType: hard
+
+"@rc-component/trigger@npm:^1.0.4":
+  version: 1.15.6
+  resolution: "@rc-component/trigger@npm:1.15.6"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@rc-component/portal": ^1.1.0
+    classnames: ^2.3.2
+    rc-align: ^4.0.0
+    rc-motion: ^2.0.0
+    rc-resize-observer: ^1.3.1
+    rc-util: ^5.33.0
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: c812ac986c89d4c56c59d9759bcd478076038d25072118a516c9132e3800881e51fb17de6999b9e361b57ba80e5f18298aaedc15604f6f7366e5584da05a40b4
   languageName: node
   linkType: hard
 
@@ -5305,55 +5314,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/button@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@react-aria/button@npm:3.6.1"
-  dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/focus": ^3.8.0
-    "@react-aria/interactions": ^3.11.0
-    "@react-aria/utils": ^3.13.3
-    "@react-stately/toggle": ^3.4.1
-    "@react-types/button": ^3.6.1
-    "@react-types/shared": ^3.14.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b7c520e7d7b885314cd3455f7b50cfd47f423740873718a2fed9a5721904cd29673efb210101896464afd9392adfec3cba546d118b8f4e6e84cb9ab7ee4b7018
-  languageName: node
-  linkType: hard
-
-"@react-aria/dialog@npm:3.3.1":
-  version: 3.3.1
-  resolution: "@react-aria/dialog@npm:3.3.1"
-  dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/focus": ^3.8.0
-    "@react-aria/utils": ^3.13.3
-    "@react-stately/overlays": ^3.4.1
-    "@react-types/dialog": ^3.4.3
-    "@react-types/shared": ^3.14.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: ba924f07a7974b0f9a90902c8b2a41490536194e38b53dc069b4ba275c4a557f4aa4ab87e22e2b1f69d8aa8ef42ede142bf45273bf3e55ff9a38cd687d0ee235
-  languageName: node
-  linkType: hard
-
-"@react-aria/focus@npm:3.8.0":
+"@react-aria/button@npm:3.8.0":
   version: 3.8.0
-  resolution: "@react-aria/focus@npm:3.8.0"
+  resolution: "@react-aria/button@npm:3.8.0"
   dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/interactions": ^3.11.0
-    "@react-aria/utils": ^3.13.3
-    "@react-types/shared": ^3.14.1
-    clsx: ^1.1.1
+    "@react-aria/focus": ^3.13.0
+    "@react-aria/interactions": ^3.16.0
+    "@react-aria/utils": ^3.18.0
+    "@react-stately/toggle": ^3.6.0
+    "@react-types/button": ^3.7.3
+    "@react-types/shared": ^3.18.1
+    "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 2250e610c3753d008e01d39bed41d961bf795a4cec8873b76fda0adc3ad48811ae5cad0d2e222cca41c43454666d492e130113533e1609fd3cea8721108863a3
+  checksum: ad24c87609bdff0fb6fc975c6c84a3d3b38f2f2981c0e1914aaed82654db388c9abd16fa127d1b15c1def61085afc63acf2d3686321086215cbb1f148cf54012
   languageName: node
   linkType: hard
 
-"@react-aria/focus@npm:^3.13.0, @react-aria/focus@npm:^3.8.0":
+"@react-aria/dialog@npm:3.5.3":
+  version: 3.5.3
+  resolution: "@react-aria/dialog@npm:3.5.3"
+  dependencies:
+    "@react-aria/focus": ^3.13.0
+    "@react-aria/overlays": ^3.15.0
+    "@react-aria/utils": ^3.18.0
+    "@react-stately/overlays": ^3.6.0
+    "@react-types/dialog": ^3.5.3
+    "@react-types/shared": ^3.18.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 053e37148b75b32a818936f85eb0e9619ca5fe48c79c7f6fd464d3f11702839a54d85f1fcef8447960f6f8df60f3399a6d2ea341f3c2cd2fa208449e1d8eae63
+  languageName: node
+  linkType: hard
+
+"@react-aria/focus@npm:3.13.0, @react-aria/focus@npm:^3.13.0":
   version: 3.13.0
   resolution: "@react-aria/focus@npm:3.13.0"
   dependencies:
@@ -5368,7 +5363,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/i18n@npm:^3.6.0, @react-aria/i18n@npm:^3.8.0":
+"@react-aria/focus@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-aria/focus@npm:3.14.0"
+  dependencies:
+    "@react-aria/interactions": ^3.17.0
+    "@react-aria/utils": ^3.19.0
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 8a0a44bf559a1b79c39f50860285170bf5376e18141edc7b3b953250950b72d3f2deadbb17f42827c9be4156e5bc49a03a841f738619bf958ab78000250c9fa0
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.8.0":
   version: 3.8.0
   resolution: "@react-aria/i18n@npm:3.8.0"
   dependencies:
@@ -5386,7 +5396,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/interactions@npm:^3.11.0, @react-aria/interactions@npm:^3.16.0":
+"@react-aria/i18n@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@react-aria/i18n@npm:3.8.1"
+  dependencies:
+    "@internationalized/date": ^3.4.0
+    "@internationalized/message": ^3.1.1
+    "@internationalized/number": ^3.2.1
+    "@internationalized/string": ^3.1.1
+    "@react-aria/ssr": ^3.7.1
+    "@react-aria/utils": ^3.19.0
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 2a32fbbc66eca3c6fa8217c8df4c3d8189b9b5e5db4a2c0dd13c7810f6efd418aef7d6ce5b9402f8bce06f6cbf96e00ff50cedc08f62a989e4009bb51cfbc4e6
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.16.0":
   version: 3.16.0
   resolution: "@react-aria/interactions@npm:3.16.0"
   dependencies:
@@ -5400,51 +5428,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/menu@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@react-aria/menu@npm:3.6.1"
+"@react-aria/interactions@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "@react-aria/interactions@npm:3.17.0"
   dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/i18n": ^3.6.0
-    "@react-aria/interactions": ^3.11.0
-    "@react-aria/overlays": ^3.10.1
-    "@react-aria/selection": ^3.10.1
-    "@react-aria/utils": ^3.13.3
-    "@react-stately/collections": ^3.4.3
-    "@react-stately/menu": ^3.4.1
-    "@react-stately/tree": ^3.3.3
-    "@react-types/button": ^3.6.1
-    "@react-types/menu": ^3.7.1
-    "@react-types/shared": ^3.14.1
+    "@react-aria/ssr": ^3.7.1
+    "@react-aria/utils": ^3.19.0
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: a2632174aa2abfdd6a4e01430f543b8b7f68b49eb27d29418468364962f438234d5c06b1c37c8cd33da52d1e9c752bb1df9c9c7e8a3938c962ed25f2a8031661
+  checksum: f83109ded62b3a46a9c0c9ca22bafafef57e755444108ba16ce3fe808ae007f924d9f2287ec5e1f30bfdb502ce28946a3d6babed59ac9fb5893b0c7deec7f4d4
   languageName: node
   linkType: hard
 
-"@react-aria/overlays@npm:3.10.1":
-  version: 3.10.1
-  resolution: "@react-aria/overlays@npm:3.10.1"
+"@react-aria/menu@npm:3.10.0":
+  version: 3.10.0
+  resolution: "@react-aria/menu@npm:3.10.0"
   dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/i18n": ^3.6.0
-    "@react-aria/interactions": ^3.11.0
-    "@react-aria/ssr": ^3.3.0
-    "@react-aria/utils": ^3.13.3
-    "@react-aria/visually-hidden": ^3.4.1
-    "@react-stately/overlays": ^3.4.1
-    "@react-types/button": ^3.6.1
-    "@react-types/overlays": ^3.6.3
-    "@react-types/shared": ^3.14.1
+    "@react-aria/focus": ^3.13.0
+    "@react-aria/i18n": ^3.8.0
+    "@react-aria/interactions": ^3.16.0
+    "@react-aria/overlays": ^3.15.0
+    "@react-aria/selection": ^3.16.0
+    "@react-aria/utils": ^3.18.0
+    "@react-stately/collections": ^3.9.0
+    "@react-stately/menu": ^3.5.3
+    "@react-stately/tree": ^3.7.0
+    "@react-types/button": ^3.7.3
+    "@react-types/menu": ^3.9.2
+    "@react-types/shared": ^3.18.1
+    "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: b83ec155d34a2cfe7c26d4b4bd5b620c3895642521717c99212aa0878fb4716cc42665a7f80b844185ee4ee4f7e1a367b42399724fa769079d46f29b1c7b67ef
+  checksum: b6722c5ddbfa082addea4d7edaa57ba441f0a150dca0ecf5d174c795a91678a11b1fa5a5d6ebb626276d7e74d1919b4b0bf5933bfb5eb11b2ff298d9ee56ed54
   languageName: node
   linkType: hard
 
-"@react-aria/overlays@npm:^3.10.1":
+"@react-aria/overlays@npm:3.15.0":
   version: 3.15.0
   resolution: "@react-aria/overlays@npm:3.15.0"
   dependencies:
@@ -5466,25 +5488,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/selection@npm:^3.10.1":
+"@react-aria/overlays@npm:^3.15.0":
   version: 3.16.0
-  resolution: "@react-aria/selection@npm:3.16.0"
+  resolution: "@react-aria/overlays@npm:3.16.0"
   dependencies:
-    "@react-aria/focus": ^3.13.0
-    "@react-aria/i18n": ^3.8.0
-    "@react-aria/interactions": ^3.16.0
-    "@react-aria/utils": ^3.18.0
-    "@react-stately/collections": ^3.9.0
-    "@react-stately/selection": ^3.13.2
-    "@react-types/shared": ^3.18.1
+    "@react-aria/focus": ^3.14.0
+    "@react-aria/i18n": ^3.8.1
+    "@react-aria/interactions": ^3.17.0
+    "@react-aria/ssr": ^3.7.1
+    "@react-aria/utils": ^3.19.0
+    "@react-aria/visually-hidden": ^3.8.3
+    "@react-stately/overlays": ^3.6.1
+    "@react-types/button": ^3.7.4
+    "@react-types/overlays": ^3.8.1
+    "@react-types/shared": ^3.19.0
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: fb12513e0f5e13f429a1a38af5c9f7480e913d42aa20fb1677a7de12d62605ea05484e4611eaae1b62081eb449fff7b7a0b264de4f050274b2faf529cdda2467
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: fdf3207787c46cc623c9a0f926814baef33101b1b320996943242abb2d31c53ceddce85751802951a6b96530bd64c00a8b1a495dd05df727afec0ecd9038b75b
   languageName: node
   linkType: hard
 
-"@react-aria/ssr@npm:^3.2.0, @react-aria/ssr@npm:^3.3.0, @react-aria/ssr@npm:^3.7.0":
+"@react-aria/selection@npm:^3.16.0":
+  version: 3.16.1
+  resolution: "@react-aria/selection@npm:3.16.1"
+  dependencies:
+    "@react-aria/focus": ^3.14.0
+    "@react-aria/i18n": ^3.8.1
+    "@react-aria/interactions": ^3.17.0
+    "@react-aria/utils": ^3.19.0
+    "@react-stately/collections": ^3.10.0
+    "@react-stately/selection": ^3.13.3
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 4fd1304c50b2b7228816a88032320d62aecc4434fdc09aa0961dc32236203e5ea89ece4f2571e391eebcd62daab67585276e00c1874ee131017acb731906c117
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.7.0":
   version: 3.7.0
   resolution: "@react-aria/ssr@npm:3.7.0"
   dependencies:
@@ -5495,22 +5539,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/utils@npm:3.13.1":
-  version: 3.13.1
-  resolution: "@react-aria/utils@npm:3.13.1"
+"@react-aria/ssr@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "@react-aria/ssr@npm:3.7.1"
   dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/ssr": ^3.2.0
-    "@react-stately/utils": ^3.5.0
-    "@react-types/shared": ^3.13.1
-    clsx: ^1.1.1
+    "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 378b32809677114cff580fce100e151921a78ffc9ef75e45aaea3dd765c1e73055e73743fb868eb690a3729592cb1ba9d8a008adf39b0f7932d9f98377ddc07f
+  checksum: 2d388f9ced2e8822f1393f04418a8c783fa8b6577edca477fd517f2a43202038aba0117a92a1bc3fdc3a1360cf52bc0585290dc6861761b90130f37096f56791
   languageName: node
   linkType: hard
 
-"@react-aria/utils@npm:^3.13.3, @react-aria/utils@npm:^3.18.0":
+"@react-aria/utils@npm:3.18.0, @react-aria/utils@npm:^3.18.0":
   version: 3.18.0
   resolution: "@react-aria/utils@npm:3.18.0"
   dependencies:
@@ -5525,7 +5565,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/visually-hidden@npm:^3.4.1, @react-aria/visually-hidden@npm:^3.8.2":
+"@react-aria/utils@npm:^3.19.0":
+  version: 3.19.0
+  resolution: "@react-aria/utils@npm:3.19.0"
+  dependencies:
+    "@react-aria/ssr": ^3.7.1
+    "@react-stately/utils": ^3.7.0
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 90dbf8b859f2a2687de3de894971a2c28278b15e452480eb47707756e8c7743f7d102627b64d0a2e523f9d6112b348f48dca55207494467ddc08173bb516f9c0
+  languageName: node
+  linkType: hard
+
+"@react-aria/visually-hidden@npm:^3.8.2":
   version: 3.8.2
   resolution: "@react-aria/visually-hidden@npm:3.8.2"
   dependencies:
@@ -5540,7 +5595,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/collections@npm:^3.4.3, @react-stately/collections@npm:^3.9.0":
+"@react-aria/visually-hidden@npm:^3.8.3":
+  version: 3.8.3
+  resolution: "@react-aria/visually-hidden@npm:3.8.3"
+  dependencies:
+    "@react-aria/interactions": ^3.17.0
+    "@react-aria/utils": ^3.19.0
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: c298e4aed0597f147b71f17de8630c122f35a1805da96d4cebce0f8215a21bfbb02c33c0e342db91057e5f6d9d80ab31aa894a61cf1a6737941c93cb27dce8a5
+  languageName: node
+  linkType: hard
+
+"@react-stately/collections@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "@react-stately/collections@npm:3.10.0"
+  dependencies:
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: de5dcac9b07cc47c33a292132f9dba8d65798524c9e10a0152526d0ae0527e35897e5f415fc4bb9845b76e27d60882dcaacfeb011615ee700d9aeef30ec16a62
+  languageName: node
+  linkType: hard
+
+"@react-stately/collections@npm:^3.9.0":
   version: 3.9.0
   resolution: "@react-stately/collections@npm:3.9.0"
   dependencies:
@@ -5552,22 +5634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/menu@npm:3.4.1":
-  version: 3.4.1
-  resolution: "@react-stately/menu@npm:3.4.1"
-  dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-stately/overlays": ^3.4.1
-    "@react-stately/utils": ^3.5.1
-    "@react-types/menu": ^3.7.1
-    "@react-types/shared": ^3.14.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: a944d6e3a3caf400ffc52738ee8d586db6c6846d0ecc009de4bbedc88202f63d6bbddbd3d577f730f98f28404b077676af4c307f4ba09314c79cf56087a5aa8c
-  languageName: node
-  linkType: hard
-
-"@react-stately/menu@npm:^3.4.1":
+"@react-stately/menu@npm:3.5.3":
   version: 3.5.3
   resolution: "@react-stately/menu@npm:3.5.3"
   dependencies:
@@ -5582,7 +5649,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/overlays@npm:^3.4.1, @react-stately/overlays@npm:^3.6.0":
+"@react-stately/menu@npm:^3.5.3":
+  version: 3.5.4
+  resolution: "@react-stately/menu@npm:3.5.4"
+  dependencies:
+    "@react-stately/overlays": ^3.6.1
+    "@react-stately/utils": ^3.7.0
+    "@react-types/menu": ^3.9.3
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 848e75dc9d1645d94fb77a2d14aa1d88ae56ce8a34b6e740488e632ffa9bb2fc8bd1935ce6cafd1e477feee039f698821d6d5acce35b2ac6f5843ce2c5381d44
+  languageName: node
+  linkType: hard
+
+"@react-stately/overlays@npm:^3.6.0":
   version: 3.6.0
   resolution: "@react-stately/overlays@npm:3.6.0"
   dependencies:
@@ -5595,50 +5677,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-stately/selection@npm:^3.13.2":
-  version: 3.13.2
-  resolution: "@react-stately/selection@npm:3.13.2"
+"@react-stately/overlays@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "@react-stately/overlays@npm:3.6.1"
   dependencies:
-    "@react-stately/collections": ^3.9.0
     "@react-stately/utils": ^3.7.0
-    "@react-types/shared": ^3.18.1
+    "@react-types/overlays": ^3.8.1
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: bdb5b24ed9400e9d6738c80962c6a8260c4e197a975c5ac23c10df652df4efc910cf69cdd88b30bd8c72d1f565b132872d373e24175910ec2a38b567ab9769a3
+  checksum: 991721e6259cc7e81aff85282c41f1779608606243f8b82d19ddaf69c8adb8663b6122107d992cad614a417f765a305386f3f10de8b07dc237fcaf10f08b4a39
   languageName: node
   linkType: hard
 
-"@react-stately/toggle@npm:^3.4.1":
-  version: 3.6.0
-  resolution: "@react-stately/toggle@npm:3.6.0"
+"@react-stately/selection@npm:^3.13.3":
+  version: 3.13.3
+  resolution: "@react-stately/selection@npm:3.13.3"
   dependencies:
+    "@react-stately/collections": ^3.10.0
     "@react-stately/utils": ^3.7.0
-    "@react-types/checkbox": ^3.4.4
-    "@react-types/shared": ^3.18.1
+    "@react-types/shared": ^3.19.0
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 8ab0bd4e65133019c74f6f30d40f620a48d3c6592f558131553181cd98b4d014fba387d554d412a65ca3b6460294f968d8ded694432635c00e11ee358e497219
+  checksum: 3f197749543e3c74cda460961ff4c845cf26bd73507bbb0c5b86e9bdd55b732ee5b949808ce38377a3be2bccd8ec1e6a766ee018dbf2b80460e28e63937ac281
   languageName: node
   linkType: hard
 
-"@react-stately/tree@npm:^3.3.3":
-  version: 3.7.0
-  resolution: "@react-stately/tree@npm:3.7.0"
+"@react-stately/toggle@npm:^3.6.0":
+  version: 3.6.1
+  resolution: "@react-stately/toggle@npm:3.6.1"
   dependencies:
-    "@react-stately/collections": ^3.9.0
-    "@react-stately/selection": ^3.13.2
     "@react-stately/utils": ^3.7.0
-    "@react-types/shared": ^3.18.1
+    "@react-types/checkbox": ^3.5.0
+    "@react-types/shared": ^3.19.0
     "@swc/helpers": ^0.5.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 407f616775f6d605ac1136534218b37db1117fcee51e0edbcec2082cc5205b86ff64c1bc1a02c6adeaf4fe524506fef1a224cd1264fdb98694fefd180b6378a1
+  checksum: 84426c687dd63536e91459761f162e76937874424365a99ff5bfccd2c21734aa425989e6ba19c77de0a0ee4ee11549e008b224acda230c969040cc6a20fa4ca2
   languageName: node
   linkType: hard
 
-"@react-stately/utils@npm:^3.5.0, @react-stately/utils@npm:^3.5.1, @react-stately/utils@npm:^3.7.0":
+"@react-stately/tree@npm:^3.7.0":
+  version: 3.7.1
+  resolution: "@react-stately/tree@npm:3.7.1"
+  dependencies:
+    "@react-stately/collections": ^3.10.0
+    "@react-stately/selection": ^3.13.3
+    "@react-stately/utils": ^3.7.0
+    "@react-types/shared": ^3.19.0
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 246209edc8845a1d5880796ee76704a6a2b74c1909f5e19982e5bf932a1e0dc0b337f52f189024128b8d27469c78004b257e2d5cfd3b286dafa09bd83b4750ee
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.7.0":
   version: 3.7.0
   resolution: "@react-stately/utils@npm:3.7.0"
   dependencies:
@@ -5649,7 +5744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-types/button@npm:^3.6.1, @react-types/button@npm:^3.7.3":
+"@react-types/button@npm:^3.7.3":
   version: 3.7.3
   resolution: "@react-types/button@npm:3.7.3"
   dependencies:
@@ -5660,30 +5755,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-types/checkbox@npm:^3.4.4":
-  version: 3.4.4
-  resolution: "@react-types/checkbox@npm:3.4.4"
+"@react-types/button@npm:^3.7.4":
+  version: 3.7.4
+  resolution: "@react-types/button@npm:3.7.4"
   dependencies:
-    "@react-types/shared": ^3.18.1
+    "@react-types/shared": ^3.19.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 147bd4288ee714ead98433388589673632d92e26a7152032809dbcab9424b219505aabed9ad49770197c5d8cc0e660cad7cb077426eb08f333b333aecacd40fc
+  checksum: ea9465fa4fc5f544bd05c2ea7f0cea05910dc59d6a7d18e224707fbd1ff69600d3a3dc37706ed61f20b6a80e65b5baca84266518261d3fb85f11871588098082
   languageName: node
   linkType: hard
 
-"@react-types/dialog@npm:^3.4.3":
-  version: 3.5.3
-  resolution: "@react-types/dialog@npm:3.5.3"
+"@react-types/checkbox@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@react-types/checkbox@npm:3.5.0"
   dependencies:
-    "@react-types/overlays": ^3.8.0
-    "@react-types/shared": ^3.18.1
+    "@react-types/shared": ^3.19.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 0c9970ee7e37a1fd45a5665b36c94aafdb2856023a71612ed036c692db10d2882f0c736c2f4c1a0e0b6e797aa5a6c101df043e29ae415242d95e2fd420acb74c
+  checksum: ed3833fe7cbadd1de3ae816d602538a12aec80c6e56fd5c06c7a09a5859fdbe2125200fe91dc7d5721d33b646ba1e2fec03b3c0bc48d98d6b8555c0937a31020
   languageName: node
   linkType: hard
 
-"@react-types/menu@npm:^3.7.1, @react-types/menu@npm:^3.9.2":
+"@react-types/dialog@npm:^3.5.3":
+  version: 3.5.4
+  resolution: "@react-types/dialog@npm:3.5.4"
+  dependencies:
+    "@react-types/overlays": ^3.8.1
+    "@react-types/shared": ^3.19.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 7ac7f1b059fe08b776dc89779c25a9aaf2f9118ebdd73b70b81c91f952f1328af914812e63692263cd1c8717b7160ee6ad09cf7a543ea0cf02ec74cad475e1fc
+  languageName: node
+  linkType: hard
+
+"@react-types/menu@npm:^3.9.2":
   version: 3.9.2
   resolution: "@react-types/menu@npm:3.9.2"
   dependencies:
@@ -5695,7 +5801,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-types/overlays@npm:^3.6.3, @react-types/overlays@npm:^3.8.0":
+"@react-types/menu@npm:^3.9.3":
+  version: 3.9.3
+  resolution: "@react-types/menu@npm:3.9.3"
+  dependencies:
+    "@react-types/overlays": ^3.8.1
+    "@react-types/shared": ^3.19.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 5498401d8190eb3636e39d17ac24b31b5d132f2c36d01ea71ba3a80c0d1396508fa3ba0fb78cfeadfed6792c994f77875ead1d60a878388bd6fd3ac46980fdf6
+  languageName: node
+  linkType: hard
+
+"@react-types/overlays@npm:^3.8.0":
   version: 3.8.0
   resolution: "@react-types/overlays@npm:3.8.0"
   dependencies:
@@ -5706,12 +5824,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-types/shared@npm:^3.13.1, @react-types/shared@npm:^3.14.1, @react-types/shared@npm:^3.18.1":
+"@react-types/overlays@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@react-types/overlays@npm:3.8.1"
+  dependencies:
+    "@react-types/shared": ^3.19.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: fcdd5b80e6638ef01caa496afd890a4373d11fa450465364a43eb498369928b11cab7de07a662b3e72d629c65759d1c0da01118c4d29b6725d870f8993549ecf
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.18.1":
   version: 3.18.1
   resolution: "@react-types/shared@npm:3.18.1"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: 298822d1cca26b5da1bdf53a57d26d5619f3af816db3fdecdc8b99a3a305ca8ee352347ca43f426a5d79045b08cf32c00c6b083ad4a1002abf673de9dd4a9bb5
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.19.0":
+  version: 3.19.0
+  resolution: "@react-types/shared@npm:3.19.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: e1cdabe05980be44b20d68e424f5891753f359c96bf151a17befa5a6e965dac315fd595657ed7c6572042078b5ca735735204175b020a8bdbb7dc11379a3be46
   languageName: node
   linkType: hard
 
@@ -5772,70 +5910,6 @@ __metadata:
     rollup:
       optional: true
   checksum: edea15e543bebc7dcac3b0ac8bc7b8e8e6dbd46e2864dbe5dd28072de1fbd5b0e10d545a610c0edaa178e8a7ac432e2a2a52e547ece1308471412caba47db8ce
-  languageName: node
-  linkType: hard
-
-"@sentry/browser@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/browser@npm:6.19.7"
-  dependencies:
-    "@sentry/core": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: 071d00c76c2d0384580474c634c58c6196bbd1a3cf510da1309bd1565c57df7422fca8ceb717db189fa557f2c711a21664ee1ab935dfd9869faf416d388e6f78
-  languageName: node
-  linkType: hard
-
-"@sentry/core@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/core@npm:6.19.7"
-  dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/minimal": 6.19.7
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: d212e8ef07114549de4a93b81f8bfa217ca1550ca7a5eeaa611e5629faef78ff72663ce561ffa2cff48f3dc556745ef65177044f9965cdd3cbccf617cf3bf675
-  languageName: node
-  linkType: hard
-
-"@sentry/hub@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/hub@npm:6.19.7"
-  dependencies:
-    "@sentry/types": 6.19.7
-    "@sentry/utils": 6.19.7
-    tslib: ^1.9.3
-  checksum: 10bb1c5cba1b0f1e27a3dd0a186c22f94aeaf11c4662890ab07b2774f46f46af78d61e3ba71d76edc750a7b45af86edd032f35efecdb4efa2eaf551080ccdcb1
-  languageName: node
-  linkType: hard
-
-"@sentry/minimal@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/minimal@npm:6.19.7"
-  dependencies:
-    "@sentry/hub": 6.19.7
-    "@sentry/types": 6.19.7
-    tslib: ^1.9.3
-  checksum: 9153ac426ee056fc34c5be898f83d74ec08f559d69f544c5944ec05e584b62ed356b92d1a9b08993a7022ad42b5661c3d72881221adc19bee5fc1af3ad3864a8
-  languageName: node
-  linkType: hard
-
-"@sentry/types@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/types@npm:6.19.7"
-  checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
-  languageName: node
-  linkType: hard
-
-"@sentry/utils@npm:6.19.7":
-  version: 6.19.7
-  resolution: "@sentry/utils@npm:6.19.7"
-  dependencies:
-    "@sentry/types": 6.19.7
-    tslib: ^1.9.3
-  checksum: a000223b9c646c64e3565e79cace1eeb75114342b768367c4dddd646476c215eb1bddfb70c63f05e2352d3bce2d7d415344e4757a001605d0e01ac74da5dd306
   languageName: node
   linkType: hard
 
@@ -6765,6 +6839,22 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: e009a2bfb50e90ca9b7c6e8f648f8464067271fd99116f881073fa6fa76dc8d0133181dd65e6614d5fb1220d671d67b0124aef7d97dc02d7e342ab143a47779d
+  languageName: node
+  linkType: hard
+
+"@types/lodash.memoize@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "@types/lodash.memoize@npm:4.1.7"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 85f128b6606ab0545c11194208cf844536f981859221dff0032b1043dd4e02ee5aa1b96020d1e02a24db31be7493f2e9ff45836d2e3c35cf973fc6488f129eed
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.14.197
+  resolution: "@types/lodash@npm:4.14.197"
+  checksum: 53d7567d1704de76cf33266c78062e0fd722d4b846e5b1417d0b6ef0ee41c0d9c451b92bc34f73d5f1fcc45c7d36511e92f6f47a9279b48157ba60a92ddaa078
   languageName: node
   linkType: hard
 
@@ -7726,10 +7816,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wojtekmaj/date-utils@npm:^1.0.2":
-  version: 1.4.1
-  resolution: "@wojtekmaj/date-utils@npm:1.4.1"
-  checksum: e1def2f26e2b2e781152b9f2b847f849abfb4ad90d2fddb77dc418ec4c8753dc29775d52205bc47952a71e47abf53bcb6df6306707486b3aa3b69ef9c359d8d6
+"@wojtekmaj/date-utils@npm:^1.1.3":
+  version: 1.5.0
+  resolution: "@wojtekmaj/date-utils@npm:1.5.0"
+  checksum: ad0fbb7345d879f99b7db549af5c9c05407d5eb87ab92f8a5a76b790f3f53f35476d40aa828b7343e3af91b566b34a5aa1fed396accad783e4b52dd9a5a8ba43
   languageName: node
   linkType: hard
 
@@ -10638,10 +10728,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:3.28.0":
-  version: 3.28.0
-  resolution: "core-js@npm:3.28.0"
-  checksum: 3155fd0ec16d0089106b145e9595280a4ea4bde0d7ff26aa14364cd4f1c203baf6620c3025acd284f363d08b9f21104101692766ca9a36ffeee7307bdf3e1881
+"core-js@npm:3.31.1, core-js@npm:^3.23.3":
+  version: 3.31.1
+  resolution: "core-js@npm:3.31.1"
+  checksum: 14519213a63c55cf188bdd2f4dece54583feaf6b90e75d6c65e07f509cd487055bf64898aeda7c97c36029ac1ea2f2ed8e4b02281553f6a257e7143a32a14015
   languageName: node
   linkType: hard
 
@@ -10649,13 +10739,6 @@ __metadata:
   version: 2.6.12
   resolution: "core-js@npm:2.6.12"
   checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^3.23.3":
-  version: 3.31.1
-  resolution: "core-js@npm:3.31.1"
-  checksum: 14519213a63c55cf188bdd2f4dece54583feaf6b90e75d6c65e07f509cd487055bf64898aeda7c97c36029ac1ea2f2ed8e4b02281553f6a257e7143a32a14015
   languageName: node
   linkType: hard
 
@@ -11466,9 +11549,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3@npm:7.8.2":
-  version: 7.8.2
-  resolution: "d3@npm:7.8.2"
+"d3@npm:7.8.5":
+  version: 7.8.5
+  resolution: "d3@npm:7.8.5"
   dependencies:
     d3-array: 3
     d3-axis: 3
@@ -11500,7 +11583,7 @@ __metadata:
     d3-timer: 3
     d3-transition: 3
     d3-zoom: 3
-  checksum: e7bf5918f2a97d0c0cc489d64348b323446aa824c32b65f0888846c26f80ed05dbee18a4b7c9a487b3e60d9d404e4672d169573fe63439e3e53abd5812bcd766
+  checksum: e407e79731f74d946a5eb8dec2f037b5a4ad33c294409b1d3531fdf7094de48adfe364974cb37e2396bdb81e23149d56d0ede716c004d6aebb52b3cc114cd15c
   languageName: node
   linkType: hard
 
@@ -11542,10 +11625,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:2.29.3":
-  version: 2.29.3
-  resolution: "date-fns@npm:2.29.3"
-  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
+"date-fns@npm:2.30.0":
+  version: 2.30.0
+  resolution: "date-fns@npm:2.30.0"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
   languageName: node
   linkType: hard
 
@@ -13464,10 +13549,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:5.0.0":
-  version: 5.0.0
-  resolution: "eventemitter3@npm:5.0.0"
-  checksum: b974bafbab860e0a5bbb21add4c4e82f9d5691c583c03f2e4c5d44a2d6c4556d79223621bdcfc6c8e14366a4af9df6b5ea9d6caf65fbffc80b66f3e1dceacbc9
+"eventemitter3@npm:5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
   languageName: node
   linkType: hard
 
@@ -14686,12 +14771,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-user-locale@npm:^1.2.0":
-  version: 1.5.1
-  resolution: "get-user-locale@npm:1.5.1"
+"get-user-locale@npm:^2.2.1":
+  version: 2.3.0
+  resolution: "get-user-locale@npm:2.3.0"
   dependencies:
+    "@types/lodash.memoize": ^4.1.7
     lodash.memoize: ^4.1.1
-  checksum: 4ab9ae83264c8b4f376b7690578ee3b332808d40f49e500469d476b832d4fddcf8477b7a01b60a242fd232b5a2ae8f6b7620f731d67350e89fd17ddd91fc8a0e
+  checksum: 8a815e7528d1a75d85b25573ecd66890b126cdc6759f06354dd0b59371d88618aad5a4955ccab5c1267a9ca6a6e46b9362e9bad2639ad5949d3e90542a480791
   languageName: node
   linkType: hard
 
@@ -15749,6 +15835,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"i18next-browser-languagedetector@npm:^7.0.2":
+  version: 7.1.0
+  resolution: "i18next-browser-languagedetector@npm:7.1.0"
+  dependencies:
+    "@babel/runtime": ^7.19.4
+  checksum: 36981b9a9995ed66387f3735cceffe107ed3cdb6ca278d45fa243fabc65669c0eca095ed4a55a93dac046ca1eb23fd986ec0079723be7ebb8505e6ba25f379bb
+  languageName: node
+  linkType: hard
+
 "i18next@npm:^22.0.0":
   version: 22.5.1
   resolution: "i18next@npm:22.5.1"
@@ -15849,10 +15944,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:4.2.4":
-  version: 4.2.4
-  resolution: "immutable@npm:4.2.4"
-  checksum: 3be84eded37b05e65cad57bfba630bc1bf170c498b7472144bc02d2650cc9baef79daf03574a9c2e41d195ebb55a1c12c9b312f41ee324b653927b24ad8bcaa7
+"immutable@npm:4.3.1":
+  version: 4.3.1
+  resolution: "immutable@npm:4.3.1"
+  checksum: a3a5ba29bd43f3f9a2e4d599763d7455d11a0ea57e50bf43f2836672fc80003e90d69f2a4f5b589f1f3d6986faf97f08ce1e253583740dd33c00adebab88b217
   languageName: node
   linkType: hard
 
@@ -17908,10 +18003,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jquery@npm:3.6.3":
-  version: 3.6.3
-  resolution: "jquery@npm:3.6.3"
-  checksum: 0fd366bdcaa0c84a7a8751ce20f8192290141913978b5059574426d9b01f4365daa675f95aab3eec94fd794d27b08d32078a2236bef404b8ba78073009988ce6
+"jquery@npm:3.7.0":
+  version: 3.7.0
+  resolution: "jquery@npm:3.7.0"
+  checksum: 907785e133afc427650a131af5fccef66a404885037513b3d4d7d63aee6409bcc32a39836868c60e59b05aa0fb8ace8961c18b2ee3ffdf6ffdb571d6d7cd88ff
   languageName: node
   linkType: hard
 
@@ -19037,12 +19132,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:4.2.12":
-  version: 4.2.12
-  resolution: "marked@npm:4.2.12"
+"marked-mangle@npm:1.1.0":
+  version: 1.1.0
+  resolution: "marked-mangle@npm:1.1.0"
+  peerDependencies:
+    marked: ^4 || ^5
+  checksum: 3897cb6b0ed580e9be029bf78f8b3b22534ca3e0c061fd9e45d0f256263c01f9667122d68235c767583c7109347bd1cc823dca5f428b95460123ba4b212cdb11
+  languageName: node
+  linkType: hard
+
+"marked@npm:5.1.1":
+  version: 5.1.1
+  resolution: "marked@npm:5.1.1"
   bin:
     marked: bin/marked.js
-  checksum: bd551cd61028ee639d4ca2ccdfcc5a6ba4227c1b143c4538f3cde27f569dcb57df8e6313560394645b418b84a7336c07ab1e438b89b6324c29d7d8cdd3102d63
+  checksum: e0c6d3a63d01c3b47f7758c3add02abdb3747701b6fce60c4b5602cc3b33122439c5c0a95ac1e8b5fcbb0f7d3aa7af2126aa56074c3d41e207bf9a9ed9948026
   languageName: node
   linkType: hard
 
@@ -19676,12 +19780,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment-timezone@npm:0.5.41":
-  version: 0.5.41
-  resolution: "moment-timezone@npm:0.5.41"
+"moment-timezone@npm:0.5.43":
+  version: 0.5.43
+  resolution: "moment-timezone@npm:0.5.43"
   dependencies:
     moment: ^2.29.4
-  checksum: 30bf42265f749d4d17e78cf94f49d8354d9fbf2dea060a5b89895979642035734512a23cb7a90c0e93593bc11eb698b78b601b7dd5d9a708eb7c4f733a927a71
+  checksum: 8075c897ed8a044f992ef26fe8cdbcad80caf974251db424cae157473cca03be2830de8c74d99341b76edae59f148c9d9d19c1c1d9363259085688ec1cf508d0
   languageName: node
   linkType: hard
 
@@ -20574,26 +20678,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ol-mapbox-style@npm:^9.2.0":
-  version: 9.7.0
-  resolution: "ol-mapbox-style@npm:9.7.0"
+"ol-mapbox-style@npm:^10.1.0":
+  version: 10.7.0
+  resolution: "ol-mapbox-style@npm:10.7.0"
   dependencies:
     "@mapbox/mapbox-gl-style-spec": ^13.23.1
     mapbox-to-css-font: ^2.4.1
-  checksum: 0c03c997a1d76d8f8a4a7b73102400a086efb5e6f02ba7de1fbf3db8c99ae6ce7fc3beeb746451a08befb26fa6d516766cea6b975fad390abda03be1cf04ed11
+    ol: ^7.3.0
+  checksum: c6f9b121b69870a6b68969a108f5272d2e2e4c629dfac9ad317c3bd1a676fe5cc5e4e9fb9e8bea9f86122707cd9af378ee80bd60ec9c9528005128a7438be959
   languageName: node
   linkType: hard
 
-"ol@npm:7.2.2":
-  version: 7.2.2
-  resolution: "ol@npm:7.2.2"
+"ol@npm:7.4.0":
+  version: 7.4.0
+  resolution: "ol@npm:7.4.0"
   dependencies:
     earcut: ^2.2.3
     geotiff: ^2.0.7
-    ol-mapbox-style: ^9.2.0
+    ol-mapbox-style: ^10.1.0
     pbf: 3.2.1
     rbush: ^3.0.1
-  checksum: 025b58ad79d8b3f1036632306cc2f38fa02aa6e18504916ec4242b5b4f5672d8068d8f45190896241cb1975d331f993b512b60b667e92e9fa126bfbb6b87557d
+  checksum: 0cc8cfbbb0fb2f2d6037e53e56cfbe24eabce647eefc73e03b3ee285973ee39f6ec45276fb2b3ef877878b3f28b75914cac054e036ea3b82e1314d5eeb28e723
+  languageName: node
+  linkType: hard
+
+"ol@npm:^7.3.0":
+  version: 7.5.1
+  resolution: "ol@npm:7.5.1"
+  dependencies:
+    earcut: ^2.2.3
+    geotiff: ^2.0.7
+    ol-mapbox-style: ^10.1.0
+    pbf: 3.2.1
+    rbush: ^3.0.1
+  checksum: afebc55b87778afc9995ef9c957955238d56767ed5c0c72f8be9092da38e4088251a789c5cca78680150a099da6774713b2501862d82225c8c6d1338a633889e
   languageName: node
   linkType: hard
 
@@ -20963,10 +21081,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"papaparse@npm:5.3.2":
-  version: 5.3.2
-  resolution: "papaparse@npm:5.3.2"
-  checksum: a5950ef931a42f6759a8d3823a43dd30f375b37a0ddea6ea5448c0c5024cd226819231958c49c24fbcdeab297c63fd1d630130b3439876ea0fd17d8a267738ae
+"papaparse@npm:5.4.1":
+  version: 5.4.1
+  resolution: "papaparse@npm:5.4.1"
+  checksum: fc9e52f7158dca3517c229e3309065b1ab5da6c7194572fba4f31ff138bc43e3c91182cc40365cc828f97fe10d0aca416068fd731661058bea0f69ddb84a411a
   languageName: node
   linkType: hard
 
@@ -22447,36 +22565,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-cascader@npm:3.10.2":
-  version: 3.10.2
-  resolution: "rc-cascader@npm:3.10.2"
+"rc-cascader@npm:3.12.1":
+  version: 3.12.1
+  resolution: "rc-cascader@npm:3.12.1"
   dependencies:
     "@babel/runtime": ^7.12.5
     array-tree-filter: ^2.1.0
     classnames: ^2.3.1
-    rc-select: ~14.4.0
+    rc-select: ~14.5.0
     rc-tree: ~5.7.0
     rc-util: ^5.6.1
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: f4df7dc148578410e24521120ef2b96108164a83aa6339e522c682c911cc8368729a8d04ac66bfd7cc785bc69b5ffbbc6f9d98ec11a62f8b273871ad63d4941c
+  checksum: 11fddad49d7c6dcd06f7875b34fb40d798d912e2280e75e4f89777ade05d8a162f2c8f81e447dec44b327603e92f15c93b5c1a7489353732ca37f4c020d45624
   languageName: node
   linkType: hard
 
-"rc-drawer@npm:6.1.3":
-  version: 6.1.3
-  resolution: "rc-drawer@npm:6.1.3"
+"rc-drawer@npm:6.3.0":
+  version: 6.3.0
+  resolution: "rc-drawer@npm:6.3.0"
   dependencies:
     "@babel/runtime": ^7.10.1
-    "@rc-component/portal": ^1.0.0-6
+    "@rc-component/portal": ^1.1.1
     classnames: ^2.2.6
     rc-motion: ^2.6.1
     rc-util: ^5.21.2
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 09fa3085312f668b27e0a8acae7f560a7d45ad52e4554020a6d3801352331b1173b20f57d32f876cfc1b359bd3088190e90bd7815619144d6d50b83c4ab44196
+  checksum: 63c9c5d05590a35dc9a66b03544626180e8df08c593568e32f5ac86e0078b09a7388a60441f357b7c71a31715aa18f43fc4a1e165d745d58861380c88b8c9d36
   languageName: node
   linkType: hard
 
@@ -22524,9 +22642,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-select@npm:~14.4.0":
-  version: 14.4.3
-  resolution: "rc-select@npm:14.4.3"
+"rc-select@npm:~14.5.0":
+  version: 14.5.2
+  resolution: "rc-select@npm:14.5.2"
   dependencies:
     "@babel/runtime": ^7.10.1
     "@rc-component/trigger": ^1.5.0
@@ -22534,17 +22652,17 @@ __metadata:
     rc-motion: ^2.0.1
     rc-overflow: ^1.0.0
     rc-util: ^5.16.1
-    rc-virtual-list: ^3.4.13
+    rc-virtual-list: ^3.5.2
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 6f5654bf30e571a52842fe8f5542c6c3c833f4756d5686d82548845a31bf4bd299e2a1931cfdd1b47f522402acd38ffe869ff422a6ade0bffed6167fe7fe2f39
+  checksum: d3f55543eae15ac9bf56019345ad94268f9e063ede38c3d8c46dc59b1bc47c0f4c724613a9e9a6f4dc0d5bc0e31c7f7029e6bef717b335432818fbeea0f7398f
   languageName: node
   linkType: hard
 
-"rc-slider@npm:10.1.1":
-  version: 10.1.1
-  resolution: "rc-slider@npm:10.1.1"
+"rc-slider@npm:10.2.1":
+  version: 10.2.1
+  resolution: "rc-slider@npm:10.2.1"
   dependencies:
     "@babel/runtime": ^7.10.1
     classnames: ^2.2.5
@@ -22552,7 +22670,7 @@ __metadata:
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 8df66142f1be00d31aaa45f3cf266fa30d03b70c74c734502389bbfacdb6741e149cd36dc1d3557d9dbb0194ed2733748366d888651d1120098338086419ba2c
+  checksum: 565eb55302c776a7a48bfbe6761f52bab6b0d3ea4f53fc10d32ae9958340708bc5072a9c254bb5ddfa822492093032b94cb03d5e52cdff774e076b90e20b9145
   languageName: node
   linkType: hard
 
@@ -22570,17 +22688,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-tooltip@npm:5.3.1":
-  version: 5.3.1
-  resolution: "rc-tooltip@npm:5.3.1"
+"rc-tooltip@npm:6.0.1":
+  version: 6.0.1
+  resolution: "rc-tooltip@npm:6.0.1"
   dependencies:
     "@babel/runtime": ^7.11.2
+    "@rc-component/trigger": ^1.0.4
     classnames: ^2.3.1
-    rc-trigger: ^5.3.1
   peerDependencies:
     react: ">=16.9.0"
     react-dom: ">=16.9.0"
-  checksum: 93a99dd8f83ca6187cae7d09e498156e660331837f7ff16d6c50165e5cbc810d566552535d8c92c6fb3093f45cadfa0b62a03b9f78ba22e8b6123eda27333cf4
+  checksum: fe7f617a4f4e0085d8f5eb5e8da5598f0164841c841f62f77966706ae604491246441a469aeb44f1dec7001bb4716ee81d11ec646e8889f4164fcba3a024eea5
   languageName: node
   linkType: hard
 
@@ -22615,22 +22733,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-trigger@npm:^5.3.1":
-  version: 5.3.4
-  resolution: "rc-trigger@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": ^7.18.3
-    classnames: ^2.2.6
-    rc-align: ^4.0.0
-    rc-motion: ^2.0.0
-    rc-util: ^5.19.2
-  peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 6ca7694a4cf064040b5e0fd9b4629b0e0a19ebb29c4eb5614ee9eb22b4193e21909171fd95e48be73a94e44f249cb9616d7670b696164620b722d3de6f280017
-  languageName: node
-  linkType: hard
-
 "rc-util@npm:^4.0.4, rc-util@npm:^4.15.3, rc-util@npm:^4.4.0":
   version: 4.21.1
   resolution: "rc-util@npm:4.21.1"
@@ -22657,7 +22759,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc-virtual-list@npm:^3.4.13, rc-virtual-list@npm:^3.5.1":
+"rc-util@npm:^5.36.0":
+  version: 5.37.0
+  resolution: "rc-util@npm:5.37.0"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    react-is: ^16.12.0
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+  checksum: 0a72644f0924235044eb20bbc73081356c1fb98459f6cce0f4b75807c82cb71c050e5f36cf6d82f8a8a07b5955632e1198b8884cd96fe2d8d92f2289f9058a7e
+  languageName: node
+  linkType: hard
+
+"rc-virtual-list@npm:^3.5.1":
   version: 3.5.3
   resolution: "rc-virtual-list@npm:3.5.3"
   dependencies:
@@ -22669,6 +22784,21 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: 670ee4fbaa413706666f5ed6133a14e14ad2c3433acd1f95c24b8586a68b021b8bca4de81cf630973577adb28c58329da7bd005728cc3189facb8927c6be5632
+  languageName: node
+  linkType: hard
+
+"rc-virtual-list@npm:^3.5.2":
+  version: 3.10.5
+  resolution: "rc-virtual-list@npm:3.10.5"
+  dependencies:
+    "@babel/runtime": ^7.20.0
+    classnames: ^2.2.6
+    rc-resize-observer: ^1.0.0
+    rc-util: ^5.36.0
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 0d8d8a20eba339eb639a898e43df6ec0210f10f21ba3e760bacff6352f15b2d725fd37fd4eb6348b9e6cddb1dd29761671c48e5f604e9f55bdc52453822023f2
   languageName: node
   linkType: hard
 
@@ -22716,18 +22846,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-calendar@npm:4.0.0":
-  version: 4.0.0
-  resolution: "react-calendar@npm:4.0.0"
+"react-calendar@npm:4.3.0":
+  version: 4.3.0
+  resolution: "react-calendar@npm:4.3.0"
   dependencies:
-    "@wojtekmaj/date-utils": ^1.0.2
+    "@types/react": "*"
+    "@wojtekmaj/date-utils": ^1.1.3
     clsx: ^1.2.1
-    get-user-locale: ^1.2.0
+    get-user-locale: ^2.2.1
     prop-types: ^15.6.0
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: a470ea1eab914cda9f76245060e15129a220c30f2942a28c20b3cb999fd994d0c0fadae849184ba123b3b78541fbb3301c5ac0c44e0bd2ab156bfba8cc587593
+  checksum: 0abfb0e6c6c8ea6d5d10a9073db1861b9d6c746905573a1ba576d77e260c4cf4d90cc45a7eccb3166e8ccdad71df787cd629ae2d0b2839409db7e25c76f8cd32
   languageName: node
   linkType: hard
 
@@ -23010,6 +23141,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-loading-skeleton@npm:3.3.1":
+  version: 3.3.1
+  resolution: "react-loading-skeleton@npm:3.3.1"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 0de3437a5da8b7133bf86043e4e002e5422b50cd71b9a650f2947a89ace39be8b7c61a098f1d7dd0be559dc3ac293d60697fdae23cb09c3905b2952e1a68693d
+  languageName: node
+  linkType: hard
+
 "react-popper-tooltip@npm:4.4.2":
   version: 4.4.2
   resolution: "react-popper-tooltip@npm:4.4.2"
@@ -23165,9 +23305,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-select@npm:5.7.0":
-  version: 5.7.0
-  resolution: "react-select@npm:5.7.0"
+"react-select@npm:5.7.4":
+  version: 5.7.4
+  resolution: "react-select@npm:5.7.4"
   dependencies:
     "@babel/runtime": ^7.12.0
     "@emotion/cache": ^11.4.0
@@ -23181,7 +23321,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 3d29f7bb6dd66ad55396d820f05da6112f1d21b67526422a8ff5aa6cd47c783804c1b73042ac2949ba0871056a3dc68c06a73a8281abb61571e475d72bbd80dc
+  checksum: ca72941ad1d2c578ec04c09ed3deb7e373f987e589f403fadedc6fcc3e29935b5425ec4d2628f0fe58c21319bcaf153c0d0172432e09fc6423da869d848de757
   languageName: node
   linkType: hard
 
@@ -23267,16 +23407,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-window@npm:1.8.8":
-  version: 1.8.8
-  resolution: "react-window@npm:1.8.8"
+"react-window@npm:1.8.9":
+  version: 1.8.9
+  resolution: "react-window@npm:1.8.9"
   dependencies:
     "@babel/runtime": ^7.0.0
     memoize-one: ">=3.1.1 <6"
   peerDependencies:
     react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: a19f43b9015fb84e16db983617dac618a8b298881d2ca96ffc2fb00534afd958ee57a00fd0017733b56f8c34dd84e5be59337877aed3c66329ed3b84e8d018ba
+  checksum: cefa232f4f37269d292529ef15780fb108123d6bb5beee19eeac657e75cf8d4664be66f2da04baf0cb1bc64c5ab3d83a88199c3358f023b78940acd37b0673b2
   languageName: node
   linkType: hard
 
@@ -23560,6 +23700,13 @@ __metadata:
   version: 0.11.1
   resolution: "regenerator-runtime@npm:0.11.1"
   checksum: 3c97bd2c7b2b3247e6f8e2147a002eb78c995323732dad5dc70fac8d8d0b758d0295e7015b90d3d444446ae77cbd24b9f9123ec3a77018e81d8999818301b4f4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "regenerator-runtime@npm:0.14.0"
+  checksum: 1c977ad82a82a4412e4f639d65d22be376d3ebdd30da2c003eeafdaaacd03fc00c2320f18120007ee700900979284fc78a9f00da7fb593f6e6eeebc673fba9a3
   languageName: node
   linkType: hard
 
@@ -24260,7 +24407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.1, rxjs@npm:^7.5.4, rxjs@npm:^7.5.5, rxjs@npm:^7.8.0":
+"rxjs@npm:7.8.1, rxjs@npm:^7.5.1, rxjs@npm:^7.5.4, rxjs@npm:^7.5.5, rxjs@npm:^7.8.0":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -24367,15 +24514,15 @@ __metadata:
   dependencies:
     "@babel/core": ^7.16.7
     "@emotion/css": ^11.1.3
-    "@grafana/data": 10.0.3
+    "@grafana/data": 10.2.0-131492
     "@grafana/e2e": 9.2.1
     "@grafana/e2e-selectors": 10.0.2
     "@grafana/eslint-config": 5.0.0
-    "@grafana/runtime": 10.0.3
+    "@grafana/runtime": 10.2.0-131492
     "@grafana/scenes": "workspace:*"
-    "@grafana/schema": 10.0.3
+    "@grafana/schema": 10.2.0-131492
     "@grafana/tsconfig": 1.2.0-rc1
-    "@grafana/ui": 10.0.3
+    "@grafana/ui": 10.2.0-131492
     "@swc/core": ^1.2.144
     "@swc/helpers": ^0.3.6
     "@swc/jest": ^0.2.20
@@ -26587,17 +26734,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1, tslib@npm:^1.9.3":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0":
+"tslib@npm:2.6.0, tslib@npm:^2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0":
   version: 2.6.0
   resolution: "tslib@npm:2.6.0"
   checksum: c01066038f950016a18106ddeca4649b4d76caa76ec5a31e2a26e10586a59fceb4ee45e96719bf6c715648e7c14085a81fee5c62f7e9ebee68e77a5396e5538f
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.8.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is just prep for an eventual bump of peer dependencies when they are released.