### PR TITLE
sceneUtils: cloneSceneObjectState

### DIFF
--- a/packages/scenes/src/core/sceneGraph/utils.ts
+++ b/packages/scenes/src/core/sceneGraph/utils.ts
@@ -9,7 +9,15 @@ export function cloneSceneObject<T extends SceneObjectBase<TState>, TState exten
   sceneObject: SceneObjectBase<TState>,
   withState?: Partial<TState>
 ): T {
-  const clonedState = { ...sceneObject.state };
+  const clonedState = cloneSceneObjectState(sceneObject.state, withState);
+  return new (sceneObject.constructor as any)(clonedState);
+}
+
+export function cloneSceneObjectState<TState extends SceneObjectState>(
+  sceneState: TState,
+  withState?: Partial<TState>
+): TState {
+  const clonedState = { ...sceneState };
 
   // Clone any SceneItems in state
   for (const key in clonedState) {
@@ -34,7 +42,7 @@ export function cloneSceneObject<T extends SceneObjectBase<TState>, TState exten
 
   Object.assign(clonedState, withState);
 
-  return new (sceneObject.constructor as any)(clonedState);
+  return clonedState;
 }
 
 /** Walks up the scene graph, returning the first non-undefined result of `extract` */

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -1,5 +1,6 @@
 import { getUrlWithAppState } from './components/SceneApp/utils';
 import { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
+import { cloneSceneObjectState } from './core/sceneGraph/utils';
 import { registerRuntimeDataSource } from './querying/RuntimeDataSource';
 
 export * from './core/types';
@@ -62,4 +63,5 @@ export const sceneUtils = {
   getUrlWithAppState,
   registerRuntimePanelPlugin,
   registerRuntimeDataSource,
+  cloneSceneObjectState,
 };


### PR DESCRIPTION
Have a scenario where I want to only clone the state of a scene object, and not it's containing scene object instance.

This is for the discard mechanic found in https://github.com/grafana/grafana/pull/73873, If I do a full clone and then try to reuse that state with another
instance I hit my setParent warning of changing scene parent.

DashboardScene want's to copy it's current state so it can revert back to it, so it wants to clone it's state (but not itself) 
