### PR TITLE
VizPanel: Allow panels to rendered without layout parent

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -22,16 +22,11 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     hoverHeader,
     menu,
     headerActions,
-    ...state
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
   const plugin = model.getPlugin();
-  const parentLayout = sceneGraph.getLayout(model);
 
-  // If parent has enabled dragging and we have not explicitly disabled it then dragging is enabled
-  const isDraggable = parentLayout.isDraggable() && (state.isDraggable ?? true);
-  const dragClass = isDraggable && parentLayout.getDragClass ? parentLayout.getDragClass() : '';
-  const dragClassCancel = isDraggable && parentLayout.getDragClassCancel ? parentLayout.getDragClassCancel() : '';
+  const { dragClass, dragClassCancel } = getDragClasses(model);
   const dataObject = sceneGraph.getData(model);
   const rawData = dataObject.useState();
   const dataWithFieldConfig = model.applyFieldConfig(rawData.data!);
@@ -137,6 +132,16 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
       )}
     </div>
   );
+}
+
+function getDragClasses(panel: VizPanel) {
+  const parentLayout = sceneGraph.getLayout(panel);
+
+  // If parent has enabled dragging and we have not explicitly disabled it then dragging is enabled
+  const isDraggable = parentLayout?.isDraggable() && (panel.state.isDraggable ?? true);
+  const dragClass = isDraggable && parentLayout?.getDragClass ? parentLayout.getDragClass() : '';
+  const dragClassCancel = isDraggable && parentLayout?.getDragClassCancel ? parentLayout.getDragClassCancel() : '';
+  return { dragClass, dragClassCancel };
 }
 
 function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | undefined) {

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -136,12 +136,13 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
 function getDragClasses(panel: VizPanel) {
   const parentLayout = sceneGraph.getLayout(panel);
-
-  // If parent has enabled dragging and we have not explicitly disabled it then dragging is enabled
   const isDraggable = parentLayout?.isDraggable() && (panel.state.isDraggable ?? true);
-  const dragClass = isDraggable && parentLayout?.getDragClass ? parentLayout.getDragClass() : '';
-  const dragClassCancel = isDraggable && parentLayout?.getDragClassCancel ? parentLayout.getDragClassCancel() : '';
-  return { dragClass, dragClassCancel };
+
+  if (!parentLayout || !isDraggable) {
+    return { dragClass: '', dragClassCancel: '' };
+  }
+
+  return { dragClass: parentLayout.getDragClass?.(), dragClassCancel: parentLayout?.getDragClassCancel?.() };
 }
 
 function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | undefined) {

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -29,13 +29,13 @@ function isSceneLayout(s: SceneObject): s is SceneLayout {
 /**
  * Will walk up the scene object graph to the closest $layout scene object
  */
-export function getLayout(scene: SceneObject): SceneLayout {
+export function getLayout(scene: SceneObject): SceneLayout | null {
   const parent = getClosest(scene, (s) => (isSceneLayout(s) ? s : undefined));
   if (parent) {
     return parent;
   }
 
-  throw new Error('No layout found in scene tree');
+  return null;
 }
 
 /**


### PR DESCRIPTION
Hit this limitation when trying to render a VizPanel in panel edit (outside any layout). 

I don't think we should require VizPanel to always be placed inside a layout 