### PR TITLE
SceneObjectRef: Provide a way to have references to other scene objects without impacting parent 

### DIFF
--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -254,7 +254,7 @@ const scene = new EmbeddedScene({
 It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A scene object's parent is automatically set when it's part of the state of another scene object. So if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
 
 * Clone the source scene object. This will create a separate instance with no connection to the source object.
-* Use SceneObjectRef to wrap the instance. This makes sure the object's original parent is not changed while allowing you to store a reference to the instance in the state of another scene object.
+* Use `SceneObjectRef` to wrap the instance. This makes sure the object's original parent is not changed while allowing you to store a reference to the instance in the state of another scene object.
 
 
 ## Source code

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -251,8 +251,7 @@ const scene = new EmbeddedScene({
 
 ## References to SceneObject's and the parent reference
 
-It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A SceneObject's parent is automatically set when it's part of the state of another scene object. So
-if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
+It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A SceneObject's parent is automatically set when it's part of the state of another scene object. So if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
 
 * Clone the source scene object. This will create a separate instance with no connection to the source object.
 * Use SceneObjectRef to wrap the instance. This makes sure the object's original parent is not changed while allowing you store a reference to the instance in the state of another scene object.

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -254,7 +254,7 @@ const scene = new EmbeddedScene({
 It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A SceneObject's parent is automatically set when it's part of the state of another scene object. So if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
 
 * Clone the source scene object. This will create a separate instance with no connection to the source object.
-* Use SceneObjectRef to wrap the instance. This makes sure the object's original parent is not changed while allowing you store a reference to the instance in the state of another scene object.
+* Use SceneObjectRef to wrap the instance. This makes sure the object's original parent is not changed while allowing you to store a reference to the instance in the state of another scene object.
 
 
 ## Source code

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -249,6 +249,15 @@ const scene = new EmbeddedScene({
 });
 ```
 
+## References to SceneObject's and the parent reference
+
+It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A SceneObject's parent is automatically set when it's part of the state of another scene object. So
+if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
+
+* Clone the source scene object. This will create a separate instance with no connection to the source object.
+* Use SceneObjectRef to wrap the instance. This makes sure the object's original parent is not changed while allowing you store a reference to the instance in the state of another scene object.
+
+
 ## Source code
 
 [View the examples source code](https://github.com/grafana/scenes/tree/main/docusaurus/docs/core-concepts.tsx)

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -251,7 +251,7 @@ const scene = new EmbeddedScene({
 
 ## References to SceneObject's and the parent reference
 
-It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A SceneObject's parent is automatically set when it's part of the state of another scene object. So if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
+It's very important that you do not reuse the same instance to a scene object in multiple different scenes or locations within the same scene. A scene object's parent is automatically set when it's part of the state of another scene object. So if you want to use the same scene object instance as the part of the state of more than one scene object you have two options.
 
 * Clone the source scene object. This will create a separate instance with no connection to the source object.
 * Use SceneObjectRef to wrap the instance. This makes sure the object's original parent is not changed while allowing you to store a reference to the instance in the state of another scene object.

--- a/packages/scenes/src/core/SceneObjectRef.test.ts
+++ b/packages/scenes/src/core/SceneObjectRef.test.ts
@@ -10,7 +10,7 @@ interface TestSceneState extends SceneObjectState {
 class TestScene extends SceneObjectBase<TestSceneState> {}
 
 interface OtherSceneState extends SceneObjectState {
-  testSceneRef: SceneObjectRef<TestScene>;
+  scene: SceneObjectRef<TestScene>;
 }
 
 class OtherScene extends SceneObjectBase<OtherSceneState> {}
@@ -19,8 +19,8 @@ describe('SceneObjectRef', () => {
   it('Can clone with ref pointing to clone', () => {
     const innerScene = new TestScene({ name: 'inner' });
     const outer = new TestScene({ name: 'outer', nested: innerScene });
-    const otherScene = new OtherScene({ testSceneRef: new SceneObjectRef(innerScene) });
+    const otherScene = new OtherScene({ scene: new SceneObjectRef(innerScene) });
     expect(innerScene.parent).toBe(outer);
-    expect(otherScene.state.testSceneRef.get()).toBe(innerScene);
+    expect(otherScene.state.scene.resolve()).toBe(innerScene);
   });
 });

--- a/packages/scenes/src/core/SceneObjectRef.test.ts
+++ b/packages/scenes/src/core/SceneObjectRef.test.ts
@@ -10,7 +10,7 @@ interface TestSceneState extends SceneObjectState {
 class TestScene extends SceneObjectBase<TestSceneState> {}
 
 interface OtherSceneState extends SceneObjectState {
-  scene: SceneObjectRef<TestScene>;
+  sceneRef: SceneObjectRef<TestScene>;
 }
 
 class OtherScene extends SceneObjectBase<OtherSceneState> {}
@@ -19,8 +19,8 @@ describe('SceneObjectRef', () => {
   it('Can clone with ref pointing to clone', () => {
     const innerScene = new TestScene({ name: 'inner' });
     const outer = new TestScene({ name: 'outer', nested: innerScene });
-    const otherScene = new OtherScene({ scene: new SceneObjectRef(innerScene) });
+    const otherScene = new OtherScene({ sceneRef: new SceneObjectRef(innerScene) });
     expect(innerScene.parent).toBe(outer);
-    expect(otherScene.state.scene.resolve()).toBe(innerScene);
+    expect(otherScene.state.sceneRef.resolve()).toBe(innerScene);
   });
 });

--- a/packages/scenes/src/core/SceneObjectRef.test.ts
+++ b/packages/scenes/src/core/SceneObjectRef.test.ts
@@ -1,0 +1,26 @@
+import { SceneObjectBase } from './SceneObjectBase';
+import { SceneObjectState } from './types';
+import { SceneObjectRef } from './SceneObjectRef';
+
+interface TestSceneState extends SceneObjectState {
+  name?: string;
+  nested?: TestScene;
+}
+
+class TestScene extends SceneObjectBase<TestSceneState> {}
+
+interface OtherSceneState extends SceneObjectState {
+  testSceneRef: SceneObjectRef<TestScene>;
+}
+
+class OtherScene extends SceneObjectBase<OtherSceneState> {}
+
+describe('SceneObjectRef', () => {
+  it('Can clone with ref pointing to clone', () => {
+    const innerScene = new TestScene({ name: 'inner' });
+    const outer = new TestScene({ name: 'outer', nested: innerScene });
+    const otherScene = new OtherScene({ testSceneRef: new SceneObjectRef(innerScene) });
+    expect(innerScene.parent).toBe(outer);
+    expect(otherScene.state.testSceneRef.get()).toBe(innerScene);
+  });
+});

--- a/packages/scenes/src/core/SceneObjectRef.ts
+++ b/packages/scenes/src/core/SceneObjectRef.ts
@@ -5,7 +5,7 @@ export class SceneObjectRef<T> {
     this.#ref = ref;
   }
 
-  public get(): T {
+  public resolve(): T {
     return this.#ref;
   }
 }

--- a/packages/scenes/src/core/SceneObjectRef.ts
+++ b/packages/scenes/src/core/SceneObjectRef.ts
@@ -1,0 +1,11 @@
+export class SceneObjectRef<T> {
+  #ref: T;
+
+  public constructor(ref: T) {
+    this.#ref = ref;
+  }
+
+  public get(): T {
+    return this.#ref;
+  }
+}

--- a/packages/scenes/src/core/sceneGraph/utils.ts
+++ b/packages/scenes/src/core/sceneGraph/utils.ts
@@ -1,6 +1,7 @@
 import { SceneObject, SceneObjectState } from '../types';
 
 import { SceneObjectBase } from '../SceneObjectBase';
+import { SceneObjectRef } from '../SceneObjectRef';
 
 /**
  * Will create new SceneItem with shalled cloned state, but all states items of type SceneObject are deep cloned
@@ -24,6 +25,10 @@ export function cloneSceneObjectState<TState extends SceneObjectState>(
     const propValue = clonedState[key];
     if (propValue instanceof SceneObjectBase) {
       clonedState[key] = propValue.clone();
+    }
+
+    if (propValue instanceof SceneObjectRef) {
+      throw new Error('Cannot clone a SceneObject with a SceneObjectRef in state');
     }
 
     // Clone scene objects in arrays

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -58,6 +58,7 @@ export {
 export { SceneApp } from './components/SceneApp/SceneApp';
 export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
+export { SceneObjectRef } from './core/SceneObjectRef';
 export { PanelBuilders } from './core/PanelBuilders';
 
 export const sceneUtils = {


### PR DESCRIPTION
Can't figure out how to make this be clonable (without making clone a lot more complicated), and even then there is no guarantee it will work as the reference could be to a scene object in a different scene graph tree.  

But not sure if this SceneObjectRef is any better than simple having a function in state that returns the instance alla
```ts
    getDashboard: () => dashboard,
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.27.1--canary.304.6034526594.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.27.1--canary.304.6034526594.0
  # or 
  yarn add @grafana/scenes@0.27.1--canary.304.6034526594.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
