### PR TITLE
SceneGridLayout: Remove z-index

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -52,15 +52,13 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
             >
               {layout.map((gridItem, index) => {
                 const sceneChild = model.getSceneLayoutChild(gridItem.i)!;
-                // This it have panels higher up the page have higher z-index
-                const style = { zIndex: layout.length - index };
 
                 return isLazy ? (
-                  <LazyLoader key={sceneChild.state.key!} style={style} data-panelid={sceneChild.state.key}>
+                  <LazyLoader key={sceneChild.state.key!} data-panelid={sceneChild.state.key}>
                     <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
                   </LazyLoader>
                 ) : (
-                  <div key={sceneChild.state.key} style={style} data-panelid={sceneChild.state.key}>
+                  <div key={sceneChild.state.key} data-panelid={sceneChild.state.key}>
                     <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
                   </div>
                 );


### PR DESCRIPTION
This was reverted in main repo as well as it caused issues, seeing another issue with the time picker showing under panel.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.28.1--canary.308.6035159966.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@0.28.1--canary.308.6035159966.0
  # or 
  yarn add @grafana/scenes@0.28.1--canary.308.6035159966.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
