### PR TITLE
DataQueryRequest enricher

### DIFF
--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -19,6 +19,7 @@ const getScene = () => {
   const demos = getDemos();
 
   return new SceneApp({
+    name: 'Demos',
     pages: [
       new SceneAppPage({
         title: 'Demos',

--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -19,7 +19,7 @@ const getScene = () => {
   const demos = getDemos();
 
   return new SceneApp({
-    name: 'Demos',
+    name: 'scenes-demos-app',
     pages: [
       new SceneAppPage({
         title: 'Demos',

--- a/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
@@ -165,9 +165,11 @@ describe('SceneApp', () => {
       const page1Scene = setupScene(p1Object);
 
       const app = new SceneApp({
+        key: 'app',
         pages: [
           // Page with tabs
           new SceneAppPage({
+            key: 'top-level-page',
             title: 'Top level page',
             url: '/test-drilldown',
             getScene: () => {
@@ -178,6 +180,7 @@ describe('SceneApp', () => {
                 routePath: '/test-drilldown/:id',
                 getPage: (match: SceneRouteMatch<{ id: string }>, parent) => {
                   return new SceneAppPage({
+                    key: 'drilldown-page',
                     title: `Drilldown ${match.params.id}`,
                     url: `/test-drilldown/${match.params.id}`,
                     getScene: () => getDrilldownScene(match),

--- a/packages/scenes/src/components/SceneApp/SceneApp.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { DataRequestEnricher, SceneComponentProps, SceneObject } from '../../core/types';
+import { DataRequestEnricher, SceneComponentProps } from '../../core/types';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneAppState } from './types';
 import { renderSceneComponentWithRouteProps } from './utils';
-import { DataQueryRequest } from '@grafana/data';
 
 /**
  * Responsible for top level pages routing
  */
 export class SceneApp extends SceneObjectBase<SceneAppState> implements DataRequestEnricher {
-  public enrichDataRequest(source: SceneObject, request: DataQueryRequest): DataQueryRequest {
-    if (this.state.dataRequestEnricher) {
-      return this.state.dataRequestEnricher(source, request);
-    }
-
-    return request;
+  public enrichDataRequest() {
+    return {
+      app: this.state.name || 'app',
+    };
   }
 
   public static Component = ({ model }: SceneComponentProps<SceneApp>) => {

--- a/packages/scenes/src/components/SceneApp/SceneApp.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { SceneComponentProps } from '../../core/types';
+import { DataRequestEnricher, SceneComponentProps, SceneObject } from '../../core/types';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneAppState } from './types';
 import { renderSceneComponentWithRouteProps } from './utils';
+import { DataQueryRequest } from '@grafana/data';
 
 /**
  * Responsible for top level pages routing
  */
-export class SceneApp extends SceneObjectBase<SceneAppState> {
+export class SceneApp extends SceneObjectBase<SceneAppState> implements DataRequestEnricher {
+  public enrichDataRequest(source: SceneObject, request: DataQueryRequest): DataQueryRequest {
+    if (this.state.dataRequestEnricher) {
+      return this.state.dataRequestEnricher(source, request);
+    }
+
+    return request;
+  }
+
   public static Component = ({ model }: SceneComponentProps<SceneApp>) => {
     const { pages } = model.useState();
 

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneComponentProps, SceneObject, SceneObjectState } from '../../core/types';
+import { SceneComponentProps } from '../../core/types';
 import { getUrlSyncManager } from '../../services/UrlSyncManager';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
@@ -58,10 +58,6 @@ export class SceneAppPage extends SceneObjectBase<SceneAppPageState> implements 
     this._drilldownCache.set(routeMatch!.url, page);
 
     return page;
-  }
-
-  public get parent(): SceneObject<SceneObjectState> | undefined {
-    return super.parent || this.state.getParentPage?.();
   }
 }
 

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneComponentProps } from '../../core/types';
+import { SceneComponentProps, SceneObject, SceneObjectState } from '../../core/types';
 import { getUrlSyncManager } from '../../services/UrlSyncManager';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
@@ -58,6 +58,10 @@ export class SceneAppPage extends SceneObjectBase<SceneAppPageState> implements 
     this._drilldownCache.set(routeMatch!.url, page);
 
     return page;
+  }
+
+  public get parent(): SceneObject<SceneObjectState> | undefined {
+    return super.parent || this.state.getParentPage?.();
   }
 }
 

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneComponentProps } from '../../core/types';
+import { SceneComponentProps, SceneObject, isDataRequestEnricher } from '../../core/types';
 import { getUrlSyncManager } from '../../services/UrlSyncManager';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
@@ -58,6 +58,20 @@ export class SceneAppPage extends SceneObjectBase<SceneAppPageState> implements 
     this._drilldownCache.set(routeMatch!.url, page);
 
     return page;
+  }
+
+  public enrichDataRequest(source: SceneObject) {
+    if (!this.parent && this.state.getParentPage) {
+      return this.state.getParentPage().enrichDataRequest(source);
+    }
+
+    const root = this.getRoot();
+
+    if (isDataRequestEnricher(root)) {
+      return root.enrichDataRequest(source);
+    }
+
+    return null;
   }
 }
 

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -13,7 +13,6 @@ export interface SceneRouteMatch<Params extends { [K in keyof Params]?: string }
 export interface SceneAppState extends SceneObjectState {
   // Array of SceneAppPage objects that are considered app's top level pages
   pages: SceneAppPageLike[];
-  dataRequestEnricher?: DataRequestEnricher['enrichDataRequest'];
   name?: string;
 }
 
@@ -63,7 +62,7 @@ export interface SceneAppPageState extends SceneObjectState {
   initializedScene?: SceneObject;
 }
 
-export interface SceneAppPageLike extends SceneObject<SceneAppPageState> {
+export interface SceneAppPageLike extends SceneObject<SceneAppPageState>, DataRequestEnricher {
   initializeScene(scene: SceneObject): void;
   /**
    * @internal. Please don't call this from plugin code.

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -14,6 +14,7 @@ export interface SceneAppState extends SceneObjectState {
   // Array of SceneAppPage objects that are considered app's top level pages
   pages: SceneAppPageLike[];
   dataRequestEnricher?: DataRequestEnricher['enrichDataRequest'];
+  name?: string;
 }
 
 export interface SceneAppRoute {

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react';
-import { SceneObject, SceneObjectState } from '../../core/types';
+import { DataRequestEnricher, SceneObject, SceneObjectState } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { IconName } from '@grafana/data';
 
@@ -13,6 +13,7 @@ export interface SceneRouteMatch<Params extends { [K in keyof Params]?: string }
 export interface SceneAppState extends SceneObjectState {
   // Array of SceneAppPage objects that are considered app's top level pages
   pages: SceneAppPageLike[];
+  dataRequestEnricher?: DataRequestEnricher['enrichDataRequest'];
 }
 
 export interface SceneAppRoute {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -19,7 +19,7 @@ import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@gra
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { DeepPartial, SceneObject, SceneObjectState } from '../../core/types';
+import { DataRequestEnricher, DeepPartial, SceneObject, SceneObjectState } from '../../core/types';
 
 import { VizPanelRenderer } from './VizPanelRenderer';
 import { VizPanelMenu } from './VizPanelMenu';
@@ -53,7 +53,10 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   pluginInstanceState?: any;
 }
 
-export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<VizPanelState<TOptions, TFieldConfig>> {
+export class VizPanel<TOptions = {}, TFieldConfig = {}>
+  extends SceneObjectBase<VizPanelState<TOptions, TFieldConfig>>
+  implements DataRequestEnricher
+{
   public static Component = VizPanelRenderer;
 
   protected _variableDependency = new VariableDependencyConfig(this, {
@@ -67,6 +70,11 @@ export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<
   private _dataWithFieldConfig?: PanelData;
   private _structureRev: number = 0;
 
+  public enrichDataRequest() {
+    return {
+      panelId: Math.random(),
+    };
+  }
   public constructor(state: Partial<VizPanelState<TOptions, TFieldConfig>>) {
     super({
       options: {} as TOptions,

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -19,7 +19,7 @@ import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@gra
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { DataRequestEnricher, DeepPartial, SceneObject, SceneObjectState } from '../../core/types';
+import { DeepPartial, SceneObject, SceneObjectState } from '../../core/types';
 
 import { VizPanelRenderer } from './VizPanelRenderer';
 import { VizPanelMenu } from './VizPanelMenu';
@@ -53,10 +53,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   pluginInstanceState?: any;
 }
 
-export class VizPanel<TOptions = {}, TFieldConfig = {}>
-  extends SceneObjectBase<VizPanelState<TOptions, TFieldConfig>>
-  implements DataRequestEnricher
-{
+export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<VizPanelState<TOptions, TFieldConfig>> {
   public static Component = VizPanelRenderer;
 
   protected _variableDependency = new VariableDependencyConfig(this, {
@@ -70,11 +67,6 @@ export class VizPanel<TOptions = {}, TFieldConfig = {}>
   private _dataWithFieldConfig?: PanelData;
   private _structureRev: number = 0;
 
-  public enrichDataRequest() {
-    return {
-      panelId: Math.random(),
-    };
-  }
   public constructor(state: Partial<VizPanelState<TOptions, TFieldConfig>>) {
     super({
       options: {} as TOptions,

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -167,7 +167,7 @@ export interface SceneObjectUrlSyncHandler {
 
 export interface DataRequestEnricher {
   // Return partial data query request that will be merged with the original request provided by SceneQueryRunner
-  enrichDataRequest(source: SceneObject): Partial<DataQueryRequest>;
+  enrichDataRequest(source: SceneObject): Partial<DataQueryRequest> | null;
 }
 
 export function isDataRequestEnricher(obj: any): obj is DataRequestEnricher {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -166,7 +166,7 @@ export interface SceneObjectUrlSyncHandler {
 }
 
 export interface DataRequestEnricher {
-  enrichDataRequest(source: SceneObject, request: DataQueryRequest): DataQueryRequest;
+  enrichDataRequest(): Partial<DataQueryRequest>;
 }
 
 export function isDataRequestEnricher(obj: any): obj is DataRequestEnricher {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -165,12 +165,12 @@ export interface SceneObjectUrlSyncHandler {
   updateFromUrl(values: SceneObjectUrlValues): void;
 }
 
-export interface DataQueryRequestEnricher {
-  enrichDataQueryRequest(source: SceneObject, request: DataQueryRequest): DataQueryRequest;
+export interface DataRequestEnricher {
+  enrichDataRequest(source: SceneObject, request: DataQueryRequest): DataQueryRequest;
 }
 
-export function isDataQueryRequestEnricher(obj: any): obj is DataQueryRequestEnricher {
-  return 'enrichDataQueryRequest' in obj;
+export function isDataRequestEnricher(obj: any): obj is DataRequestEnricher {
+  return 'enrichDataRequest' in obj;
 }
 
 export type SceneObjectUrlValue = string | string[] | undefined | null;

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -166,7 +166,8 @@ export interface SceneObjectUrlSyncHandler {
 }
 
 export interface DataRequestEnricher {
-  enrichDataRequest(): Partial<DataQueryRequest>;
+  // Return partial data query request that will be merged with the original request provided by SceneQueryRunner
+  enrichDataRequest(source: SceneObject): Partial<DataQueryRequest>;
 }
 
 export function isDataRequestEnricher(obj: any): obj is DataRequestEnricher {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -6,6 +6,7 @@ import {
   BusEventHandler,
   BusEventType,
   DataFrame,
+  DataQueryRequest,
   DataTransformContext,
   PanelData,
   TimeRange,
@@ -162,6 +163,14 @@ export interface SceneObjectUrlSyncHandler {
   getKeys(): string[];
   getUrlState(): SceneObjectUrlValues;
   updateFromUrl(values: SceneObjectUrlValues): void;
+}
+
+export interface DataQueryRequestEnricher {
+  enrichDataQueryRequest(source: SceneObject, request: DataQueryRequest): DataQueryRequest;
+}
+
+export function isDataQueryRequestEnricher(obj: any): obj is DataQueryRequestEnricher {
+  return 'enrichDataQueryRequest' in obj;
 }
 
 export type SceneObjectUrlValue = string | string[] | undefined | null;

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -263,7 +263,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     let secondaryRequest: DataQueryRequest | undefined;
 
     let request: DataQueryRequest = {
-      app: CoreApp.Dashboard,
+      app: 'scenes',
       requestId: getNextRequestId(),
       timezone: timeRange.getTimeZone(),
       panelId: 1,
@@ -279,6 +279,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
         from: timeRange.state.from,
         to: timeRange.state.to,
       },
+      // This asks the scene root to provide context properties like app, panel and dashboardUID
+      ...getEnrichedDataRequest(this),
     };
 
     request.targets = request.targets.map((query) => {
@@ -287,11 +289,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       }
       return query;
     });
-
-    const enrichedDataRequest = getEnrichedDataRequest(this);
-    if (enrichedDataRequest) {
-      Object.assign(request, enrichedDataRequest);
-    }
 
     // TODO interpolate minInterval
     const lowerIntervalLimit = minInterval ? minInterval : ds.interval;

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -3,15 +3,7 @@ import { forkJoin, Unsubscribable } from 'rxjs';
 
 import { DataQuery, DataSourceRef, LoadingState } from '@grafana/schema';
 
-import {
-  CoreApp,
-  DataQueryRequest,
-  DataSourceApi,
-  PanelData,
-  preProcessPanelData,
-  rangeUtil,
-  ScopedVar,
-} from '@grafana/data';
+import { DataQueryRequest, DataSourceApi, PanelData, preProcessPanelData, rangeUtil, ScopedVar } from '@grafana/data';
 import { getRunRequest } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -290,7 +290,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     });
 
     const enrichDataRequest = getEnrichedDataRequest(this);
-    console.log('enrichDataRequest', enrichDataRequest);
     if (Object.keys(enrichDataRequest).length > 0) {
       request = {
         ...request,

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -17,8 +17,8 @@ import { getRunRequest } from '@grafana/runtime';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import {
-  DataQueryRequestEnricher,
-  isDataQueryRequestEnricher,
+  DataRequestEnricher,
+  isDataRequestEnricher,
   SceneDataProvider,
   SceneObjectState,
   SceneTimeRangeLike,
@@ -294,9 +294,9 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       return query;
     });
 
-    const enricher = getDataQueryEnricher(this);
+    const enricher = getDataRequestEnricher(this);
     if (enricher) {
-      enricher.enrichDataQueryRequest(this, request);
+      enricher.enrichDataRequest(this, request);
     }
 
     // TODO interpolate minInterval
@@ -378,10 +378,10 @@ export function findFirstDatasource(targets: DataQuery[]): DataSourceRef | undef
   return targets.find((t) => t.datasource !== null)?.datasource ?? undefined;
 }
 
-function getDataQueryEnricher(queryRunner: SceneQueryRunner): DataQueryRequestEnricher | null {
+function getDataRequestEnricher(queryRunner: SceneQueryRunner): DataRequestEnricher | null {
   const parent = queryRunner.parent;
   while (parent) {
-    if (isDataQueryRequestEnricher(parent)) {
+    if (isDataRequestEnricher(parent)) {
       return parent;
     }
   }

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -379,11 +379,14 @@ export function findFirstDatasource(targets: DataQuery[]): DataSourceRef | undef
 }
 
 function getDataRequestEnricher(queryRunner: SceneQueryRunner): DataRequestEnricher | null {
-  const parent = queryRunner.parent;
+  let parent = queryRunner.parent;
+
   while (parent) {
     if (isDataRequestEnricher(parent)) {
       return parent;
     }
+
+    parent = parent.parent;
   }
 
   return null;


### PR DESCRIPTION
Trying to simplify (and optimize) https://github.com/grafana/scenes/pull/309 a bit by 

* Skipping having to walk the full scene graph and progressively setting & resetting props (to make deeper props override) 
* Skip providing the enricher via SceneApp state (I don't think this is needed right now). For scene app plugin just setting the app name should be enough. We do not have any other prop they can set. And when we do I think we should have some built-in mechanism to set panel or query tracking name directly on SQR or VizPanel. 

To skip the direct instanceof SceneAppPage and check getParentPage I do that instead in SceneAppPage by implementing the enrichDataRequest method. 


Closes https://github.com/grafana/scenes/issues/298
