### PR TITLE
VizPanel: Remove left-over isDraggable/isResizable state

### DIFF
--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -37,11 +37,7 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
               height: 10,
               isResizable: false,
               isDraggable: false,
-              body: PanelBuilders.timeseries()
-                .setTitle('No drag and no resize')
-                .setIsDraggable(false)
-                .setIsResizable(false)
-                .build(),
+              body: PanelBuilders.timeseries().setTitle('No drag and no resize').build(),
             }),
 
             new SceneGridItem({

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -45,8 +45,6 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   displayMode?: 'default' | 'transparent';
   hoverHeader?: boolean;
   menu?: VizPanelMenu;
-  isDraggable?: boolean;
-  isResizable?: boolean;
   headerActions?: React.ReactNode | SceneObject | SceneObject[];
   // internal state
   pluginLoadError?: string;

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -6,7 +6,7 @@ import { getAppEvents } from '@grafana/runtime';
 import { PanelChrome, ErrorBoundaryAlert, PanelContextProvider } from '@grafana/ui';
 
 import { sceneGraph } from '../../core/sceneGraph';
-import { isSceneObject, SceneComponentProps } from '../../core/types';
+import { isSceneObject, SceneComponentProps, SceneObject } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
 
@@ -144,13 +144,17 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
 function getDragClasses(panel: VizPanel) {
   const parentLayout = sceneGraph.getLayout(panel);
-  const isDraggable = parentLayout?.isDraggable() && (panel.state.isDraggable ?? true);
+  const isDraggable = parentLayout?.isDraggable();
 
-  if (!parentLayout || !isDraggable) {
+  if (!parentLayout || !isDraggable || itemDraggingDisabled(panel.parent)) {
     return { dragClass: '', dragClassCancel: '' };
   }
 
   return { dragClass: parentLayout.getDragClass?.(), dragClassCancel: parentLayout?.getDragClassCancel?.() };
+}
+
+function itemDraggingDisabled(parent: SceneObject | undefined) {
+  return parent && 'isDraggable' in parent.state && parent.state.isDraggable === false;
 }
 
 function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | undefined) {

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
@@ -54,8 +54,6 @@ const configurablePropertiesTest: Array<[string, string | boolean]> = [
   ['description', 'My panel description'],
   ['displayMode', 'transparent'],
   ['hoverHeader', true],
-  ['isDraggable', true],
-  ['isResizable', true],
 ];
 
 describe('VizPanelBuilder', () => {

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -22,8 +22,6 @@ export class VizPanelBuilder<TOptions, TFieldConfig extends {}>
     this._state.description = '';
     this._state.displayMode = 'default';
     this._state.hoverHeader = false;
-    this._state.isDraggable = false;
-    this._state.isResizable = false;
     this._state.pluginId = pluginId;
     this._state.pluginVersion = pluginVersion;
     const fieldConfig: FieldConfigSource<TFieldConfig> = {
@@ -66,22 +64,6 @@ export class VizPanelBuilder<TOptions, TFieldConfig extends {}>
    */
   public setHoverHeader(hoverHeader: VizPanelState['hoverHeader']): this {
     this._state.hoverHeader = hoverHeader;
-    return this;
-  }
-
-  /**
-   * Set if panel is draggable.
-   */
-  public setIsDraggable(isDraggable: VizPanelState['isDraggable']): this {
-    this._state.isDraggable = isDraggable;
-    return this;
-  }
-
-  /**
-   * Set if panel is resizable.
-   */
-  public setIsResizable(isResizable: VizPanelState['isResizable']): this {
-    this._state.isResizable = isResizable;
     return this;
   }
 


### PR DESCRIPTION
Left over state from before we introduced layout item wrappers
