### PR TITLE
QueryVariable: Support null ds

### DIFF
--- a/packages/scenes/src/utils/getDataSource.ts
+++ b/packages/scenes/src/utils/getDataSource.ts
@@ -4,7 +4,7 @@ import { DataSourceRef } from '@grafana/schema';
 import { runtimeDataSources } from '../querying/RuntimeDataSource';
 
 export async function getDataSource(
-  datasource: DataSourceRef | undefined,
+  datasource: DataSourceRef | undefined | null,
   scopedVars: ScopedVars
 ): Promise<DataSourceApi> {
   if (datasource?.uid) {

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -231,6 +231,25 @@ describe('QueryVariable', () => {
     });
   });
 
+  describe('When ds is null', () => {
+    beforeEach(() => {
+      setCreateQueryVariableRunnerFactory(() => new FakeQueryRunner(fakeDsMock, runRequestMock));
+    });
+
+    it('should get options for default ds', async () => {
+      const variable = new QueryVariable({
+        name: 'test',
+        datasource: null,
+        query: 'query',
+        regex: '/^A/',
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(runRequestMock).toBeCalledTimes(1);
+    });
+  });
+
   describe('When regex provided', () => {
     beforeEach(() => {
       setCreateQueryVariableRunnerFactory(() => new FakeQueryRunner(fakeDsMock, runRequestMock));

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -57,7 +57,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
   }
 
   public getValueOptions(args: VariableGetOptionsArgs): Observable<VariableValueOption[]> {
-    if (this.state.query === '' || !this.state.datasource) {
+    if (!this.state.query) {
       return of([]);
     }
 


### PR DESCRIPTION
The datasource reference can be null (for instance default).


