### PR TITLE
Variables: New LocalValueVariable to better support repeating panels 

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -28,6 +28,7 @@ export { DataSourceVariable } from './variables/variants/DataSourceVariable';
 export { QueryVariable } from './variables/variants/query/QueryVariable';
 export { TestVariable } from './variables/variants/TestVariable';
 export { TextBoxVariable } from './variables/variants/TextBoxVariable';
+export { LocalValueVariable } from './variables/variants/LocalValueVariable';
 
 export { type UrlSyncManagerLike as UrlSyncManager, getUrlSyncManager } from './services/UrlSyncManager';
 export { SceneObjectUrlSyncConfig } from './services/SceneObjectUrlSyncConfig';

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -524,6 +524,10 @@ describe('SceneVariableList', () => {
       scene.state.nested?.activate();
 
       expect(innerSet.isVariableLoadingOrWaitingToUpdate(scopedA)).toBe(true);
+
+      A.signalUpdateCompleted();
+
+      expect(innerSet.isVariableLoadingOrWaitingToUpdate(scopedA)).toBe(false);
     });
   });
 });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -13,7 +13,6 @@ import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
-import { ConstantVariable } from '../variants/ConstantVariable';
 import { LocalValueVariable } from '../variants/LocalValueVariable';
 
 interface TestSceneState extends SceneObjectState {
@@ -503,6 +502,7 @@ describe('SceneVariableList', () => {
 
       A.signalUpdateCompleted();
       expect(set.isVariableLoadingOrWaitingToUpdate(A)).toBe(false);
+      expect(set.isVariableLoadingOrWaitingToUpdate(B)).toBe(true);
     });
 
     it('Should check ancestor set for LocalValueVariable', async () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -13,6 +13,8 @@ import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
+import { ConstantVariable } from '../variants/ConstantVariable';
+import { LocalValueVariable } from '../variants/LocalValueVariable';
 
 interface TestSceneState extends SceneObjectState {
   nested?: SceneObject;
@@ -481,6 +483,47 @@ describe('SceneVariableList', () => {
       expect(A.state.loading).toBe(false);
       expect(B.state.loading).toBe(false);
       expect(C.state.loading).toBe(false);
+    });
+  });
+
+  describe('isVariableLoadingOrWaitingToUpdate', () => {
+    it('Should return true when loading or waiting to update', async () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const B = new TestVariable({ name: 'B', query: 'A.$A', value: '', text: '', options: [] });
+
+      const set = new SceneVariableSet({ variables: [A, B] });
+      set.activate();
+
+      // Should start variables with no dependencies
+      expect(A.state.loading).toBe(true);
+      expect(B.state.loading).toBe(undefined);
+
+      expect(set.isVariableLoadingOrWaitingToUpdate(A)).toBe(true);
+      expect(set.isVariableLoadingOrWaitingToUpdate(B)).toBe(true);
+
+      A.signalUpdateCompleted();
+      expect(set.isVariableLoadingOrWaitingToUpdate(A)).toBe(false);
+    });
+
+    it('Should check ancestor set for LocalValueVariable', async () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const scopedA = new LocalValueVariable({ name: 'A', value: 'AA' });
+
+      const innerSet = new SceneVariableSet({
+        variables: [scopedA],
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [A] }),
+        nested: new TestScene({
+          $variables: innerSet,
+        }),
+      });
+
+      scene.activate();
+      scene.state.nested?.activate();
+
+      expect(innerSet.isVariableLoadingOrWaitingToUpdate(scopedA)).toBe(true);
     });
   });
 });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -7,6 +7,7 @@ import { SceneObject } from '../../core/types';
 import { writeSceneLog } from '../../utils/writeSceneLog';
 import { SceneVariable, SceneVariables, SceneVariableSetState, SceneVariableValueChangedEvent } from '../types';
 import { VariableValueRecorder } from '../VariableValueRecorder';
+import { ConstantVariable } from '../variants/ConstantVariable';
 
 export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
   /** Variables that have changed in since the activation or since the first manual value change */
@@ -318,6 +319,10 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
   public isVariableLoadingOrWaitingToUpdate(variable: SceneVariable) {
     // If we have not activated yet then variables are not up to date
     if (!this.isActive) {
+      return true;
+    }
+
+    if (variable.isAncestorLoading && variable.isAncestorLoading()) {
       return true;
     }
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -7,7 +7,6 @@ import { SceneObject } from '../../core/types';
 import { writeSceneLog } from '../../utils/writeSceneLog';
 import { SceneVariable, SceneVariables, SceneVariableSetState, SceneVariableValueChangedEvent } from '../types';
 import { VariableValueRecorder } from '../VariableValueRecorder';
-import { ConstantVariable } from '../variants/ConstantVariable';
 
 export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
   /** Variables that have changed in since the activation or since the first manual value change */

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -33,6 +33,11 @@ export interface SceneVariable<TState extends SceneVariableState = SceneVariable
    * Useful for variables that have non user friendly values but friendly display text names.
    */
   getValueText?(fieldPath?: string): string;
+
+  /**
+   * A special function that locally scoped variables can implement
+   **/
+  isAncestorLoading?(): boolean;
 }
 
 export type VariableValue = VariableValueSingle | VariableValueSingle[];

--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -34,6 +34,10 @@ export class LocalValueVariable
     return this.state.text.toString();
   }
 
+  /**
+   * Checks the ancestor of our parent SceneVariableSet for loading state of a variable with the same name
+   * This function is unit tested from SceneVariableSet tests.
+   */
   public isAncestorLoading(): boolean {
     // Parent (SceneVariableSet) -> Parent (The object that has our parent set) -> Parent (scope we need to access our sets ancestor)
     const ancestorScope = this.parent?.parent?.parent;
@@ -41,7 +45,6 @@ export class LocalValueVariable
       throw new Error('LocalValueVariable requires a parent SceneVariableSet that has an ancestor SceneVariableSet');
     }
 
-    //
     const set = sceneGraph.getVariables(ancestorScope);
     const parentVar = sceneGraph.lookupVariable(this.state.name, ancestorScope);
     if (set && parentVar) {

--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -1,0 +1,53 @@
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { sceneGraph } from '../../core/sceneGraph';
+import { SceneVariable, SceneVariableState, VariableValue } from '../types';
+
+export interface LocalValueVariableState extends SceneVariableState {
+  value: VariableValue;
+  text: VariableValue;
+}
+
+/**
+ * This is a special type of variable that is used for repeating panels and layouts to create a local scoped value for a variable
+ * that exists in a ancestor SceneVariableSet.
+ */
+export class LocalValueVariable
+  extends SceneObjectBase<LocalValueVariableState>
+  implements SceneVariable<LocalValueVariableState>
+{
+  public constructor(initialState: Partial<LocalValueVariableState>) {
+    super({
+      type: 'system',
+      value: '',
+      text: '',
+      name: '',
+      ...initialState,
+      skipUrlSync: true,
+    });
+  }
+
+  public getValue(): VariableValue {
+    return this.state.value;
+  }
+
+  public getValueText(): string {
+    return this.state.text.toString();
+  }
+
+  public isAncestorLoading(): boolean {
+    // Parent (SceneVariableSet) -> Parent (The object that has our parent set) -> Parent (scope we need to access our sets ancestor)
+    const ancestorScope = this.parent?.parent?.parent;
+    if (!ancestorScope) {
+      throw new Error('LocalValueVariable requires a parent SceneVariableSet that has an ancestor SceneVariableSet');
+    }
+
+    //
+    const set = sceneGraph.getVariables(ancestorScope);
+    const parentVar = sceneGraph.lookupVariable(this.state.name, ancestorScope);
+    if (set && parentVar) {
+      return set.isVariableLoadingOrWaitingToUpdate(parentVar);
+    }
+
+    throw new Error('LocalValueVariable requires a parent SceneVariableSet that has an ancestor SceneVariableSet');
+  }
+}


### PR DESCRIPTION
This is to block query execution for repeating panels where the variable is refreshed on time range change. 

- LocalValueVariable: Special variable value to better support repeating panels
- Update comment
