### PR TITLE
MultiValueVariable: Fix url sync for isMulti when default value is not an array

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -348,6 +348,18 @@ describe('MultiValueVariable', () => {
       expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: ['1', '2'] });
     });
 
+    it('getUrlState should always return array if isMulti is true', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        value: 'A',
+        isMulti: true,
+        delayMs: 0,
+      });
+
+      expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: ['A'] });
+    });
+
     it('fromUrlState should update value for single value', async () => {
       const variable = new ExampleVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -349,12 +349,11 @@ describe('MultiValueVariable', () => {
     });
 
     it('getUrlState should always return array if isMulti is true', async () => {
-      const variable = new TestVariable({
+      const variable = new ExampleVariable({
         name: 'test',
         options: [],
         value: 'A',
         isMulti: true,
-        delayMs: 0,
       });
 
       expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: ['A'] });

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -262,6 +262,9 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
 
     if (Array.isArray(value)) {
       urlValue = value.map(String);
+    } else if ((this, this._sceneObject.state.isMulti)) {
+      // If we are inMulti mode we must return an array here as otherwise UrlSyncManager will not pass all values (in an array) in updateFromUrl
+      urlValue = [String(value)];
     } else {
       urlValue = String(value);
     }


### PR DESCRIPTION
Fixe a bug with all MultiValueVariables with isMulti true and the initial/default value is not an array.
This causes the UrlSyncManager to only pass the first value from the URL to updateFromUrl. So if you have multiple
values selected and do a full page reload only the first item would be set after url sync.

This change fixes this bug by making sure we always return an array in getUrlState.
