### PR TITLE
SceneObject: Support changing $data, $timeRange and $variables during the active phase 

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -198,12 +198,32 @@ describe('SceneObject', () => {
     it('Call activation handlers for new objects in state', () => {
       const scene = new TestScene({
         name: 'root',
+        $variables: new SceneVariableSet({ variables: [] }),
+        $data: new SceneDataNode({}),
+        $timeRange: new SceneTimeRange({}),
       });
 
       scene.activate();
-      scene.setState({ $variables: new SceneVariableSet({ variables: [] }) });
 
-      expect(scene.state.$variables!.isActive).toBe(true);
+      const oldState = scene.state;
+
+      scene.setState({
+        $variables: new SceneVariableSet({ variables: [] }),
+        $data: new SceneDataNode({}),
+        $timeRange: new SceneTimeRange({}),
+      });
+
+      const newState = scene.state;
+
+      // Verify old state is deactivated
+      expect(oldState.$variables!.isActive).toBe(false);
+      expect(oldState.$data!.isActive).toBe(false);
+      expect(oldState.$timeRange!.isActive).toBe(false);
+
+      // Verify new state is activated
+      expect(newState.$variables!.isActive).toBe(true);
+      expect(newState.$data!.isActive).toBe(true);
+      expect(newState.$timeRange!.isActive).toBe(true);
     });
   });
 

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -194,6 +194,17 @@ describe('SceneObject', () => {
       nestedScene.setState({ name: 'new name 3' });
       expect(scene.state.name).toBe('new name 3');
     });
+
+    it('Call activation handlers for new objects in state', () => {
+      const scene = new TestScene({
+        name: 'root',
+      });
+
+      scene.activate();
+      scene.setState({ $variables: new SceneVariableSet({ variables: [] }) });
+
+      expect(scene.state.$variables!.isActive).toBe(true);
+    });
   });
 
   describe('Ref counting activations', () => {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -133,6 +133,20 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
       true
     );
   }
+
+  /**
+   * This handles activation and deactivation of $data, $timeRange and $variables when they change
+   * during the active phase of the scene object.
+   */
+  private _handleActivationAndDeactivationOnStateChange(prevState: TState, newState: TState) {
+    if (!this.isActive) {
+      return;
+    }
+
+    if (newState.$data !== prevState.$data) {
+    }
+  }
+
   /*
    * Publish an event and optionally bubble it up the scene
    **/


### PR DESCRIPTION
Currently, nothing happens if you set SceneVariableSet on an active SceneObject (even if it was undefined before). As $data, $timeRange and $variables are only activated when the parent scene object is activated. For repeating rows I have a scenario where I want to set a $variables set to the first already active row. 

To support this scenario I had to change the deactivation handler array to a map so we can know which deactivation handler to call when state is changed/removed. 

I skip supporting this for $behaviors for now as it's a bit more complicated, we can add that later if we need to  