### PR TITLE
SceneGridLayout: Fix toggle row issue

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -358,7 +358,8 @@ describe('SceneGridLayout', () => {
     it('should update position of objects when row is expanded', () => {
       const rowAChild1 = new SceneGridItem({
         x: 0,
-        y: 1,
+        // deliberately set higher than the row
+        y: 10,
         width: 1,
         height: 1,
         isResizable: false,
@@ -368,7 +369,7 @@ describe('SceneGridLayout', () => {
 
       const rowAChild2 = new SceneGridItem({
         x: 1,
-        y: 1,
+        y: 10,
         width: 1,
         height: 1,
         isResizable: false,
@@ -403,6 +404,7 @@ describe('SceneGridLayout', () => {
         isDraggable: false,
         body: new TestObject({ key: 'row-b-child1' }),
       });
+
       const rowB = new SceneGridRow({
         title: 'Row B',
         key: 'row-b',
@@ -417,6 +419,10 @@ describe('SceneGridLayout', () => {
       });
 
       layout.toggleRow(rowA);
+
+      // should correct rowA children y position
+      expect(rowAChild1.state!.y).toEqual(1);
+      expect(rowAChild2.state!.y).toEqual(1);
 
       expect(panelOutsideARow.state!.y).toEqual(2);
       expect(rowB.state!.y).toEqual(3);

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -82,9 +82,11 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
       newSize.y = newSize.y ?? rowY;
       // make sure y is adjusted (in case row moved while collapsed)
       newSize.y -= yDiff;
-      if (newSize.y! > panel.state.y!) {
+
+      if (newSize.y! !== panel.state.y!) {
         panel.setState(newSize);
       }
+
       // update insert post and y max
       yMax = Math.max(yMax, Number(newSize.y!) + Number(newSize.height!));
     }

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -31,8 +31,6 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
       children: state.children || [],
       isCollapsible: state.isCollapsible || true,
       title: state.title || '',
-      isDraggable: state.isDraggable || true,
-      isResizable: state.isResizable || false,
       ...state,
       x: 0,
       height: 1,

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -6,7 +6,6 @@ import { Icon, useStyles2 } from '@grafana/ui';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
 import { SceneComponentProps, SceneObject, SceneObjectUrlValues } from '../../../core/types';
-import { SceneObjectUrlSyncConfig } from '../../../services/SceneObjectUrlSyncConfig';
 
 import { SceneGridLayout } from './SceneGridLayout';
 import { GRID_COLUMN_COUNT } from './constants';
@@ -23,8 +22,6 @@ export interface SceneGridRowState extends SceneGridItemStateLike {
 
 export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
   public static Component = SceneGridRowRenderer;
-
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['rowc'] });
 
   public constructor(state: Partial<SceneGridRowState>) {
     super({

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -82,7 +82,6 @@ export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow
         {isCollapsible && <Icon name={isCollapsed ? 'angle-right' : 'angle-down'} />}
         <span className={styles.rowTitle}>{sceneGraph.interpolate(model, title, undefined, 'text')}</span>
       </button>
-      {isCollapsed && <div className={styles.collapsedInfo}>({model.state.children.length} panels)</div>}
       {actions && <actions.Component model={actions} />}
       {isDraggable && isCollapsed && (
         <div className={cx(styles.dragHandle, layoutDragClass)}>


### PR DESCRIPTION
Noticed panels appearing below other rows when expanding a collapsed row.

Happens if you collapse a row. and then collapse another row above it.

Then try to expand the first row. The children it contains have to high y position
and needs to be corrected. We had a condition that only corrected the row child position
if it needed to be made higher not smaller.

I checked the current arch toggleRow logic and it did not have this condition that only correct y pos when greater 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.0--canary.326.6111681445.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.2.0--canary.326.6111681445.0
  # or 
  yarn add @grafana/scenes@1.2.0--canary.326.6111681445.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
