### PR TITLE
DataLayers: Add filtering options to SceneQueryRunner

### DIFF
--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -207,6 +207,10 @@ export interface SceneDataLayerProvider extends SceneObject {
   getResultsStream(): Observable<SceneDataLayerProviderResult>;
 }
 
+export interface DataLayerFilter {
+  panelId: number;
+}
+
 export interface SceneStatelessBehavior<T extends SceneObject = any> {
   (sceneObject: T): CancelActivationHandler | void;
 }

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -1429,14 +1429,6 @@ describe('SceneQueryRunner', () => {
           [
             {
               "config": {},
-              "name": "time",
-              "type": "time",
-              "values": [
-                100,
-              ],
-            },
-            {
-              "config": {},
               "name": "text",
               "type": "string",
               "values": [
@@ -1445,12 +1437,17 @@ describe('SceneQueryRunner', () => {
             },
             {
               "config": {},
-              "name": "tags",
+              "name": "source",
               "type": "other",
               "values": [
-                [
-                  "tag1",
-                ],
+                {
+                  "filter": {
+                    "exclude": true,
+                    "ids": [
+                      1,
+                    ],
+                  },
+                },
               ],
             },
           ]
@@ -1499,6 +1496,13 @@ class TestAnnotationsDataLayer
         tags: ['tag1'],
       },
     ];
+
+    if (this.state.fakeAnnotations) {
+      ano = this.state.fakeAnnotations().map((a) => ({
+        text: `${this.state.prefix}: Test annotation`,
+        ...a,
+      }));
+    }
 
     const result: SceneDataLayerProviderResult = {
       origin: this,

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -656,7 +656,7 @@ describe('SceneQueryRunner', () => {
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A' }],
         $timeRange: new SceneTimeRange(),
-        $data: new SceneDataLayers({ layers: [new TestAnnoationsDataLayer({ prefix: 'Layer 1' })] }),
+        $data: new SceneDataLayers({ layers: [new TestAnnotationsDataLayer({ prefix: 'Layer 1' })] }),
       });
 
       expect(queryRunner.state.data).toBeUndefined();
@@ -702,7 +702,7 @@ describe('SceneQueryRunner', () => {
       `);
     });
     it('should not block queries when layer provides data slower', async () => {
-      const layer = new TestAnnoationsDataLayer({ prefix: 'Layer 1', delay: true });
+      const layer = new TestAnnotationsDataLayer({ prefix: 'Layer 1', delay: true });
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A' }],
         $timeRange: new SceneTimeRange(),
@@ -759,8 +759,8 @@ describe('SceneQueryRunner', () => {
 
     describe('canceling queries', () => {
       it('should unsubscribe from data layers when query is canceled', async () => {
-        const layer1 = new TestAnnoationsDataLayer({ prefix: 'Layer 1', delay: true });
-        const layer2 = new TestAnnoationsDataLayer({ prefix: 'Layer 2', delay: true });
+        const layer1 = new TestAnnotationsDataLayer({ prefix: 'Layer 1', delay: true });
+        const layer2 = new TestAnnotationsDataLayer({ prefix: 'Layer 2', delay: true });
         const queryRunner = new SceneQueryRunner({
           queries: [{ refId: 'A' }],
           $timeRange: new SceneTimeRange(),
@@ -789,8 +789,8 @@ describe('SceneQueryRunner', () => {
       });
 
       it('should re-subscribe to data layers when query is canceled and run again', async () => {
-        const layer1 = new TestAnnoationsDataLayer({ prefix: 'Layer 1', delay: true });
-        const layer2 = new TestAnnoationsDataLayer({ prefix: 'Layer 2', delay: true });
+        const layer1 = new TestAnnotationsDataLayer({ prefix: 'Layer 1', delay: true });
+        const layer2 = new TestAnnotationsDataLayer({ prefix: 'Layer 2', delay: true });
         const queryRunner = new SceneQueryRunner({
           queries: [{ refId: 'A' }],
           $timeRange: new SceneTimeRange(),
@@ -890,8 +890,8 @@ describe('SceneQueryRunner', () => {
 
     describe('Multiple layers', () => {
       it('combines multiple layers attached on the same level', async () => {
-        const layer1 = new TestAnnoationsDataLayer({ prefix: 'Layer 1' });
-        const layer2 = new TestAnnoationsDataLayer({ prefix: 'Layer 2' });
+        const layer1 = new TestAnnotationsDataLayer({ prefix: 'Layer 1' });
+        const layer2 = new TestAnnotationsDataLayer({ prefix: 'Layer 2' });
 
         const queryRunner = new SceneQueryRunner({
           queries: [{ refId: 'A' }],
@@ -973,8 +973,8 @@ describe('SceneQueryRunner', () => {
         `);
       });
       it('combines multiple layers attached on different levels', async () => {
-        const layer1 = new TestAnnoationsDataLayer({ prefix: 'Layer 1' });
-        const layer2 = new TestAnnoationsDataLayer({ prefix: 'Layer 2' });
+        const layer1 = new TestAnnotationsDataLayer({ prefix: 'Layer 1' });
+        const layer2 = new TestAnnotationsDataLayer({ prefix: 'Layer 2' });
 
         const queryRunner = new SceneQueryRunner({
           queries: [{ refId: 'A' }],
@@ -1065,8 +1065,8 @@ describe('SceneQueryRunner', () => {
       });
 
       it('combines multiple layers that complete non-simultaneously', async () => {
-        const layer1 = new TestAnnoationsDataLayer({ prefix: 'Layer 1', delay: true });
-        const layer2 = new TestAnnoationsDataLayer({ prefix: 'Layer 2', delay: true });
+        const layer1 = new TestAnnotationsDataLayer({ prefix: 'Layer 1', delay: true });
+        const layer2 = new TestAnnotationsDataLayer({ prefix: 'Layer 2', delay: true });
         const queryRunner = new SceneQueryRunner({
           queries: [{ refId: 'A' }],
           $timeRange: new SceneTimeRange(),
@@ -1194,6 +1194,269 @@ describe('SceneQueryRunner', () => {
         `);
       });
     });
+
+    describe('filtering results', () => {
+      it('should filter Grafana annotations added to a specific panel', async () => {
+        const layer1 = new TestAnnotationsDataLayer({
+          prefix: 'Layer 1',
+          fakeAnnotations: () => {
+            // This function is faking annotation events coming from Grafana data source.
+            return [
+              {
+                panelId: 1,
+                source: {
+                  type: 'dashboard',
+                },
+              },
+              {
+                panelId: 123,
+                source: {
+                  type: 'dashboard',
+                },
+              },
+              {
+                panelId: 2,
+                source: {
+                  type: 'dashboard',
+                },
+              },
+              {
+                panelId: 123,
+                source: {
+                  type: 'dashboard',
+                },
+              },
+            ];
+          },
+        });
+
+        const queryRunner = new SceneQueryRunner({
+          queries: [{ refId: 'A' }],
+          $timeRange: new SceneTimeRange(),
+          dataLayerFilter: {
+            panelId: 123,
+          },
+          $data: new SceneDataLayers({ layers: [layer1] }),
+        });
+
+        queryRunner.activate();
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(queryRunner.state.data?.annotations?.[0].length).toEqual(2);
+        expect(queryRunner.state.data?.annotations?.[0].fields).toMatchInlineSnapshot(`
+          [
+            {
+              "config": {},
+              "name": "text",
+              "type": "string",
+              "values": [
+                "Layer 1: Test annotation",
+                "Layer 1: Test annotation",
+              ],
+            },
+            {
+              "config": {},
+              "name": "panelId",
+              "type": "number",
+              "values": [
+                123,
+                123,
+              ],
+            },
+            {
+              "config": {},
+              "name": "source",
+              "type": "other",
+              "values": [
+                {
+                  "type": "dashboard",
+                },
+                {
+                  "type": "dashboard",
+                },
+              ],
+            },
+          ]
+        `);
+      });
+
+      it('should filter annotations with include filter specified', async () => {
+        const layer1 = new TestAnnotationsDataLayer({
+          prefix: 'Layer 1',
+          fakeAnnotations: () => {
+            // This function is faking annotation events coming from Grafana data source.
+            return [
+              {
+                source: {
+                  filter: {
+                    exclude: false,
+                    ids: [1],
+                  },
+                },
+              },
+              {
+                // this annotation should should be included in panel 123
+                source: {
+                  filter: {
+                    exclude: false,
+                    ids: [123],
+                  },
+                },
+              },
+              {
+                source: {
+                  filter: {
+                    exclude: false,
+                    ids: [2],
+                  },
+                },
+              },
+              {
+                // this annotation should should be included in panel 123
+                source: {
+                  filter: {
+                    exclude: false,
+                    ids: [123],
+                  },
+                },
+              },
+            ];
+          },
+        });
+
+        const queryRunner = new SceneQueryRunner({
+          queries: [{ refId: 'A' }],
+          $timeRange: new SceneTimeRange(),
+          dataLayerFilter: {
+            panelId: 123,
+          },
+          $data: new SceneDataLayers({ layers: [layer1] }),
+        });
+
+        queryRunner.activate();
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(queryRunner.state.data?.annotations?.[0].length).toEqual(2);
+        expect(queryRunner.state.data?.annotations?.[0].fields).toMatchInlineSnapshot(`
+          [
+            {
+              "config": {},
+              "name": "text",
+              "type": "string",
+              "values": [
+                "Layer 1: Test annotation",
+                "Layer 1: Test annotation",
+              ],
+            },
+            {
+              "config": {},
+              "name": "source",
+              "type": "other",
+              "values": [
+                {
+                  "filter": {
+                    "exclude": false,
+                    "ids": [
+                      123,
+                    ],
+                  },
+                },
+                {
+                  "filter": {
+                    "exclude": false,
+                    "ids": [
+                      123,
+                    ],
+                  },
+                },
+              ],
+            },
+          ]
+        `);
+      });
+
+      it('should filter annotations with exlude filter specified', async () => {
+        const layer1 = new TestAnnotationsDataLayer({
+          prefix: 'Layer 1',
+          fakeAnnotations: () => {
+            // This function is faking annotation events with exclude filter
+            return [
+              {
+                // only this annotation should we returned
+                source: {
+                  filter: {
+                    exclude: true,
+                    ids: [1],
+                  },
+                },
+              },
+              {
+                // this annotation should should be excluded from panel 123
+                source: {
+                  filter: {
+                    exclude: true,
+                    ids: [123],
+                  },
+                },
+              },
+              {
+                // this annotation should should be excluded from panel 123
+                source: {
+                  filter: {
+                    exclude: true,
+                    ids: [123],
+                  },
+                },
+              },
+            ];
+          },
+        });
+
+        const queryRunner = new SceneQueryRunner({
+          queries: [{ refId: 'A' }],
+          $timeRange: new SceneTimeRange(),
+          dataLayerFilter: {
+            panelId: 123,
+          },
+          $data: new SceneDataLayers({ layers: [layer1] }),
+        });
+
+        queryRunner.activate();
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(queryRunner.state.data?.annotations?.[0].length).toEqual(1);
+        expect(queryRunner.state.data?.annotations?.[0].fields).toMatchInlineSnapshot(`
+          [
+            {
+              "config": {},
+              "name": "time",
+              "type": "time",
+              "values": [
+                100,
+              ],
+            },
+            {
+              "config": {},
+              "name": "text",
+              "type": "string",
+              "values": [
+                "Layer 1: Test annotation",
+              ],
+            },
+            {
+              "config": {},
+              "name": "tags",
+              "type": "other",
+              "values": [
+                [
+                  "tag1",
+                ],
+              ],
+            },
+          ]
+        `);
+      });
+    });
   });
 });
 
@@ -1207,16 +1470,20 @@ class CustomDataSource extends RuntimeDataSource {
   }
 }
 
-interface TestAnnoationsDataLayerState extends SceneObjectState {
+interface TestAnnotationsDataLayerState extends SceneObjectState {
   prefix: string;
   delay?: boolean;
+  fakeAnnotations?: () => AnnotationEvent[];
   cancellationSpy?: jest.Mock;
 }
 
-class TestAnnoationsDataLayer extends SceneObjectBase<TestAnnoationsDataLayerState> implements SceneDataLayerProvider {
+class TestAnnotationsDataLayer
+  extends SceneObjectBase<TestAnnotationsDataLayerState>
+  implements SceneDataLayerProvider
+{
   private _runs = new ReplaySubject<number>();
 
-  public constructor(state: TestAnnoationsDataLayerState) {
+  public constructor(state: TestAnnotationsDataLayerState) {
     super({
       delay: false,
       ...state,
@@ -1225,7 +1492,7 @@ class TestAnnoationsDataLayer extends SceneObjectBase<TestAnnoationsDataLayerSta
 
   public getResultsStream(): Observable<SceneDataLayerProviderResult> {
     const { delay } = this.state;
-    const ano: AnnotationEvent[] = [
+    let ano: AnnotationEvent[] = [
       {
         time: 100,
         text: `${this.state.prefix}: Test annotation`,

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -12,12 +12,14 @@ import {
   preProcessPanelData,
   rangeUtil,
   ScopedVar,
+  transformDataFrame,
 } from '@grafana/data';
 import { getRunRequest } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import {
+  DataLayerFilter,
   isDataRequestEnricher,
   SceneDataLayerProviderResult,
   SceneDataProvider,
@@ -34,6 +36,7 @@ import { emptyPanelData } from '../core/SceneDataNode';
 import { SceneTimeRangeCompare } from '../components/SceneTimeRangeCompare';
 import { getClosest } from '../core/sceneGraph/utils';
 import { timeShiftQueryResponseOperator } from './timeShiftQueryResponseOperator';
+import { filterAnnotationsOperator } from './layers/annotations/filterAnnotationsOperator';
 
 let counter = 100;
 
@@ -49,6 +52,8 @@ export interface QueryRunnerState extends SceneObjectState {
   maxDataPoints?: number;
   liveStreaming?: boolean;
   maxDataPointsFromWidth?: boolean;
+  // Filters to be applied to data layer results before combining them with SQR results
+  dataLayerFilter?: DataLayerFilter;
   // Private runtime state
   _isWaitingForVariables?: boolean;
   _hasFetchedData?: boolean;
@@ -150,6 +155,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   }
 
   private _onLayersReceived(results: Map<string, PanelData>) {
+    const { dataLayerFilter } = this.state;
     let annotations: DataFrame[] = [];
 
     Array.from(results.values()).forEach((result) => {
@@ -158,12 +164,23 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       }
     });
 
-    this.setState({
-      data: {
-        ...this.state.data!,
-        annotations,
-      },
-    });
+    if (dataLayerFilter?.panelId) {
+      transformDataFrame([filterAnnotationsOperator(dataLayerFilter)], annotations).subscribe((result) => {
+        this.setState({
+          data: {
+            ...this.state.data!,
+            annotations: result,
+          },
+        });
+      });
+    } else {
+      this.setState({
+        data: {
+          ...this.state.data!,
+          annotations,
+        },
+      });
+    }
   }
 
   /**

--- a/packages/scenes/src/querying/layers/annotations/filterAnnotationsOperator.ts
+++ b/packages/scenes/src/querying/layers/annotations/filterAnnotationsOperator.ts
@@ -1,0 +1,89 @@
+import { CustomTransformOperator, DataFrame, Field } from '@grafana/data';
+import { map } from 'rxjs';
+import { DataLayerFilter } from '../../../core/types';
+
+// Provided SceneDataLayerProviderResult is an array of DataFrames.
+export const filterAnnotationsOperator: (filters: DataLayerFilter) => CustomTransformOperator =
+  (filters) => (ctx) => (source) => {
+    return source.pipe(
+      map((data) => {
+        if (!Array.isArray(data) || data.length === 0) {
+          return data;
+        }
+
+        const rows = new Set<number>();
+
+        for (const frame of data) {
+          for (let index = 0; index < frame.length; index++) {
+            if (rows.has(index)) {
+              continue;
+            }
+            let matching = true;
+
+            // Let's call those standard fields that annotations data frame has.
+            // panelId is a standard field, but it's not always present. It's added to annotations that were added to a particular panel.
+            const panelIdField = frame.fields.find((f) => f.name === 'panelId');
+            // Source field contains annotation definition, with type and filters included.
+            const sourceField = frame.fields.find((f) => f.name === 'source');
+
+            if (sourceField) {
+              // Here we are filtering Grafana annotations that were added to a particular panel.
+              if (panelIdField && sourceField.values[index].type === 'dashboard') {
+                matching = panelIdField.values[index] === filters.panelId;
+              }
+
+              const sourceFilter = sourceField.values[index].filter;
+
+              // Here we are filtering based on annotation filter definition.
+              // Those fitlers are: Show annotation in selected panels, Exclude annotation from selected panels.
+              if (sourceFilter) {
+                const includes = (sourceFilter.ids ?? []).includes(filters.panelId);
+                if (sourceFilter.exclude) {
+                  if (includes) {
+                    matching = false;
+                  }
+                } else if (!includes) {
+                  matching = false;
+                }
+              }
+            }
+
+            if (matching) {
+              rows.add(index);
+            }
+          }
+        }
+
+        const processed: DataFrame[] = [];
+        const frameLength = rows.size;
+
+        for (const frame of data) {
+          const fields: Field[] = [];
+
+          for (const field of frame.fields) {
+            const buffer = [];
+
+            for (let index = 0; index < frame.length; index++) {
+              if (rows.has(index)) {
+                buffer.push(field.values[index]);
+                continue;
+              }
+            }
+
+            fields.push({
+              ...field,
+              values: buffer,
+            });
+          }
+
+          processed.push({
+            ...frame,
+            fields: fields,
+            length: frameLength,
+          });
+        }
+
+        return processed;
+      })
+    );
+  };


### PR DESCRIPTION
Based on https://github.com/grafana/scenes/pull/328

This adds a `dataLayerFilters` property to SceneQueryRunner to perform annotations filtering per panel. This should serve exclusively Grafana Dashboard use case, as in apps, annotations could possibly be scoped to a panel by scene hierarchy.