### PR TITLE
SceneControlsSpacer: Fix flickering

### DIFF
--- a/packages/scenes/src/components/SceneControlsSpacer.tsx
+++ b/packages/scenes/src/components/SceneControlsSpacer.tsx
@@ -3,9 +3,14 @@ import React from 'react';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneComponentProps } from '../core/types';
 
-export class SceneControlsSpacer extends SceneObjectBase<{}> {
+export class SceneControlsSpacer extends SceneObjectBase {
   public constructor() {
     super({});
+  }
+
+  public get Component() {
+    // Skipping wrapper component for this scene object so that it renders right away
+    return SceneControlsSpacer.Component;
   }
 
   public static Component = (_props: SceneComponentProps<SceneControlsSpacer>) => {

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -4,15 +4,19 @@ import { TimeRangePicker } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneObjectState } from '../core/types';
+import { SceneComponentProps, SceneControlObject, SceneObjectState } from '../core/types';
 
 export interface SceneTimePickerState extends SceneObjectState {
   hidePicker?: boolean;
   isOnCanvas?: boolean;
 }
 
-export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
+export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> implements SceneControlObject {
   public static Component = SceneTimePickerRenderer;
+
+  public getPositionPreference() {
+    return 'right' as const;
+  }
 }
 
 function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>) {

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -4,19 +4,15 @@ import { TimeRangePicker } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
-import { SceneComponentProps, SceneControlObject, SceneObjectState } from '../core/types';
+import { SceneComponentProps, SceneObjectState } from '../core/types';
 
 export interface SceneTimePickerState extends SceneObjectState {
   hidePicker?: boolean;
   isOnCanvas?: boolean;
 }
 
-export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> implements SceneControlObject {
+export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
   public static Component = SceneTimePickerRenderer;
-
-  public getPositionPreference() {
-    return 'right' as const;
-  }
 }
 
 function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>) {


### PR DESCRIPTION
This is a fix for flickering that happens in core dashboards when we
discard the edits the time range controls for 1 frame move left.

This is due to all objects being inactive & active when restoring state.

The component wrapper does not render the component when inactive causing
this flickering when this spacer component is not rendered. For some
reason the time range controls are rendered before.

I think we might need to revisit this spacer logic at some point, either
introduce separate props for "filters" (left aligned), and controls (right aligned),
or some layout option on a Controls type/ interface.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.0--canary.332.6168332968.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.2.0--canary.332.6168332968.0
  # or 
  yarn add @grafana/scenes@1.2.0--canary.332.6168332968.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
