### PR TITLE
DataLayers: Allow cancelling layers from layer control

### DIFF
--- a/packages/scenes-app/src/demos/annotations.tsx
+++ b/packages/scenes-app/src/demos/annotations.tsx
@@ -20,65 +20,59 @@ import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './u
 export function getAnnotationsDemo(defaults: SceneAppPageState) {
   const globalAnnotations = new dataLayers.AnnotationsDataLayer({
     name: 'Global annotations',
-    queries: [
-      {
-        datasource: {
-          type: 'testdata',
-          uid: 'gdev-testdata',
-        },
-        enable: true,
-        iconColor: 'yellow',
-        name: 'New annotation',
-        target: {
-          // @ts-ignore
-          lines: 10,
-          refId: 'Anno',
-          scenarioId: 'annotations',
-        },
+    query: {
+      datasource: {
+        type: 'testdata',
+        uid: 'gdev-testdata',
       },
-    ],
+      enable: true,
+      iconColor: 'yellow',
+      name: 'New annotation',
+      target: {
+        // @ts-ignore
+        lines: 10,
+        refId: 'Anno',
+        scenarioId: 'annotations',
+      },
+    },
   });
 
   const nestedAnnotationsDataLayer = new dataLayers.AnnotationsDataLayer({
     name: 'Nested annotations',
-    queries: [
-      {
-        datasource: {
-          type: 'testdata',
-          uid: 'gdev-testdata',
-        },
-        enable: true,
-        iconColor: 'red',
-        name: 'New annotation',
-        target: {
-          // @ts-ignore
-          lines: 5,
-          refId: 'Anno',
-          scenarioId: 'annotations',
-        },
+    query: {
+      datasource: {
+        type: 'testdata',
+        uid: 'gdev-testdata',
       },
-    ],
+      enable: true,
+      iconColor: 'red',
+      name: 'New annotation',
+      target: {
+        // @ts-ignore
+        lines: 5,
+        refId: 'Anno',
+        scenarioId: 'annotations',
+      },
+    },
   });
 
   const independentAnnotations = new dataLayers.AnnotationsDataLayer({
     name: 'Independent annotations',
-    queries: [
-      {
-        datasource: {
-          type: 'testdata',
-          uid: 'gdev-testdata',
-        },
-        enable: true,
-        iconColor: 'purple',
-        name: 'New annotation',
-        target: {
-          // @ts-ignore
-          lines: 3,
-          refId: 'Anno',
-          scenarioId: 'annotations',
-        },
+    query: {
+      datasource: {
+        type: 'testdata',
+        uid: 'gdev-testdata',
       },
-    ],
+      enable: true,
+      iconColor: 'purple',
+      name: 'New annotation',
+      target: {
+        // @ts-ignore
+        lines: 3,
+        refId: 'Anno',
+        scenarioId: 'annotations',
+      },
+    },
   });
 
   return new SceneAppPage({
@@ -179,23 +173,21 @@ export function getAnnotationsDemo(defaults: SceneAppPageState) {
                     layers: [
                       new dataLayers.AnnotationsDataLayer({
                         name: 'Local annotations',
-                        queries: [
-                          {
-                            datasource: {
-                              type: 'testdata',
-                              uid: 'gdev-testdata',
-                            },
-                            enable: true,
-                            iconColor: 'green',
-                            name: 'New annotation',
-                            target: {
-                              // @ts-ignore
-                              lines: 4,
-                              refId: 'Anno',
-                              scenarioId: 'annotations',
-                            },
+                        query: {
+                          datasource: {
+                            type: 'testdata',
+                            uid: 'gdev-testdata',
                           },
-                        ],
+                          enable: true,
+                          iconColor: 'green',
+                          name: 'New annotation',
+                          target: {
+                            // @ts-ignore
+                            lines: 4,
+                            refId: 'Anno',
+                            scenarioId: 'annotations',
+                          },
+                        },
                       }),
                     ],
                   }),

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -204,6 +204,7 @@ export interface SceneDataProvider extends SceneObject<SceneDataState> {
 
 export interface SceneDataLayerProviderState extends SceneObjectState {
   name: string;
+  description?: string;
   isEnabled?: boolean;
   data?: PanelData;
 }

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -205,6 +205,7 @@ export interface SceneDataProvider extends SceneObject<SceneDataState> {
 export interface SceneDataLayerProviderState extends SceneObjectState {
   name: string;
   isEnabled?: boolean;
+  data?: PanelData;
 }
 
 export interface SceneDataLayerProvider extends SceneObject<SceneDataLayerProviderState> {

--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.test.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.test.ts
@@ -3,12 +3,24 @@ import { SceneDataLayerProviderResult } from '../../core/types';
 import { TestAnnotationsDataLayer } from './TestDataLayer';
 
 describe('SceneDataLayerBase', () => {
+  const runLayerSpy = jest.fn();
   const enableSpy = jest.fn();
   const disableSpy = jest.fn();
 
   beforeEach(() => {
     enableSpy.mockClear();
     disableSpy.mockClear();
+  });
+
+  describe('when activated', () => {
+    const layer = new TestAnnotationsDataLayer({
+      name: 'Layer 1',
+      isEnabled: true,
+      runLayerSpy: runLayerSpy,
+    });
+    layer.activate();
+
+    expect(runLayerSpy).toBeCalledTimes(1);
   });
 
   describe('when enabled', () => {

--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
@@ -63,7 +63,7 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState =
       this.onEnable();
     }
 
-    if (this.shouldRunQueriesOnActivate()) {
+    if (this.shouldRunLayerOnActivate()) {
       this.runLayer();
     }
 
@@ -75,16 +75,21 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState =
         this.querySub = undefined;
         this.onDisable();
 
+        // Manually publishing the results to state and results stream as publishPublish results has a guard for the layer to be enabled.
         this._results.next({
           origin: this,
           data: emptyPanelData,
           topic: this.topic,
+        });
+        this.setStateHelper({
+          data: emptyPanelData,
         });
       }
 
       if (n.isEnabled && !p.isEnabled) {
         // When layer enabled, run queries.
         this.onEnable();
+        this.runLayer();
       }
     });
 
@@ -129,7 +134,7 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState =
     return this._results;
   }
 
-  private shouldRunQueriesOnActivate() {
+  private shouldRunLayerOnActivate() {
     if (this.state.data) {
       return false;
     }

--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.test.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.test.tsx
@@ -9,7 +9,7 @@ describe('SceneDataLayerControl', () => {
     jest.useFakeTimers();
   });
 
-  it('renders loading indicator after 500ms without a response', () => {
+  it('renders loading indicator when layers state is Loading', () => {
     const layer = new TestAnnotationsDataLayer({
       name: 'Layer 1',
     });
@@ -17,15 +17,14 @@ describe('SceneDataLayerControl', () => {
     render(<SceneDataLayerControl layer={layer} isEnabled={true} onToggleLayer={() => {}} />);
     expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
 
-    layer.activate();
     act(() => {
-      layer.startRun();
-      jest.advanceTimersByTime(499);
+      layer.activate();
     });
+
     expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
 
     act(() => {
-      jest.advanceTimersByTime(501);
+      layer.startRun();
     });
     expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(1);
 
@@ -36,12 +35,6 @@ describe('SceneDataLayerControl', () => {
 
     act(() => {
       layer.startRun();
-      jest.advanceTimersByTime(499);
-    });
-    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
-
-    act(() => {
-      jest.advanceTimersByTime(501);
     });
     expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(1);
 
@@ -58,11 +51,9 @@ describe('SceneDataLayerControl', () => {
 
     render(<SceneDataLayerControl layer={layer} isEnabled={true} onToggleLayer={() => {}} />);
 
-    layer.activate();
-
     act(() => {
+      layer.activate();
       layer.startRun();
-      jest.advanceTimersByTime(600);
     });
     expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(1);
 

--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.test.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { selectors } from '@grafana/e2e-selectors';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { SceneDataLayerControl } from './SceneDataLayerControls';
+import { TestAnnotationsDataLayer } from './TestDataLayer';
+
+describe('SceneDataLayerControl', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  it('renders loading indicator after 500ms without a response', () => {
+    const layer = new TestAnnotationsDataLayer({
+      name: 'Layer 1',
+    });
+
+    render(<SceneDataLayerControl layer={layer} isEnabled={true} onToggleLayer={() => {}} />);
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
+
+    layer.activate();
+    act(() => {
+      layer.startRun();
+      jest.advanceTimersByTime(499);
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(501);
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(1);
+
+    act(() => {
+      layer.completeRun();
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
+
+    act(() => {
+      layer.startRun();
+      jest.advanceTimersByTime(499);
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(501);
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(1);
+
+    act(() => {
+      layer.completeRunWithError();
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
+  });
+
+  it('hides loading indicator when query canceled by loading indicator click', async () => {
+    const layer = new TestAnnotationsDataLayer({
+      name: 'Layer 1',
+    });
+
+    render(<SceneDataLayerControl layer={layer} isEnabled={true} onToggleLayer={() => {}} />);
+
+    layer.activate();
+
+    act(() => {
+      layer.startRun();
+      jest.advanceTimersByTime(600);
+    });
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(1);
+
+    act(() => {
+      fireEvent.mouseDown(screen.getByLabelText(selectors.components.LoadingIndicator.icon));
+    });
+
+    expect(screen.queryAllByLabelText(selectors.components.LoadingIndicator.icon)).toHaveLength(0);
+  });
+});

--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
@@ -1,13 +1,12 @@
 import { css } from '@emotion/css';
 import { LoadingState } from '@grafana/schema';
-import { InlineSwitch, useTheme2 } from '@grafana/ui';
+import { InlineSwitch } from '@grafana/ui';
 import React, { useEffect } from 'react';
 import { map, of, switchMap, timer } from 'rxjs';
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps, SceneDataLayerProvider, SceneObjectState } from '../../core/types';
 import { ControlsLabel } from '../../utils/ControlsLabel';
-import { LoadingIndicator } from '../../utils/LoadingIndicator';
 
 interface SceneDataLayerControlsState extends SceneObjectState {
   layersMap: Record<string, boolean>;
@@ -67,7 +66,6 @@ interface SceneDataLayerControlProps {
 }
 
 export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: SceneDataLayerControlProps) {
-  const theme = useTheme2();
   const elementId = `data-layer-${layer.state.key}`;
   const [showLoading, setShowLoading] = React.useState(false);
 
@@ -96,22 +94,10 @@ export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: Scene
     <div className={containerStyle}>
       <ControlsLabel
         htmlFor={elementId}
-        label={
-          <>
-            {layer.state.name}
-            {showLoading && (
-              <div style={{ marginLeft: theme.spacing(1), marginTop: '-1px' }}>
-                <LoadingIndicator
-                  onCancel={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    layer.cancelQuery?.();
-                  }}
-                />
-              </div>
-            )}
-          </>
-        }
+        isLoading={showLoading}
+        onCancel={() => layer.cancelQuery?.()}
+        label={layer.state.name}
+        description={layer.state.description}
       />
       <InlineSwitch id={elementId} value={isEnabled} onChange={onToggleLayer} />
     </div>

--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
 import { LoadingState } from '@grafana/schema';
 import { InlineSwitch } from '@grafana/ui';
-import React, { useEffect } from 'react';
-import { map, of, switchMap, timer } from 'rxjs';
+import React from 'react';
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps, SceneDataLayerProvider, SceneObjectState } from '../../core/types';
@@ -67,28 +66,8 @@ interface SceneDataLayerControlProps {
 
 export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: SceneDataLayerControlProps) {
   const elementId = `data-layer-${layer.state.key}`;
-  const [showLoading, setShowLoading] = React.useState(false);
-
-  useEffect(() => {
-    const stateStream = layer.getResultsStream().pipe(map((r) => r.data.state));
-
-    const loadingIndicatorSub = stateStream
-      .pipe(
-        switchMap((event) => {
-          if (event === LoadingState.Loading) {
-            return timer(500).pipe(map(() => true));
-          }
-          return of(false);
-        })
-      )
-      .subscribe((v) => {
-        setShowLoading(v);
-      });
-
-    return () => {
-      loadingIndicatorSub.unsubscribe();
-    };
-  }, [layer]);
+  const { data } = layer.useState();
+  const showLoading = Boolean(data && data.state === LoadingState.Loading);
 
   return (
     <div className={containerStyle}>

--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { LoadingState } from '@grafana/schema';
 import { InlineSwitch, useTheme2 } from '@grafana/ui';
 import React, { useEffect } from 'react';
@@ -92,12 +93,7 @@ export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: Scene
   }, [layer]);
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'middle',
-      }}
-    >
+    <div className={containerStyle}>
       <ControlsLabel
         htmlFor={elementId}
         label={
@@ -121,3 +117,5 @@ export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: Scene
     </div>
   );
 }
+
+const containerStyle = css({ display: 'flex' });

--- a/packages/scenes/src/querying/layers/TestDataLayer.ts
+++ b/packages/scenes/src/querying/layers/TestDataLayer.ts
@@ -1,4 +1,5 @@
 import { AnnotationEvent, arrayToDataFrame, DataTopic } from '@grafana/data';
+import { LoadingState } from '@grafana/schema';
 import { Subscription } from 'rxjs';
 import { emptyPanelData } from '../../core/SceneDataNode';
 import { SceneDataLayerProvider, SceneDataLayerProviderState } from '../../core/types';
@@ -9,6 +10,7 @@ interface TestAnnotationsDataLayerState extends SceneDataLayerProviderState {
   cancellationSpy?: jest.Mock;
   onEnableSpy?: jest.Mock;
   onDisableSpy?: jest.Mock;
+  runLayerSpy?: jest.Mock;
 }
 
 export class TestAnnotationsDataLayer
@@ -23,8 +25,15 @@ export class TestAnnotationsDataLayer
     });
   }
 
+  public startRun() {
+    this.publishResults({ ...emptyPanelData, state: LoadingState.Loading }, this.topic);
+  }
   public completeRun() {
     this.publishResults(this.getResults(), this.topic);
+  }
+
+  public completeRunWithError() {
+    this.publishResults({ ...emptyPanelData, state: LoadingState.Error }, this.topic);
   }
 
   private getResults() {
@@ -53,6 +62,8 @@ export class TestAnnotationsDataLayer
     if (this.state.cancellationSpy) {
       this.state.cancellationSpy();
     }
+
+    super.cancelQuery();
   }
 
   public onEnable(): void {
@@ -70,6 +81,11 @@ export class TestAnnotationsDataLayer
   }
 
   private setupQuerySub() {
+    this.querySub = new Subscription();
+  }
+
+  protected runLayer(): void {
+    this.state.runLayerSpy?.();
     this.querySub = new Subscription();
   }
 }

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -1,4 +1,4 @@
-import { arrayToDataFrame, DataTopic, AnnotationQuery, PanelData } from '@grafana/data';
+import { arrayToDataFrame, DataTopic, AnnotationQuery } from '@grafana/data';
 import { map, Unsubscribable } from 'rxjs';
 import { emptyPanelData } from '../../../core/SceneDataNode';
 import { sceneGraph } from '../../../core/sceneGraph';

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -64,20 +64,16 @@ export class AnnotationsDataLayer
             dataTopic: DataTopic.Annotations,
           };
 
+          stateUpdate.annotations = [df];
           return stateUpdate;
         })
       );
 
       this.querySub = queryExecution.subscribe((stateUpdate) => {
-        this.onDataReceived(stateUpdate);
+        this.publishResults(stateUpdate, DataTopic.Annotations);
       });
     } catch (e) {
       console.error('AnnotationsDataLayer error', e);
     }
-  }
-
-  private onDataReceived(stateUpdate: PanelData) {
-    // This is only faking panel data
-    this.publishResults(stateUpdate, DataTopic.Annotations);
   }
 }

--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -1,31 +1,48 @@
 import React from 'react';
-import { Tooltip, useStyles2 } from '@grafana/ui';
+import { Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
+import { LoadingIndicator } from './LoadingIndicator';
 
 interface ControlsLabelProps {
-  label: string | React.ReactNode;
+  label: string;
   htmlFor: string;
   description?: string;
+  isLoading?: boolean;
+  onCancel?: () => void;
 }
 
 export function ControlsLabel(props: ControlsLabelProps) {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+
+  const loadingIndicator = Boolean(props.isLoading) ? (
+    <div style={{ marginLeft: theme.spacing(1), marginTop: '-1px' }}>
+      <LoadingIndicator
+        onCancel={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          props.onCancel?.();
+        }}
+      />
+    </div>
+  ) : null;
 
   if (props.description) {
     return (
-      <Tooltip content={props.description} placement={'bottom'}>
-        <label
-          className={styles.label}
-          data-testid={
-            typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : ''
-          }
-          htmlFor={props.htmlFor}
-        >
-          {props.label}
-        </label>
-      </Tooltip>
+      <label
+        className={styles.label}
+        data-testid={
+          typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : ''
+        }
+        htmlFor={props.htmlFor}
+      >
+        <Tooltip content={props.description} placement={'bottom'}>
+          <span>{props.label}</span>
+        </Tooltip>
+        {loadingIndicator}
+      </label>
     );
   }
 
@@ -38,6 +55,7 @@ export function ControlsLabel(props: ControlsLabelProps) {
       htmlFor={props.htmlFor}
     >
       {props.label}
+      {loadingIndicator}
     </label>
   );
 }

--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 
 interface ControlsLabelProps {
-  label: string;
+  label: string | React.ReactNode;
   htmlFor: string;
   description?: string;
 }
@@ -18,7 +18,9 @@ export function ControlsLabel(props: ControlsLabelProps) {
       <Tooltip content={props.description} placement={'bottom'}>
         <label
           className={styles.label}
-          data-testid={selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label)}
+          data-testid={
+            typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : ''
+          }
           htmlFor={props.htmlFor}
         >
           {props.label}
@@ -30,7 +32,9 @@ export function ControlsLabel(props: ControlsLabelProps) {
   return (
     <label
       className={styles.label}
-      data-testid={selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label)}
+      data-testid={
+        typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : ''
+      }
       htmlFor={props.htmlFor}
     >
       {props.label}

--- a/packages/scenes/src/utils/LoadingIndicator.tsx
+++ b/packages/scenes/src/utils/LoadingIndicator.tsx
@@ -1,0 +1,42 @@
+import { selectors } from '@grafana/e2e-selectors';
+import { Icon, Tooltip } from '@grafana/ui';
+import React, { useCallback } from 'react';
+import { LoadingIndicatorProps as SelectLoadingIndicatorProps } from 'react-select';
+
+export const SelectLoadingIndicator = ({
+  innerProps,
+  ...props
+}: SelectLoadingIndicatorProps & { selectProps: { onCancel: () => void } }) => {
+  const { onCancel } = props.selectProps;
+  const onMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onCancel();
+    },
+    [onCancel]
+  );
+
+  return <LoadingIndicator onCancel={onMouseDown} />;
+};
+
+interface LoadingIndicatorProps {
+  onCancel: (event: React.MouseEvent) => void;
+}
+
+export function LoadingIndicator(props: LoadingIndicatorProps) {
+  return (
+    <Tooltip content="Cancel query">
+      <Icon
+        className="spin-clockwise"
+        name="sync"
+        size="xs"
+        aria-label={selectors.components.LoadingIndicator.icon}
+        role="button"
+        onMouseDown={(e) => {
+          props.onCancel(e);
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -6,53 +6,42 @@ import { MultiSelect, Select } from '@grafana/ui';
 import { SceneComponentProps } from '../../core/types';
 import { MultiValueVariable } from '../variants/MultiValueVariable';
 import { VariableValue, VariableValueSingle } from '../types';
-import { SelectLoadingIndicator } from '../../utils/LoadingIndicator';
 
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, key, loading } = model.useState();
+  const { value, key } = model.useState();
 
   return (
-    <Select<VariableValue, { onCancel: () => void }>
+    <Select<VariableValue>
       id={key}
       placeholder="Select value"
       width="auto"
       value={value}
       allowCustomValue
       tabSelectsValue={false}
-      isLoading={loading}
       options={model.getOptionsForSelect()}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);
       }}
-      onCancel={() => {
-        model.cancel?.();
-      }}
-      components={{ LoadingIndicator: SelectLoadingIndicator }}
     />
   );
 }
 
 export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, key, loading } = model.useState();
+  const { value, key } = model.useState();
   const arrayValue = isArray(value) ? value : [value];
 
   return (
-    <MultiSelect<VariableValueSingle, { onCancel: () => void }>
+    <MultiSelect<VariableValueSingle>
       id={key}
       placeholder="Select value"
       width="auto"
       value={arrayValue}
       tabSelectsValue={false}
       allowCustomValue
-      isLoading={loading}
       options={model.getOptionsForSelect()}
       closeMenuOnSelect={false}
       isClearable={true}
       onOpenMenu={() => {}}
-      onCancel={() => {
-        model.cancel?.();
-      }}
-      components={{ LoadingIndicator: SelectLoadingIndicator }}
       onChange={(newValue) => {
         model.changeValueTo(
           newValue.map((v) => v.value!),

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -1,39 +1,12 @@
 import { isArray } from 'lodash';
-import React, { useCallback } from 'react';
+import React from 'react';
 
-import { Icon, MultiSelect, Select, Tooltip } from '@grafana/ui';
-import { LoadingIndicatorProps } from 'react-select';
+import { MultiSelect, Select } from '@grafana/ui';
 
 import { SceneComponentProps } from '../../core/types';
 import { MultiValueVariable } from '../variants/MultiValueVariable';
-import { selectors } from '@grafana/e2e-selectors';
 import { VariableValue, VariableValueSingle } from '../types';
-
-
-const LoadingIndicator = ({ innerProps, ...props }: LoadingIndicatorProps & { selectProps: { onCancel: () => void }}) => {
-  const { onCancel } = props.selectProps;
-  const onMouseDown = useCallback(
-    (event: React.MouseEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      onCancel();
-    },
-    [onCancel]
-  );
-
-  return (
-    <Tooltip content="Cancel query">
-      <Icon
-        className="spin-clockwise"
-        name="sync"
-        size="xs"
-        aria-label={selectors.components.LoadingIndicator.icon}
-        role="button"
-        onMouseDown={onMouseDown}
-      />
-    </Tooltip>
-  );
-};
+import { SelectLoadingIndicator } from '../../utils/LoadingIndicator';
 
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, key, loading } = model.useState();
@@ -51,8 +24,10 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);
       }}
-      onCancel={() => { model.cancel?.() }}
-      components={{ LoadingIndicator }}
+      onCancel={() => {
+        model.cancel?.();
+      }}
+      components={{ LoadingIndicator: SelectLoadingIndicator }}
     />
   );
 }
@@ -74,8 +49,10 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       closeMenuOnSelect={false}
       isClearable={true}
       onOpenMenu={() => {}}
-      onCancel={() => { model.cancel?.() }}
-      components={{ LoadingIndicator }}
+      onCancel={() => {
+        model.cancel?.();
+      }}
+      components={{ LoadingIndicator: SelectLoadingIndicator }}
       onChange={(newValue) => {
         model.changeValueTo(
           newValue.map((v) => v.value!),

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -4,8 +4,8 @@ import { VariableHide } from '@grafana/data';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { SceneComponentProps, SceneObject, SceneObjectState } from '../../core/types';
-import { SceneVariableState } from '../types';
+import { SceneComponentProps, SceneObjectState } from '../../core/types';
+import { SceneVariable } from '../types';
 import { ControlsLabel } from '../../utils/ControlsLabel';
 import { css } from '@emotion/css';
 
@@ -25,7 +25,7 @@ function VariableValueSelectorsRenderer({ model }: SceneComponentProps<VariableV
   );
 }
 
-function VariableValueSelectWrapper({ variable }: { variable: SceneObject<SceneVariableState> }) {
+function VariableValueSelectWrapper({ variable }: { variable: SceneVariable }) {
   const state = variable.useState();
 
   if (state.hide === VariableHide.hideVariable) {
@@ -34,21 +34,29 @@ function VariableValueSelectWrapper({ variable }: { variable: SceneObject<SceneV
 
   return (
     <div className={containerStyle}>
-      <VariableLabel state={state} />
+      <VariableLabel model={variable} />
       <variable.Component model={variable} />
     </div>
   );
 }
 
-function VariableLabel({ state }: { state: SceneVariableState }) {
-  if (state.hide === VariableHide.hideLabel) {
+function VariableLabel({ model }: { model: SceneVariable }) {
+  if (model.state.hide === VariableHide.hideLabel) {
     return null;
   }
 
-  const elementId = `var-${state.key}`;
-  const labelOrName = state.label ?? state.name;
+  const elementId = `var-${model.state.key}`;
+  const labelOrName = model.state.label ?? model.state.name;
 
-  return <ControlsLabel htmlFor={elementId} label={labelOrName} description={state.description ?? undefined} />;
+  return (
+    <ControlsLabel
+      htmlFor={elementId}
+      isLoading={model.state.loading}
+      onCancel={() => model.onCancel?.()}
+      label={labelOrName}
+      description={model.state.description ?? undefined}
+    />
+  );
 }
 
 const containerStyle = css({ display: 'flex' });

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -38,6 +38,11 @@ export interface SceneVariable<TState extends SceneVariableState = SceneVariable
    * A special function that locally scoped variables can implement
    **/
   isAncestorLoading?(): boolean;
+
+  /**
+   * Allows cancelling variable execution.
+   */
+  onCancel?(): void;
 }
 
 export type VariableValue = VariableValueSingle | VariableValueSingle[];

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -59,7 +59,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     );
   }
 
-  public cancel?(): void {
+  public onCancel(): void {
     this.setStateHelper({ loading: false });
     const sceneVarSet = this.parent as SceneVariableSet;
     sceneVarSet?.cancel(this);


### PR DESCRIPTION
Introduces the possibility of canceling data layer queries using a button (spinner) in the data layer control.

- `SceneDataLayerBase` now has `data: PanelData` state so that layer doesn't have to implement it.
- `SceneDataLayerBase` now has `runLayer` abstract method that should implement query execution logic and subscription setup. `runLayer` is now executed also in the base class, so that layers don't have to implement `shouldRunQueriesOnActivate`. This is now handled in the base class, so activation handlers should not be needed in the layers, unless some peculiar logic is required.
- `SceneDataLayerControls` now renders a loading spinner for layers that take >500ms to resolve results. Clicking on the icon will cancel layer query.

https://github.com/grafana/scenes/assets/2376619/e03a071f-9d60-47b4-b0be-08bb8cf4b9c6


