### PR TITLE
Unify layers and variables loading/cancellation UI

### DIFF
--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -204,6 +204,7 @@ export interface SceneDataProvider extends SceneObject<SceneDataState> {
 
 export interface SceneDataLayerProviderState extends SceneObjectState {
   name: string;
+  description?: string;
   isEnabled?: boolean;
   data?: PanelData;
 }

--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
@@ -1,12 +1,11 @@
 import { LoadingState } from '@grafana/schema';
-import { InlineSwitch, useTheme2 } from '@grafana/ui';
+import { InlineSwitch } from '@grafana/ui';
 import React, { useEffect } from 'react';
 import { map, of, switchMap, timer } from 'rxjs';
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps, SceneDataLayerProvider, SceneObjectState } from '../../core/types';
 import { ControlsLabel } from '../../utils/ControlsLabel';
-import { LoadingIndicator } from '../../utils/LoadingIndicator';
 
 interface SceneDataLayerControlsState extends SceneObjectState {
   layersMap: Record<string, boolean>;
@@ -66,7 +65,6 @@ interface SceneDataLayerControlProps {
 }
 
 export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: SceneDataLayerControlProps) {
-  const theme = useTheme2();
   const elementId = `data-layer-${layer.state.key}`;
   const [showLoading, setShowLoading] = React.useState(false);
 
@@ -100,22 +98,10 @@ export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: Scene
     >
       <ControlsLabel
         htmlFor={elementId}
-        label={
-          <>
-            {layer.state.name}
-            {showLoading && (
-              <div style={{ marginLeft: theme.spacing(1), marginTop: '-1px' }}>
-                <LoadingIndicator
-                  onCancel={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    layer.cancelQuery?.();
-                  }}
-                />
-              </div>
-            )}
-          </>
-        }
+        isLoading={showLoading}
+        onCancel={() => layer.cancelQuery?.()}
+        label={layer.state.name}
+        description={layer.state.description}
       />
       <InlineSwitch id={elementId} value={isEnabled} onChange={onToggleLayer} />
     </div>

--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -1,31 +1,48 @@
 import React from 'react';
-import { Tooltip, useStyles2 } from '@grafana/ui';
+import { Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
+import { LoadingIndicator } from './LoadingIndicator';
 
 interface ControlsLabelProps {
-  label: string | React.ReactNode;
+  label: string;
   htmlFor: string;
   description?: string;
+  isLoading?: boolean;
+  onCancel?: () => void;
 }
 
 export function ControlsLabel(props: ControlsLabelProps) {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+
+  const loadingIndicator = Boolean(props.isLoading) ? (
+    <div style={{ marginLeft: theme.spacing(1), marginTop: '-1px' }}>
+      <LoadingIndicator
+        onCancel={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          props.onCancel?.();
+        }}
+      />
+    </div>
+  ) : null;
 
   if (props.description) {
     return (
-      <Tooltip content={props.description} placement={'bottom'}>
-        <label
-          className={styles.label}
-          data-testid={
-            typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : ''
-          }
-          htmlFor={props.htmlFor}
-        >
-          {props.label}
-        </label>
-      </Tooltip>
+      <label
+        className={styles.label}
+        data-testid={
+          typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : ''
+        }
+        htmlFor={props.htmlFor}
+      >
+        <Tooltip content={props.description} placement={'bottom'}>
+          <span>{props.label}</span>
+        </Tooltip>
+        {loadingIndicator}
+      </label>
     );
   }
 
@@ -38,6 +55,7 @@ export function ControlsLabel(props: ControlsLabelProps) {
       htmlFor={props.htmlFor}
     >
       {props.label}
+      {loadingIndicator}
     </label>
   );
 }

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -6,53 +6,42 @@ import { MultiSelect, Select } from '@grafana/ui';
 import { SceneComponentProps } from '../../core/types';
 import { MultiValueVariable } from '../variants/MultiValueVariable';
 import { VariableValue, VariableValueSingle } from '../types';
-import { SelectLoadingIndicator } from '../../utils/LoadingIndicator';
 
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, key, loading } = model.useState();
+  const { value, key } = model.useState();
 
   return (
-    <Select<VariableValue, { onCancel: () => void }>
+    <Select<VariableValue>
       id={key}
       placeholder="Select value"
       width="auto"
       value={value}
       allowCustomValue
       tabSelectsValue={false}
-      isLoading={loading}
       options={model.getOptionsForSelect()}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);
       }}
-      onCancel={() => {
-        model.cancel?.();
-      }}
-      components={{ LoadingIndicator: SelectLoadingIndicator }}
     />
   );
 }
 
 export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, key, loading } = model.useState();
+  const { value, key } = model.useState();
   const arrayValue = isArray(value) ? value : [value];
 
   return (
-    <MultiSelect<VariableValueSingle, { onCancel: () => void }>
+    <MultiSelect<VariableValueSingle>
       id={key}
       placeholder="Select value"
       width="auto"
       value={arrayValue}
       tabSelectsValue={false}
       allowCustomValue
-      isLoading={loading}
       options={model.getOptionsForSelect()}
       closeMenuOnSelect={false}
       isClearable={true}
       onOpenMenu={() => {}}
-      onCancel={() => {
-        model.cancel?.();
-      }}
-      components={{ LoadingIndicator: SelectLoadingIndicator }}
       onChange={(newValue) => {
         model.changeValueTo(
           newValue.map((v) => v.value!),

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -4,8 +4,8 @@ import { VariableHide } from '@grafana/data';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
-import { SceneComponentProps, SceneObject, SceneObjectState } from '../../core/types';
-import { SceneVariableState } from '../types';
+import { SceneComponentProps, SceneObjectState } from '../../core/types';
+import { SceneVariable } from '../types';
 import { ControlsLabel } from '../../utils/ControlsLabel';
 import { css } from '@emotion/css';
 
@@ -25,7 +25,7 @@ function VariableValueSelectorsRenderer({ model }: SceneComponentProps<VariableV
   );
 }
 
-function VariableValueSelectWrapper({ variable }: { variable: SceneObject<SceneVariableState> }) {
+function VariableValueSelectWrapper({ variable }: { variable: SceneVariable }) {
   const state = variable.useState();
 
   if (state.hide === VariableHide.hideVariable) {
@@ -34,21 +34,29 @@ function VariableValueSelectWrapper({ variable }: { variable: SceneObject<SceneV
 
   return (
     <div className={containerStyle}>
-      <VariableLabel state={state} />
+      <VariableLabel model={variable} />
       <variable.Component model={variable} />
     </div>
   );
 }
 
-function VariableLabel({ state }: { state: SceneVariableState }) {
-  if (state.hide === VariableHide.hideLabel) {
+function VariableLabel({ model }: { model: SceneVariable }) {
+  if (model.state.hide === VariableHide.hideLabel) {
     return null;
   }
 
-  const elementId = `var-${state.key}`;
-  const labelOrName = state.label ?? state.name;
+  const elementId = `var-${model.state.key}`;
+  const labelOrName = model.state.label ?? model.state.name;
 
-  return <ControlsLabel htmlFor={elementId} label={labelOrName} description={state.description ?? undefined} />;
+  return (
+    <ControlsLabel
+      htmlFor={elementId}
+      isLoading={model.state.loading}
+      onCancel={() => model.onCancel?.()}
+      label={labelOrName}
+      description={model.state.description ?? undefined}
+    />
+  );
 }
 
 const containerStyle = css({ display: 'flex' });

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -38,6 +38,11 @@ export interface SceneVariable<TState extends SceneVariableState = SceneVariable
    * A special function that locally scoped variables can implement
    **/
   isAncestorLoading?(): boolean;
+
+  /**
+   * Allows cancelling variable execution.
+   */
+  onCancel?(): void;
 }
 
 export type VariableValue = VariableValueSingle | VariableValueSingle[];

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -59,7 +59,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     );
   }
 
-  public cancel?(): void {
+  public onCancel(): void {
     this.setStateHelper({ loading: false });
     const sceneVarSet = this.parent as SceneVariableSet;
     sceneVarSet?.cancel(this);


### PR DESCRIPTION
Based on #337 

This unifies the loading indicator (that serves as a cancellation trigger) between data layer controls and variable controls.

Before:
<img width="717" alt="Screenshot 2023-09-14 at 22 40 23" src="https://github.com/grafana/scenes/assets/2376619/c20cda43-50c3-4aa5-bda6-c5428a0bd132">

After:
<img width="717" alt="Screenshot 2023-09-14 at 22 39 57" src="https://github.com/grafana/scenes/assets/2376619/cdb405be-a60e-4ceb-ad58-7ac676033f26">



