### PR TITLE
QueryVariable: Fixes queries with older model

### DIFF
--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -72,6 +72,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
         const runner = createQueryVariableRunner(ds);
         const target = runner.getTarget(this);
         const request = this.getRequest(target);
+
         return runner.runRequest({ variable: this }, request).pipe(
           filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error), // we only care about done or error for now
           take(1), // take the first result, using first caused a bug where it in some situations throw an uncaught error because of no results had been received yet

--- a/packages/scenes/src/variables/variants/query/createQueryVariableRunner.ts
+++ b/packages/scenes/src/variables/variants/query/createQueryVariableRunner.ts
@@ -29,6 +29,11 @@ class StandardQueryRunner implements QueryRunner {
 
   public getTarget(variable: QueryVariable) {
     if (hasStandardVariableSupport(this.datasource)) {
+      // Migrate legacy queries
+      if (!isDataQueryType(variable.state.query)) {
+        variable.setState({ query: { query: variable.state.query, refId: `variable-${variable.state.name}` } });
+      }
+
       return this.datasource.variables.toDataQuery(variable.state.query);
     }
 
@@ -138,4 +143,12 @@ export let createQueryVariableRunner = createQueryVariableRunnerFactory;
  */
 export function setCreateQueryVariableRunnerFactory(fn: (datasource: DataSourceApi) => QueryRunner) {
   createQueryVariableRunner = fn;
+}
+
+function isDataQueryType(query: any): query is DataQuery {
+  if (!query) {
+    return false;
+  }
+
+  return query.hasOwnProperty('refId') && typeof query.refId === 'string';
 }


### PR DESCRIPTION
Fixes #69

Noticed the variables in this dashboard did not work:
http://localhost:3000/grafana/d/-Y-tnEDWk/templating-nested-template-variables?orgId=1

Tracked it down some a migration that happens here: 
https://github.com/grafana/grafana/blob/main/public/app/features/variables/state/actions.ts#L1064

Not sure where we should place this migration, here, when we load the dashboard in core? 