### PR TITLE
AnnotationsDataLayer: Handle data source error

### DIFF
--- a/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
+++ b/packages/scenes/src/querying/layers/SceneDataLayerControls.tsx
@@ -77,6 +77,7 @@ export function SceneDataLayerControl({ layer, isEnabled, onToggleLayer }: Scene
         onCancel={() => layer.cancelQuery?.()}
         label={layer.state.name}
         description={layer.state.description}
+        error={layer.state.data?.errors?.[0].message}
       />
       <InlineSwitch id={elementId} value={isEnabled} onChange={onToggleLayer} />
     </div>

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -1,9 +1,11 @@
 import { arrayToDataFrame, DataTopic, AnnotationQuery } from '@grafana/data';
+import { LoadingState } from '@grafana/schema';
 import { map, Unsubscribable } from 'rxjs';
 import { emptyPanelData } from '../../../core/SceneDataNode';
 import { sceneGraph } from '../../../core/sceneGraph';
 import { SceneDataLayerProvider, SceneTimeRangeLike, SceneDataLayerProviderState } from '../../../core/types';
 import { getDataSource } from '../../../utils/getDataSource';
+import { getMessageFromError } from '../../../utils/getMessageFromError';
 import { SceneDataLayerBase } from '../SceneDataLayerBase';
 import { executeAnnotationQuery } from './standardAnnotationQuery';
 import { postProcessQueryResult } from './utils';
@@ -73,6 +75,18 @@ export class AnnotationsDataLayer
         this.publishResults(stateUpdate, DataTopic.Annotations);
       });
     } catch (e) {
+      this.publishResults(
+        {
+          ...emptyPanelData,
+          state: LoadingState.Error,
+          errors: [
+            {
+              message: getMessageFromError(e),
+            },
+          ],
+        },
+        DataTopic.Annotations
+      );
       console.error('AnnotationsDataLayer error', e);
     }
   }

--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
+import { Icon, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
@@ -10,6 +10,7 @@ interface ControlsLabelProps {
   htmlFor: string;
   description?: string;
   isLoading?: boolean;
+  error?: string;
   onCancel?: () => void;
 }
 
@@ -46,6 +47,15 @@ export function ControlsLabel(props: ControlsLabelProps) {
     );
   }
 
+  let errorIndicator = null;
+  if (props.error) {
+    errorIndicator = (
+      <Tooltip content={props.error} placement={'bottom'}>
+        <Icon className={styles.errorIcon} name="exclamation-triangle" />
+      </Tooltip>
+    );
+  }
+
   return (
     <label
       className={styles.label}
@@ -54,6 +64,7 @@ export function ControlsLabel(props: ControlsLabelProps) {
       }
       htmlFor={props.htmlFor}
     >
+      {errorIndicator}
       {props.label}
       {loadingIndicator}
     </label>
@@ -76,5 +87,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     // To make the border line up with the input border
     right: -1,
     whiteSpace: 'nowrap',
+  }),
+
+  errorIcon: css({
+    color: theme.colors.error.text,
+    marginRight: theme.spacing(1),
   }),
 });

--- a/packages/scenes/src/utils/getMessageFromError.ts
+++ b/packages/scenes/src/utils/getMessageFromError.ts
@@ -1,0 +1,24 @@
+import { isFetchError } from '@grafana/runtime';
+
+export function getMessageFromError(err: unknown): string {
+  if (typeof err === 'string') {
+    return err;
+  }
+
+  if (err) {
+    if (err instanceof Error) {
+      return err.message;
+    } else if (isFetchError(err)) {
+      if (err.data && err.data.message) {
+        return err.data.message;
+      } else if (err.statusText) {
+        return err.statusText;
+      }
+    } else if (err.hasOwnProperty('message')) {
+      // @ts-expect-error
+      return err.message;
+    }
+  }
+
+  return JSON.stringify(err);
+}


### PR DESCRIPTION
Just a cosmetic addition that shows an error message in the data layer control when there's a data source loading error. Other errors for standard annotation queries are emitted from the `runRequest` call.


https://github.com/grafana/scenes/assets/2376619/b760ee5f-3b1d-4736-8f21-5e0b0bf9b4aa





<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.1--canary.342.6223317385.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.3.1--canary.342.6223317385.0
  # or 
  yarn add @grafana/scenes@1.3.1--canary.342.6223317385.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
