### PR TITLE
Annotations filtering operator: Correctly populate filtered frames

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/filterAnnotationsOperator.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/filterAnnotationsOperator.test.ts
@@ -1,0 +1,59 @@
+import { arrayToDataFrame } from '@grafana/data';
+import { of } from 'rxjs';
+import { filterAnnotationsOperator } from './filterAnnotationsOperator';
+
+describe('filterAnnotationsOperator', () => {
+  test('multiple frames', (done) => {
+    const events1 = [
+      {
+        source: {
+          filter: {
+            exclude: true,
+            ids: [1, 2],
+          },
+        },
+      },
+      {
+        source: {
+          filter: {
+            exclude: true,
+            ids: [1, 2],
+          },
+        },
+      },
+    ];
+
+    const events2 = [
+      {
+        source: {
+          filter: {
+            exclude: false,
+            ids: [2],
+          },
+        },
+      },
+      {
+        source: {
+          filter: {
+            exclude: false,
+            ids: [2],
+          },
+        },
+      },
+    ];
+
+    const df1 = arrayToDataFrame(events1);
+    const df2 = arrayToDataFrame(events2);
+
+    const filter = filterAnnotationsOperator({ panelId: 2 })({
+      interpolate: () => '',
+    });
+
+    filter(of([df1, df2])).subscribe((frames) => {
+      expect(frames.length).toBe(2);
+      expect(frames[0].length).toBe(0);
+      expect(frames[1].length).toBe(2);
+      done();
+    });
+  });
+});

--- a/packages/scenes/src/querying/layers/annotations/filterAnnotationsOperator.ts
+++ b/packages/scenes/src/querying/layers/annotations/filterAnnotationsOperator.ts
@@ -11,11 +11,12 @@ export const filterAnnotationsOperator: (filters: DataLayerFilter) => CustomTran
           return data;
         }
 
-        const rows = new Set<number>();
+        const rows = Array.from({ length: data.length }, () => new Set<number>());
 
+        let frameIdx = 0;
         for (const frame of data) {
           for (let index = 0; index < frame.length; index++) {
-            if (rows.has(index)) {
+            if (rows[frameIdx].has(index)) {
               continue;
             }
             let matching = true;
@@ -49,22 +50,24 @@ export const filterAnnotationsOperator: (filters: DataLayerFilter) => CustomTran
             }
 
             if (matching) {
-              rows.add(index);
+              rows[frameIdx].add(index);
             }
           }
+          frameIdx++;
         }
 
         const processed: DataFrame[] = [];
-        const frameLength = rows.size;
 
+        frameIdx = 0;
         for (const frame of data) {
+          const frameLength = rows[frameIdx].size;
           const fields: Field[] = [];
 
           for (const field of frame.fields) {
             const buffer = [];
 
             for (let index = 0; index < frame.length; index++) {
-              if (rows.has(index)) {
+              if (rows[frameIdx].has(index)) {
                 buffer.push(field.values[index]);
                 continue;
               }
@@ -81,8 +84,8 @@ export const filterAnnotationsOperator: (filters: DataLayerFilter) => CustomTran
             fields: fields,
             length: frameLength,
           });
+          frameIdx++;
         }
-
         return processed;
       })
     );


### PR DESCRIPTION
Noticed an issue with filtering when applying data layers in https://github.com/grafana/grafana/pull/74610.


Basically, the resulting frames were all assigned the same length and hence incorrect results were added to frame that should have had annotations filtered out.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.2--canary.343.6224826285.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.3.2--canary.343.6224826285.0
  # or 
  yarn add @grafana/scenes@1.3.2--canary.343.6224826285.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
