### PR TITLE
SceneAppPage: Fix infinite recurision of enrichDataRequest

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneAppPage.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.test.tsx
@@ -1,0 +1,11 @@
+import { SceneAppPage } from './SceneAppPage';
+import { SceneCanvasText } from '../SceneCanvasText';
+
+describe('SceneAppPage', () => {
+  it('enrichDataRequest should handle standalone pages', () => {
+    const page = new SceneAppPage({ title: 'Page', url: '/page' });
+    const source = new SceneCanvasText({ text: 'text' });
+    const result = page.enrichDataRequest(source);
+    expect(result).toBe(null);
+  });
+});

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -61,8 +61,8 @@ export class SceneAppPage extends SceneObjectBase<SceneAppPageState> implements 
   }
 
   public enrichDataRequest(source: SceneObject) {
-    if (!this.parent && this.state.getParentPage) {
-      return this.state.getParentPage().enrichDataRequest(source);
+    if (!this.parent) {
+      return null;
     }
 
     const root = this.getRoot();


### PR DESCRIPTION
Fixes infinite recursion of enrichDataRequest when SceneAppPage is rendered standalone (without a SceneApp parent). 

Also simplify the logic 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.3--canary.345.6226201564.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.3.3--canary.345.6226201564.0
  # or 
  yarn add @grafana/scenes@1.3.3--canary.345.6226201564.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
