### PR TITLE
AnnotationsDataLayer: Provide inheritance extension points

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -27,11 +27,16 @@ export interface AnnotationQueryOptions {
   panel: PanelModel;
 }
 
+export interface AnnotationQueryResults {
+  state: LoadingState;
+  events: AnnotationEvent[];
+}
+
 export function executeAnnotationQuery(
   datasource: DataSourceApi,
   timeRange: SceneTimeRangeLike,
   query: AnnotationQuery
-): Observable<{ state: LoadingState; events: AnnotationEvent[] }> {
+): Observable<AnnotationQueryResults> {
   // Check if we should use the old annotationQuery method
   if (datasource.annotationQuery && shouldUseLegacyRunner(datasource)) {
     console.warn('Using deprecated annotationQuery method, please upgrade your datasource');


### PR DESCRIPTION
This is to allow public dashboards handling in core - in particular to allow PublicAnnotationsDataSource drop in and skipping annotations post processing for public dash.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.4--canary.347.6238186653.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.3.4--canary.347.6238186653.0
  # or 
  yarn add @grafana/scenes@1.3.4--canary.347.6238186653.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
