### PR TITLE
Variables: Fix issue with previous fix

### DIFF
--- a/packages/scenes/src/variables/variants/query/createQueryVariableRunner.ts
+++ b/packages/scenes/src/variables/variants/query/createQueryVariableRunner.ts
@@ -23,7 +23,7 @@ class StandardQueryRunner implements QueryRunner {
 
   public getTarget(variable: QueryVariable) {
     if (hasStandardVariableSupport(this.datasource)) {
-      return this.datasource.variables.toDataQuery(ensureVariableQueryModelIsADataQuery(variable.state.query));
+      return this.datasource.variables.toDataQuery(ensureVariableQueryModelIsADataQuery(variable));
     }
 
     throw new Error("Couldn't create a target with supplied arguments.");


### PR DESCRIPTION
Argh, 

just as I merged https://github.com/grafana/scenes/pull/348 I found an issue with it, sadly typescript did not catch it because query is typed: any in QueryVariable 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.0--canary.350.6245657382.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.5.0--canary.350.6245657382.0
  # or 
  yarn add @grafana/scenes@1.5.0--canary.350.6245657382.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
