### PR TITLE
AnnotationsDataLayer: Events deduplication

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -1,0 +1,80 @@
+import { AnnotationEvent } from '@grafana/data';
+import { LoadingState } from '@grafana/schema';
+import { of } from 'rxjs';
+import { AnnotationsDataLayer } from './AnnotationsDataLayer';
+
+let mockedEvents: AnnotationEvent[] = [];
+jest.mock('./standardAnnotationQuery', () => ({
+  executeAnnotationQuery: () => {
+    return of({
+      state: LoadingState.Done,
+      events: mockedEvents,
+    });
+  },
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => {
+    return {
+      get: jest.fn().mockReturnValue({}),
+    };
+  },
+
+  config: {
+    theme2: {
+      visualization: {
+        getColorByName: jest.fn().mockReturnValue('red'),
+      },
+    },
+  },
+}));
+
+describe('AnnotationsDataLayer', () => {
+  describe('deduplication', () => {
+    it('should remove duplicated annotations', (done) => {
+      const layer = new AnnotationsDataLayer({
+        name: 'Test layer',
+        query: { enable: true, iconColor: 'red', name: 'Test' },
+      });
+      mockedEvents = [
+        { id: '1', time: 1 },
+        { id: '2', time: 2 },
+        { id: '2', time: 2 },
+        { id: '5', time: 5 },
+        { id: '5', time: 5 },
+      ];
+
+      layer.activate();
+
+      layer.getResultsStream().subscribe((res) => {
+        expect(res.data.annotations).toBeDefined();
+        expect(res.data.annotations?.[0].length).toBe(3);
+        done();
+      });
+    });
+
+    it('should leave non "panel-alert" event if present', (done) => {
+      const layer = new AnnotationsDataLayer({
+        name: 'Test layer',
+        query: { enable: true, iconColor: 'red', name: 'Test' },
+      });
+      mockedEvents = [
+        { id: '1', time: 1 },
+        { id: '2', time: 2 },
+        // @ts-expect-error
+        { id: '2', time: 2, eventType: 'panel-alert' },
+        { id: '5', time: 5 },
+        { id: '5', time: 5 },
+      ];
+
+      layer.activate();
+
+      layer.getResultsStream().subscribe((res) => {
+        expect(res.data.annotations).toBeDefined();
+        expect(res.data.annotations?.[0].length).toBe(3);
+        done();
+      });
+    });
+  });
+});

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -8,7 +8,7 @@ import { getDataSource } from '../../../utils/getDataSource';
 import { getMessageFromError } from '../../../utils/getMessageFromError';
 import { SceneDataLayerBase } from '../SceneDataLayerBase';
 import { executeAnnotationQuery } from './standardAnnotationQuery';
-import { postProcessQueryResult } from './utils';
+import { dedupAnnotations, postProcessQueryResult } from './utils';
 
 interface AnnotationsDataLayerState extends SceneDataLayerProviderState {
   query: AnnotationQuery;
@@ -58,7 +58,9 @@ export class AnnotationsDataLayer
       const queryExecution = executeAnnotationQuery(ds, timeRange, query).pipe(
         map((events) => {
           // Feels like this should be done in annotation processing, not as a separate step.
-          const processedEvents = postProcessQueryResult(query, events.events || []);
+          let processedEvents = postProcessQueryResult(query, events.events || []);
+          processedEvents = dedupAnnotations(processedEvents);
+
           const stateUpdate = { ...emptyPanelData, state: events.state };
           const df = arrayToDataFrame(processedEvents);
           df.meta = {

--- a/packages/scenes/src/querying/layers/annotations/utils.ts
+++ b/packages/scenes/src/querying/layers/annotations/utils.ts
@@ -4,7 +4,7 @@
 
 import { AnnotationEvent, AnnotationQuery, DataSourceApi } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, concat, every, find, groupBy, head, map, partition } from 'lodash';
 
 const legacyRunner = [
   'prometheus',
@@ -63,4 +63,30 @@ export function postProcessQueryResult(annotation: AnnotationQuery, results: Ann
   });
 
   return processed;
+}
+
+export function dedupAnnotations(annotations: any) {
+  let dedup = [];
+
+  // Split events by annotationId property existence
+  const events = partition(annotations, 'id');
+
+  const eventsById = groupBy(events[0], 'id');
+  dedup = map(eventsById, (eventGroup) => {
+    if (eventGroup.length > 1 && !every(eventGroup, isPanelAlert)) {
+      // Get first non-panel alert
+      return find(eventGroup, (event) => {
+        return event.eventType !== 'panel-alert';
+      });
+    } else {
+      return head(eventGroup);
+    }
+  });
+
+  dedup = concat(dedup, events[1]);
+  return dedup;
+}
+
+function isPanelAlert(event: { eventType: string }) {
+  return event.eventType === 'panel-alert';
 }


### PR DESCRIPTION
Moves core deduplication logic to `AnnotationsDataLayer`, ref https://github.com/grafana/grafana/blob/main/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts#L64
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.2--canary.351.6247316628.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.5.2--canary.351.6247316628.0
  # or 
  yarn add @grafana/scenes@1.5.2--canary.351.6247316628.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
