### PR TITLE
POC: Panel level group by variable 

### DIFF
--- a/packages/scenes-app/src/demos/groupByAction.tsx
+++ b/packages/scenes-app/src/demos/groupByAction.tsx
@@ -1,0 +1,109 @@
+import {
+  SceneFlexLayout,
+  SceneTimeRange,
+  EmbeddedScene,
+  SceneFlexItem,
+  SceneAppPage,
+  SceneAppPageState,
+  behaviors,
+  PanelBuilders,
+  SceneQueryRunner,
+  SceneVariableSet,
+  QueryVariable,
+  VariableValueSelectors,
+} from '@grafana/scenes';
+import { getEmbeddedSceneDefaults } from './utils';
+
+export function getGoupByActionDemo(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Test of panel level group by variable',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        body: new SceneFlexLayout({
+          direction: 'row',
+          $behaviors: [
+            new behaviors.ActWhenVariableChanged({
+              variableName: 'server',
+              onChange: (variable) => {
+                console.log('server effect', variable);
+              },
+            }),
+          ],
+          children: [
+            new SceneFlexItem({
+              maxHeight: 500,
+              body: PanelBuilders.timeseries()
+                .setTitle('HTTP Requests')
+                .setData(
+                  new SceneQueryRunner({
+                    queries: [
+                      {
+                        refId: 'A',
+                        datasource: { uid: 'gdev-prometheus' },
+                        expr: 'sum(rate(grafana_http_request_duration_seconds_bucket[$__rate_interval])) by ($groupby)',
+                      },
+                    ],
+                  })
+                )
+                .setVariables(
+                  new SceneVariableSet({
+                    variables: [
+                      new QueryVariable({
+                        name: 'groupby',
+                        label: 'Group by',
+                        datasource: { uid: 'gdev-prometheus' },
+                        query: 'label_names(grafana_http_request_duration_seconds_bucket)',
+                        value: '',
+                        text: '',
+                        lazyValue: '',
+                        includeNoValue: true,
+                      }),
+                    ],
+                  })
+                )
+                .setHeaderActions([new VariableValueSelectors({})])
+                .build(),
+            }),
+            new SceneFlexItem({
+              maxHeight: 500,
+              body: PanelBuilders.timeseries()
+                .setTitle('GC Duration')
+                .setData(
+                  new SceneQueryRunner({
+                    queries: [
+                      {
+                        refId: 'A',
+                        datasource: { uid: 'gdev-prometheus' },
+                        expr: 'sum(rate(go_gc_duration_seconds[$__rate_interval])) by ($groupby)',
+                      },
+                    ],
+                  })
+                )
+                .setVariables(
+                  new SceneVariableSet({
+                    variables: [
+                      new QueryVariable({
+                        name: 'groupby',
+                        label: 'Group by',
+                        datasource: { uid: 'gdev-prometheus' },
+                        query: 'label_names(go_gc_duration_seconds)',
+                        value: '',
+                        text: '',
+                        lazyValue: '',
+                        includeNoValue: true,
+                      }),
+                    ],
+                  })
+                )
+                .setHeaderActions([new VariableValueSelectors({})])
+                .build(),
+            }),
+          ],
+        }),
+        $timeRange: new SceneTimeRange(),
+      });
+    },
+  });
+}

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -22,6 +22,7 @@ import { getDocsExamples } from './docs-examples';
 import { getTimeRangeComparisonTest } from './timeRangeComparison';
 import { getCursorSyncTest } from './cursorSync';
 import { getAnnotationsDemo } from './annotations';
+import { getGoupByActionDemo } from './groupByAction';
 
 export interface DemoDescriptor {
   title: string;
@@ -53,5 +54,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Time range comparison', getPage: getTimeRangeComparisonTest },
     { title: 'Data layers', getPage: getAnnotationsDemo },
     { title: 'Docs examples', getPage: getDocsExamples },
+    { title: 'Group by action', getPage: getGoupByActionDemo },
   ];
 }

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -8,7 +8,7 @@ import { MultiValueVariable } from '../variants/MultiValueVariable';
 import { VariableValue, VariableValueSingle } from '../types';
 
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, key } = model.useState();
+  const { value, key, includeNoValue } = model.useState();
 
   return (
     <Select<VariableValue>
@@ -18,9 +18,10 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       value={value}
       allowCustomValue
       tabSelectsValue={false}
+      isClearable={includeNoValue}
       options={model.getOptionsForSelect()}
       onChange={(newValue) => {
-        model.changeValueTo(newValue.value!, newValue.label!);
+        model.changeValueTo(newValue?.value ?? '', newValue?.label ?? '');
       }}
     />
   );

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import { map, Observable } from 'rxjs';
+import { map, Observable, of } from 'rxjs';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 
@@ -30,6 +30,8 @@ export interface MultiValueVariableState extends SceneVariableState {
   defaultToAll?: boolean;
   allValue?: string;
   placeholder?: string;
+  lazyValue?: string;
+  includeNoValue?: boolean;
 }
 
 export interface VariableGetOptionsArgs {
@@ -51,6 +53,11 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
    * This function is called on when SceneVariableSet is activated or when a dependency changes.
    */
   public validateAndUpdate(): Observable<ValidateAndUpdateResult> {
+    // if our current value is same as lazy value we have nothing to do
+    // if (this.state.lazyValue === this.state.value) {
+    //   return of({});
+    // }
+
     return this.getValueOptions({}).pipe(
       map((options) => {
         this.updateValueGivenNewOptions(options);
@@ -75,6 +82,10 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       value: this.state.value,
       text: this.state.text,
     };
+
+    if (this.state.includeNoValue) {
+      stateUpdate.options?.unshift({ value: '', label: '' });
+    }
 
     if (options.length === 0) {
       // TODO handle the no value state


### PR DESCRIPTION
Just a quick POC to explore group by action (variable) on the panel level. 

Platform changes needed 

* Support empty / clearable variables (Very old limitation that we need to address, really unsure how to represent the "no value" value, should it be an empty string or a custom value like `__no_value` like we do for the All value. 
* Support for lazy variables that only issue query for options when you open select (Would be a huge boost in performance for many dashboards load times), and relatively easy  
* PanelChrome header does not fit our selects/input controls. We either need to increase our PanelChrome header height from 32px to possibly as much as 42px, or we need new small variable select controls & inputs 

[Group-by-action---Demos---Scenes-Test-App---Apps---Grafana.webm](https://github.com/grafana/scenes/assets/10999/d2d94750-cd82-4513-bd54-37f6d22e298e)
