### PR TITLE
SceneDataTransformer: Handle transformation errors

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -22,6 +22,7 @@ import { getDocsExamples } from './docs-examples';
 import { getTimeRangeComparisonTest } from './timeRangeComparison';
 import { getCursorSyncTest } from './cursorSync';
 import { getAnnotationsDemo } from './annotations';
+import { getTransformationsTest } from './transformations';
 
 export interface DemoDescriptor {
   title: string;
@@ -52,6 +53,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Cursor sync', getPage: getCursorSyncTest },
     { title: 'Time range comparison', getPage: getTimeRangeComparisonTest },
     { title: 'Data layers', getPage: getAnnotationsDemo },
+    { title: 'Transformations', getPage: getTransformationsTest },
     { title: 'Docs examples', getPage: getDocsExamples },
   ];
 }

--- a/packages/scenes-app/src/demos/transformations.tsx
+++ b/packages/scenes-app/src/demos/transformations.tsx
@@ -1,0 +1,145 @@
+import { CustomTransformOperator, DataFrame, FieldType } from '@grafana/data';
+import { Observable, map } from 'rxjs';
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneDataTransformer,
+  SceneFlexItem,
+  SceneFlexLayout,
+} from '@grafana/scenes';
+import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
+
+export function getTransformationsTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Transformations support ',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        $data: getQueryRunnerWithRandomWalkQuery({
+          scenarioId: 'csv_metric_values',
+          stringInput: '1,20,90,30,5,0',
+        }),
+        body: new SceneFlexLayout({
+          direction: 'row',
+          children: [
+            new SceneFlexItem({
+              body: new SceneFlexLayout({
+                direction: 'column',
+                children: [
+                  new SceneFlexItem({
+                    body: new SceneFlexLayout({
+                      direction: 'row',
+                      children: [
+                        new SceneFlexItem({
+                          body: PanelBuilders.timeseries().setTitle('Source data (global query)').build(),
+                        }),
+                        new SceneFlexItem({
+                          body: PanelBuilders.stat()
+                            .setTitle('Transformed data')
+                            .setData(
+                              new SceneDataTransformer({
+                                transformations: [
+                                  {
+                                    id: 'reduce',
+                                    options: {
+                                      reducers: ['last', 'mean'],
+                                    },
+                                  },
+                                ],
+                              })
+                            )
+                            .build(),
+                        }),
+                        new SceneFlexItem({
+                          body: PanelBuilders.timeseries()
+                            .setTitle('Custom transformer (log10 scale)')
+                            .setData(
+                              new SceneDataTransformer({
+                                transformations: [log10Transform()],
+                              })
+                            )
+                            .build(),
+                        }),
+                        new SceneFlexItem({
+                          body: PanelBuilders.timeseries()
+                            .setTitle('Custom transformer (log10 scale) that throws')
+                            .setData(
+                              new SceneDataTransformer({
+                                transformations: [log10Transform(true)],
+                              })
+                            )
+                            .build(),
+                        }),
+                      ],
+                    }),
+                  }),
+                  new SceneFlexItem({
+                    body: PanelBuilders.stat()
+                      .setTitle('Query with predefined transformations')
+                      .setData(
+                        new SceneDataTransformer({
+                          $data: getQueryRunnerWithRandomWalkQuery(),
+                          transformations: [
+                            {
+                              id: 'reduce',
+                              options: {
+                                reducers: ['mean'],
+                              },
+                            },
+                          ],
+                        })
+                      )
+                      .build(),
+                  }),
+                  new SceneFlexItem({
+                    body: PanelBuilders.stat()
+                      .setTitle('Datasoure and transformations error')
+                      .setData(
+                        new SceneDataTransformer({
+                          $data: getQueryRunnerWithRandomWalkQuery({ datasource: { uid: 'nonexistent' } }),
+                          transformations: [log10Transform(true)],
+                        })
+                      )
+                      .build(),
+                  }),
+                ],
+              }),
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}
+
+const log10Transform: (shouldThrow?: boolean) => CustomTransformOperator =
+  (shouldThrow = false) =>
+  () =>
+  (source: Observable<DataFrame[]>) => {
+    return source.pipe(
+      map((data: DataFrame[]) => {
+        return data.map((frame) => {
+          if (shouldThrow) {
+            data[1999].fields = [];
+          }
+
+          return {
+            ...frame,
+            fields: frame.fields.map((field) => {
+              if (field.type === FieldType.number) {
+                return {
+                  ...field,
+                  values: field.values.map((v) => Math.log(v) / Math.log(10)),
+                };
+              }
+
+              return field;
+            }),
+          };
+        });
+      })
+    );
+  };

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -176,5 +176,11 @@ function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | un
     return pluginLoadingError;
   }
 
-  return data.error ? data.error.message : undefined;
+  let message = data.error ? data.error.message : undefined;
+
+  // Handling multiple errors with a single string until we integrate VizPanel with inspector
+  if (data.errors) {
+    message = data.errors.map((e) => e.message).join(', ');
+  }
+  return message;
 }

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -1,5 +1,6 @@
-import { DataTransformerConfig, PanelData, transformDataFrame } from '@grafana/data';
-import { map, ReplaySubject, Unsubscribable } from 'rxjs';
+import { DataTransformerConfig, LoadingState, PanelData, transformDataFrame } from '@grafana/data';
+import { toDataQueryError } from '@grafana/runtime';
+import { catchError, map, of, ReplaySubject, Unsubscribable } from 'rxjs';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { CustomTransformOperator, SceneDataProvider, SceneDataProviderResult, SceneDataState } from '../core/types';
@@ -118,7 +119,24 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
     };
 
     this._transformSub = transformDataFrame(transformations, data.series, ctx)
-      .pipe(map((series) => ({ ...data, series })))
+      .pipe(
+        map((series) => ({ ...data, series })),
+        catchError((err) => {
+          console.error('Error transforming data: ', err);
+          const sourceErr = this.getSourceData().state.data?.errors || [];
+
+          const transformationError = toDataQueryError(err);
+          transformationError.message = `Error transforming data: ${transformationError.message}`;
+
+          const result: PanelData = {
+            ...data,
+            state: LoadingState.Error,
+            // Combine transformation error with upstream errors
+            errors: [...sourceErr, transformationError],
+          };
+          return of(result);
+        })
+      )
       .subscribe((data) => {
         this._results.next({ origin: this, data });
         this.setState({ data });

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -14,7 +14,7 @@ import {
   ScopedVar,
   transformDataFrame,
 } from '@grafana/data';
-import { getRunRequest } from '@grafana/runtime';
+import { getRunRequest, toDataQueryError } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
@@ -344,6 +344,17 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       }
     } catch (err) {
       console.error('PanelQueryRunner Error', err);
+
+      const result = {
+        ...emptyPanelData,
+        ...this.state.data,
+        state: LoadingState.Error,
+        errors: [toDataQueryError(err)],
+      };
+
+      this.setState({
+        data: result,
+      });
     }
   }
 


### PR DESCRIPTION
This PR applies work by @ryantxu (https://github.com/grafana/grafana/pull/73451) to `SceneDataTransformer`.

Additionally, adds transformations demo to the demo app.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.2--canary.354.6254117203.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.5.2--canary.354.6254117203.0
  # or 
  yarn add @grafana/scenes@1.5.2--canary.354.6254117203.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
