### PR TITLE
SceneApp: Introduce a useSceneApp hook that should replace useMemo as method of caching SceneApp instance 

### DIFF
--- a/docusaurus/docs/scene-app.md
+++ b/docusaurus/docs/scene-app.md
@@ -21,10 +21,11 @@ Scenes come with the following objects that make it easy to build highly interac
 Define a new Scenes app using the `SceneApp` object :
 
 ```tsx
-const getSceneApp = () =>
-  new SceneApp({
+function getSceneApp() {
+  return new SceneApp({
     pages: [],
   });
+}
 ```
 
 ### Step 2. Render the Scenes app in a plugin
@@ -33,7 +34,7 @@ Define a component that will render the Scenes app:
 
 ```tsx
 function MyApp() {
-  const scene = useMemo(() => getSceneApp(), []);
+  const scene = useSceneApp(getSceneApp);
 
   return <scene.Component model={scene} />;
 }

--- a/docusaurus/docs/scene-app.md
+++ b/docusaurus/docs/scene-app.md
@@ -41,7 +41,8 @@ function MyApp() {
 ```
 
 :::note
-Memoize `SceneApp` using `React.useMemo` to avoid unnecessary re-renders.
+Memoize and cache the creation of your `SceneApp` instance using useSceneApp hook. This is very important for url syncing to work properly and it also makes sure data and scene app state
+is not lost when users move away from you app and back.
 :::
 
 In the app plugin, render the Scenes app:

--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -5,8 +5,9 @@ import {
   SceneFlexLayout,
   SceneFlexItem,
   SceneReactObject,
+  useSceneApp,
 } from '@grafana/scenes';
-import React, { useMemo, CSSProperties, useCallback } from 'react';
+import React, { CSSProperties, useCallback } from 'react';
 import { demoUrl, prefixRoute } from '../utils/utils.routing';
 import { DATASOURCE_REF, ROUTES } from '../constants';
 import { DemoDescriptor, getDemos } from '../demos';
@@ -15,7 +16,7 @@ import { config } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 
-const getScene = () => {
+function getDemoSceneApp() {
   const demos = getDemos();
 
   return new SceneApp({
@@ -63,10 +64,10 @@ const getScene = () => {
       }),
     ],
   });
-};
+}
 
 export const DemoListPage = () => {
-  const scene = useMemo(() => getScene(), []);
+  const scene = useSceneApp(getDemoSceneApp);
   return <scene.Component model={scene} />;
 };
 

--- a/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
@@ -8,7 +8,7 @@ import { SceneObject } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
 import { SceneCanvasText } from '../SceneCanvasText';
-import { SceneApp } from './SceneApp';
+import { SceneApp, useSceneApp } from './SceneApp';
 import { SceneAppPage } from './SceneAppPage';
 import { SceneRouteMatch } from './types';
 
@@ -334,6 +334,24 @@ describe('SceneApp', () => {
         expect(await screen.findByTestId('default-fallback-content')).toBeInTheDocument();
       });
     });
+  });
+
+  it('useSceneApp should cache instance', () => {
+    const getSceneApp1 = () =>
+      new SceneApp({
+        pages: [],
+      });
+
+    const getSceneApp2 = () =>
+      new SceneApp({
+        pages: [],
+      });
+
+    const app1 = useSceneApp(getSceneApp1);
+    const app2 = useSceneApp(getSceneApp2);
+
+    expect(app1).toBe(useSceneApp(getSceneApp1));
+    expect(app2).toBe(useSceneApp(getSceneApp2));
   });
 });
 

--- a/packages/scenes/src/components/SceneApp/SceneApp.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.tsx
@@ -33,3 +33,21 @@ export class SceneApp extends SceneObjectBase<SceneAppState> implements DataRequ
     );
   };
 }
+
+const sceneAppCache = new Map<object, SceneApp>();
+
+/**
+ * Caches the the resulting SceneApp returned by the factory function so that it's only called once during the lifetime of the browser tab
+ */
+export function useSceneApp(factory: () => SceneApp) {
+  const cachedApp = sceneAppCache.get(factory);
+
+  if (cachedApp) {
+    return cachedApp;
+  }
+
+  const newApp = factory();
+  sceneAppCache.set(factory, newApp);
+
+  return newApp;
+}

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -63,7 +63,7 @@ export {
   type SceneAppDrilldownView,
   type SceneAppRoute,
 } from './components/SceneApp/types';
-export { SceneApp } from './components/SceneApp/SceneApp';
+export { SceneApp, useSceneApp } from './components/SceneApp/SceneApp';
 export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
 export { SceneObjectRef } from './core/SceneObjectRef';


### PR DESCRIPTION
The problem with our current useMemo recommended approach is that the whole scene app and all the data/scene caches are lost when you leave the app (say click on a link to explore, and then go back)

So this adds a new useSceneApp that adds a global cache that stays put even when you leave the app 