### PR TITLE
AnnotationsDataLayer: Add variables support

### DIFF
--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -208,6 +208,9 @@ export interface SceneDataLayerProviderState extends SceneObjectState {
   data?: PanelData;
   isEnabled?: boolean;
   isHidden?: boolean;
+
+  // Private runtime state
+  _isWaitingForVariables?: boolean;
 }
 
 export interface SceneDataLayerProvider extends SceneObject<SceneDataLayerProviderState> {

--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
@@ -11,6 +11,7 @@ import {
 import { setBaseClassState } from '../../utils/utils';
 import { writeSceneLog } from '../../utils/writeSceneLog';
 import { SceneVariable } from '../../variables/types';
+import { VariableDependencyConfig } from '../../variables/VariableDependencyConfig';
 import { VariableValueRecorder } from '../../variables/VariableValueRecorder';
 
 /**
@@ -54,12 +55,21 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState>
 
   private _variableValueRecorder = new VariableValueRecorder();
 
-  public constructor(initialState: T) {
+  protected _variableDependency: VariableDependencyConfig<T> = new VariableDependencyConfig(this, {
+    onVariableUpdatesCompleted: (variables, dependencyChanged) =>
+      this.onVariableUpdatesCompleted(variables, dependencyChanged),
+  });
+
+  /**
+   * For variables support in data layer provide variableDependencyStatePaths with keys of the state to be scanned for variables.
+   */
+  public constructor(initialState: T, variableDependencyStatePaths: Array<keyof T> = []) {
     super({
       isEnabled: true,
       ...initialState,
     });
 
+    this._variableDependency.setPaths(variableDependencyStatePaths);
     this.addActivationHandler(() => this.onActivate());
   }
 

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -1,24 +1,64 @@
-import { AnnotationEvent } from '@grafana/data';
-import { LoadingState } from '@grafana/schema';
-import { of } from 'rxjs';
+import { DataQueryRequest, DataQueryResponse, DataSourceApi, Field, PanelData, toDataFrame } from '@grafana/data';
+import { AnnotationQuery, LoadingState } from '@grafana/schema';
+import { map, Observable, of } from 'rxjs';
+import { SceneFlexLayout } from '../../../components/layout/SceneFlexLayout';
+import { SceneTimeRange } from '../../../core/SceneTimeRange';
+import { SceneVariableSet } from '../../../variables/sets/SceneVariableSet';
+import { TestScene } from '../../../variables/TestScene';
+import { TestVariable } from '../../../variables/variants/TestVariable';
+import { SceneDataLayers } from '../../SceneDataLayers';
 import { AnnotationsDataLayer } from './AnnotationsDataLayer';
 
-let mockedEvents: AnnotationEvent[] = [];
-jest.mock('./standardAnnotationQuery', () => ({
-  executeAnnotationQuery: () => {
-    return of({
-      state: LoadingState.Done,
-      events: mockedEvents,
-    });
+let mockedEvents: Array<Partial<Field>> = [];
+
+const getDataSourceMock = jest.fn().mockReturnValue({
+  // getRef: () => ({ uid: 'test' }),
+  annotations: {
+    prepareAnnotation: (q: AnnotationQuery) => q,
+    prepareQuery: (q: AnnotationQuery) => q,
   },
-}));
+  query: () =>
+    of({
+      data: [
+        toDataFrame({
+          fields: mockedEvents,
+        }),
+      ],
+    }),
+});
+
+const runRequestMock = jest.fn().mockImplementation((ds: DataSourceApi, request: DataQueryRequest) => {
+  const result: PanelData = {
+    state: LoadingState.Loading,
+    series: [],
+    annotations: [
+      toDataFrame({
+        fields: mockedEvents,
+      }),
+    ],
+    timeRange: request.range,
+  };
+
+  return (ds.query(request) as Observable<DataQueryResponse>).pipe(
+    map((packet) => {
+      result.state = LoadingState.Done;
+      result.annotations = packet.data;
+
+      return result;
+    })
+  );
+});
+
+let sentRequest: DataQueryRequest | undefined;
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => {
-    return {
-      get: jest.fn().mockReturnValue({}),
-    };
+    return { get: getDataSourceMock };
+  },
+  getRunRequest: () => (ds: DataSourceApi, request: DataQueryRequest) => {
+    sentRequest = request;
+    return runRequestMock(ds, request);
   },
 
   config: {
@@ -31,18 +71,21 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('AnnotationsDataLayer', () => {
+  beforeEach(() => {
+    runRequestMock.mockClear();
+  });
+
   describe('deduplication', () => {
     it('should remove duplicated annotations', (done) => {
       const layer = new AnnotationsDataLayer({
         name: 'Test layer',
         query: { enable: true, iconColor: 'red', name: 'Test' },
       });
+
       mockedEvents = [
-        { id: '1', time: 1 },
-        { id: '2', time: 2 },
-        { id: '2', time: 2 },
-        { id: '5', time: 5 },
-        { id: '5', time: 5 },
+        { name: 'time', values: [1, 2, 2, 5, 5] },
+        { name: 'id', values: ['1', '2', '2', '5', '5'] },
+        { name: 'text', values: ['t1', 't2', 't3', 't4', 't5'] },
       ];
 
       layer.activate();
@@ -59,13 +102,12 @@ describe('AnnotationsDataLayer', () => {
         name: 'Test layer',
         query: { enable: true, iconColor: 'red', name: 'Test' },
       });
+
       mockedEvents = [
-        { id: '1', time: 1 },
-        { id: '2', time: 2 },
-        // @ts-expect-error
-        { id: '2', time: 2, eventType: 'panel-alert' },
-        { id: '5', time: 5 },
-        { id: '5', time: 5 },
+        { name: 'time', values: [1, 2, 2, 5, 5] },
+        { name: 'id', values: ['1', '2', '2', '5', '5'] },
+        { name: 'text', values: ['t1', 't2', 't3', 't4', 't5'] },
+        { name: 'eventType', values: [null, null, 'panel-alert', null, null] },
       ];
 
       layer.activate();
@@ -74,6 +116,204 @@ describe('AnnotationsDataLayer', () => {
         expect(res.data.annotations).toBeDefined();
         expect(res.data.annotations?.[0].length).toBe(3);
         done();
+      });
+    });
+  });
+
+  describe('variables support', () => {
+    beforeEach(() => {});
+    describe('When query is using variable that is still loading', () => {
+      it('Should not executed query on activate', async () => {
+        const variable = new TestVariable({ name: 'A', value: '1' });
+        const layer = new AnnotationsDataLayer({
+          name: 'Test layer',
+          query: { name: 'Test', enable: true, iconColor: 'red', theActualQuery: '$A' },
+        });
+
+        const scene = new SceneFlexLayout({
+          $variables: new SceneVariableSet({ variables: [variable] }),
+          $timeRange: new SceneTimeRange(),
+          $data: new SceneDataLayers({
+            layers: [layer],
+          }),
+          children: [],
+        });
+
+        scene.activate();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(variable.state.loading).toBe(true);
+        expect(layer.state.data?.state).toBe(undefined);
+      });
+
+      it('Should not executed query when time range change', async () => {
+        const timeRange = new SceneTimeRange();
+        const variable = new TestVariable({ name: 'A', value: '1' });
+
+        const layer = new AnnotationsDataLayer({
+          name: 'Test layer',
+          query: { name: 'Test', enable: true, iconColor: 'red', theActualQuery: '$A' },
+        });
+
+        const scene = new SceneFlexLayout({
+          $variables: new SceneVariableSet({ variables: [variable] }),
+          $timeRange: timeRange,
+          $data: new SceneDataLayers({
+            layers: [layer],
+          }),
+          children: [],
+        });
+
+        scene.activate();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        timeRange.onRefresh();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(layer.state.data?.state).toBe(undefined);
+      });
+
+      it('Should execute query when variable updates', async () => {
+        const variable = new TestVariable({ name: 'A', value: '', query: 'A.*' });
+
+        mockedEvents = [
+          { name: 'time', values: [1, 2, 3, 4, 5] },
+          { name: 'id', values: ['1', '2', '3', '4', '5'] },
+          { name: 'text', values: ['t1', 't2', 't3', 't4', 't5'] },
+        ];
+
+        const timeRange = new SceneTimeRange();
+        const layer = new AnnotationsDataLayer({
+          name: 'Test layer',
+          query: { name: 'Test', enable: true, iconColor: 'red', theActualQuery: '$A' },
+        });
+
+        const scene = new SceneFlexLayout({
+          $variables: new SceneVariableSet({ variables: [variable] }),
+          $timeRange: timeRange,
+          $data: new SceneDataLayers({
+            layers: [layer],
+          }),
+          children: [],
+        });
+
+        scene.activate();
+        // should execute query when variable completes update
+        variable.signalUpdateCompleted();
+        await new Promise((r) => setTimeout(r, 1));
+        expect(layer.state.data?.state).toBe(LoadingState.Done);
+        expect(layer.state.data?.annotations).toBeDefined();
+        expect(layer.state.data?.annotations?.[0].length).toBe(5);
+
+        variable.changeValueTo('AB');
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        expect(layer.state.data?.annotations).toBeDefined();
+        expect(layer.state.data?.annotations?.[0].length).toBe(5);
+
+        expect(runRequestMock).toBeCalledTimes(2);
+        const { scopedVars } = sentRequest!;
+
+        expect(scopedVars['__sceneObject']).toBeDefined();
+        expect(scopedVars['__sceneObject']?.value).toBe(layer);
+        expect(Object.keys(scopedVars)).toMatchInlineSnapshot(`
+          [
+            "__interval",
+            "__interval_ms",
+            "__annotation",
+            "__sceneObject",
+          ]
+        `);
+      });
+
+      it('Should execute query again after variable changed while inactive', async () => {
+        const variable = new TestVariable({ name: 'A', value: 'AA', query: 'A.*' });
+        const layer = new AnnotationsDataLayer({
+          name: 'Test layer',
+          query: { name: 'Test', enable: true, iconColor: 'red', theActualQuery: '$A' },
+        });
+
+        const innerScene = new TestScene({
+          $data: layer,
+        });
+
+        const scene = new TestScene({
+          $variables: new SceneVariableSet({ variables: [variable] }),
+          $timeRange: new SceneTimeRange(),
+          nested: innerScene,
+        });
+
+        scene.activate();
+        const deactivateInnerScene = innerScene.activate();
+
+        // should execute query when variable completes update
+        variable.signalUpdateCompleted();
+        await new Promise((r) => setTimeout(r, 1));
+        expect(layer.state.data?.state).toBe(LoadingState.Done);
+
+        // simulate we collapse a part of the scene where this query runner is
+        deactivateInnerScene();
+
+        variable.changeValueTo('AB');
+
+        await new Promise((r) => setTimeout(r, 1));
+        // Should not execute query
+        expect(runRequestMock.mock.calls.length).toBe(1);
+        expect(layer.state.data?.state).toBe(LoadingState.Done);
+
+        // now activate again it should detect value change and issue new query
+        innerScene.activate();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        // Should execute query a second time
+        expect(runRequestMock.mock.calls.length).toBe(2);
+      });
+
+      it('Should execute query again after variable changed while whole scene was inactive', async () => {
+        const variable = new TestVariable({ name: 'A', value: 'AA', query: 'A.*' });
+        const layer = new AnnotationsDataLayer({
+          name: 'Test layer',
+          query: { name: 'Test', enable: true, iconColor: 'red', theActualQuery: '$A' },
+        });
+
+        const scene = new TestScene({
+          $variables: new SceneVariableSet({ variables: [variable] }),
+          $timeRange: new SceneTimeRange(),
+          $data: new SceneDataLayers({
+            layers: [layer],
+          }),
+        });
+
+        const deactivateScene = scene.activate();
+
+        // should execute query when variable completes update
+        variable.signalUpdateCompleted();
+        await new Promise((r) => setTimeout(r, 1));
+        expect(layer.state.data?.state).toBe(LoadingState.Done);
+
+        // Deactivate scene which deactivates SceneVariableSet
+        deactivateScene();
+
+        // Now change value
+        variable.changeValueTo('AB');
+        // Allow rxjs logic time run
+        await new Promise((r) => setTimeout(r, 1));
+        // Should not execute query
+        expect(runRequestMock.mock.calls.length).toBe(1);
+        expect(layer.state.data?.state).toBe(LoadingState.Done);
+
+        // now activate again it should detect value change and issue new query
+        scene.activate();
+
+        await new Promise((r) => setTimeout(r, 1));
+
+        // Should execute query a second time
+        expect(runRequestMock.mock.calls.length).toBe(2);
       });
     });
   });

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -6,6 +6,8 @@ import { sceneGraph } from '../../../core/sceneGraph';
 import { SceneDataLayerProvider, SceneTimeRangeLike, SceneDataLayerProviderState } from '../../../core/types';
 import { getDataSource } from '../../../utils/getDataSource';
 import { getMessageFromError } from '../../../utils/getMessageFromError';
+import { writeSceneLog } from '../../../utils/writeSceneLog';
+import { VariableDependencyConfig } from '../../../variables/VariableDependencyConfig';
 import { SceneDataLayerBase } from '../SceneDataLayerBase';
 import { AnnotationQueryResults, executeAnnotationQuery } from './standardAnnotationQuery';
 import { dedupAnnotations, postProcessQueryResult } from './utils';
@@ -20,6 +22,15 @@ export class AnnotationsDataLayer
 {
   private _timeRangeSub: Unsubscribable | undefined;
   public topic = DataTopic.Annotations;
+
+  protected _variableDependency: VariableDependencyConfig<AnnotationsDataLayerState> = new VariableDependencyConfig(
+    this,
+    {
+      statePaths: ['query'],
+      onVariableUpdatesCompleted: (variables, dependencyChanged) =>
+        this.onVariableUpdatesCompleted(variables, dependencyChanged),
+    }
+  );
 
   public constructor(initialState: AnnotationsDataLayerState) {
     super({
@@ -41,6 +52,7 @@ export class AnnotationsDataLayer
   }
 
   public runLayer() {
+    writeSceneLog('AnnotationsDataLayer', 'run layer');
     const timeRange = sceneGraph.getTimeRange(this);
     this.runWithTimeRange(timeRange);
   }
@@ -52,10 +64,16 @@ export class AnnotationsDataLayer
       this.querySub.unsubscribe();
     }
 
+    if (sceneGraph.hasVariableDependencyInLoadingState(this)) {
+      writeSceneLog('AnnotationsDataLayer', 'Variable dependency is in loading state, skipping query execution');
+      this.setState({ _isWaitingForVariables: true });
+      return;
+    }
+
     try {
       const ds = await this.resolveDataSource(query);
 
-      const queryExecution = executeAnnotationQuery(ds, timeRange, query).pipe(
+      const queryExecution = executeAnnotationQuery(ds, timeRange, query, this).pipe(
         map((events) => {
           const stateUpdate = this.processEvents(query, events);
           return stateUpdate;

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -7,7 +7,6 @@ import { SceneDataLayerProvider, SceneTimeRangeLike, SceneDataLayerProviderState
 import { getDataSource } from '../../../utils/getDataSource';
 import { getMessageFromError } from '../../../utils/getMessageFromError';
 import { writeSceneLog } from '../../../utils/writeSceneLog';
-import { VariableDependencyConfig } from '../../../variables/VariableDependencyConfig';
 import { SceneDataLayerBase } from '../SceneDataLayerBase';
 import { AnnotationQueryResults, executeAnnotationQuery } from './standardAnnotationQuery';
 import { dedupAnnotations, postProcessQueryResult } from './utils';
@@ -23,20 +22,14 @@ export class AnnotationsDataLayer
   private _timeRangeSub: Unsubscribable | undefined;
   public topic = DataTopic.Annotations;
 
-  protected _variableDependency: VariableDependencyConfig<AnnotationsDataLayerState> = new VariableDependencyConfig(
-    this,
-    {
-      statePaths: ['query'],
-      onVariableUpdatesCompleted: (variables, dependencyChanged) =>
-        this.onVariableUpdatesCompleted(variables, dependencyChanged),
-    }
-  );
-
   public constructor(initialState: AnnotationsDataLayerState) {
-    super({
-      isEnabled: true,
-      ...initialState,
-    });
+    super(
+      {
+        isEnabled: true,
+        ...initialState,
+      },
+      ['query']
+    );
   }
 
   public onEnable(): void {

--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -16,7 +16,7 @@ import {
 import { getRunRequest } from '@grafana/runtime';
 import { shouldUseLegacyRunner, standardAnnotationSupport } from './standardAnnotationsSupport';
 import { Dashboard, LoadingState } from '@grafana/schema';
-import { SceneTimeRangeLike } from '../../../core/types';
+import { SceneObject, SceneTimeRangeLike } from '../../../core/types';
 let counter = 100;
 function getNextRequestId() {
   return 'AQ' + counter++;
@@ -35,7 +35,8 @@ export interface AnnotationQueryResults {
 export function executeAnnotationQuery(
   datasource: DataSourceApi,
   timeRange: SceneTimeRangeLike,
-  query: AnnotationQuery
+  query: AnnotationQuery,
+  layer: SceneObject
 ): Observable<AnnotationQueryResults> {
   // Check if we should use the old annotationQuery method
   if (datasource.annotationQuery && shouldUseLegacyRunner(datasource)) {
@@ -94,6 +95,7 @@ export function executeAnnotationQuery(
     __interval: { text: interval.interval, value: interval.interval },
     __interval_ms: { text: interval.intervalMs.toString(), value: interval.intervalMs },
     __annotation: { text: annotation.name, value: annotation },
+    __sceneObject: { text: '__sceneObject', value: layer },
   };
 
   const queryRequest: DataQueryRequest = {

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -109,6 +109,10 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
     return this._dependencies;
   }
 
+  public setPaths(paths: Array<keyof TState>) {
+    this._statePaths = paths;
+  }
+
   private scanStateForDependencies(state: TState) {
     this._dependencies.clear();
     this.scanCount += 1;

--- a/packages/scenes/src/variables/VariableValueRecorder.ts
+++ b/packages/scenes/src/variables/VariableValueRecorder.ts
@@ -12,7 +12,11 @@ export class VariableValueRecorder {
   public recordCurrentDependencyValuesForSceneObject(sceneObject: SceneObject) {
     this.clearValues();
 
-    for (const variableName of sceneObject.variableDependency!.getNames()) {
+    if (!sceneObject.variableDependency) {
+      return;
+    }
+
+    for (const variableName of sceneObject.variableDependency.getNames()) {
       const variable = sceneGraph.lookupVariable(variableName, sceneObject);
       if (variable) {
         this._values.set(variable, variable.getValue());
@@ -52,7 +56,11 @@ export class VariableValueRecorder {
       return false;
     }
 
-    for (const variableName of sceneObject.variableDependency!.getNames()) {
+    if (!sceneObject.variableDependency) {
+      return false;
+    }
+
+    for (const variableName of sceneObject.variableDependency.getNames()) {
       const variable = sceneGraph.lookupVariable(variableName, sceneObject);
       if (variable && this._values.has(variable)) {
         const value = this._values.get(variable);


### PR DESCRIPTION
This mostly does the same thing as `SceneQueryRunner` to support variables in annotation queries. Tests are literally the same.

`SceneDataLayerBase` handles basic behaviors (like skipping execution on activation when the variable is not loaded), while AnnotationsDataLayer implements the variables to support itself. `SceneDataLayerBase` also handles variable values recording, hence the subtle change in `VariableValueRecorder`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.6.0--canary.358.6274180040.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.6.0--canary.358.6274180040.0
  # or 
  yarn add @grafana/scenes@1.6.0--canary.358.6274180040.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
