### PR TITLE
VizPanel: Allow options and field config updates

### DIFF
--- a/packages/scenes-app/src/demos/dynamicPanelOptions.tsx
+++ b/packages/scenes-app/src/demos/dynamicPanelOptions.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import {
+  EmbeddedScene,
+  FieldConfigBuilders,
+  PanelBuilders,
+  PanelOptionsBuilders,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneComponentProps,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanel,
+} from '@grafana/scenes';
+import { RadioButtonGroup } from '@grafana/ui';
+import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
+import { GraphDrawStyle, LegendDisplayMode, StackingMode, TooltipDisplayMode } from '@grafana/schema';
+
+export function getDynamicVizOptionsTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'A panel with actions that change visualization settings',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        key: 'Dynamic options demo',
+        $data: getQueryRunnerWithRandomWalkQuery({ seriesCount: 3, spread: 15 }, { maxDataPoints: 50 }),
+        body: new SceneFlexLayout({
+          direction: 'row',
+          children: [
+            new SceneFlexItem({
+              body: PanelBuilders.timeseries()
+                .setTitle('Graph')
+                .setHeaderActions([new VizOptions({ value: 'lines' })])
+                .build(),
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}
+
+interface VizOptionsState extends SceneObjectState {
+  value: string;
+}
+
+class VizOptions extends SceneObjectBase<VizOptionsState> {
+  private intervalId?: NodeJS.Timer;
+
+  public onChange = (value: string) => {
+    clearInterval(this.intervalId);
+    this.setState({ value });
+    const viz = this.parent as VizPanel;
+
+    switch (value) {
+      case 'random_description':
+        viz.onDescriptionChange(getRandomSentence());
+        break;
+      case 'random_title':
+        viz.onTitleChange(getRandomSentence());
+        this.intervalId = setInterval(() => {
+          viz.onTitleChange(getRandomSentence());
+        }, 2000);
+        break;
+      case 'lines':
+        viz.onFieldConfigChange(FieldConfigBuilders.timeseries().build(), true);
+        viz.onOptionsChange(PanelOptionsBuilders.timeseries().build(), true);
+        break;
+      case 'bars_stacked':
+        viz.onFieldConfigChange(
+          FieldConfigBuilders.timeseries()
+            .setCustomFieldConfig('fillOpacity', 35)
+            .setCustomFieldConfig('drawStyle', GraphDrawStyle.Bars)
+            .setCustomFieldConfig('stacking', {
+              mode: StackingMode.Normal,
+              group: 'A',
+            })
+            .build()
+        );
+        viz.onOptionsChange(
+          PanelOptionsBuilders.timeseries()
+            .setOption('legend', {
+              displayMode: LegendDisplayMode.Table,
+            })
+            .build()
+        );
+        break;
+      case 'lines_stacked':
+        viz.onFieldConfigChange(
+          FieldConfigBuilders.timeseries()
+            .setCustomFieldConfig('fillOpacity', 10)
+            .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+            .setCustomFieldConfig('stacking', {
+              mode: StackingMode.Normal,
+              group: 'A',
+            })
+            .build()
+        );
+        viz.onOptionsChange(
+          PanelOptionsBuilders.timeseries()
+            .setOption('tooltip', {
+              mode: TooltipDisplayMode.Multi,
+            })
+            .build(),
+          true
+        );
+        break;
+    }
+  };
+
+  public static Component = ({ model }: SceneComponentProps<VizOptions>) => {
+    const { value } = model.useState();
+
+    const vizOptions = [
+      { label: 'Default config', value: 'lines' },
+      { label: 'Bars stacked & table legend', value: 'bars_stacked' },
+      { label: 'Lines stacked & tooltip multi', value: 'lines_stacked' },
+      { label: 'Random title (every 2 sec)', value: 'random_title' },
+      { label: 'Random description', value: 'random_description' },
+    ];
+
+    return (
+      <>
+        <RadioButtonGroup value={value} options={vizOptions} onChange={model.onChange} size="sm" />
+      </>
+    );
+  };
+}
+
+function getRandomSentence(): string {
+  const subjects = ['I', 'You', 'We', 'They'];
+  const verbs = ['run', 'eat', 'sleep', 'dance', 'sing'];
+  const objects = ['apples', 'bananas', 'books', 'cats', 'dogs'];
+
+  const randomSubject = subjects[Math.floor(Math.random() * subjects.length)];
+  const randomVerb = verbs[Math.floor(Math.random() * verbs.length)];
+  const randomObject = objects[Math.floor(Math.random() * objects.length)];
+
+  return `${randomSubject} ${randomVerb} ${randomObject}.`;
+}

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -23,6 +23,7 @@ import { getTimeRangeComparisonTest } from './timeRangeComparison';
 import { getCursorSyncTest } from './cursorSync';
 import { getAnnotationsDemo } from './annotations';
 import { getTransformationsTest } from './transformations';
+import { getDynamicVizOptionsTest } from './dynamicPanelOptions';
 
 export interface DemoDescriptor {
   title: string;
@@ -54,6 +55,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Time range comparison', getPage: getTimeRangeComparisonTest },
     { title: 'Data layers', getPage: getAnnotationsDemo },
     { title: 'Transformations', getPage: getTransformationsTest },
+    { title: 'Dynamic panel options and field config', getPage: getDynamicVizOptionsTest },
     { title: 'Docs examples', getPage: getDocsExamples },
   ];
 }

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -30,15 +30,16 @@ import { emptyPanelData } from '../../core/SceneDataNode';
 import { changeSeriesColorConfigFactory } from './colorSeriesConfigFactory';
 import { loadPanelPluginSync } from './registerRuntimePanelPlugin';
 import { getCursorSyncScope } from '../../behaviors/CursorSync';
+import { cloneDeep, merge } from 'lodash';
 
 export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectState {
-  title: string;
-  description?: string;
   /**
    * This is usually a plugin id that references a core plugin or an external plugin. But this can also reference a
    * runtime registered PanelPlugin registered via function registerScenePanelPlugin.
    */
   pluginId: string;
+  title: string;
+  description?: string;
   options: DeepPartial<TOptions>;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;
@@ -51,7 +52,9 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   pluginInstanceState?: any;
 }
 
-export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<VizPanelState<TOptions, TFieldConfig>> {
+export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends SceneObjectBase<
+  VizPanelState<TOptions, TFieldConfig>
+> {
   public static Component = VizPanelRenderer;
 
   protected _variableDependency = new VariableDependencyConfig(this, {
@@ -159,7 +162,7 @@ export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<
     return this._panelContext!;
   }
 
-  public onChangeTimeRange = (timeRange: AbsoluteTimeRange) => {
+  public onTimeRangeChange = (timeRange: AbsoluteTimeRange) => {
     const sceneTimeRange = sceneGraph.getTimeRange(this);
     sceneTimeRange.onTimeRangeChange({
       raw: {
@@ -171,12 +174,52 @@ export class VizPanel<TOptions = {}, TFieldConfig = {}> extends SceneObjectBase<
     });
   };
 
-  public onOptionsChange = (options: TOptions) => {
-    this.setState({ options });
+  public onTitleChange = (title: string) => {
+    this.setState({ title });
   };
 
-  public onFieldConfigChange = (fieldConfig: FieldConfigSource<TFieldConfig>) => {
-    this.setState({ fieldConfig });
+  public onDescriptionChange = (description: string) => {
+    this.setState({ description });
+  };
+
+  public onDisplayModeChange = (displayMode: 'default' | 'transparent') => {
+    this.setState({ displayMode });
+  };
+
+  public onOptionsChange = (optionsUpdate: DeepPartial<TOptions>, replace = false) => {
+    const { fieldConfig, options } = this.state;
+
+    // When replace is true, we want to replace the entire options object. Default will be applied.
+    const nextOptions = replace ? optionsUpdate : merge(cloneDeep(options), optionsUpdate);
+
+    const withDefaults = getPanelOptionsWithDefaults({
+      plugin: this._plugin!,
+      currentOptions: nextOptions,
+      currentFieldConfig: fieldConfig,
+      isAfterPluginChange: false,
+    });
+
+    this.setState({
+      options: withDefaults.options,
+    });
+  };
+
+  public onFieldConfigChange = (fieldConfigUpdate: FieldConfigSource<DeepPartial<TFieldConfig>>, replace?: boolean) => {
+    const { fieldConfig, options } = this.state;
+
+    // When replace is true, we want to replace the entire field config. Default will be applied.
+    const nextFieldConfig = replace ? fieldConfigUpdate : merge(cloneDeep(fieldConfig), fieldConfigUpdate);
+
+    const withDefaults = getPanelOptionsWithDefaults({
+      plugin: this._plugin!,
+      currentOptions: options,
+      currentFieldConfig: nextFieldConfig,
+      isAfterPluginChange: false,
+    });
+
+    this.setState({
+      fieldConfig: withDefaults.fieldConfig,
+    });
   };
 
   public interpolate = ((value: string, scoped?: ScopedVars, format?: string | VariableCustomFormatterFn) => {

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -127,7 +127,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                         replaceVariables={model.interpolate}
                         onOptionsChange={model.onOptionsChange}
                         onFieldConfigChange={model.onFieldConfigChange}
-                        onChangeTimeRange={model.onChangeTimeRange}
+                        onChangeTimeRange={model.onTimeRangeChange}
                         eventBus={getAppEvents()}
                       />
                     )}

--- a/packages/scenes/src/core/PanelBuilders/FieldConfigBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/FieldConfigBuilder.ts
@@ -1,0 +1,141 @@
+import { FieldConfigSource } from '@grafana/data';
+import { cloneDeep, merge } from 'lodash';
+import { DeepPartial } from '../types';
+import { FieldConfigOverridesBuilder } from './FieldConfigOverridesBuilder';
+import { StandardFieldConfig, StandardFieldConfigInterface } from './types';
+
+export class FieldConfigBuilder<TFieldConfig extends {}>
+  implements StandardFieldConfigInterface<StandardFieldConfig, FieldConfigBuilder<TFieldConfig>, 'set'>
+{
+  private _fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>> = {
+    defaults: {},
+    overrides: [],
+  };
+  private _overridesBuilder = new FieldConfigOverridesBuilder<TFieldConfig>();
+
+  public constructor(private defaultFieldConfig?: () => TFieldConfig) {
+    this.setDefaults();
+  }
+
+  private setDefaults() {
+    const fieldConfig: FieldConfigSource<TFieldConfig> = {
+      defaults: {
+        custom: this.defaultFieldConfig ? cloneDeep(this.defaultFieldConfig()) : ({} as TFieldConfig),
+      }, // use field config factory that will provide default field config
+      overrides: [],
+    };
+
+    this._fieldConfig = fieldConfig;
+  }
+  /**
+   * Set color.
+   */
+  public setColor(color: StandardFieldConfig['color']): this {
+    return this.setFieldConfigDefaults('color', color);
+  }
+
+  /**
+   * Set number of decimals to show.
+   */
+  public setDecimals(decimals: StandardFieldConfig['decimals']): this {
+    return this.setFieldConfigDefaults('decimals', decimals);
+  }
+
+  /**
+   * Set field display name.
+   */
+  public setDisplayName(displayName: StandardFieldConfig['displayName']): this {
+    return this.setFieldConfigDefaults('displayName', displayName);
+  }
+
+  /**
+   * Set the standard field config property filterable.
+   */
+  public setFilterable(filterable: StandardFieldConfig['filterable']): this {
+    return this.setFieldConfigDefaults('filterable', filterable);
+  }
+
+  /**
+   * Set data links.
+   */
+  public setLinks(links: StandardFieldConfig['links']): this {
+    return this.setFieldConfigDefaults('links', links);
+  }
+
+  /**
+   * Set value mappings.
+   */
+  public setMappings(mappings: StandardFieldConfig['mappings']): this {
+    return this.setFieldConfigDefaults('mappings', mappings);
+  }
+
+  /**
+   * Set the standard field config property max.
+   */
+  public setMax(max: StandardFieldConfig['max']): this {
+    return this.setFieldConfigDefaults('max', max);
+  }
+
+  /**
+   * Set the standard field config property min.
+   */
+  public setMin(min: StandardFieldConfig['min']): this {
+    return this.setFieldConfigDefaults('min', min);
+  }
+
+  /**
+   * Set the standard field config property noValue.
+   */
+  public setNoValue(noValue: StandardFieldConfig['noValue']): this {
+    return this.setFieldConfigDefaults('noValue', noValue);
+  }
+
+  /**
+   * Set the standard field config property thresholds.
+   */
+  public setThresholds(thresholds: StandardFieldConfig['thresholds']): this {
+    return this.setFieldConfigDefaults('thresholds', thresholds);
+  }
+
+  /**
+   * Set the standard field config property unit.
+   */
+  public setUnit(unit: StandardFieldConfig['unit']): this {
+    return this.setFieldConfigDefaults('unit', unit);
+  }
+
+  /**
+   * Set an individual custom field config value. This will merge the value with the existing custom field config.
+   */
+  public setCustomFieldConfig<T extends TFieldConfig, K extends keyof T>(id: K, value: DeepPartial<T[K]>): this {
+    this._fieldConfig.defaults = {
+      ...this._fieldConfig.defaults,
+      custom: merge(this._fieldConfig.defaults.custom, { [id]: value }),
+    };
+
+    return this;
+  }
+
+  /**
+   * Configure overrides for the field config. This will merge the overrides with the existing overrides.
+   */
+  public setOverrides(builder: (b: FieldConfigOverridesBuilder<TFieldConfig>) => void): this {
+    builder(this._overridesBuilder);
+    return this;
+  }
+
+  public setFieldConfigDefaults<T extends keyof StandardFieldConfig>(key: T, value: StandardFieldConfig[T]) {
+    this._fieldConfig.defaults = {
+      ...this._fieldConfig.defaults,
+      [key]: value,
+    };
+    return this;
+  }
+
+  public build() {
+    return {
+      defaults: this._fieldConfig.defaults,
+      overrides: this._overridesBuilder.build(),
+    };
+  }
+}

--- a/packages/scenes/src/core/PanelBuilders/FieldConfigBuilders.ts
+++ b/packages/scenes/src/core/PanelBuilders/FieldConfigBuilders.ts
@@ -1,0 +1,90 @@
+import { TableFieldOptions as TableFieldConfig } from '@grafana/schema';
+
+import {
+  FieldConfig as BarChartFieldConfig,
+  defaultFieldConfig as defaultBarChartFieldConfig,
+} from '@grafana/schema/dist/esm/raw/composable/barchart/panelcfg/x/BarChartPanelCfg_types.gen';
+import { FieldConfig as HeatmapFieldConfig } from '@grafana/schema/dist/esm/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen';
+import {
+  FieldConfig as HistogramFieldConfig,
+  defaultFieldConfig as defaultHistogramFieldConfig,
+} from '@grafana/schema/dist/esm/raw/composable/histogram/panelcfg/x/HistogramPanelCfg_types.gen';
+import { FieldConfig as PieChartFieldConfig } from '@grafana/schema/dist/esm/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen';
+import {
+  FieldConfig as StateTimelineFieldConfig,
+  defaultFieldConfig as defaultStateTimelineFieldConfig,
+} from '@grafana/schema/dist/esm/raw/composable/statetimeline/panelcfg/x/StateTimelinePanelCfg_types.gen';
+import {
+  FieldConfig as StatusHistoryFieldConfig,
+  defaultFieldConfig as defaultStatusHistoryFieldConfig,
+} from '@grafana/schema/dist/esm/raw/composable/statushistory/panelcfg/x/StatusHistoryPanelCfg_types.gen';
+import { FieldConfig as TimeSeriesFieldConfig } from '@grafana/schema/dist/esm/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen';
+import { FieldConfig as TrendFieldConfig } from '@grafana/schema/dist/esm/raw/composable/trend/panelcfg/x/TrendPanelCfg_types.gen';
+import { defaultScatterFieldConfig as defaultXYChartFieldConfig } from '@grafana/schema/dist/esm/raw/composable/xychart/panelcfg/x/XYChartPanelCfg_types.gen';
+import { FieldConfigBuilder } from './FieldConfigBuilder';
+
+export const FieldConfigBuilders = {
+  barchart() {
+    return new FieldConfigBuilder<BarChartFieldConfig>(() => defaultBarChartFieldConfig);
+  },
+  bargauge() {
+    return new FieldConfigBuilder<{}>();
+  },
+  datagrid() {
+    return new FieldConfigBuilder<{}>();
+  },
+  flamegraph() {
+    return new FieldConfigBuilder<{}>();
+  },
+  gauge() {
+    return new FieldConfigBuilder<{}>();
+  },
+  geomap() {
+    return new FieldConfigBuilder<{}>();
+  },
+  heatmap() {
+    return new FieldConfigBuilder<HeatmapFieldConfig>();
+  },
+  histogram() {
+    return new FieldConfigBuilder<HistogramFieldConfig>(() => defaultHistogramFieldConfig);
+  },
+  logs() {
+    return new FieldConfigBuilder<{}>();
+  },
+  news() {
+    return new FieldConfigBuilder<{}>();
+  },
+  nodegraph() {
+    return new FieldConfigBuilder<{}>();
+  },
+  piechart() {
+    return new FieldConfigBuilder<PieChartFieldConfig>();
+  },
+  stat() {
+    return new FieldConfigBuilder<{}>();
+  },
+  statetimeline() {
+    return new FieldConfigBuilder<StateTimelineFieldConfig>(() => defaultStateTimelineFieldConfig);
+  },
+  statushistory() {
+    return new FieldConfigBuilder<StatusHistoryFieldConfig>(() => defaultStatusHistoryFieldConfig);
+  },
+  table() {
+    return new FieldConfigBuilder<TableFieldConfig>();
+  },
+  text() {
+    return new FieldConfigBuilder<{}>();
+  },
+  timeseries() {
+    return new FieldConfigBuilder<TimeSeriesFieldConfig>();
+  },
+  trend() {
+    return new FieldConfigBuilder<{}>();
+  },
+  traces() {
+    return new FieldConfigBuilder<TrendFieldConfig>();
+  },
+  xychart() {
+    return new FieldConfigBuilder<{}>(() => defaultXYChartFieldConfig);
+  },
+};

--- a/packages/scenes/src/core/PanelBuilders/PanelOptionsBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/PanelOptionsBuilder.ts
@@ -1,0 +1,26 @@
+import { cloneDeep, merge } from 'lodash';
+import { DeepPartial } from '../types';
+
+export class PanelOptionsBuilder<TOptions extends {} = {}> {
+  private _options: DeepPartial<TOptions> = {};
+
+  public constructor(private defaultOptions?: () => Partial<TOptions>) {
+    this.setDefaults();
+  }
+
+  private setDefaults() {
+    this._options = this.defaultOptions ? cloneDeep(this.defaultOptions()) : ({} as TOptions);
+  }
+
+  /**
+   * Set an individual panel option. This will merge the value with the existing options.
+   */
+  public setOption<T extends TOptions, K extends keyof T>(id: K, value: DeepPartial<T[K]>): this {
+    this._options = merge(this._options, { [id]: value });
+    return this;
+  }
+
+  public build() {
+    return this._options;
+  }
+}

--- a/packages/scenes/src/core/PanelBuilders/PanelOptionsBuilders.ts
+++ b/packages/scenes/src/core/PanelBuilders/PanelOptionsBuilders.ts
@@ -1,0 +1,132 @@
+import {
+  Options as BarChartOptions,
+  defaultOptions as defaultBarChartOptions,
+} from '@grafana/schema/dist/esm/raw/composable/barchart/panelcfg/x/BarChartPanelCfg_types.gen';
+import {
+  Options as BarGaugeOptions,
+  defaultOptions as defaultBarGaugeOptions,
+} from '@grafana/schema/dist/esm/raw/composable/bargauge/panelcfg/x/BarGaugePanelCfg_types.gen';
+import {
+  Options as DataGridOptions,
+  defaultOptions as defaultDataGridOptions,
+} from '@grafana/schema/dist/esm/raw/composable/datagrid/panelcfg/x/DatagridPanelCfg_types.gen';
+import {
+  Options as GaugeOptions,
+  defaultOptions as defaultGaugeOptions,
+} from '@grafana/schema/dist/esm/raw/composable/gauge/panelcfg/x/GaugePanelCfg_types.gen';
+import {
+  Options as GeomapOptions,
+  defaultOptions as defaultGeomapOptions,
+} from '@grafana/schema/dist/esm/raw/composable/geomap/panelcfg/x/GeomapPanelCfg_types.gen';
+import {
+  Options as HeatmapOptions,
+  defaultOptions as defaultHeatmapOptions,
+} from '@grafana/schema/dist/esm/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen';
+import {
+  Options as HistogramOptions,
+  defaultOptions as defaultHistogramOptions,
+} from '@grafana/schema/dist/esm/raw/composable/histogram/panelcfg/x/HistogramPanelCfg_types.gen';
+import { Options as LogsOptions } from '@grafana/schema/dist/esm/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen';
+import {
+  Options as NewsOptions,
+  defaultOptions as defaultNewsOptions,
+} from '@grafana/schema/dist/esm/raw/composable/news/panelcfg/x/NewsPanelCfg_types.gen';
+import { Options as NodeGraphOptions } from '@grafana/schema/dist/esm/raw/composable/nodegraph/panelcfg/x/NodeGraphPanelCfg_types.gen';
+import {
+  Options as PieChartOptions,
+  defaultOptions as defaultPieChartOptions,
+} from '@grafana/schema/dist/esm/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen';
+import {
+  Options as StatOptions,
+  defaultOptions as defaultStatOptions,
+} from '@grafana/schema/dist/esm/raw/composable/stat/panelcfg/x/StatPanelCfg_types.gen';
+import {
+  Options as StateTimelineOptions,
+  defaultOptions as defaultStateTimelineOptions,
+} from '@grafana/schema/dist/esm/raw/composable/statetimeline/panelcfg/x/StateTimelinePanelCfg_types.gen';
+import {
+  Options as StatusHistoryOptions,
+  defaultOptions as defaultStatusHistoryOptions,
+} from '@grafana/schema/dist/esm/raw/composable/statushistory/panelcfg/x/StatusHistoryPanelCfg_types.gen';
+import {
+  Options as TableOptions,
+  defaultOptions as defaultTableOptions,
+} from '@grafana/schema/dist/esm/raw/composable/table/panelcfg/x/TablePanelCfg_types.gen';
+import {
+  Options as TextOptions,
+  defaultOptions as defaultTextOptions,
+} from '@grafana/schema/dist/esm/raw/composable/text/panelcfg/x/TextPanelCfg_types.gen';
+import { Options as TimeSeriesOptions } from '@grafana/schema/dist/esm/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen';
+import { Options as TrendOptions } from '@grafana/schema/dist/esm/raw/composable/trend/panelcfg/x/TrendPanelCfg_types.gen';
+import {
+  Options as XYChartOptions,
+  defaultOptions as defaultXYChartOptions,
+} from '@grafana/schema/dist/esm/raw/composable/xychart/panelcfg/x/XYChartPanelCfg_types.gen';
+
+import { PanelOptionsBuilder } from './PanelOptionsBuilder';
+
+export const PanelOptionsBuilders = {
+  barchart() {
+    return new PanelOptionsBuilder<BarChartOptions>(() => defaultBarChartOptions);
+  },
+  bargauge() {
+    return new PanelOptionsBuilder<BarGaugeOptions>(() => defaultBarGaugeOptions);
+  },
+  datagrid() {
+    return new PanelOptionsBuilder<DataGridOptions>(() => defaultDataGridOptions);
+  },
+  flamegraph() {
+    return new PanelOptionsBuilder<{}>();
+  },
+  gauge() {
+    return new PanelOptionsBuilder<GaugeOptions>(() => defaultGaugeOptions);
+  },
+  geomap() {
+    return new PanelOptionsBuilder<GeomapOptions>(() => defaultGeomapOptions);
+  },
+  heatmap() {
+    return new PanelOptionsBuilder<HeatmapOptions>(() => defaultHeatmapOptions);
+  },
+  histogram() {
+    return new PanelOptionsBuilder<HistogramOptions>(() => defaultHistogramOptions);
+  },
+  logs() {
+    return new PanelOptionsBuilder<LogsOptions>();
+  },
+  news() {
+    return new PanelOptionsBuilder<NewsOptions>(() => defaultNewsOptions);
+  },
+  nodegraph() {
+    return new PanelOptionsBuilder<NodeGraphOptions>();
+  },
+  piechart() {
+    return new PanelOptionsBuilder<PieChartOptions>(() => defaultPieChartOptions);
+  },
+  stat() {
+    return new PanelOptionsBuilder<StatOptions>(() => defaultStatOptions);
+  },
+  statetimeline() {
+    return new PanelOptionsBuilder<StateTimelineOptions>(() => defaultStateTimelineOptions);
+  },
+  statushistory() {
+    return new PanelOptionsBuilder<StatusHistoryOptions>(() => defaultStatusHistoryOptions);
+  },
+  table() {
+    return new PanelOptionsBuilder<TableOptions>(() => defaultTableOptions);
+  },
+  text() {
+    return new PanelOptionsBuilder<TextOptions>(() => defaultTextOptions);
+  },
+  timeseries() {
+    return new PanelOptionsBuilder<TimeSeriesOptions>();
+  },
+  trend() {
+    return new PanelOptionsBuilder<{}>();
+  },
+  traces() {
+    return new PanelOptionsBuilder<TrendOptions>();
+  },
+  xychart() {
+    return new PanelOptionsBuilder<XYChartOptions>(() => defaultXYChartOptions);
+  },
+};

--- a/packages/scenes/src/core/PanelBuilders/index.ts
+++ b/packages/scenes/src/core/PanelBuilders/index.ts
@@ -178,3 +178,6 @@ export const PanelBuilders = {
     );
   },
 };
+
+export { PanelOptionsBuilders } from './PanelOptionsBuilders';
+export { FieldConfigBuilders } from './FieldConfigBuilders';

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -67,7 +67,7 @@ export { SceneApp, useSceneApp } from './components/SceneApp/SceneApp';
 export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
 export { SceneObjectRef } from './core/SceneObjectRef';
-export { PanelBuilders } from './core/PanelBuilders';
+export { PanelBuilders, PanelOptionsBuilders, FieldConfigBuilders } from './core/PanelBuilders';
 export { SceneDebugger } from './components/SceneDebugger/SceneDebugger';
 
 export const sceneUtils = {


### PR DESCRIPTION
Closes https://github.com/grafana/scenes/pull/266

This PR implements logic for dynamically updating panel options and field config. 

It also refactors `VizPanelBuilder` a bit, so that field config and options are built using a respective, composed builder. I think this makes sense as for programmatic options/field config updates it's good to have typed builders for `Options` and `FieldConfig` types - at least for the built-in Grafana visualizations. So the user can use exactly the same API as they would use for building panel using `PanelBuilders`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.8.0--canary.363.6298066504.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.8.0--canary.363.6298066504.0
  # or 
  yarn add @grafana/scenes@1.8.0--canary.363.6298066504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
