### PR TITLE
AnnotationsDataLayer: Support query request enriching

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -22,10 +22,9 @@ import { DataQuery } from '@grafana/schema';
 import { EmbeddedScene } from '../components/EmbeddedScene';
 import { SceneCanvasText } from '../components/SceneCanvasText';
 import { SceneTimeRangeCompare } from '../components/SceneTimeRangeCompare';
-import { SceneObjectBase } from '../core/SceneObjectBase';
-import { DataRequestEnricher, SceneObject, SceneObjectState } from '../core/types';
 import { SceneDataLayers } from './SceneDataLayers';
 import { TestAnnotationsDataLayer } from './layers/TestDataLayer';
+import { TestSceneWithRequestEnricher } from '../utils/test/TestSceneWithRequestEnricher';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   getRef: () => ({ uid: 'test' }),
@@ -620,12 +619,6 @@ describe('SceneQueryRunner', () => {
   });
 
   test('enriching query request', async () => {
-    class TestSceneWithRequestEnricher extends SceneObjectBase<SceneObjectState> implements DataRequestEnricher {
-      public enrichDataRequest(source: SceneObject) {
-        return { app: 'enriched' };
-      }
-    }
-
     const queryRunner = new SceneQueryRunner({
       queries: [{ refId: 'A' }],
       $timeRange: new SceneTimeRange(),

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -20,7 +20,6 @@ import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import {
   DataLayerFilter,
-  isDataRequestEnricher,
   SceneDataLayerProviderResult,
   SceneDataProvider,
   SceneDataProviderResult,
@@ -37,6 +36,7 @@ import { SceneTimeRangeCompare } from '../components/SceneTimeRangeCompare';
 import { getClosest } from '../core/sceneGraph/utils';
 import { timeShiftQueryResponseOperator } from './timeShiftQueryResponseOperator';
 import { filterAnnotationsOperator } from './layers/annotations/filterAnnotationsOperator';
+import { getEnrichedDataRequest } from './getEnrichedDataRequest';
 
 let counter = 100;
 
@@ -490,14 +490,4 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
 export function findFirstDatasource(targets: DataQuery[]): DataSourceRef | undefined {
   return targets.find((t) => t.datasource !== null)?.datasource ?? undefined;
-}
-
-function getEnrichedDataRequest(sourceRunner: SceneQueryRunner): Partial<DataQueryRequest> | null {
-  const root = sourceRunner.getRoot();
-
-  if (isDataRequestEnricher(root)) {
-    return root.enrichDataRequest(sourceRunner);
-  }
-
-  return null;
 }

--- a/packages/scenes/src/querying/getEnrichedDataRequest.ts
+++ b/packages/scenes/src/querying/getEnrichedDataRequest.ts
@@ -1,0 +1,12 @@
+import { DataQueryRequest } from '@grafana/data';
+import { isDataRequestEnricher, SceneObject } from '../core/types';
+
+export function getEnrichedDataRequest(sourceRunner: SceneObject): Partial<DataQueryRequest> | null {
+  const root = sourceRunner.getRoot();
+
+  if (isDataRequestEnricher(root)) {
+    return root.enrichDataRequest(sourceRunner);
+  }
+
+  return null;
+}

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -8,6 +8,7 @@ import { TestScene } from '../../../variables/TestScene';
 import { TestVariable } from '../../../variables/variants/TestVariable';
 import { SceneDataLayers } from '../../SceneDataLayers';
 import { AnnotationsDataLayer } from './AnnotationsDataLayer';
+import { TestSceneWithRequestEnricher } from '../../../utils/test/TestSceneWithRequestEnricher';
 
 let mockedEvents: Array<Partial<Field>> = [];
 
@@ -315,6 +316,29 @@ describe('AnnotationsDataLayer', () => {
         // Should execute query a second time
         expect(runRequestMock.mock.calls.length).toBe(2);
       });
+    });
+  });
+
+  describe('enriching annotation query request', () => {
+    it('should use data enricher if provided', async () => {
+      const layer = new AnnotationsDataLayer({
+        name: 'Test layer',
+        query: { name: 'Test', enable: true, iconColor: 'red', theActualQuery: '$A' },
+      });
+
+      const scene = new TestSceneWithRequestEnricher({
+        $data: new SceneDataLayers({
+          layers: [layer],
+        }),
+      });
+
+      scene.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(runRequestMock.mock.calls.length).toBe(1);
+
+      expect(sentRequest?.app).toBe('enriched');
     });
   });
 });

--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -17,6 +17,8 @@ import { getRunRequest } from '@grafana/runtime';
 import { shouldUseLegacyRunner, standardAnnotationSupport } from './standardAnnotationsSupport';
 import { Dashboard, LoadingState } from '@grafana/schema';
 import { SceneObject, SceneTimeRangeLike } from '../../../core/types';
+import { getEnrichedDataRequest } from '../../getEnrichedDataRequest';
+
 let counter = 100;
 function getNextRequestId() {
   return 'AQ' + counter++;
@@ -113,8 +115,7 @@ export function executeAnnotationQuery(
         refId: 'Anno',
       },
     ],
-    // TODO
-    //publicDashboardAccessToken: options.dashboard.meta.publicDashboardAccessToken,
+    ...getEnrichedDataRequest(layer),
   };
 
   const runRequest = getRunRequest();

--- a/packages/scenes/src/utils/test/TestSceneWithRequestEnricher.ts
+++ b/packages/scenes/src/utils/test/TestSceneWithRequestEnricher.ts
@@ -1,0 +1,8 @@
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { SceneObjectState, DataRequestEnricher, SceneObject } from '../../core/types';
+
+export class TestSceneWithRequestEnricher extends SceneObjectBase<SceneObjectState> implements DataRequestEnricher {
+  public enrichDataRequest(_: SceneObject) {
+    return { app: 'enriched' };
+  }
+}


### PR DESCRIPTION
Needed for core dashboards to provide `publicDashbboardsAccessToken` to annotation queries. This is using `DataRequesEnricher`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.1--canary.364.6298364243.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.7.1--canary.364.6298364243.0
  # or 
  yarn add @grafana/scenes@1.7.1--canary.364.6298364243.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
