### PR TITLE
SceneVariableSet: Show and log errors

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -54,6 +54,7 @@ function VariableLabel({ model }: { model: SceneVariable }) {
       isLoading={model.state.loading}
       onCancel={() => model.onCancel?.()}
       label={labelOrName}
+      error={model.state.error}
       description={model.state.description ?? undefined}
     />
   );

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -530,6 +530,20 @@ describe('SceneVariableList', () => {
       expect(innerSet.isVariableLoadingOrWaitingToUpdate(scopedA)).toBe(false);
     });
   });
+
+  describe('When variable throws error', () => {
+    it('Should start update process', async () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [], throwError: 'Danger!' });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [A] }),
+      });
+
+      scene.activate();
+
+      expect(A.state.error).toBe('Danger!');
+    });
+  });
 });
 
 interface TestSceneObjectState extends SceneObjectState {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -224,17 +224,16 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     this._variablesToUpdate.delete(variable);
   }
 
-  /**
-   * TODO handle this properly (and show error in UI).
-   * Not sure if this should be handled here on in MultiValueVariable
-   */
   private _handleVariableError(variable: SceneVariable, err: Error) {
     const update = this._updating.get(variable);
     update?.subscription?.unsubscribe();
 
     this._updating.delete(variable);
     this._variablesToUpdate.delete(variable);
-    variable.setState({ loading: false, error: err });
+
+    variable.setState({ loading: false, error: err.message });
+
+    console.error('SceneVariableSet updateAndValidate error', err);
 
     writeVariableTraceLog(variable, 'updateAndValidate error', err);
   }

--- a/packages/scenes/src/variables/variants/TestVariable.tsx
+++ b/packages/scenes/src/variables/variants/TestVariable.tsx
@@ -17,6 +17,7 @@ export interface TestVariableState extends MultiValueVariableState {
   delayMs?: number;
   issuedQuery?: string;
   refresh?: VariableRefresh;
+  throwError?: string;
   optionsToReturn: VariableValueOption[];
 }
 
@@ -53,6 +54,10 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
 
     return new Observable<VariableValueOption[]>((observer) => {
       this.setState({ loading: true });
+
+      if (this.state.throwError) {
+        throw new Error(this.state.throwError);
+      }
 
       const sub = this.completeUpdate.subscribe({
         next: () => {


### PR DESCRIPTION
Fixes #349

Shows and logs variable errors happening in the validateAndUpdate observable / rxjs process 

![image](https://github.com/grafana/scenes/assets/10999/e35ee444-3775-46e2-8133-55e783509476)
