### PR TITLE
Variables: Support skipUrlSync option

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -390,5 +390,18 @@ describe('MultiValueVariable', () => {
       expect(variable.state.value).toEqual(['2', '1']);
       expect(variable.state.text).toEqual(['B', 'A']);
     });
+
+    it('Can disable url sync', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        value: '1',
+        text: 'A',
+        delayMs: 0,
+        skipUrlSync: true,
+      });
+
+      expect(variable.urlSync?.getUrlState()).toEqual({});
+      expect(variable.urlSync?.getKeys()).toEqual([]);
+    });
   });
 });

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -253,10 +253,18 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
   }
 
   public getKeys(): string[] {
+    if (this._sceneObject.state.skipUrlSync) {
+      return [];
+    }
+
     return [this.getKey()];
   }
 
   public getUrlState(): SceneObjectUrlValues {
+    if (this._sceneObject.state.skipUrlSync) {
+      return {};
+    }
+
     let urlValue: string | string[] | null = null;
     let value = this._sceneObject.state.value;
 


### PR DESCRIPTION
This is an opinion the old variable system supports (but only in the persisted model, not exposed in the UI from what I can tell). 

This was the simplest way I found to disable url sync for
* QueryVariable
* CustomVariable
* DataSourceVariable 
