### PR TITLE
EmbeddedScene: Patch TimeSrv

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
@@ -3,7 +3,7 @@ import { PluginPageProps } from '@grafana/runtime';
 import { screen, render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React from 'react';
-import { Router } from 'react-router-dom';
+import { renderAppInsideRouterWithStartingUrl } from '../../../utils/test/utils';
 import { SceneObject } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
@@ -78,7 +78,7 @@ describe('SceneApp', () => {
       ],
     });
 
-    beforeEach(() => renderAppInsideRouterWithStartingUrl(app, '/test'));
+    beforeEach(() => renderAppInsideRouterWithStartingUrl(history, app, '/test'));
 
     it('should render correct page on mount', async () => {
       expect(screen.queryByTestId(p1Object.state.key!)).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe('SceneApp', () => {
       ],
     });
 
-    beforeEach(() => renderAppInsideRouterWithStartingUrl(app, '/test'));
+    beforeEach(() => renderAppInsideRouterWithStartingUrl(history, app, '/test'));
 
     it('should render correct breadcrumbs', async () => {
       expect(flattenPageNav(pluginPageProps?.pageNav!)).toEqual(['Container page']);
@@ -193,7 +193,7 @@ describe('SceneApp', () => {
         ],
       });
 
-      beforeEach(() => renderAppInsideRouterWithStartingUrl(app, '/test-drilldown'));
+      beforeEach(() => renderAppInsideRouterWithStartingUrl(history, app, '/test-drilldown'));
 
       it('should render a drilldown page', async () => {
         expect(screen.queryByTestId(p1Object.state.key!)).toBeInTheDocument();
@@ -254,7 +254,7 @@ describe('SceneApp', () => {
           ],
         });
 
-        beforeEach(() => renderAppInsideRouterWithStartingUrl(app, '/main/drilldown/10'));
+        beforeEach(() => renderAppInsideRouterWithStartingUrl(history, app, '/main/drilldown/10'));
 
         it('should render a drilldown page', async () => {
           expect(await screen.findByText('10 drilldown!')).toBeInTheDocument();
@@ -305,7 +305,7 @@ describe('SceneApp', () => {
         ],
       });
 
-      beforeEach(() => renderAppInsideRouterWithStartingUrl(app, '/test/tab'));
+      beforeEach(() => renderAppInsideRouterWithStartingUrl(history, app, '/test/tab'));
 
       it('should render a drilldown that is part of tab page', async () => {
         expect(screen.queryByTestId(t1Object.state.key!)).toBeInTheDocument();
@@ -365,15 +365,6 @@ function setupScene(inspectableObject: SceneObject) {
 
 function getDrilldownScene(match: SceneRouteMatch<{ id: string }>) {
   return setupScene(new SceneCanvasText({ text: `${match.params.id} drilldown!` }));
-}
-
-function renderAppInsideRouterWithStartingUrl(app: SceneApp, startingUrl: string) {
-  history.push(startingUrl);
-  render(
-    <Router history={history}>
-      <app.Component model={app} />
-    </Router>
-  );
 }
 
 function flattenPageNav(pageNav: NavModelItem | undefined) {

--- a/packages/scenes/src/utils/compatibility/patchTimeSrv.test.tsx
+++ b/packages/scenes/src/utils/compatibility/patchTimeSrv.test.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import { EmbeddedScene } from '../../components/EmbeddedScene';
+import { SceneAppPage } from '../../components/SceneApp/SceneAppPage';
+import { SceneCanvasText } from '../../components/SceneCanvasText';
+import { SceneTimeRange } from '../../core/SceneTimeRange';
+import { SceneApp } from '../../components/SceneApp/SceneApp';
+import { createMemoryHistory } from 'history';
+import { screen } from '@testing-library/react';
+import { SceneRouteMatch } from '../../components/SceneApp/types';
+import { renderAppInsideRouterWithStartingUrl } from '../../../utils/test/utils';
+
+let history = createMemoryHistory();
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+}));
+
+describe('patchTimeSrv', () => {
+  beforeEach(() => {
+    delete (window as any).__timeRangeSceneObject;
+  });
+
+  test('standalone EmbeddedScene', () => {
+    const timeRange = new SceneTimeRange({
+      key: 'embeddedScene-tr',
+    });
+
+    const scene = new EmbeddedScene({
+      $timeRange: timeRange,
+      body: new SceneCanvasText({ text: 'Hello World' }),
+    });
+
+    const deactivate = scene.activate();
+
+    expect((window as any).__timeRangeSceneObject.state.key).toBe('embeddedScene-tr');
+
+    deactivate();
+    expect((window as any).__timeRangeSceneObject).toBeUndefined();
+  });
+
+  describe('SceneApp', () => {
+    test('SceneAppPage with time range', () => {
+      const timeRange = new SceneTimeRange({
+        key: 'app-tr',
+      });
+
+      const scene = new SceneApp({
+        pages: [
+          new SceneAppPage({
+            title: 'Page',
+            url: '/page',
+            $timeRange: timeRange,
+            getScene: () =>
+              new EmbeddedScene({
+                body: new SceneCanvasText({ text: 'Hello World' }),
+              }),
+          }),
+        ],
+      });
+
+      renderAppInsideRouterWithStartingUrl(history, scene, '/page');
+
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('app-tr');
+    });
+
+    test('SceneAppPage with time range on EmbeddedScene', () => {
+      const timeRange = new SceneTimeRange({
+        key: 'app-tr',
+      });
+
+      const pageTimeRange = new SceneTimeRange({
+        key: 'page-tr',
+      });
+
+      const scene = new SceneApp({
+        pages: [
+          new SceneAppPage({
+            title: 'Page',
+            url: '/page',
+            $timeRange: timeRange,
+            getScene: () =>
+              new EmbeddedScene({
+                $timeRange: pageTimeRange,
+                body: new SceneCanvasText({ text: 'Hello World' }),
+              }),
+          }),
+        ],
+      });
+
+      renderAppInsideRouterWithStartingUrl(history, scene, '/page');
+
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('page-tr');
+    });
+
+    test('Navigating between pages', async () => {
+      const timeRange1 = new SceneTimeRange({
+        key: 'page1-tr',
+      });
+
+      const timeRange2 = new SceneTimeRange({
+        key: 'page2-tr',
+      });
+
+      const scene = new SceneApp({
+        pages: [
+          new SceneAppPage({
+            title: 'Page',
+            url: '/page1',
+            $timeRange: timeRange1,
+            getScene: () =>
+              new EmbeddedScene({
+                body: new SceneCanvasText({ text: 'Hello World1' }),
+              }),
+          }),
+          new SceneAppPage({
+            title: 'Page',
+            url: '/page2',
+            $timeRange: timeRange2,
+            getScene: () =>
+              new EmbeddedScene({
+                body: new SceneCanvasText({ text: 'Hello World2' }),
+              }),
+          }),
+        ],
+      });
+
+      renderAppInsideRouterWithStartingUrl(history, scene, '/page1');
+
+      history.push('/page2');
+      expect(await screen.findByText('Hello World2')).toBeInTheDocument();
+
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('page2-tr');
+    });
+
+    test('Tabs support', async () => {
+      const sharedTimeRange = new SceneTimeRange({
+        key: 'shared-tr',
+      });
+
+      const tab2TimeRange = new SceneTimeRange({
+        key: 'tab2-tr',
+      });
+
+      const scene = new SceneApp({
+        pages: [
+          // Page with tabs
+          new SceneAppPage({
+            key: 'container',
+            title: 'Container page',
+            url: '/test',
+            $timeRange: sharedTimeRange,
+            tabs: [
+              new SceneAppPage({
+                key: 'tab1',
+                title: 'Tab1',
+                titleIcon: 'grafana',
+                tabSuffix: () => <strong>tab1 suffix</strong>,
+                url: '/test/tab1',
+                getScene: () =>
+                  new EmbeddedScene({
+                    body: new SceneCanvasText({ text: 'Hello World1' }),
+                  }),
+              }),
+              new SceneAppPage({
+                key: 'tab2',
+                title: 'Tab2',
+                url: '/test/tab2',
+                getScene: () =>
+                  new EmbeddedScene({
+                    $timeRange: tab2TimeRange,
+                    body: new SceneCanvasText({ text: 'Hello World2' }),
+                  }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      renderAppInsideRouterWithStartingUrl(history, scene, '/test');
+      expect(await screen.findByText('Hello World1')).toBeInTheDocument();
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('shared-tr');
+
+      history.push('/test/tab2');
+      expect(await screen.findByText('Hello World2')).toBeInTheDocument();
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('tab2-tr');
+    });
+
+    test('Drilldown support', async () => {
+      const sharedTimeRange = new SceneTimeRange({
+        key: 'shared-tr',
+      });
+
+      const drilldown1TimeRange = new SceneTimeRange({
+        key: 'drilldown1-tr',
+      });
+      const drilldown2TimeRange = new SceneTimeRange({
+        key: 'drilldown2-tr',
+      });
+
+      const app = new SceneApp({
+        key: 'app',
+        pages: [
+          // Page with tabs
+          new SceneAppPage({
+            key: 'top-level-page',
+            title: 'Top level page',
+            url: '/test-drilldown',
+            $timeRange: sharedTimeRange,
+            getScene: () =>
+              new EmbeddedScene({
+                body: new SceneCanvasText({ text: 'Hello World1' }),
+              }),
+            drilldowns: [
+              {
+                routePath: '/test-drilldown/:id',
+                getPage: (match: SceneRouteMatch<{ id: string }>, parent) => {
+                  return new SceneAppPage({
+                    key: 'drilldown-page',
+                    title: `Drilldown ${match.params.id}`,
+                    url: `/test-drilldown/${match.params.id}`,
+                    $timeRange: drilldown1TimeRange,
+                    getScene: () =>
+                      new EmbeddedScene({
+                        body: new SceneCanvasText({ text: 'Hello World2' }),
+                      }),
+                    drilldowns: [
+                      {
+                        routePath: `/test-drilldown/${match.params.id}/:id`,
+                        getPage: (innerMatch: SceneRouteMatch<{ id: string }>, parent) => {
+                          return new SceneAppPage({
+                            key: 'drilldown-page',
+                            title: `Drilldown ${match.params.id}`,
+                            url: `/test-drilldown/${match.params.id}/${innerMatch.params.id}`,
+                            getScene: () =>
+                              new EmbeddedScene({
+                                $timeRange: drilldown2TimeRange,
+                                controls: [],
+                                body: new SceneCanvasText({ text: 'Hello World3' }),
+                              }),
+                            getParentPage: () => parent,
+                          });
+                        },
+                      },
+                    ],
+                    getParentPage: () => parent,
+                  });
+                },
+              },
+            ],
+          }),
+        ],
+      });
+
+      renderAppInsideRouterWithStartingUrl(history, app, '/test-drilldown');
+
+      expect(await screen.findByText('Hello World1')).toBeInTheDocument();
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('shared-tr');
+
+      history.push('/test-drilldown/some-id');
+      expect(await screen.findByText('Hello World2')).toBeInTheDocument();
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('drilldown1-tr');
+
+      history.push('/test-drilldown/some-id/some-inner-id');
+      expect(await screen.findByText('Hello World3')).toBeInTheDocument();
+      expect((window as any).__timeRangeSceneObject.state.key).toBe('drilldown2-tr');
+    });
+  });
+});

--- a/packages/scenes/src/utils/compatibility/patchTimeSrv.ts
+++ b/packages/scenes/src/utils/compatibility/patchTimeSrv.ts
@@ -1,0 +1,22 @@
+import { SceneTimeRangeLike } from '../../core/types';
+import { writeSceneLog } from '../writeSceneLog';
+
+/**
+ * This function attaches a time range object to global scope, so that TimeSrv in core Grafana can resolve time range correctly.
+ * This is a hack to accomodate for core data sources that depend on getTimeSrv().getTimeRange() calls.
+ * This function is called from EmbededScene component.
+ **/
+export function _patchTimeSrv(timeRange: SceneTimeRangeLike) {
+  // Time range patched already from a higher level
+  if ((window as any).__timeRangeSceneObject) {
+    writeSceneLog('_patchTimeSrv', 'already patched');
+    return;
+  }
+  writeSceneLog('_patchTimeSrv', 'patching');
+  (window as any).__timeRangeSceneObject = timeRange;
+
+  return () => {
+    writeSceneLog('_patchTimeSrv', 'unpatching');
+    delete (window as any).__timeRangeSceneObject;
+  };
+}

--- a/packages/scenes/utils/test/utils.tsx
+++ b/packages/scenes/utils/test/utils.tsx
@@ -1,5 +1,10 @@
+import React from 'react';
 import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import { asapScheduler, Subscription, timer, isObservable } from 'rxjs';
+import { History } from 'history';
+import { render } from '@testing-library/react';
+import { SceneApp } from '../../src/components/SceneApp/SceneApp';
+import { Router } from 'react-router-dom';
 
 export const OBSERVABLE_TEST_TIMEOUT_IN_MS = 1000;
 
@@ -60,4 +65,13 @@ export function expectObservable(received: unknown): jest.CustomMatcherResult | 
   }
 
   return null;
+}
+
+export function renderAppInsideRouterWithStartingUrl(history: History, app: SceneApp, startingUrl: string) {
+  history.push(startingUrl);
+  render(
+    <Router history={history}>
+      <app.Component model={app} />
+    </Router>
+  );
 }


### PR DESCRIPTION
This adds a patch compatible with https://github.com/grafana/grafana/pull/75728 that will expose the most outer time range from `SceneAppPage` or `EmbeddedScene` as a global time range for `TimeSrv` in core Grafana. This is to provide happy path support for core data sources that rely on core's `TimeSrv`.