### PR TITLE
SceneAppPage: Custom fallback page

### DIFF
--- a/packages/scenes-app/src/demos/dynamicPage.tsx
+++ b/packages/scenes-app/src/demos/dynamicPage.tsx
@@ -8,6 +8,7 @@ import {
   SceneRefreshPicker,
   SceneAppPageState,
   PanelBuilders,
+  SceneReactObject,
 } from '@grafana/scenes';
 import React from 'react';
 import { demoUrl } from '../utils/utils.routing';
@@ -22,6 +23,19 @@ export function getDynamicPageDemo(defaults: SceneAppPageState): SceneAppPage {
     $timeRange: new SceneTimeRange(),
     controls: [new SceneTimePicker({}), new SceneRefreshPicker({})],
     tabs: defaultTabs,
+    // render fallback page with loading message while tabs are loading
+    // so user doesn't see "page not found" message
+    getFallbackPage: () =>
+      new SceneAppPage({
+        title: 'Loading...',
+        url: '',
+        getScene: () =>
+          new EmbeddedScene({
+            body: new SceneReactObject({
+              component: () => <p>Please wait...</p>,
+            }),
+          }),
+      }),
   });
 
   page.addActivationHandler(() => {
@@ -30,6 +44,9 @@ export function getDynamicPageDemo(defaults: SceneAppPageState): SceneAppPage {
         page.setState({
           tabs: [...defaultTabs, getSceneAppPage('/tab2', 'Humidity')],
           renderTitle: renderTitleWithImageSuffix,
+          // remove fallback page once everything is loaded
+          // so user will see "page not found" if tab is indeed non existing
+          getFallbackPage: undefined,
         });
       }, 2000);
       return () => clearTimeout(cancel);

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -150,7 +150,7 @@ function getFallbackRoute(page: SceneAppPage, routeProps: RouteComponentProps) {
     <Route
       key={'fallback route'}
       render={(props) => {
-        const fallbackPage = getDefaultFallbackPage();
+        const fallbackPage = page.state.getFallbackPage?.() ?? getDefaultFallbackPage();
         return <SceneAppPageView page={fallbackPage} routeProps={routeProps} />;
       }}
     ></Route>

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -60,6 +60,12 @@ export interface SceneAppPageState extends SceneObjectState {
    * The current initialized scene, this is set by the framework after scene url initialization
    **/
   initializedScene?: SceneObject;
+
+  /**
+   * Function that returns a fallback scene app page,
+   * to be rendered when url does not match current page exactly or any of tabs or drilldowns.
+   */
+  getFallbackPage?: () => SceneAppPageLike;
 }
 
 export interface SceneAppPageLike extends SceneObject<SceneAppPageState>, DataRequestEnricher {


### PR DESCRIPTION
* Adds ability to specify custom fallback page on `SceneAppPage`
* Update `dynamicPage` demo to use this feature to show loading message while tab is loading

Context:
App o11y service overview needs to load some metadata from metrics data source before it can figure out what tabs to show for a particular service.  For this purpose it uses a custom "loader" scene that initializes required variables and a query runner to load the metadata. But if user cold opens URL for a tab, tabs are not initialized yet. Currently we rely on a routing "hack" to show the loader scene instead of "page not  found" fallback scene. This can be nicely solved by allowing `SceneAppPage` to provide a custom fallback page.

Related discussion: https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1695390081582359

I pondered if a high level component could be made for this case, but not sure how to implement it to solve multiple possible use cases and actually add value. With custom fallback page the solution is already pretty terse and easy. May combe back to it later