### PR TITLE
SceneAppPageView: Fixes react and scene state missmatch

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -1,6 +1,6 @@
 import { NavModelItem, UrlQueryMap } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 
 import { RouteComponentProps } from 'react-router-dom';
 import { SceneObject } from '../../core/types';
@@ -20,17 +20,21 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   const containerState = containerPage.useState();
   const params = useAppQueryParams();
   const scene = page.getScene(routeProps.match);
-  const [initialized, setInitialized] = useState(false);
+  const isInitialized = containerState.initializedScene === scene;
 
   useLayoutEffect(() => {
     // Before rendering scene components, we are making sure the URL sync is enabled for.
-    if (!initialized) {
+    if (!isInitialized) {
       containerPage.initializeScene(scene);
-      setInitialized(true);
     }
-  }, [initialized, scene, containerPage]);
+  }, [scene, containerPage, isInitialized]);
 
-  if (!initialized) {
+  // Clear initializedScene when unmounting
+  useEffect(() => {
+    return () => containerPage.setState({ initializedScene: undefined });
+  }, [containerPage]);
+
+  if (!isInitialized) {
     return null;
   }
 


### PR DESCRIPTION
If the SceneApp is created with useMemo which is invalidated shortly after initial loading (causing unmount & remount of the embedded scene). This caused a state mismatch in SceneAppPageView where the local react state initialized did not match the scene state of the page containerState.initializedScene 

https://github.com/grafana/grafana-k8s-plugin/pull/819/files#diff-3bfbfb0a9f4447beaacffbc8799fc57325273a246e52244ba42dcb8d420966fdR43

Fix

* Reverted back to using only page state to know if it it initialized. And to solve the issue of re-initializing it (needed for Url sync) when coming back I clear initializedState when SceneAppPageView is unmounted. 

Not sure how to write a unit test for this, was only able to replicate it with this change to how we create the demo app

```ts

export const DemoListPage = () => {
  const [isLoading, setIsLoading] = useState(false);
  const scene = useMemo(() => getDemoSceneApp(isLoading), [isLoading]);

  useEffect(() => {
    if (!isLoading) {
      setTimeout(() => {
        setIsLoading(true);
      }, 1);
    }
  }, [isLoading]);

  return <scene.Component model={scene} />;
};
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.1--canary.381.6378419140.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.9.1--canary.381.6378419140.0
  # or 
  yarn add @grafana/scenes@1.9.1--canary.381.6378419140.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
