### PR TITLE
AdhocFilters: Pass filters via request object

### DIFF
--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -34,6 +34,7 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
                 baseFilters: [{ key: '__name__', operator: '=', value: 'ALERTS', condition: '' }],
                 datasource: { uid: 'gdev-prometheus' },
               }),
+              ...getEmbeddedSceneDefaults().controls,
             ],
             body: new SceneFlexLayout({
               direction: 'row',

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -25,9 +25,11 @@ import { SceneTimeRangeCompare } from '../components/SceneTimeRangeCompare';
 import { SceneDataLayers } from './SceneDataLayers';
 import { TestAnnotationsDataLayer } from './layers/TestDataLayer';
 import { TestSceneWithRequestEnricher } from '../utils/test/TestSceneWithRequestEnricher';
+import { AdHocFilterSet } from '../variables/adhoc/AdHocFiltersSet';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
-  getRef: () => ({ uid: 'test' }),
+  uid: 'test-uid',
+  getRef: () => ({ uid: 'test-uid' }),
   query: () =>
     of({
       data: [
@@ -68,8 +70,14 @@ jest.mock('@grafana/runtime', () => ({
     return runRequestMock(ds, request);
   },
   getDataSourceSrv: () => {
-    return { get: getDataSourceMock };
+    return {
+      get: getDataSourceMock,
+      getInstanceSettings: () => ({ uid: 'test-uid' }),
+    };
   },
+  getTemplateSrv: () => ({
+    getAdhocFilters: jest.fn(),
+  }),
   config: {
     theme: {
       palette: {
@@ -132,7 +140,7 @@ describe('SceneQueryRunner', () => {
           "targets": [
             {
               "datasource": {
-                "uid": "test",
+                "uid": "test-uid",
               },
               "refId": "A",
             },
@@ -193,6 +201,44 @@ describe('SceneQueryRunner', () => {
 
       expect(runRequestCall[1].scopedVars.__sceneObject).toEqual({ value: queryRunner, text: '__sceneObject' });
       expect(getDataSourceCall[1].__sceneObject).toEqual({ value: queryRunner, text: '__sceneObject' });
+    });
+
+    it('should pass adhoc filters via request object', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const filterSet = new AdHocFilterSet({
+        datasource: { uid: 'test-uid' },
+        filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+      });
+
+      const scene = new EmbeddedScene({
+        $data: queryRunner,
+        controls: [filterSet],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      expect(queryRunner.state.data).toBeUndefined();
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[0];
+
+      expect(runRequestCall[1].filters).toEqual(filterSet.state.filters);
+
+      // Verify updating filter re-triggers query
+      filterSet._updateFilter(filterSet.state.filters[0], 'value', 'newValue');
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(runRequestMock.mock.calls.length).toEqual(2);
+
+      const runRequestCall2 = runRequestMock.mock.calls[1];
+      expect(runRequestCall2[1].filters).toEqual(filterSet.state.filters);
     });
   });
 
@@ -1375,7 +1421,7 @@ describe('SceneQueryRunner', () => {
             // This function is faking annotation events with exclude filter
             return [
               {
-                // only this annotation should we returned
+                // this annotation should we returned
                 source: {
                   filter: {
                     exclude: true,

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -214,7 +214,7 @@ describe('SceneQueryRunner', () => {
         filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
       });
 
-      const scene = new EmbeddedScene({
+      new EmbeddedScene({
         $data: queryRunner,
         controls: [filterSet],
         body: new SceneCanvasText({ text: 'hello' }),

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -4,7 +4,6 @@ import { forkJoin, map, merge, mergeAll, Observable, ReplaySubject, Unsubscribab
 import { DataQuery, DataSourceRef, LoadingState } from '@grafana/schema';
 
 import {
-  AdHocVariableFilter,
   DataFrame,
   DataQueryRequest,
   DataSourceApi,
@@ -518,13 +517,13 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     });
 
     if (!set || set.state.applyMode !== 'same-datasource') {
-      return undefined;
+      return;
     }
 
     const setDataSource = getDataSourceSrv().getInstanceSettings(set?.state.datasource, this._scopedVars);
 
     if (setDataSource?.uid !== ourDataSourceUid) {
-      return undefined;
+      return;
     }
 
     // Subscribe to filter set state changes so that queries are re-issued when it changes

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -12,7 +12,6 @@ import {
   PanelData,
   preProcessPanelData,
   rangeUtil,
-  ScopedVar,
   transformDataFrame,
 } from '@grafana/data';
 import { getDataSourceSrv, getRunRequest, toDataQueryError } from '@grafana/runtime';
@@ -24,7 +23,6 @@ import {
   SceneDataLayerProviderResult,
   SceneDataProvider,
   SceneDataProviderResult,
-  SceneObject,
   SceneObjectState,
   SceneTimeRangeLike,
 } from '../core/types';

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
@@ -62,15 +62,19 @@ describe('AdHocFilter', () => {
   it('changes filter', async () => {
     const { filtersSet, runRequest } = setup();
 
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
     const wrapper = screen.getByTestId('AdHocFilter-key1');
     const selects = getAllByRole(wrapper, 'combobox');
 
     await waitFor(() => select(selects[2], 'val4', { container: document.body }));
 
+    // should run new query when filter changed
+    expect(runRequest.mock.calls.length).toBe(1);
     expect(filtersSet.state.filters[0].value).toBe('val4');
-
-    // should run query for scene query runner
-    expect(runRequest.mock.calls.length).toBe(2);
   });
 
   it('url sync works', async () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -27,7 +27,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
     }
 
     const filters = deserializeUrlToFilters(urlValue);
-    this._variable.updateFilters(filters);
+    this._variable.setState({ filters });
   }
 }
 


### PR DESCRIPTION
With the change in core to pass filters via request object, and to start using it in Prometheus made it so that the new adhoc filters feature was not working with scenes anymore (for prometheus). 

So I have to make this change now (before updating latest packages, hence the typescript ignore).

related to 
https://github.com/grafana/grafana/pull/75552