### PR TITLE
Variables: Updates the demo scene

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -76,6 +76,10 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                 new IntervalVariable({
                   name: 'interval',
                   intervals: ['1d', '1m'],
+                  autoEnabled: true,
+                  autoStepCount: 30,
+                  autoMinInterval: '10s',
+                  description: 'Auto step count 30, auto min interval 10s',
                   refresh: VariableRefresh.onTimeRangeChanged,
                 }),
               ],

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -17,6 +17,7 @@ import {
   SceneRefreshPicker,
   DataSourceVariable,
   SceneQueryRunner,
+  TextBoxVariable,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
@@ -28,7 +29,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
     controls: [new SceneTimePicker({}), new SceneRefreshPicker({})],
     tabs: [
       new SceneAppPage({
-        title: 'Query variables',
+        title: 'Async and chained',
         url: `${defaults.url}/query`,
         getScene: () => {
           return new EmbeddedScene({
@@ -97,7 +98,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
         },
       }),
       new SceneAppPage({
-        title: 'Data source',
+        title: 'Data source and textbox',
         url: `${defaults.url}/ds`,
         getScene: () => {
           return new EmbeddedScene({
@@ -108,6 +109,9 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                   name: 'ds',
                   pluginId: 'grafana-testdata-datasource',
                 }),
+                new TextBoxVariable({
+                  name: 'search',
+                }),
               ],
             }),
             body: new SceneFlexLayout({
@@ -115,7 +119,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
               children: [
                 new SceneFlexItem({
                   body: PanelBuilders.timeseries()
-                    .setTitle('datasource: $ds')
+                    .setTitle('datasource: $ds, search = $search')
                     .setData(
                       new SceneQueryRunner({
                         datasource: { uid: '$ds' },
@@ -123,7 +127,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                           {
                             refId: 'A',
                             scenarioId: 'random_walk',
-                            alias: 'ds = $ds',
+                            alias: 'ds = $ds, search = $search',
                           },
                         ],
                       })

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -6,190 +6,185 @@ import {
   TestVariable,
   EmbeddedScene,
   SceneFlexItem,
-  SceneCanvasText,
   NestedScene,
   SceneAppPage,
   SceneAppPageState,
   behaviors,
   PanelBuilders,
   IntervalVariable,
+  SceneTimePicker,
+  VariableValueSelectors,
+  SceneRefreshPicker,
+  DataSourceVariable,
+  SceneQueryRunner,
 } from '@grafana/scenes';
-import { AUTO_VARIABLE_VALUE } from '@grafana/scenes/src/variables/constants';
-import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
+import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
 export function getVariablesDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
     ...defaults,
     subTitle: 'Test of variable cascading updates and refresh on time range change',
-    getScene: () => {
-      return new EmbeddedScene({
-        ...getEmbeddedSceneDefaults(),
-        $variables: new SceneVariableSet({
-          variables: [
-            new TestVariable({
-              name: 'server',
-              query: 'A.*',
-              value: 'server',
-              text: '',
-              delayMs: 1000,
-              options: [],
-              refresh: VariableRefresh.onTimeRangeChanged,
+    $timeRange: new SceneTimeRange(),
+    controls: [new SceneTimePicker({}), new SceneRefreshPicker({})],
+    tabs: [
+      new SceneAppPage({
+        title: 'Query variables',
+        url: `${defaults.url}/query`,
+        getScene: () => {
+          return new EmbeddedScene({
+            controls: [new VariableValueSelectors({})],
+            $variables: new SceneVariableSet({
+              variables: [
+                new TestVariable({
+                  name: 'server',
+                  query: 'A.*',
+                  value: 'server',
+                  text: '',
+                  delayMs: 1000,
+                  options: [],
+                  refresh: VariableRefresh.onTimeRangeChanged,
+                }),
+                new TestVariable({
+                  name: 'pod',
+                  query: 'A.$server.*',
+                  value: 'pod',
+                  delayMs: 1000,
+                  isMulti: true,
+                  text: '',
+                  options: [],
+                }),
+                new TestVariable({
+                  name: 'handler',
+                  query: 'A.$server.$pod.*',
+                  value: 'pod',
+                  delayMs: 1000,
+                  isMulti: true,
+                  text: '',
+                  options: [],
+                  refresh: VariableRefresh.onTimeRangeChanged,
+                }),
+                new TestVariable({
+                  name: 'lonelyOne',
+                  query: 'B.*',
+                  value: '',
+                  delayMs: 1000,
+                  isMulti: true,
+                  text: '',
+                  options: [],
+                }),
+                new IntervalVariable({
+                  name: 'interval',
+                  intervals: ['1d', '1m'],
+                  refresh: VariableRefresh.onTimeRangeChanged,
+                }),
+              ],
             }),
-            new TestVariable({
-              name: 'pod',
-              query: 'A.$server.*',
-              value: 'pod',
-              delayMs: 1000,
-              isMulti: true,
-              text: '',
-              options: [],
-            }),
-            new TestVariable({
-              name: 'handler',
-              query: 'A.$server.$pod.*',
-              value: 'pod',
-              delayMs: 1000,
-              isMulti: true,
-              text: '',
-              options: [],
-              refresh: VariableRefresh.onTimeRangeChanged,
-            }),
-            new TestVariable({
-              name: 'lonelyOne',
-              query: 'B.*',
-              value: '',
-              delayMs: 1000,
-              isMulti: true,
-              text: '',
-              options: [],
-            }),
-            new IntervalVariable({
-              name: 'intervalVariable',
-              intervals: ['1d', '1m'],
-              refresh: VariableRefresh.onTimeRangeChanged,
-            }),
-            new IntervalVariable({
-              name: 'intervalVariableAuto',
-              autoEnabled: true,
-              refresh: VariableRefresh.onTimeRangeChanged,
-              value: AUTO_VARIABLE_VALUE,
-            }),
-          ],
-        }),
-        body: new SceneFlexLayout({
-          direction: 'row',
-          $behaviors: [
-            new behaviors.ActWhenVariableChanged({
-              variableName: 'lonelyOne',
-              onChange: (variable) => {
-                console.log('lonelyOne effect', variable);
-
-                const t = setTimeout(() => {
-                  console.log('lonelyOne post effect');
-                }, 5000);
-
-                return () => {
-                  console.log('lonelyOne cancel effect');
-                  clearTimeout(t);
-                };
-              },
-            }),
-            new behaviors.ActWhenVariableChanged({
-              variableName: 'server',
-              onChange: (variable) => {
-                console.log('server effect', variable);
-              },
-            }),
-          ],
-          children: [
-            new SceneFlexItem({
-              body: new SceneFlexLayout({
-                direction: 'column',
-                children: [
-                  new SceneFlexItem({
-                    body: new SceneFlexLayout({
-                      children: [
-                        new SceneFlexItem({
-                          body: PanelBuilders.timeseries()
-                            .setTitle('handler: $handler')
-                            .setData(
-                              getQueryRunnerWithRandomWalkQuery({
-                                alias: 'handler: $handler',
-                              })
-                            )
-                            .build(),
-                        }),
-                        new SceneFlexItem({
-                          body: new SceneCanvasText({
-                            text: 'Text: ${textbox}',
-                            fontSize: 20,
-                            align: 'center',
-                          }),
-                        }),
-                        new SceneFlexItem({
-                          width: '40%',
-                          body: new SceneCanvasText({
-                            text: 'server: ${server} pod:${pod}',
-                            fontSize: 20,
-                            align: 'center',
-                          }),
-                        }),
-                      ],
-                    }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              $behaviors: [getVariableChangeBehavior('lonelyOne'), getVariableChangeBehavior('server')],
+              children: [
+                getGraphAndTextPanel(),
+                new SceneFlexItem({
+                  body: new NestedScene({
+                    title: 'Collapsable inner scene',
+                    canCollapse: true,
+                    body: getGraphAndTextPanel(),
                   }),
-                  new SceneFlexItem({
-                    body: new NestedScene({
-                      title: 'Collapsable inner scene',
-                      canCollapse: true,
-                      body: new SceneFlexLayout({
-                        direction: 'row',
-                        children: [
-                          new SceneFlexItem({
-                            body: PanelBuilders.timeseries()
-                              .setTitle('handler: $handler')
-                              .setData(
-                                getQueryRunnerWithRandomWalkQuery({
-                                  alias: 'handler: $handler',
-                                })
-                              )
-                              .build(),
-                          }),
+                }),
+              ],
+            }),
+          });
+        },
+      }),
+      new SceneAppPage({
+        title: 'Data source',
+        url: `${defaults.url}/ds`,
+        getScene: () => {
+          return new EmbeddedScene({
+            controls: [new VariableValueSelectors({})],
+            $variables: new SceneVariableSet({
+              variables: [
+                new DataSourceVariable({
+                  name: 'ds',
+                  pluginId: 'grafana-testdata-datasource',
+                }),
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  body: PanelBuilders.timeseries()
+                    .setTitle('datasource: $ds')
+                    .setData(
+                      new SceneQueryRunner({
+                        datasource: { uid: '$ds' },
+                        queries: [
+                          {
+                            refId: 'A',
+                            scenarioId: 'random_walk',
+                            alias: 'ds = $ds',
+                          },
                         ],
-                      }),
-                    }),
-                  }),
-                  new SceneFlexItem({
-                    body: new NestedScene({
-                      title: 'Collapsable variables that use built-in variables variants',
-                      canCollapse: true,
-                      body: new SceneFlexLayout({
-                        direction: 'row',
-                        children: [
-                          new SceneFlexItem({
-                            body: new SceneCanvasText({
-                              text: 'Interval Variable: ${intervalVariable}',
-                              fontSize: 20,
-                              align: 'center',
-                            }),
-                          }),
-                          new SceneFlexItem({
-                            body: new SceneCanvasText({
-                              text: 'Interval Variable Auto: ${intervalVariableAuto}',
-                              fontSize: 20,
-                              align: 'center',
-                            }),
-                          }),
-                        ],
-                      }),
-                    }),
-                  }),
-                ],
-              }),
+                      })
+                    )
+                    .build(),
+                }),
+              ],
             }),
-          ],
-        }),
-        $timeRange: new SceneTimeRange(),
-      });
+          });
+        },
+      }),
+    ],
+  });
+}
+
+function getGraphAndTextPanel() {
+  return new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: PanelBuilders.timeseries()
+          .setTitle('handler: $handler')
+          .setData(
+            getQueryRunnerWithRandomWalkQuery({
+              alias: 'handler: $handler',
+            })
+          )
+          .build(),
+      }),
+      new SceneFlexItem({
+        body: PanelBuilders.text()
+          .setTitle('Interpolation')
+          .setOption(
+            'content',
+            `
+* server: $server
+* pod: $pod
+* handler: $handler
+* interval: $interval
+
+          `
+          )
+          .build(),
+      }),
+    ],
+  });
+}
+
+function getVariableChangeBehavior(variableName: string) {
+  return new behaviors.ActWhenVariableChanged({
+    variableName,
+    onChange: (variable) => {
+      console.log(`${variable.state.name} changed`);
+
+      const t = setTimeout(() => {
+        console.log(`${variable.state.name} post effect`);
+      }, 5000);
+
+      return () => {
+        console.log(`${variable.state.name} cancel effect`);
+        clearTimeout(t);
+      };
     },
   });
 }

--- a/packages/scenes/src/variables/components/VariableValueInput.tsx
+++ b/packages/scenes/src/variables/components/VariableValueInput.tsx
@@ -24,5 +24,5 @@ export function VariableValueInput({ model }: SceneComponentProps<TextBoxVariabl
     [setTextValue]
   );
 
-  return <Input id={key} placeholder="Enter variable value" value={textValue} loading={loading} onChange={onChange} />;
+  return <Input id={key} placeholder="Enter value" value={textValue} loading={loading} onChange={onChange} />;
 }


### PR DESCRIPTION
Started working on https://github.com/grafana/scenes/issues/383 , but found the demo scene needing some refactoring :) 

The demo scene was a bit messy with some duplicated variables and a layout that was hard to get an overview of. 

* Simplify and reduce unnecessary layout elements 
* Reduce some duplicated variables (don't need two interval variables)
* Added a new scene that has DataSourceVariable and TextBoxVariable 
* Remove unnecessary nested scene (we still have one, but we do no need two) 



![image](https://github.com/grafana/scenes/assets/10999/ca34b8aa-d408-4a99-b4fc-e480e9c70294)

