### PR TITLE
Variables: Fix issue with all value state and no options

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -145,6 +145,23 @@ describe('MultiValueVariable', () => {
       expect(variable.state.options).toEqual(variable.state.optionsToReturn);
       expect(changeEvent).toBeDefined();
     });
+
+    it('Should default to $__all even when no options are returned', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [],
+        defaultToAll: true,
+        value: [],
+        text: [],
+        delayMs: 0,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toBe(ALL_VARIABLE_VALUE);
+      expect(variable.state.text).toBe(ALL_VARIABLE_TEXT);
+    });
   });
 
   describe('changeValueTo', () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -77,7 +77,10 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     };
 
     if (options.length === 0) {
-      // TODO handle the no value state
+      if (this.state.defaultToAll || this.state.includeAll) {
+        stateUpdate.value = ALL_VARIABLE_VALUE;
+        stateUpdate.text = ALL_VARIABLE_TEXT;
+      }
     } else if (this.hasAllValue()) {
       // If value is set to All then we keep it set to All but just store the options
     } else if (this.state.isMulti) {

--- a/packages/scenes/src/variables/variants/TestVariable.tsx
+++ b/packages/scenes/src/variables/variants/TestVariable.tsx
@@ -18,7 +18,7 @@ export interface TestVariableState extends MultiValueVariableState {
   issuedQuery?: string;
   refresh?: VariableRefresh;
   throwError?: string;
-  optionsToReturn: VariableValueOption[];
+  optionsToReturn?: VariableValueOption[];
 }
 
 /**
@@ -42,7 +42,6 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
       query: 'Query',
       options: [],
       refresh: VariableRefresh.onDashboardLoad,
-      optionsToReturn: [],
       ...initialState,
     });
   }
@@ -102,7 +101,7 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
   }
 
   private getOptions(interpolatedQuery: string) {
-    if (this.state.optionsToReturn.length > 0) {
+    if (this.state.optionsToReturn) {
       return this.state.optionsToReturn;
     }
 


### PR DESCRIPTION
Fixes issue with a variable query returning no options. The All state should be set, but
was not.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.14.0--canary.391.6404398888.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.14.0--canary.391.6404398888.0
  # or 
  yarn add @grafana/scenes@1.14.0--canary.391.6404398888.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
