### PR TITLE
ActWhenVariableChanged: Add behavior to onChange callback

### DIFF
--- a/packages/scenes/src/behaviors/ActWhenVariableChanged.ts
+++ b/packages/scenes/src/behaviors/ActWhenVariableChanged.ts
@@ -6,8 +6,15 @@ import { VariableDependencyConfig } from '../variables/VariableDependencyConfig'
 interface ActWhenVariableChangedState extends SceneObjectState {
   // The name of the variable to subscribe to changes to.
   variableName: string;
-  // The handler to run when a variable changes. Return a cancellation function if you do anything async like issue a query.
-  onChange: (variable: SceneVariable) => (() => void) | void;
+  /**
+   * The handler to run when a variable changes.
+   * @param variable The variable that changed
+   * @param behavior The behavior instance where this onChange handler added to.
+   *  You can use this to access the parent SceneObject where this behavior exists.
+   *  You can also use this with the sceneGraph util functions to find objects from this scene graph location.
+   * @returns Return a cancellation function if you do anything async like issue a query.
+   */
+  onChange: (variable: SceneVariable, behavior: ActWhenVariableChanged) => (() => void) | void;
 }
 
 /**
@@ -32,7 +39,7 @@ export class ActWhenVariableChanged extends SceneObjectBase<ActWhenVariableChang
           this._runningEffect = null;
         }
 
-        const cancellation = effect(variable);
+        const cancellation = effect(variable, this);
         if (cancellation) {
           this._runningEffect = cancellation;
         }


### PR DESCRIPTION
This helps making it possible to use the behavior without declaring a variable of the behavior and the behavior parent and capturing their instances in a lambda.

Having the behavior be part of the callback makes it possible to write the onChange callback as a pure function.
