### PR TITLE
QueryVariable: Support for queries that contain "$__searchFilter" 

### DIFF
--- a/docusaurus/docs/variables.tsx
+++ b/docusaurus/docs/variables.tsx
@@ -18,6 +18,7 @@ export function getVariablesScene() {
     },
     query: {
       query: 'label_values(prometheus_http_requests_total,handler)',
+      refId: 'A',
     },
   });
 

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -18,6 +18,7 @@ import {
   DataSourceVariable,
   SceneQueryRunner,
   TextBoxVariable,
+  QueryVariable,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
@@ -135,6 +136,38 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                           },
                         ],
                       })
+                    )
+                    .build(),
+                }),
+              ],
+            }),
+          });
+        },
+      }),
+      new SceneAppPage({
+        title: 'Search filter',
+        url: `${defaults.url}/search`,
+        getScene: () => {
+          return new EmbeddedScene({
+            controls: [new VariableValueSelectors({})],
+            $variables: new SceneVariableSet({
+              variables: [
+                new QueryVariable({
+                  name: 'server',
+                  query: { query: 'A.$__searchFilter', refId: 'A' },
+                  datasource: { uid: 'gdev-testdata' },
+                }),
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  body: PanelBuilders.text()
+                    .setTitle('Variable with search filter')
+                    .setOption(
+                      'content',
+                      'This is a very old messy feature that allows data sources to filter down the options in a query variable dropdown based on what the user has typed in. Only implemented by very few data sources (Graphite, SQL, Datadog)'
                     )
                     .build(),
                 }),

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -2,6 +2,7 @@ import { SceneObject, SceneObjectState } from '../core/types';
 import { VARIABLE_REGEX } from './constants';
 
 import { SceneVariable, SceneVariableDependencyConfigLike } from './types';
+import { safeStringifyValue } from './utils';
 
 interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
   /**
@@ -152,13 +153,3 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
     }
   }
 }
-
-const safeStringifyValue = (value: unknown) => {
-  try {
-    return JSON.stringify(value, null);
-  } catch (error) {
-    console.error(error);
-  }
-
-  return '';
-};

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -39,6 +39,14 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
   const { value, key } = model.useState();
   const arrayValue = isArray(value) ? value : [value];
 
+  const onInputChange = model.onSearchChange
+    ? (value: string, meta: InputActionMeta) => {
+        if (meta.action === 'input-change') {
+          model.onSearchChange!(value);
+        }
+      }
+    : undefined;
+
   return (
     <MultiSelect<VariableValueSingle>
       id={key}
@@ -50,7 +58,7 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       options={model.getOptionsForSelect()}
       closeMenuOnSelect={false}
       isClearable={true}
-      onOpenMenu={() => {}}
+      onInputChange={onInputChange}
       onChange={(newValue) => {
         model.changeValueTo(
           newValue.map((v) => v.value!),

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -1,7 +1,7 @@
 import { isArray } from 'lodash';
 import React from 'react';
 
-import { MultiSelect, Select } from '@grafana/ui';
+import { InputActionMeta, MultiSelect, Select } from '@grafana/ui';
 
 import { SceneComponentProps } from '../../core/types';
 import { MultiValueVariable } from '../variants/MultiValueVariable';
@@ -9,6 +9,14 @@ import { VariableValue, VariableValueSingle } from '../types';
 
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, key } = model.useState();
+
+  const onInputChange = model.onSearchChange
+    ? (value: string, meta: InputActionMeta) => {
+        if (meta.action === 'input-change') {
+          model.onSearchChange!(value);
+        }
+      }
+    : undefined;
 
   return (
     <Select<VariableValue>
@@ -18,6 +26,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       value={value}
       allowCustomValue
       tabSelectsValue={false}
+      onInputChange={onInputChange}
       options={model.getOptionsForSelect()}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);

--- a/packages/scenes/src/variables/constants.ts
+++ b/packages/scenes/src/variables/constants.ts
@@ -13,3 +13,4 @@ export const AUTO_VARIABLE_VALUE = '$__auto';
  * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
  */
 export const VARIABLE_REGEX = /\$(\w+)|\[\[(\w+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
+export const SEARCH_FILTER_VARIABLE = '__searchFilter';

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -8,3 +8,13 @@ export function isVariableValueEqual(a: VariableValue | null | undefined, b: Var
 
   return isEqual(a, b);
 }
+
+export function safeStringifyValue(value: unknown) {
+  try {
+    return JSON.stringify(value, null);
+  } catch (error) {
+    console.error(error);
+  }
+
+  return '';
+}

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -244,6 +244,11 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
 
     return options;
   }
+
+  /**
+   * Can be used by subclasses to do custom handling of option search based on search input
+   */
+  public onSearchChange?(searchFilter: string): void;
 }
 
 export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = MultiValueVariableState>

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -299,7 +299,6 @@ describe('QueryVariable', () => {
       // wait for debounce
       await new Promise((r) => setTimeout(r, 500));
 
-      //screen.debug();
       expect(runRequestMock).toBeCalledTimes(2);
       expect(runRequestMock.mock.calls[1][1].scopedVars.__searchFilter.value).toEqual('muu!');
     });

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -1,4 +1,5 @@
 import { lastValueFrom, of } from 'rxjs';
+import React from 'react';
 
 import {
   DataQueryRequest,
@@ -21,18 +22,27 @@ import { SceneTimeRange } from '../../../core/SceneTimeRange';
 
 import { QueryVariable } from './QueryVariable';
 import { QueryRunner, RunnerArgs, setCreateQueryVariableRunnerFactory } from './createQueryVariableRunner';
+import { EmbeddedScene } from '../../../components/EmbeddedScene';
+import { SceneVariableSet } from '../../sets/SceneVariableSet';
+import { VariableValueSelectors } from '../../components/VariableValueSelectors';
+import { SceneCanvasText } from '../../../components/SceneCanvasText';
+import { getAllByRole, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setRunRequest } from '@grafana/runtime';
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,
     series: [
       toDataFrame({
-        fields: [{ name: 'text', type: FieldType.string, values: ['A', 'AB', 'C'] }],
+        fields: [{ name: 'text', type: FieldType.string, values: ['val1', 'val2', 'val11'] }],
       }),
     ],
     timeRange: getDefaultTimeRange(),
   })
 );
+
+setRunRequest(runRequestMock);
 
 const getDataSourceMock = jest.fn();
 
@@ -114,20 +124,6 @@ describe('QueryVariable', () => {
     });
   });
 
-  describe('When no data source is provided', () => {
-    it('Should default to empty options and empty value', async () => {
-      const variable = new QueryVariable({
-        name: 'test',
-      });
-
-      await lastValueFrom(variable.validateAndUpdate());
-
-      expect(variable.state.value).toEqual('');
-      expect(variable.state.text).toEqual('');
-      expect(variable.state.options).toEqual([]);
-    });
-  });
-
   describe('Issuing variable query', () => {
     const originalNow = Date.now;
     beforeEach(() => {
@@ -154,9 +150,9 @@ describe('QueryVariable', () => {
       variable.validateAndUpdate().subscribe({
         next: () => {
           expect(variable.state.options).toEqual([
-            { label: 'A', value: 'A' },
-            { label: 'AB', value: 'AB' },
-            { label: 'C', value: 'C' },
+            { label: 'val1', value: 'val1' },
+            { label: 'val2', value: 'val2' },
+            { label: 'val11', value: 'val11' },
           ]);
           expect(variable.state.loading).toEqual(false);
           done();
@@ -263,15 +259,49 @@ describe('QueryVariable', () => {
         name: 'test',
         datasource: { uid: 'fake-std', type: 'fake-std' },
         query: 'query',
-        regex: '/^A/',
+        regex: '/^val1/',
       });
 
       await lastValueFrom(variable.validateAndUpdate());
 
       expect(variable.state.options).toEqual([
-        { label: 'A', value: 'A' },
-        { label: 'AB', value: 'AB' },
+        { label: 'val1', value: 'val1' },
+        { label: 'val11', value: 'val11' },
       ]);
+    });
+  });
+
+  describe('Query with __searchFilter', () => {
+    beforeEach(() => {
+      runRequestMock.mockClear();
+      setCreateQueryVariableRunnerFactory(() => new FakeQueryRunner(fakeDsMock, runRequestMock));
+    });
+
+    it('Should trigger new query and show new options', async () => {
+      const variable = new QueryVariable({
+        name: 'server',
+        datasource: null,
+        query: 'A.$__searchFilter',
+      });
+
+      const scene = new EmbeddedScene({
+        $variables: new SceneVariableSet({ variables: [variable] }),
+        controls: [new VariableValueSelectors({})],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      render(<scene.Component model={scene} />);
+
+      const select = await screen.findByRole('combobox');
+      await userEvent.click(select);
+      await userEvent.type(select, 'muu!');
+
+      // wait for debounce
+      await new Promise((r) => setTimeout(r, 500));
+
+      //screen.debug();
+      expect(runRequestMock).toBeCalledTimes(2);
+      expect(runRequestMock.mock.calls[1][1].scopedVars.__searchFilter.value).toEqual('muu!');
     });
   });
 });

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -10,6 +10,7 @@ import {
   PanelData,
   PluginType,
   ScopedVars,
+  StandardVariableQuery,
   StandardVariableSupport,
   toDataFrame,
   toUtc,
@@ -83,7 +84,9 @@ class FakeQueryRunner implements QueryRunner {
   public constructor(private datasource: DataSourceApi, private _runRequest: jest.Mock) {}
 
   public getTarget(variable: QueryVariable) {
-    return (this.datasource.variables as StandardVariableSupport<DataSourceApi>).toDataQuery(variable.state.query);
+    return (this.datasource.variables as StandardVariableSupport<DataSourceApi>).toDataQuery(
+      variable.state.query as StandardVariableQuery
+    );
   }
   public runRequest(args: RunnerArgs, request: DataQueryRequest) {
     return this._runRequest(

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -26,7 +26,7 @@ import { EmbeddedScene } from '../../../components/EmbeddedScene';
 import { SceneVariableSet } from '../../sets/SceneVariableSet';
 import { VariableValueSelectors } from '../../components/VariableValueSelectors';
 import { SceneCanvasText } from '../../../components/SceneCanvasText';
-import { getAllByRole, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setRunRequest } from '@grafana/runtime';
 

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -43,11 +43,6 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
     statePaths: ['regex', 'query', 'datasource'],
   });
 
-  /**
-   * True when we detect $__searchFilter in query model
-   */
-  //private _searchFilterDetected?: boolean;
-
   public constructor(initialState: Partial<QueryVariableState>) {
     super({
       type: 'query',
@@ -55,7 +50,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       value: '',
       text: '',
       options: [],
-      datasource: {},
+      datasource: null,
       regex: '',
       query: { refId: 'A' },
       refresh: VariableRefresh.onDashboardLoad,
@@ -151,7 +146,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
   private _updateOptionsBasedOnSearchFilter = debounce(async (searchFilter: string) => {
     const result = await lastValueFrom(this.getValueOptions({ searchFilter }));
     this.setState({ options: result, loading: false });
-  }, 500);
+  }, 400);
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
     return renderSelectForVariable(model);

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -1,11 +1,9 @@
-import { Observable, of, filter, take, mergeMap, catchError, throwError, from } from 'rxjs';
+import { Observable, of, filter, take, mergeMap, catchError, throwError, from, lastValueFrom } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
   CoreApp,
-  DataQuery,
   DataQueryRequest,
-  DataSourceRef,
   getDefaultTimeRange,
   LoadingState,
   PanelData,
@@ -25,11 +23,16 @@ import { createQueryVariableRunner } from './createQueryVariableRunner';
 import { metricNamesToVariableValues } from './utils';
 import { toMetricFindValues } from './toMetricFindValues';
 import { getDataSource } from '../../../utils/getDataSource';
+import { safeStringifyValue } from '../../utils';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
+import { SEARCH_FILTER_VARIABLE } from '../../constants';
+import { DataQueryExtended } from '../../../querying/SceneQueryRunner';
+import { debounce } from 'lodash';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
   datasource: DataSourceRef | null;
-  query: any;
+  query: string | DataQueryExtended;
   regex: string;
   refresh: VariableRefresh;
   sort: VariableSort;
@@ -40,16 +43,21 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
     statePaths: ['regex', 'query', 'datasource'],
   });
 
+  /**
+   * True when we detect $__searchFilter in query model
+   */
+  //private _searchFilterDetected?: boolean;
+
   public constructor(initialState: Partial<QueryVariableState>) {
     super({
       type: 'query',
       name: '',
       value: '',
       text: '',
-      query: '',
       options: [],
-      datasource: null,
+      datasource: {},
       regex: '',
+      query: { refId: 'A' },
       refresh: VariableRefresh.onDashboardLoad,
       sort: VariableSort.alphabeticalAsc,
       ...initialState,
@@ -71,9 +79,9 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       mergeMap((ds) => {
         const runner = createQueryVariableRunner(ds);
         const target = runner.getTarget(this);
-        const request = this.getRequest(target);
+        const request = this.getRequest(target, args.searchFilter);
 
-        return runner.runRequest({ variable: this }, request).pipe(
+        return runner.runRequest({ variable: this, searchFilter: args.searchFilter }, request).pipe(
           filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error), // we only care about done or error for now
           take(1), // take the first result, using first caused a bug where it in some situations throw an uncaught error because of no results had been received yet
           mergeMap((data: PanelData) => {
@@ -101,15 +109,15 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
     );
   }
 
-  private getRequest(target: DataQuery) {
-    // TODO: add support for search filter
-    // const { searchFilter } = this.state.searchFilter;
-    // const searchFilterScope = { searchFilter: { text: searchFilter, value: searchFilter } };
-    // const searchFilterAsVars = searchFilter ? searchFilterScope : {};
+  private getRequest(target: DataQuery | string, searchFilter?: string) {
     const scopedVars: ScopedVars = {
-      // ...searchFilterAsVars,
       __sceneObject: { text: '__sceneObject', value: this },
+      variable: { text: this.getValueText(), value: this.getValue() },
     };
+
+    if (searchFilter) {
+      scopedVars.__searchFilter = { value: searchFilter, text: searchFilter };
+    }
 
     const range =
       this.state.refresh === VariableRefresh.onTimeRangeChanged
@@ -123,14 +131,34 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       range,
       interval: '',
       intervalMs: 0,
+      // @ts-ignore
       targets: [target],
       scopedVars,
       startTime: Date.now(),
     };
+
     return request;
   }
+
+  onSearchChange = (searchFilter: string) => {
+    if (!containsSearchFilter(this.state.query)) {
+      return;
+    }
+
+    this._updateOptionsBasedOnSearchFilter(searchFilter);
+  };
+
+  private _updateOptionsBasedOnSearchFilter = debounce(async (searchFilter: string) => {
+    const result = await lastValueFrom(this.getValueOptions({ searchFilter }));
+    this.setState({ options: result, loading: false });
+  }, 500);
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
     return renderSelectForVariable(model);
   };
+}
+
+function containsSearchFilter(query: string | DataQuery) {
+  const str = safeStringifyValue(query);
+  return str.indexOf(SEARCH_FILTER_VARIABLE);
 }

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -107,7 +107,6 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
   private getRequest(target: DataQuery | string, searchFilter?: string) {
     const scopedVars: ScopedVars = {
       __sceneObject: { text: '__sceneObject', value: this },
-      variable: { text: this.getValueText(), value: this.getValue() },
     };
 
     if (searchFilter) {

--- a/packages/scenes/src/variables/variants/query/toMetricFindValues.ts
+++ b/packages/scenes/src/variables/variants/query/toMetricFindValues.ts
@@ -21,6 +21,10 @@ export function toMetricFindValues(): OperatorFunction<PanelData, MetricFindValu
           return frames;
         }
 
+        if (frames[0].fields.length === 0) {
+          return [];
+        }
+
         const processedDataFrames = getProcessedDataFrames(frames);
         const metrics: MetricFindValue[] = [];
 


### PR DESCRIPTION
Closes #208

Tested with Graphite (and TestData data source). 

This is such a messy feature that barely works (in the old template variable system implementation) for some legacy data sources. 

Discovered some strange things.
On the old code we only check the query if it's a string or if it has a "target" property (only graphite query editor has this)
https://github.com/grafana/grafana/blob/main/public/app/features/variables/pickers/OptionsPicker/actions.ts#L81 

I solved this in this implementation by stringifying the whole query model then looking for "__searchFilter" .

Second strange / buggy thing in the old implementation is: For Custom and Standard variable support we pass it as scopedVars but not with leading underscores (so it wont work as way to interpolate the query).
https://github.com/grafana/grafana/blob/main/public/app/features/variables/query/VariableQueryRunner.ts#L175 

I fixed that in this implementation by passing __searchFilter as scoped var. 

* [x] __searchFilter support for legacy runner
* [x] __searchFilter support for custom & standard runners
* [x] unit tests
* [x] trying to rid of the query: any type (would love to make it only be DataQueryExtended but so hard to know if we have changed string => object and need to change back when calling metricFindQuery). 

