### PR TITLE
VizPanel: Add support for a custom migration handler

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -50,8 +50,11 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   // internal state
   pluginLoadError?: string;
   pluginInstanceState?: any;
-  /** Only for use from core to handle migration from old angular panels */
-  customMigrationHandler?: (panel: PanelModel, plugin: PanelPlugin) => void;
+  /**
+   * @internal
+   * Only for use from core to handle migration from old angular panels
+   **/
+  UNSAFE_customMigrationHandler?: (panel: PanelModel, plugin: PanelPlugin) => void;
 }
 
 export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends SceneObjectBase<
@@ -112,7 +115,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   }
 
   private async _pluginLoaded(plugin: PanelPlugin) {
-    const { options, fieldConfig, title, pluginVersion, customMigrationHandler } = this.state;
+    const { options, fieldConfig, title, pluginVersion, UNSAFE_customMigrationHandler } = this.state;
 
     const panel: PanelModel = {
       title,
@@ -125,8 +128,8 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     const currentVersion = this._getPluginVersion(plugin);
 
-    if (customMigrationHandler) {
-      customMigrationHandler(panel, plugin);
+    if (UNSAFE_customMigrationHandler) {
+      UNSAFE_customMigrationHandler(panel, plugin);
     }
 
     if (plugin.onPanelMigration) {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -54,7 +54,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
    * @internal
    * Only for use from core to handle migration from old angular panels
    **/
-  UNSAFE_customMigrationHandler?: (panel: PanelModel, plugin: PanelPlugin) => void;
+  _UNSAFE_customMigrationHandler?: (panel: PanelModel, plugin: PanelPlugin) => void;
 }
 
 export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends SceneObjectBase<
@@ -115,7 +115,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   }
 
   private async _pluginLoaded(plugin: PanelPlugin) {
-    const { options, fieldConfig, title, pluginVersion, UNSAFE_customMigrationHandler } = this.state;
+    const { options, fieldConfig, title, pluginVersion, _UNSAFE_customMigrationHandler } = this.state;
 
     const panel: PanelModel = {
       title,
@@ -128,8 +128,8 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     const currentVersion = this._getPluginVersion(plugin);
 
-    if (UNSAFE_customMigrationHandler) {
-      UNSAFE_customMigrationHandler(panel, plugin);
+    if (_UNSAFE_customMigrationHandler) {
+      _UNSAFE_customMigrationHandler(panel, plugin);
     }
 
     if (plugin.onPanelMigration) {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -50,6 +50,8 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   // internal state
   pluginLoadError?: string;
   pluginInstanceState?: any;
+  /** Only for use from core to handle migration from old angular panels */
+  customMigrationHandler?: (panel: PanelModel, plugin: PanelPlugin) => void;
 }
 
 export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends SceneObjectBase<
@@ -110,7 +112,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   }
 
   private async _pluginLoaded(plugin: PanelPlugin) {
-    const { options, fieldConfig, title, pluginVersion } = this.state;
+    const { options, fieldConfig, title, pluginVersion, customMigrationHandler } = this.state;
 
     const panel: PanelModel = {
       title,
@@ -122,6 +124,10 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     };
 
     const currentVersion = this._getPluginVersion(plugin);
+
+    if (customMigrationHandler) {
+      customMigrationHandler(panel, plugin);
+    }
 
     if (plugin.onPanelMigration) {
       if (currentVersion !== this.state.pluginVersion) {


### PR DESCRIPTION
This is one required to handle the auto migration of old angular panels. 

Because the panel type change migration handlers already work by mutating a "PanelModel" like object I am continuing to use that model here as it makes the logic very simple, we just build this mutatable panel model-like object once and pass it through the custom handler, and then through the normal migration handler. 

used in https://github.com/grafana/grafana/pull/76100



