### PR TITLE
DataSourceVariable: Value should be uid, and other fixes

### DIFF
--- a/packages/scenes/src/variables/variants/DataSourceVariable.test.ts
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.test.ts
@@ -6,16 +6,17 @@ import { SceneObject } from '../../core/types';
 
 import { DataSourceVariable } from './DataSourceVariable';
 import { VariableCustomFormatterFn } from '../types';
+import { DataSourceSrv, GetDataSourceListFilters, setDataSourceSrv } from '@grafana/runtime';
 
-function getDataSource(name: string, type: string, isDefault = false): DataSourceInstanceSettings {
+function getDataSource(overrides: Partial<DataSourceInstanceSettings>): DataSourceInstanceSettings {
   return {
     id: 1,
-    uid: 'c8eceabb-0275-4108-8f03-8f74faf4bf6d',
-    type,
-    name,
+    uid: '1',
+    type: 'prometheus',
+    name: 'name',
     meta: {
-      id: type,
-      name,
+      id: 'prometheus',
+      name: 'name',
       type: PluginType.datasource,
       info: {
         author: { name: 'Grafana Labs' },
@@ -35,20 +36,34 @@ function getDataSource(name: string, type: string, isDefault = false): DataSourc
     jsonData: {},
     access: 'proxy',
     readOnly: false,
-    isDefault,
+    isDefault: false,
+    ...overrides,
   };
 }
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    getList: () => [
-      getDataSource('prometheus-mocked', 'prometheus'),
-      getDataSource('slow-prometheus-mocked', 'prometheus', true),
-      getDataSource('elastic-mocked', 'elastic'),
-    ],
-  }),
-}));
+const getDataSourceListMock = jest.fn().mockImplementation((filters: GetDataSourceListFilters) => {
+  if (filters.pluginId === 'prometheus') {
+    return [
+      getDataSource({ name: 'prometheus-mocked', type: 'prometheus', uid: 'prometheus-mocked-uid' }),
+      getDataSource({
+        name: 'slow-prometheus-mocked',
+        type: 'prometheus',
+        uid: 'slow-prometheus-mocked-uid',
+        isDefault: true,
+      }),
+    ];
+  }
+
+  if (filters.pluginId === 'elastic') {
+    return [getDataSource({ name: 'elastic-mocked', type: 'elastic', uid: 'elastic-mocked-uid' })];
+  }
+
+  return [];
+});
+
+setDataSourceSrv({
+  getList: getDataSourceListMock,
+} as any as DataSourceSrv);
 
 jest.mock('../../core/sceneGraph', () => {
   return {
@@ -99,35 +114,31 @@ describe('DataSourceVariable', () => {
 
       expect(variable.state.value).toEqual('');
       expect(variable.state.text).toEqual('');
-      expect(variable.state.options).toEqual([
-        {
-          label: 'No data sources found',
-          value: '',
-        },
-      ]);
+      expect(variable.state.error).toEqual('No data sources found');
     });
 
-    it('Should default to first item datasource when options available', async () => {
+    it('Should add default as first item when addDefaultOption is true', async () => {
       const variable = new DataSourceVariable({
         name: 'test',
         options: [],
         value: '',
         text: '',
         pluginId: 'prometheus',
+        addDefaultOption: true,
       });
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toEqual('prometheus-mocked');
+      expect(variable.state.value).toEqual('prometheus-mocked-uid');
       expect(variable.state.text).toEqual('prometheus-mocked');
       expect(variable.state.options).toEqual([
         {
           label: 'prometheus-mocked',
-          value: 'prometheus-mocked',
+          value: 'prometheus-mocked-uid',
         },
         {
           label: 'slow-prometheus-mocked',
-          value: 'slow-prometheus-mocked',
+          value: 'slow-prometheus-mocked-uid',
         },
         {
           label: 'default',
@@ -147,12 +158,11 @@ describe('DataSourceVariable', () => {
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toEqual('prometheus-mocked');
+      expect(variable.state.value).toEqual('prometheus-mocked-uid');
       expect(variable.state.text).toEqual('prometheus-mocked');
       expect(variable.state.options).toEqual([
-        { label: 'prometheus-mocked', value: 'prometheus-mocked' },
-        { label: 'slow-prometheus-mocked', value: 'slow-prometheus-mocked' },
-        { label: 'default', value: 'default' },
+        { label: 'prometheus-mocked', value: 'prometheus-mocked-uid' },
+        { label: 'slow-prometheus-mocked', value: 'slow-prometheus-mocked-uid' },
       ]);
     });
   });
@@ -170,9 +180,11 @@ describe('DataSourceVariable', () => {
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toEqual('slow-prometheus-mocked');
+      expect(variable.state.value).toEqual('slow-prometheus-mocked-uid');
       expect(variable.state.text).toEqual('slow-prometheus-mocked');
-      expect(variable.state.options).toEqual([{ label: 'slow-prometheus-mocked', value: 'slow-prometheus-mocked' }]);
+      expect(variable.state.options).toEqual([
+        { label: 'slow-prometheus-mocked', value: 'slow-prometheus-mocked-uid' },
+      ]);
     });
 
     it('Should generate correctly the options after interpolating variables', async () => {
@@ -187,9 +199,11 @@ describe('DataSourceVariable', () => {
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toEqual('slow-prometheus-mocked');
+      expect(variable.state.value).toEqual('slow-prometheus-mocked-uid');
       expect(variable.state.text).toEqual('slow-prometheus-mocked');
-      expect(variable.state.options).toEqual([{ label: 'slow-prometheus-mocked', value: 'slow-prometheus-mocked' }]);
+      expect(variable.state.options).toEqual([
+        { label: 'slow-prometheus-mocked', value: 'slow-prometheus-mocked-uid' },
+      ]);
     });
   });
 
@@ -199,13 +213,13 @@ describe('DataSourceVariable', () => {
         name: 'test',
         options: [],
         pluginId: 'prometheus',
-        value: 'slow-prometheus-mocked',
+        value: 'slow-prometheus-mocked-uid',
         text: 'slow-prometheus-mocked',
       });
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toBe('slow-prometheus-mocked');
+      expect(variable.state.value).toBe('slow-prometheus-mocked-uid');
       expect(variable.state.text).toBe('slow-prometheus-mocked');
     });
 
@@ -215,13 +229,13 @@ describe('DataSourceVariable', () => {
         options: [],
         isMulti: true,
         pluginId: 'prometheus',
-        value: ['prometheus-mocked', 'slow-prometheus-mocked', 'elastic-mocked'],
+        value: ['prometheus-mocked-uid', 'slow-prometheus-mocked-uid', 'elastic-mocked-uid'],
         text: ['prometheus-mocked', 'slow-prometheus-mocked', 'elastic-mocked'],
       });
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toEqual(['prometheus-mocked', 'slow-prometheus-mocked']);
+      expect(variable.state.value).toEqual(['prometheus-mocked-uid', 'slow-prometheus-mocked-uid']);
       expect(variable.state.text).toEqual(['prometheus-mocked', 'slow-prometheus-mocked']);
     });
 
@@ -231,13 +245,13 @@ describe('DataSourceVariable', () => {
         options: [],
         isMulti: true,
         pluginId: 'elastic',
-        value: ['prometheus-mocked', 'slow-prometheus-mocked'],
+        value: ['prometheus-mocked-uid', 'slow-prometheus-mocked-uid'],
         text: ['prometheus-mocked', 'slow-prometheus-mocked'],
       });
 
       await lastValueFrom(variable.validateAndUpdate());
 
-      expect(variable.state.value).toEqual(['elastic-mocked']);
+      expect(variable.state.value).toEqual(['elastic-mocked-uid']);
       expect(variable.state.text).toEqual(['elastic-mocked']);
     });
   });

--- a/packages/scenes/src/variables/variants/DataSourceVariable.test.ts
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.test.ts
@@ -117,14 +117,14 @@ describe('DataSourceVariable', () => {
       expect(variable.state.error).toEqual('No data sources found');
     });
 
-    it('Should add default as first item when addDefaultOption is true', async () => {
+    it('Should add default as first item when defaultOptionEnabled is true', async () => {
       const variable = new DataSourceVariable({
         name: 'test',
         options: [],
         value: '',
         text: '',
         pluginId: 'prometheus',
-        addDefaultOption: true,
+        defaultOptionEnabled: true,
       });
 
       await lastValueFrom(variable.validateAndUpdate());

--- a/packages/scenes/src/variables/variants/DataSourceVariable.tsx
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.tsx
@@ -20,6 +20,10 @@ export interface DataSourceVariableState extends MultiValueVariableState {
    * Filter data source instances based on name
    */
   regex: string;
+  /**
+   * For backwards compatability with old dashboards, will likely be removed
+   */
+  addDefaultOption?: boolean;
 }
 
 export class DataSourceVariable extends MultiValueVariable<DataSourceVariableState> {
@@ -45,7 +49,7 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
       return of([]);
     }
 
-    const dataSourceTypes = this.getDataSourceTypes();
+    const dataSources = getDataSourceSrv().getList({ metrics: true, variables: false, pluginId: this.state.pluginId });
 
     let regex;
     if (this.state.regex) {
@@ -55,31 +59,23 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
 
     const options: VariableValueOption[] = [];
 
-    for (let i = 0; i < dataSourceTypes.length; i++) {
-      const source = dataSourceTypes[i];
-      // must match on type
-      if (source.meta.id !== this.state.pluginId) {
-        continue;
-      }
+    for (let i = 0; i < dataSources.length; i++) {
+      const source = dataSources[i];
 
       if (isValid(source, regex)) {
-        options.push({ label: source.name, value: source.name });
+        options.push({ label: source.name, value: source.uid });
       }
 
-      if (isDefault(source, regex)) {
+      if (this.state.addDefaultOption && isDefault(source, regex)) {
         options.push({ label: 'default', value: 'default' });
       }
     }
 
     if (options.length === 0) {
-      options.push({ label: 'No data sources found', value: '' });
+      this.setState({ error: 'No data sources found' });
     }
 
     return of(options);
-  }
-
-  private getDataSourceTypes(): DataSourceInstanceSettings[] {
-    return getDataSourceSrv().getList({ metrics: true, variables: false });
   }
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {

--- a/packages/scenes/src/variables/variants/DataSourceVariable.tsx
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.tsx
@@ -23,7 +23,7 @@ export interface DataSourceVariableState extends MultiValueVariableState {
   /**
    * For backwards compatability with old dashboards, will likely be removed
    */
-  addDefaultOption?: boolean;
+  defaultOptionEnabled?: boolean;
 }
 
 export class DataSourceVariable extends MultiValueVariable<DataSourceVariableState> {
@@ -66,7 +66,7 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
         options.push({ label: source.name, value: source.uid });
       }
 
-      if (this.state.addDefaultOption && isDefault(source, regex)) {
+      if (this.state.defaultOptionEnabled && isDefault(source, regex)) {
         options.push({ label: 'default', value: 'default' });
       }
     }

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -61,6 +61,22 @@ describe('MultiValueVariable', () => {
       expect(variable.state.text).toBe('A');
     });
 
+    it('Should update text representation if current matched option has different text value', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [{ label: 'displayName for A', value: 'A' }],
+        value: 'A',
+        text: 'A',
+        delayMs: 0,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toBe('A');
+      expect(variable.state.text).toBe('displayName for A');
+    });
+
     it('Should maintain the valid values when multiple selected', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -103,7 +103,14 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     } else {
       // Single valued variable
       const foundCurrent = options.find((x) => x.value === this.state.value);
-      if (!foundCurrent) {
+      if (foundCurrent) {
+        // When updating the initial state from URL the text property is set the same as value
+        // Here we can correct the text value state
+        if (foundCurrent.label !== this.state.text) {
+          stateUpdate.text = foundCurrent.label;
+        }
+      } else {
+        // Current value is found in options
         if (this.state.defaultToAll) {
           stateUpdate.value = ALL_VARIABLE_VALUE;
           stateUpdate.text = ALL_VARIABLE_TEXT;


### PR DESCRIPTION
old (current) template variable system DataSourceVariable was changed in May in the main repo to put uid as the value (https://github.com/grafana/grafana/pull/69259) 

* [x] Fixes value issue (so it's set to uid and not name). Old implementation in core sets value to the uid so the url state also has the uid. So when opening the dashboard in scenes the uid was shown in the variable dropdown. 
* [x] Fixes issue with validateAndUpdate when the value matches a option but the current text value is not correct. This can happen after initial url sync sets both text & value (due to no options as url sync happens before validateAndUpdate). Added corrective logic to fix text state. 
* [x] Move pluginId fitlering to DataSourceSrv.getList
* [x] Adds option to only add default option when defaultOptionEnabled (Not 100% sure we needed, definitely not for scene apps where this option is just causing problems). It is causing problems in core dashbords as well. If I enable Multi value and All value and repeat a row I get a duplicate row for "default".  I think we can remove this option and keep url compatability with old dashboards if we make sure the default data source is first in the options array? 


Fixes https://github.com/grafana/scenes/issues/383 