### PR TITLE
Markup: element data keys changes 

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -9,6 +9,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { isSceneObject, SceneComponentProps, SceneLayout, SceneObject } from '../../core/types';
 
 import { VizPanel } from './VizPanel';
+import { css } from '@emotion/css';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -87,7 +88,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const isReadyToRender = dataObject.isDataReadyToDisplay ? dataObject.isDataReadyToDisplay() : true;
 
   return (
-    <div ref={ref as RefCallback<HTMLDivElement>} style={{ position: 'absolute', width: '100%', height: '100%' }}>
+    <div ref={ref as RefCallback<HTMLDivElement>} className={wrapperDivStyles} data-viz-panel-key={model.state.key}>
       {width > 0 && height > 0 && (
         <PanelChrome
           title={titleInterpolated}
@@ -184,3 +185,9 @@ function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | un
   }
   return message;
 }
+
+const wrapperDivStyles = css({
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+});

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -55,11 +55,15 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
                 const className = sceneChild.getClassName?.();
 
                 return isLazy ? (
-                  <LazyLoader key={sceneChild.state.key!} data-panelid={sceneChild.state.key} className={className}>
+                  <LazyLoader
+                    key={sceneChild.state.key!}
+                    data-griditem-key={sceneChild.state.key}
+                    className={className}
+                  >
                     <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
                   </LazyLoader>
                 ) : (
-                  <div key={sceneChild.state.key} data-panelid={sceneChild.state.key} className={className}>
+                  <div key={sceneChild.state.key} data-griditem-key={sceneChild.state.key} className={className}>
                     <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
                   </div>
                 );


### PR DESCRIPTION
To support keybindings that need access to hovered over panel (and maybe some e2e tests) we need these data attributes on the element.

* [x] Rename the grid item data attribute to "grid-item-key" , it's not compatible with the old panel ids anyway
* [x] Add data key id to VizPanel div wrapper

Used in https://github.com/grafana/grafana/pull/76233 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.0--canary.403.6466736145.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.15.0--canary.403.6466736145.0
  # or 
  yarn add @grafana/scenes@1.15.0--canary.403.6466736145.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
