### PR TITLE
SceneVariableSet: isVariableLoadingOrWaitingToUpdate should ignore isActive state

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -522,6 +522,20 @@ describe('SceneVariableList', () => {
 
       expect(innerSet.isVariableLoadingOrWaitingToUpdate(scopedA)).toBe(false);
     });
+
+    it('Should ignore isActivate state', async () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const set = new SceneVariableSet({ variables: [A] });
+      const deactivate = set.activate();
+
+      // Should start variables with no dependencies
+      expect(A.state.loading).toBe(true);
+      A.signalUpdateCompleted();
+
+      deactivate();
+
+      expect(set.isVariableLoadingOrWaitingToUpdate(A)).toBe(false);
+    });
   });
 
   describe('When variable throws error', () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -315,11 +315,6 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
    * Return true if variable is waiting to update or currently updating
    */
   public isVariableLoadingOrWaitingToUpdate(variable: SceneVariable) {
-    // If we have not activated yet then variables are not up to date
-    if (!this.isActive) {
-      return true;
-    }
-
     if (variable.isAncestorLoading && variable.isAncestorLoading()) {
       return true;
     }


### PR DESCRIPTION
Working on fixing "viewPanel" for repeated panels on full page reload, and this old condition caused the panel to be empty as the row level SceneVariableSet is not active when viewing the panel. 

This old condition is not needed anymore now that we have fixed the flow of activation by not rendering components until they are active (so that higher level objects are activated before children). 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.16.0--canary.405.6471182532.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.16.0--canary.405.6471182532.0
  # or 
  yarn add @grafana/scenes@1.16.0--canary.405.6471182532.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
