### PR TITLE
Scenes: Interval Variable now considers $__auto_interval

### DIFF
--- a/packages/scenes/src/variables/variants/IntervalVariable.tsx
+++ b/packages/scenes/src/variables/variants/IntervalVariable.tsx
@@ -57,7 +57,11 @@ export class IntervalVariable
     const update: Partial<IntervalVariableState> = {};
     const val = values[this.getKey()];
     if (typeof val === 'string') {
-      update.value = val;
+      if (val.startsWith('$__auto_interval_')) {
+        update.value = AUTO_VARIABLE_VALUE;
+      } else {
+        update.value = val;
+      }
     }
     this.setState(update);
   }

--- a/packages/scenes/src/variables/variants/IntervalVariable.tsx
+++ b/packages/scenes/src/variables/variants/IntervalVariable.tsx
@@ -57,6 +57,7 @@ export class IntervalVariable
     const update: Partial<IntervalVariableState> = {};
     const val = values[this.getKey()];
     if (typeof val === 'string') {
+      // support old auto interval url value
       if (val.startsWith('$__auto_interval_')) {
         update.value = AUTO_VARIABLE_VALUE;
       } else {


### PR DESCRIPTION
The old variable system uses `$__auto_interval`... and in the scenes, we changed the prefix to be `$__auto`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.1--canary.407.6480642750.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.15.1--canary.407.6480642750.0
  # or 
  yarn add @grafana/scenes@1.15.1--canary.407.6480642750.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
