### PR TITLE
AdHocVariable: Fixes trailing comma

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -22,6 +22,6 @@ describe('AdHocFiltersVariable', () => {
 
     variable.activate();
 
-    expect(variable.getValue()).toBe(`key1="val1",key2=~"\\\\[val2\\\\]",`);
+    expect(variable.getValue()).toBe(`key1="val1",key2=~"\\\\[val2\\\\]"`);
   });
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -68,6 +68,10 @@ export class AdHocFiltersVariable
       expr += `${this._renderFilter(filter)},`;
     }
 
+    if (expr.length > 0) {
+      expr = expr.slice(0, -1);
+    }
+
     this.setState({ filterExpression: expr });
     this.publishEvent(new SceneVariableValueChangedEvent(this), true);
   }


### PR DESCRIPTION
Removes the last trailing comma.

It was not a problem for prometheus as it was valid label filter expression but
it's not valid for loki.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.19.0--canary.411.6525620163.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.19.0--canary.411.6525620163.0
  # or 
  yarn add @grafana/scenes@1.19.0--canary.411.6525620163.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
