### PR TITLE
SceneTimeRange: Respect time zone when updating time range

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -1,4 +1,4 @@
-import { getTimeZone, setWeekStart, TimeRange } from '@grafana/data';
+import { dateTimeFormat, getTimeZone, setWeekStart, TimeRange } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
@@ -96,18 +96,19 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   }
 
   public onTimeRangeChange = (timeRange: TimeRange) => {
+    const tz = this.getTimeZone();
     const update: Partial<SceneTimeRangeState> = {};
 
     if (typeof timeRange.raw.from === 'string') {
       update.from = timeRange.raw.from;
     } else {
-      update.from = timeRange.raw.from.toISOString();
+      update.from = dateTimeFormat(timeRange.raw.from, { timeZone: tz });
     }
 
     if (typeof timeRange.raw.to === 'string') {
       update.to = timeRange.raw.to;
     } else {
-      update.to = timeRange.raw.to.toISOString();
+      update.to = dateTimeFormat(timeRange.raw.to, { timeZone: tz });
     }
 
     update.value = evaluateTimeRange(update.from, update.to, this.getTimeZone(), this.state.fiscalYearStartMonth);


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/412

When setting the time range, `moment.toISOString` method was used that returns UTC time. This changes the time range update function to respect the closest time zone.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.19.1--canary.413.6544510710.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.19.1--canary.413.6544510710.0
  # or 
  yarn add @grafana/scenes@1.19.1--canary.413.6544510710.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
