### PR TITLE
Remove checkbox from time window comparison

### DIFF
--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.ts
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.ts
@@ -466,4 +466,32 @@ describe('SceneTimeRangeCompare', () => {
     timeRange.setState({ from: 'now-8d', to: 'now' });
     expect(comparer.state.compareWith).toBe(PREVIOUS_PERIOD_COMPARE_OPTION.value);
   });
+
+  test('should allow for clearing comparison', () => {
+    const timeRange = new SceneTimeRange({
+      from: 'now-3d',
+      to: 'now',
+    });
+
+    const comparer = new SceneTimeRangeCompare({});
+
+    const scene = new EmbeddedScene({
+      $timeRange: timeRange,
+      body: new SceneFlexLayout({
+        children: [new SceneFlexItem({ body: comparer })],
+      }),
+    });
+
+    scene.activate();
+    // activating comparer manually as we do not render scene in this test
+    comparer.activate();
+    expect(comparer.state.compareWith).toBeUndefined();
+
+    // Check that we can remove previously selected comparison
+    comparer.onCompareWithChanged('7d');
+    expect(comparer.state.compareWith).toBe('7d');
+
+    comparer.onCompareWithChanged(NO_COMPARE_OPTION.value);
+    expect(comparer.state.compareWith).toBeUndefined();
+  });
 });

--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.ts
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.ts
@@ -1,7 +1,7 @@
 import { SceneTimeRange } from '../core/SceneTimeRange';
 import { EmbeddedScene } from './EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from './layout/SceneFlexLayout';
-import { PREVIOUS_PERIOD_COMPARE_OPTION, SceneTimeRangeCompare } from './SceneTimeRangeCompare';
+import { NO_COMPARE_OPTION, PREVIOUS_PERIOD_COMPARE_OPTION, SceneTimeRangeCompare } from './SceneTimeRangeCompare';
 
 describe('SceneTimeRangeCompare', () => {
   describe('given a time range', () => {
@@ -16,10 +16,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(9);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(10);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
               [
+                {
+                  "label": "No comparison",
+                  "value": "__noPeriod",
+                },
                 {
                   "label": "Previous period",
                   "value": "__previousPeriod",
@@ -68,10 +73,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(9);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(10);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
               [
+                {
+                  "label": "No comparison",
+                  "value": "__noPeriod",
+                },
                 {
                   "label": "Previous period",
                   "value": "__previousPeriod",
@@ -124,10 +134,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(8);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(9);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
               [
+                {
+                  "label": "No comparison",
+                  "value": "__noPeriod",
+                },
                 {
                   "label": "Previous period",
                   "value": "__previousPeriod",
@@ -172,10 +187,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(8);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(9);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
               [
+                {
+                  "label": "No comparison",
+                  "value": "__noPeriod",
+                },
                 {
                   "label": "Previous period",
                   "value": "__previousPeriod",
@@ -220,10 +240,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(7);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(8);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
                 [
+                  {
+                    "label": "No comparison",
+                    "value": "__noPeriod",
+                  },
                   {
                     "label": "Previous period",
                     "value": "__previousPeriod",
@@ -267,10 +292,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(6);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(7);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
                   [
+                    {
+                      "label": "No comparison",
+                      "value": "__noPeriod",
+                    },
                     {
                       "label": "Previous period",
                       "value": "__previousPeriod",
@@ -307,10 +337,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(6);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(7);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
                     [
+                      {
+                        "label": "No comparison",
+                        "value": "__noPeriod",
+                      },
                       {
                         "label": "Previous period",
                         "value": "__previousPeriod",
@@ -347,10 +382,15 @@ describe('SceneTimeRangeCompare', () => {
 
         const result = comparer.getCompareOptions(timeRange.state.value);
 
-        expect(result).toHaveLength(4);
-        expect(result[0]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
+        expect(result).toHaveLength(5);
+        expect(result[0]).toBe(NO_COMPARE_OPTION);
+        expect(result[1]).toBe(PREVIOUS_PERIOD_COMPARE_OPTION);
         expect(result).toMatchInlineSnapshot(`
               [
+                {
+                  "label": "No comparison",
+                  "value": "__noPeriod",
+                },
                 {
                   "label": "Previous period",
                   "value": "__previousPeriod",

--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -166,7 +166,6 @@ function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeR
     <Menu>
       {compareOptions.map(({ label, value }, idx) => (
         <>
-          {idx === 1 && <Menu.Divider />}
           <Menu.Item
             key={idx}
             label={label}
@@ -175,6 +174,7 @@ function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeR
               setIsOpen(false);
             }}
           />
+          {value === NO_PERIOD_VALUE && <Menu.Divider />}
         </>
       ))}
     </Menu>


### PR DESCRIPTION
Fixes [#447](https://github.com/grafana/app-observability-plugin/issues/447).

Update Time Range comparison component:
- Removed checkbox
- Add new `No comparison` option
- Display chosen comparison option on select