### PR TITLE
SceneTimeRange: Respect time zone when updating time range

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -97,20 +97,32 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
   public onTimeRangeChange = (timeRange: TimeRange) => {
     const update: Partial<SceneTimeRangeState> = {};
+    const updateToEval: Partial<SceneTimeRangeState> = {};
 
     if (typeof timeRange.raw.from === 'string') {
       update.from = timeRange.raw.from;
+      updateToEval.from = timeRange.raw.from;
     } else {
       update.from = timeRange.raw.from.toISOString();
+      // @ts-expect-error Need an update in core API
+      updateToEval.from = timeRange.raw.from.toISOString(true);
     }
 
     if (typeof timeRange.raw.to === 'string') {
       update.to = timeRange.raw.to;
+      updateToEval.to = timeRange.raw.to;
     } else {
       update.to = timeRange.raw.to.toISOString();
+      // @ts-expect-error Need an update in core API
+      updateToEval.to = timeRange.raw.to.toISOString(true);
     }
 
-    update.value = evaluateTimeRange(update.from, update.to, this.getTimeZone(), this.state.fiscalYearStartMonth);
+    update.value = evaluateTimeRange(
+      updateToEval.from,
+      updateToEval.to,
+      this.getTimeZone(),
+      this.state.fiscalYearStartMonth
+    );
 
     // Only update if time range actually changed
     if (update.from !== this.state.from || update.to !== this.state.to) {


### PR DESCRIPTION
Alt to https://github.com/grafana/scenes/pull/413

In SceneTimeRange we are storing the range in two places `state.from` / `state.to` and `state.value` which holds the actual evaluated time range. The former holds state that's used in the url or comes from configuration, while the `state.value` holds the parsed time range, used downstream in quiery runners, pickers and more.. When updating the abs time range from the UI, the value was calculated against the UTC value of the selected range. 

This PR makes sure the evaluation happens against the value that the user actually selected in the UI, not the UTC-converted one.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.19.1--canary.420.6573494215.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.19.1--canary.420.6573494215.0
  # or 
  yarn add @grafana/scenes@1.19.1--canary.420.6573494215.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
