### PR TITLE
SceneQueryRunner: Fixes adhoc filters when using a variable data source

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -13,7 +13,7 @@ import {
   rangeUtil,
   transformDataFrame,
 } from '@grafana/data';
-import { getDataSourceSrv, getRunRequest, toDataQueryError } from '@grafana/runtime';
+import { getRunRequest, toDataQueryError } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -337,7 +337,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       const ds = await getDataSource(datasource, this._scopedVars);
 
       if (!this._adhocFilterSet) {
-        this.findAndSubscribeToAdhocFilters(ds.uid);
+        this.findAndSubscribeToAdhocFilters();
       }
 
       const [request, secondaryRequest] = this.prepareRequests(timeRange, ds);
@@ -502,7 +502,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   /**
    * Walk up scene graph and find the closest filterset with matching data source
    */
-  private findAndSubscribeToAdhocFilters(ourDataSourceUid: string) {
+  private findAndSubscribeToAdhocFilters() {
     const set = getClosest(this, (s) => {
       let found = null;
       if (s instanceof AdHocFilterSet && s.state.datasource?.uid === this.state.datasource?.uid) {
@@ -517,12 +517,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     });
 
     if (!set || set.state.applyMode !== 'same-datasource') {
-      return;
-    }
-
-    const setDataSource = getDataSourceSrv().getInstanceSettings(set?.state.datasource, this._scopedVars);
-
-    if (setDataSource?.uid !== ourDataSourceUid) {
       return;
     }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
@@ -73,7 +73,7 @@ describe('AdHocFilter', () => {
     await waitFor(() => select(selects[2], 'val4', { container: document.body }));
 
     // should run new query when filter changed
-    expect(runRequest.mock.calls.length).toBe(1);
+    expect(runRequest.mock.calls.length).toBe(2);
     expect(filtersSet.state.filters[0].value).toBe('val4');
   });
 


### PR DESCRIPTION
I am removing this condition as I don't think it's needed, at least not if you use the data source variable consistently (in both the set and queries) 