### PR TITLE
[cr] adds docs for SceneCSSGridLayout

### DIFF
--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -197,7 +197,7 @@ To build a grid with 3 columns, rows with a height of 150px and a gap between it
 ```ts
 const scene = new EmbeddedScene({
   body: new SceneCSSGridLayout({
-    templateColumns: `repeat(3, 1fr)`,
+    templateColumns: `repeat(auto-fit, minmax(400px, 1fr))`,
     autoRows: '150px',
     rowGap: '5px',
     columnGap: '5px',

--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -169,14 +169,10 @@ As an alternative to `SceneFlexLayout`, `SceneCSSGridLayout` is available to wra
 ```ts
 const scene = new EmbeddedScene({
   body: new SceneCSSGridLayout({
-    templateColumns: `repeat(2, 1fr)`,
+    templateColumns: `repeat(auto-fit, minmax(400px, 1fr))`,
     children: [
-      new SceneCSSGridItem({
-        body: PanelBuilders.timeseries().setTitle('Time series').build(),
-      }),
-      new SceneCSSGridItem({
-        body: PanelBuilders.table().setTitle('Table').build(),
-      }),
+      PanelBuilders.timeseries().setTitle('Graph 1').build(),
+      PanelBuilders.timeseries().setTitle('Graph 2').build(),
     ],
   }),
 });
@@ -199,17 +195,19 @@ justifyContent?: CSSProperties['justifyContent'];
 md?: SceneCSSGridLayoutState;
 ```
 
-All properties are optional except for `children` and `templateColumns`. `rowGap` and `columGap` default to `8px`.
+With CSS Grid it's easy to build a dynamic grid of panels where panel size constraints can be specific on the grid itself instead of each panel. Very useful
+for building grids of equally sized panels.
 
-To build a grid with 3 columns, rows with a height of 150px and a gap between items of 5px, it would look like this:
+The grid layout below is configured to have child elements with a minimum size of 400px and if there is more space available split it equally. The height
+is set using autoRows. This configuration will enable a very responsive layout of equally sized panels.
 
 ```ts
 const scene = new EmbeddedScene({
   body: new SceneCSSGridLayout({
     templateColumns: `repeat(auto-fit, minmax(400px, 1fr))`,
     autoRows: '150px',
-    rowGap: 1,
-    columnGap: 1,
+    rowGap: 2,
+    columnGap: 2,
     children: [
       new SceneCSSGridItem({
         body: PanelBuilders.timeseries().setTitle('Time series').build(),
@@ -228,9 +226,12 @@ const scene = new EmbeddedScene({
 });
 ```
 
+The SceneCSSGridItem wrapper around each child is optional.
+
 ## Grid layout
 
-`SceneGridLayout` allows you to build scenes as grids. This is the default behavior of Dashboards in Grafana, and grid layout lets you add a similar experience to your scene.
+`SceneGridLayout` allows you to build scenes as grids of elements that can be dragged and moved around. This is the default layout used by the core Dashboard experiance in Grafana. It is
+not recommended for scene app plugins unless you need users to be able to move panels around.
 
 ### Step 1. Create a scene
 

--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -162,6 +162,58 @@ new SceneFlexLayout({
 
 In the preceding example, we use the `md` property to override the default responsive behavior that changes a row layout to a column layout. We also apply a tighter `minHeight` constraint.
 
+## CSS grid layout
+
+As an alternative to `SceneFlexLayout`, `SceneCSSGridLayout` is available to wrap scene items in a CSS Grid.
+
+```ts
+const scene = new EmbeddedScene({
+  body: new SceneCSSGridLayout({
+    templateColumns: `repeat(2, 1fr)`,
+    children: [new SceneFlexItem({ minHeight: 200 }), new SceneFlexItem({ minHeight: 300 })],
+  }),
+});
+```
+
+`SceneCSSGridLayout` accepts `children` the same as `SceneFlexLayout`, and has the following properties for applying CSS grid styles:
+
+```ts
+autoRows?: CSSProperties['gridAutoRows'];
+templateRows?: CSSProperties['gridTemplateRows'];
+templateColumns: CSSProperties['gridTemplateColumns'];
+rowGap?: CSSProperties['rowGap'];
+columnGap?: CSSProperties['columnGap'];
+justifyItems?: CSSProperties['justifyItems'];
+alignItems?: CSSProperties['alignItems'];
+justifyContent?: CSSProperties['justifyContent'];
+// For sizing constaints on smaller screens
+md?: SceneCSSGridLayoutState;
+```
+
+All properties are optional except for `children` and `templateColumns`. `rowGap` and `columGap` default to `8px`.
+
+To build a grid with 3 columns, rows with a height of 150px and a gap between items of 5px, it would look like this:
+
+```ts
+const scene = new EmbeddedScene({
+  body: new SceneCSSGridLayout({
+    templateColumns: `repeat(3, 1fr)`,
+    autoRows: '150px',
+    rowGap: '5px',
+    columnGap: '5px',
+    children: [
+      new SceneFlexItem({ minHeight: 150 }),
+      new SceneFlexItem({ minHeight: 150 }),
+      new SceneFlexItem({ minHeight: 150 }),
+      new SceneFlexItem({ minHeight: 150 }),
+      new SceneFlexItem({ minHeight: 150 }),
+      new SceneFlexItem({ minHeight: 150 }),
+      new SceneFlexItem({ minHeight: 150 }),
+    ],
+  }),
+});
+```
+
 ## Grid layout
 
 `SceneGridLayout` allows you to build scenes as grids. This is the default behavior of Dashboards in Grafana, and grid layout lets you add a similar experience to your scene.

--- a/docusaurus/docs/scene-layout.md
+++ b/docusaurus/docs/scene-layout.md
@@ -170,7 +170,14 @@ As an alternative to `SceneFlexLayout`, `SceneCSSGridLayout` is available to wra
 const scene = new EmbeddedScene({
   body: new SceneCSSGridLayout({
     templateColumns: `repeat(2, 1fr)`,
-    children: [new SceneFlexItem({ minHeight: 200 }), new SceneFlexItem({ minHeight: 300 })],
+    children: [
+      new SceneCSSGridItem({
+        body: PanelBuilders.timeseries().setTitle('Time series').build(),
+      }),
+      new SceneCSSGridItem({
+        body: PanelBuilders.table().setTitle('Table').build(),
+      }),
+    ],
   }),
 });
 ```
@@ -181,8 +188,10 @@ const scene = new EmbeddedScene({
 autoRows?: CSSProperties['gridAutoRows'];
 templateRows?: CSSProperties['gridTemplateRows'];
 templateColumns: CSSProperties['gridTemplateColumns'];
-rowGap?: CSSProperties['rowGap'];
-columnGap?: CSSProperties['columnGap'];
+/** In Grafana design system grid units (8px)  */
+rowGap: number;
+/** In Grafana design system grid units (8px)  */
+columnGap: number;
 justifyItems?: CSSProperties['justifyItems'];
 alignItems?: CSSProperties['alignItems'];
 justifyContent?: CSSProperties['justifyContent'];
@@ -199,16 +208,21 @@ const scene = new EmbeddedScene({
   body: new SceneCSSGridLayout({
     templateColumns: `repeat(auto-fit, minmax(400px, 1fr))`,
     autoRows: '150px',
-    rowGap: '5px',
-    columnGap: '5px',
+    rowGap: 1,
+    columnGap: 1,
     children: [
-      new SceneFlexItem({ minHeight: 150 }),
-      new SceneFlexItem({ minHeight: 150 }),
-      new SceneFlexItem({ minHeight: 150 }),
-      new SceneFlexItem({ minHeight: 150 }),
-      new SceneFlexItem({ minHeight: 150 }),
-      new SceneFlexItem({ minHeight: 150 }),
-      new SceneFlexItem({ minHeight: 150 }),
+      new SceneCSSGridItem({
+        body: PanelBuilders.timeseries().setTitle('Time series').build(),
+      }),
+      new SceneCSSGridItem({
+        body: PanelBuilders.table().setTitle('Table').build(),
+      }),
+      new SceneCSSGridItem({
+        body: PanelBuilders.timeseries().setTitle('Time series').build(),
+      }),
+      new SceneCSSGridItem({
+        body: PanelBuilders.table().setTitle('Table').build(),
+      }),
     ],
   }),
 });

--- a/docusaurus/docs/scene-layout.tsx
+++ b/docusaurus/docs/scene-layout.tsx
@@ -1,6 +1,7 @@
 import {
   EmbeddedScene,
   PanelBuilders,
+  SceneCSSGridLayout,
   SceneFlexItem,
   SceneFlexLayout,
   SceneGridItem,
@@ -30,6 +31,51 @@ export function getFlexBoxLayoutScene() {
       children: [
         new SceneFlexItem({
           body: PanelBuilders.timeseries().setTitle('Time series').build(),
+        }),
+        new SceneFlexItem({
+          body: PanelBuilders.table().setTitle('Table').build(),
+        }),
+      ],
+    }),
+  });
+
+  return scene;
+}
+
+export function getCSSGridLayoutScene() {
+  const queryRunner = new SceneQueryRunner({
+    datasource: {
+      type: 'prometheus',
+      uid: 'gdev-prometheus',
+    },
+    queries: [
+      {
+        refId: 'A',
+        expr: 'rate(prometheus_http_requests_total{}[5m])',
+      },
+    ],
+  });
+
+  const scene = new EmbeddedScene({
+    $data: queryRunner,
+    body: new SceneCSSGridLayout({
+      templateColumns: 'repeat(2, 1fr)',
+      autoRows: '150px',
+      children: [
+        new SceneFlexItem({
+          body: PanelBuilders.timeseries().setTitle('Time series').build(),
+        }),
+        new SceneFlexItem({
+          body: PanelBuilders.table().setTitle('Time series').build(),
+        }),
+        new SceneFlexItem({
+          body: PanelBuilders.timeseries().setTitle('Time series').build(),
+        }),
+        new SceneFlexItem({
+          body: PanelBuilders.table().setTitle('Time series').build(),
+        }),
+        new SceneFlexItem({
+          body: PanelBuilders.timeseries().setTitle('Table').build(),
         }),
         new SceneFlexItem({
           body: PanelBuilders.table().setTitle('Table').build(),

--- a/docusaurus/docs/scene-layout.tsx
+++ b/docusaurus/docs/scene-layout.tsx
@@ -1,6 +1,7 @@
 import {
   EmbeddedScene,
   PanelBuilders,
+  SceneCSSGridItem,
   SceneCSSGridLayout,
   SceneFlexItem,
   SceneFlexLayout,
@@ -62,22 +63,22 @@ export function getCSSGridLayoutScene() {
       templateColumns: 'repeat(2, 1fr)',
       autoRows: '150px',
       children: [
-        new SceneFlexItem({
+        new SceneCSSGridItem({
           body: PanelBuilders.timeseries().setTitle('Time series').build(),
         }),
-        new SceneFlexItem({
+        new SceneCSSGridItem({
           body: PanelBuilders.table().setTitle('Time series').build(),
         }),
-        new SceneFlexItem({
+        new SceneCSSGridItem({
           body: PanelBuilders.timeseries().setTitle('Time series').build(),
         }),
-        new SceneFlexItem({
+        new SceneCSSGridItem({
           body: PanelBuilders.table().setTitle('Time series').build(),
         }),
-        new SceneFlexItem({
+        new SceneCSSGridItem({
           body: PanelBuilders.timeseries().setTitle('Table').build(),
         }),
-        new SceneFlexItem({
+        new SceneCSSGridItem({
           body: PanelBuilders.table().setTitle('Table').build(),
         }),
       ],

--- a/docusaurus/docs/scene-layout.tsx
+++ b/docusaurus/docs/scene-layout.tsx
@@ -60,8 +60,10 @@ export function getCSSGridLayoutScene() {
   const scene = new EmbeddedScene({
     $data: queryRunner,
     body: new SceneCSSGridLayout({
-      templateColumns: 'repeat(2, 1fr)',
+      templateColumns: `repeat(auto-fit, minmax(400px, 1fr))`,
       autoRows: '150px',
+      rowGap: 2,
+      columnGap: 2,
       children: [
         new SceneCSSGridItem({
           body: PanelBuilders.timeseries().setTitle('Time series').build(),

--- a/packages/scenes-app/src/demos/docs-examples.tsx
+++ b/packages/scenes-app/src/demos/docs-examples.tsx
@@ -5,6 +5,7 @@ import { getAdvancedCustomObjectScene } from '../../../../docusaurus/docs/advanc
 import { getCustomObjectScene, getDataAndTimeRangeScene } from '../../../../docusaurus/docs/core-concepts';
 import { getHelloWorldScene } from '../../../../docusaurus/docs/getting-started';
 import {
+  getCSSGridLayoutScene,
   getFlexBoxLayoutScene,
   getGridLayoutScene,
   getSplitLayoutScene,
@@ -37,6 +38,11 @@ const docs = [
     title: 'Flexbox layout',
     url: 'scene-layout-flexbox',
     getScene: getFlexBoxLayoutScene,
+  },
+  {
+    title: 'CSS grid layout',
+    url: 'scene-layout-css-grid',
+    getScene: getCSSGridLayoutScene,
   },
   {
     title: 'Grid layout',


### PR DESCRIPTION
Fixes #421 

Question: should we put some clarification in the docs about the difference between `SceneCSSGridLayout` and `SceneGridLayout`?

# Release notes 

As an alternative to `SceneFlexLayout`, `SceneCSSGridLayout` is now available to wrap scene items in a CSS grid. To create a scene with a CSS grid with two columns and rows with a height of `150px`, see example below:

```ts
  const queryRunner = new SceneQueryRunner({
    datasource: {
      type: 'prometheus',
      uid: 'gdev-prometheus',
    },
    queries: [
      {
        refId: 'A',
        expr: 'rate(prometheus_http_requests_total{}[5m])',
      },
    ],
  });

  const scene = new EmbeddedScene({
    $data: queryRunner,
    body: new SceneCSSGridLayout({
      templateColumns: 'repeat(auto-fit, minmax(400px, 1fr))`,
      autoRows: '150px',
      children: [
          PanelBuilders.timeseries().setTitle('Graph 1').build(),
          PanelBuilders.timeseries().setTitle('Graph 2').build(),
      ],
    }),
  });
```

