### PR TITLE
SceneObjectBase: Add utility function getAncestor

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -5,6 +5,8 @@ import { SceneObjectBase } from './SceneObjectBase';
 import { SceneObjectStateChangedEvent } from './events';
 import { SceneObject, SceneObjectState } from './types';
 import { SceneTimeRange } from '../core/SceneTimeRange';
+import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
+import { SceneCanvasText } from '../components/SceneCanvasText';
 
 interface TestSceneState extends SceneObjectState {
   name?: string;
@@ -267,6 +269,25 @@ describe('SceneObject', () => {
       deactivateScene();
 
       expect(() => deactivateScene()).toThrow();
+    });
+  });
+
+  describe('getAncestor', () => {
+    it('Can get ancestor', () => {
+      const innerObj = new SceneCanvasText({ text: 'hello' });
+      const scene = new SceneFlexLayout({
+        children: [
+          new SceneFlexItem({
+            body: innerObj,
+          }),
+        ],
+      });
+
+      expect(innerObj.getAncestor(SceneFlexLayout)).toBe(scene);
+      expect(innerObj.getAncestor(SceneFlexItem)).toBe(scene.state.children![0]);
+      expect(() => {
+        innerObj.getAncestor(TestScene);
+      }).toThrow();
     });
   });
 });

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -325,6 +325,23 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
     }
   }
 
+  /**
+   * A utility function to find the closest ancestor of a given type. This function expects
+   * to find it and will throw an error if it does noit.
+   */
+  public getAncestor<ParentType>(type: { new (...args: never[]): ParentType }): ParentType {
+    let parent: SceneObject | undefined = this;
+
+    while (parent) {
+      if (parent instanceof type) {
+        return parent;
+      }
+      parent = parent.parent;
+    }
+
+    throw new Error('Unable to find parent of type ' + type.name);
+  }
+
   /** Returns a SceneObjectRef that will resolve to this object */
   public getRef(): SceneObjectRef<this> {
     if (!this._ref) {


### PR DESCRIPTION
After developing the data trails https://github.com/grafana/grafana/pull/77019https://github.com/grafana/grafana/pull/77019
I found myself needing to get a parent object of a specific type a lot.

I think a utility function like this could be useful.


