### PR TITLE
VizPanel: Make VizPanel usable without relative position parent 

### DIFF
--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -72,15 +72,11 @@ export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
 }
 
 function getLayoutChildren(count: number) {
-  return Array.from(
-    Array(count),
-    (v, index) =>
-      new SceneCSSGridItem({
-        body: PanelBuilders.stat()
-          .setTitle(`Panel ${count}`)
-          .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
-          .build(),
-      })
+  return Array.from(Array(count), (v, index) =>
+    PanelBuilders.stat()
+      .setTitle(`Panel ${count}`)
+      .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
+      .build()
   );
 }
 

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -88,57 +88,59 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const isReadyToRender = dataObject.isDataReadyToDisplay ? dataObject.isDataReadyToDisplay() : true;
 
   return (
-    <div ref={ref as RefCallback<HTMLDivElement>} className={wrapperDivStyles} data-viz-panel-key={model.state.key}>
-      {width > 0 && height > 0 && (
-        <PanelChrome
-          title={titleInterpolated}
-          description={description ? () => model.interpolate(description) : ''}
-          loadingState={data.state}
-          statusMessage={getChromeStatusMessage(data, _pluginLoadError)}
-          width={width}
-          height={height}
-          displayMode={displayMode}
-          hoverHeader={hoverHeader}
-          titleItems={titleItems}
-          dragClass={dragClass}
-          actions={actionsElement}
-          dragClassCancel={dragClassCancel}
-          padding={plugin.noPadding ? 'none' : 'md'}
-          menu={panelMenu}
-          onCancelQuery={model.onCancelQuery}
-        >
-          {(innerWidth, innerHeight) => (
-            <>
-              <ErrorBoundaryAlert dependencies={[plugin, data]}>
-                <PluginContextProvider meta={plugin.meta}>
-                  <PanelContextProvider value={model.getPanelContext()}>
-                    {isReadyToRender && (
-                      <PanelComponent
-                        id={1}
-                        data={data}
-                        title={title}
-                        timeRange={data.timeRange}
-                        timeZone={timeZone}
-                        options={options}
-                        fieldConfig={fieldConfig}
-                        transparent={false}
-                        width={innerWidth}
-                        height={innerHeight}
-                        renderCounter={0}
-                        replaceVariables={model.interpolate}
-                        onOptionsChange={model.onOptionsChange}
-                        onFieldConfigChange={model.onFieldConfigChange}
-                        onChangeTimeRange={model.onTimeRangeChange}
-                        eventBus={getAppEvents()}
-                      />
-                    )}
-                  </PanelContextProvider>
-                </PluginContextProvider>
-              </ErrorBoundaryAlert>
-            </>
-          )}
-        </PanelChrome>
-      )}
+    <div className={relativeWrapper}>
+      <div ref={ref as RefCallback<HTMLDivElement>} className={absoluteWrapper} data-viz-panel-key={model.state.key}>
+        {width > 0 && height > 0 && (
+          <PanelChrome
+            title={titleInterpolated}
+            description={description ? () => model.interpolate(description) : ''}
+            loadingState={data.state}
+            statusMessage={getChromeStatusMessage(data, _pluginLoadError)}
+            width={width}
+            height={height}
+            displayMode={displayMode}
+            hoverHeader={hoverHeader}
+            titleItems={titleItems}
+            dragClass={dragClass}
+            actions={actionsElement}
+            dragClassCancel={dragClassCancel}
+            padding={plugin.noPadding ? 'none' : 'md'}
+            menu={panelMenu}
+            onCancelQuery={model.onCancelQuery}
+          >
+            {(innerWidth, innerHeight) => (
+              <>
+                <ErrorBoundaryAlert dependencies={[plugin, data]}>
+                  <PluginContextProvider meta={plugin.meta}>
+                    <PanelContextProvider value={model.getPanelContext()}>
+                      {isReadyToRender && (
+                        <PanelComponent
+                          id={1}
+                          data={data}
+                          title={title}
+                          timeRange={data.timeRange}
+                          timeZone={timeZone}
+                          options={options}
+                          fieldConfig={fieldConfig}
+                          transparent={false}
+                          width={innerWidth}
+                          height={innerHeight}
+                          renderCounter={0}
+                          replaceVariables={model.interpolate}
+                          onOptionsChange={model.onOptionsChange}
+                          onFieldConfigChange={model.onFieldConfigChange}
+                          onChangeTimeRange={model.onTimeRangeChange}
+                          eventBus={getAppEvents()}
+                        />
+                      )}
+                    </PanelContextProvider>
+                  </PluginContextProvider>
+                </ErrorBoundaryAlert>
+              </>
+            )}
+          </PanelChrome>
+        )}
+      </div>
     </div>
   );
 }
@@ -186,7 +188,18 @@ function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | un
   return message;
 }
 
-const wrapperDivStyles = css({
+const relativeWrapper = css({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+});
+
+/**
+ * Sadly this this absolute wrapper is needed for the panel to adopt smaller sizes.
+ * The combo of useMeasure and PanelChrome makes the panel take up the width it get's but that makes it impossible to
+ * Then adapt to smaller space (say resizing the browser window or undocking menu).
+ */
+const absoluteWrapper = css({
   position: 'absolute',
   width: '100%',
   height: '100%',


### PR DESCRIPTION
Currently VizPanel requires a relative positioned parent (something SceneFlexItem and SceneCSSGridItem both add). 

SceneFlexItem is really needed anyway for flex layouts as it has size constraints. But for CSS Grid layout the size constraints are on the grid itself and you rarely need the item level props (grid-column-start, etc). 

So I think it could make sense to add this relative wrapper to VizPanel so that i can be used directly as a child anywhere (but esp in css grid layouts) 