### PR TITLE
SceneCSSGridLayout: Make rowGap and columnGap use grid units

### DIFF
--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -17,9 +17,9 @@ import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './u
 import { ControlsLabel } from '@grafana/scenes/src/utils/ControlsLabel';
 import { SelectableValue } from '@grafana/data';
 
-const columnTemplateOptions = ['repeat(3, 1fr)', '2fr 1fr 1fr', 'auto'];
-const rowTemplateOptions = ['unset', 'auto', '150px repeat(4, 100px)', 'repeat(4, 1fr)', '100%'];
-const autoRowOptions = ['auto', '150px', '250px'];
+const columnTemplateOptions = ['repeat(auto-fit, minmax(400px, 1fr))', 'repeat(3, 1fr)', '2fr 1fr 1fr', 'auto'];
+const rowTemplateOptions = ['unset', 'auto', '350px repeat(4, 150px)', 'repeat(4, 1fr)', '100%'];
+const autoRowOptions = ['150px', '250px', 'auto'];
 
 export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
@@ -30,7 +30,8 @@ export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
         children: getLayoutChildren(10),
         templateColumns: columnTemplateOptions[0],
         templateRows: rowTemplateOptions[0],
-        rowGap: '8px',
+        autoRows: autoRowOptions[0],
+        rowGap: 2,
       });
 
       const inputControl = new SceneToolbarInput({

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -9,8 +9,12 @@ interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridItemPlac
   children: Array<SceneCSSGridItem | SceneObject>;
   /**
    * Useful for setting a height on items without specifying how many rows there will be.
+   * Defaults to 30px
    */
   autoRows?: CSSProperties['gridAutoRows'];
+  /**
+   * This overrides the autoRows with a specific row template.
+   */
   templateRows?: CSSProperties['gridTemplateRows'];
   /**
    * Defaults to repeat(auto-fit, minmax(400px, 1fr)). This pattern us useful for equally sized items with a min width of 400px
@@ -21,16 +25,14 @@ interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridItemPlac
   rowGap: number;
   /** In Grafana design system grid units (8px)  */
   columnGap: number;
-  justifyItems?: CSSProperties['justifyItems'];
-  alignItems?: CSSProperties['alignItems'];
-  justifyContent?: CSSProperties['justifyContent'];
-
   /**
    * True when the item should rendered but not visible.
    * Useful for conditional display of layout items
    */
   isHidden?: boolean;
-
+  /**
+   * For media query for sceens smaller than md breakpoint
+   */
   md?: SceneCSSGridLayoutState;
 }
 
@@ -42,6 +44,7 @@ export class SceneCSSGridLayout extends SceneObjectBase<SceneCSSGridLayoutState>
       rowGap: 1,
       columnGap: 1,
       templateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
+      autoRows: state.autoRows ?? `320px`,
       children: state.children ?? [],
       ...state,
     });
@@ -126,9 +129,6 @@ function useLayoutStyle(state: SceneCSSGridLayoutState) {
     style.gridAutoRows = state.autoRows || 'unset';
     style.rowGap = theme.spacing(state.rowGap ?? 1);
     style.columnGap = theme.spacing(state.columnGap ?? 1);
-    style.justifyItems = state.justifyItems || 'unset';
-    style.alignItems = state.alignItems || 'unset';
-    style.justifyContent = state.justifyContent || 'unset';
     style.flexGrow = 1;
 
     if (state.md) {
@@ -137,9 +137,6 @@ function useLayoutStyle(state: SceneCSSGridLayoutState) {
         gridTemplateColumns: state.md?.templateColumns,
         rowGap: state.md.rowGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
         columnGap: state.md.columnGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
-        justifyItems: state.md?.justifyItems,
-        alignItems: state.md?.alignItems,
-        justifyContent: state.md?.justifyContent,
       };
     }
 

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -5,8 +5,20 @@ import { SceneObjectBase } from '../../../core/SceneObjectBase';
 import { SceneComponentProps, SceneLayout, SceneObjectState, SceneObject } from '../../../core/types';
 import { config } from '@grafana/runtime';
 
-interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridItemPlacement {
+export interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridLayoutOptions {
   children: Array<SceneCSSGridItem | SceneObject>;
+  /**
+   * True when the item should rendered but not visible.
+   * Useful for conditional display of layout items
+   */
+  isHidden?: boolean;
+  /**
+   * For media query for sceens smaller than md breakpoint
+   */
+  md?: SceneCSSGridLayoutOptions;
+}
+
+export interface SceneCSSGridLayoutOptions {
   /**
    * Useful for setting a height on items without specifying how many rows there will be.
    * Defaults to 30px
@@ -25,15 +37,9 @@ interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridItemPlac
   rowGap: number;
   /** In Grafana design system grid units (8px)  */
   columnGap: number;
-  /**
-   * True when the item should rendered but not visible.
-   * Useful for conditional display of layout items
-   */
-  isHidden?: boolean;
-  /**
-   * For media query for sceens smaller than md breakpoint
-   */
-  md?: SceneCSSGridLayoutState;
+  justifyItems?: CSSProperties['justifyItems'];
+  alignItems?: CSSProperties['alignItems'];
+  justifyContent?: CSSProperties['justifyContent'];
 }
 
 export class SceneCSSGridLayout extends SceneObjectBase<SceneCSSGridLayoutState> implements SceneLayout {
@@ -129,6 +135,9 @@ function useLayoutStyle(state: SceneCSSGridLayoutState) {
     style.gridAutoRows = state.autoRows || 'unset';
     style.rowGap = theme.spacing(state.rowGap ?? 1);
     style.columnGap = theme.spacing(state.columnGap ?? 1);
+    style.justifyItems = state.justifyItems || 'unset';
+    style.alignItems = state.alignItems || 'unset';
+    style.justifyContent = state.justifyContent || 'unset';
     style.flexGrow = 1;
 
     if (state.md) {
@@ -137,6 +146,9 @@ function useLayoutStyle(state: SceneCSSGridLayoutState) {
         gridTemplateColumns: state.md?.templateColumns,
         rowGap: state.md.rowGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
         columnGap: state.md.columnGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
+        justifyItems: state.md?.justifyItems,
+        alignItems: state.md?.alignItems,
+        justifyContent: state.md?.justifyContent,
       };
     }
 

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -1,17 +1,26 @@
 import { css, CSSObject } from '@emotion/css';
-import { config } from '@grafana/runtime';
 import React, { ComponentType, CSSProperties, useMemo } from 'react';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
 import { SceneComponentProps, SceneLayout, SceneObjectState, SceneObject } from '../../../core/types';
+import { config } from '@grafana/runtime';
 
 interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridItemPlacement {
   children: Array<SceneCSSGridItem | SceneObject>;
+  /**
+   * Useful for setting a height on items without specifying how many rows there will be.
+   */
   autoRows?: CSSProperties['gridAutoRows'];
   templateRows?: CSSProperties['gridTemplateRows'];
+  /**
+   * Defaults to repeat(auto-fit, minmax(400px, 1fr)). This pattern us useful for equally sized items with a min width of 400px
+   * and dynamic max width split equally among columns.
+   */
   templateColumns: CSSProperties['gridTemplateColumns'];
-  rowGap?: CSSProperties['rowGap'];
-  columnGap?: CSSProperties['columnGap'];
+  /** In Grafana design system grid units (8px)  */
+  rowGap: number;
+  /** In Grafana design system grid units (8px)  */
+  columnGap: number;
   justifyItems?: CSSProperties['justifyItems'];
   alignItems?: CSSProperties['alignItems'];
   justifyContent?: CSSProperties['justifyContent'];
@@ -27,6 +36,16 @@ interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridItemPlac
 
 export class SceneCSSGridLayout extends SceneObjectBase<SceneCSSGridLayoutState> implements SceneLayout {
   public static Component = SceneCSSGridLayoutRenderer;
+
+  public constructor(state: Partial<SceneCSSGridLayoutState>) {
+    super({
+      rowGap: 1,
+      columnGap: 1,
+      templateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
+      children: state.children ?? [],
+      ...state,
+    });
+  }
 
   public isDraggable(): boolean {
     return false;
@@ -98,30 +117,31 @@ function useLayoutStyle(state: SceneCSSGridLayoutState) {
   return useMemo(() => {
     const {} = state;
     // only need breakpoints so accessing theme from config instead of context is ok
-    const theme = config.theme2;
-
     const style: CSSObject = {};
+    const theme = config.theme2;
 
     style.display = 'grid';
     style.gridTemplateColumns = state.templateColumns;
     style.gridTemplateRows = state.templateRows || 'unset';
     style.gridAutoRows = state.autoRows || 'unset';
-    style.rowGap = state.rowGap || '8px';
-    style.columnGap = state.columnGap || '8px';
+    style.rowGap = theme.spacing(state.rowGap ?? 1);
+    style.columnGap = theme.spacing(state.columnGap ?? 1);
     style.justifyItems = state.justifyItems || 'unset';
     style.alignItems = state.alignItems || 'unset';
     style.justifyContent = state.justifyContent || 'unset';
     style.flexGrow = 1;
 
-    style[theme.breakpoints.down('md')] = {
-      gridTemplateRows: state.md?.templateRows,
-      columns: state.md?.templateColumns,
-      rowGap: state.md?.rowGap || '8px',
-      columnGap: state.md?.columnGap || '8px',
-      justifyItems: state.md?.justifyItems || 'unset',
-      alignItems: state.md?.alignItems || 'unset',
-      justifyContent: state.md?.justifyContent || 'unset',
-    };
+    if (state.md) {
+      style[theme.breakpoints.down('md')] = {
+        gridTemplateRows: state.md?.templateRows,
+        gridTemplateColumns: state.md?.templateColumns,
+        rowGap: state.md.rowGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
+        columnGap: state.md.columnGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
+        justifyItems: state.md?.justifyItems,
+        alignItems: state.md?.alignItems,
+        justifyContent: state.md?.justifyContent,
+      };
+    }
 
     return css(style);
   }, [state]);

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -21,7 +21,7 @@ export interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridL
 export interface SceneCSSGridLayoutOptions {
   /**
    * Useful for setting a height on items without specifying how many rows there will be.
-   * Defaults to 30px
+   * Defaults to 320px
    */
   autoRows?: CSSProperties['gridAutoRows'];
   /**


### PR DESCRIPTION
* [x] Changes the rowGap and columnGap to use design system grid units 
* [x] Adds some good defaults to templateColumns and autoRows 
* [x] Fixes the types so md property is not recursive. 

