### PR TITLE
Variables: Fixes SQL formatting and escaping double quotes 

### DIFF
--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -61,6 +61,7 @@ describe('formatRegistry', () => {
 
     expect(formatValue(VariableFormatID.SQLString, "test'value")).toBe(`'test''value'`);
     expect(formatValue(VariableFormatID.SQLString, ['test', "test'value2"])).toBe(`'test','test''value2'`);
+    expect(formatValue(VariableFormatID.SQLString, ['test', "test'value2", "test\"value3"])).toBe(`'test','test''value2','test\\"value3'`);
 
     expect(formatValue(VariableFormatID.Date, 1594671549254)).toBe('2020-07-13T20:19:09.254Z');
     expect(formatValue(VariableFormatID.Date, 1594671549254, 'text', ['seconds'])).toBe('1594671549');

--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -60,8 +60,11 @@ describe('formatRegistry', () => {
     expect(formatValue(VariableFormatID.DoubleQuote, ['test', `test"2`])).toBe('"test","test\\"2"');
 
     expect(formatValue(VariableFormatID.SQLString, "test'value")).toBe(`'test''value'`);
+    expect(formatValue(VariableFormatID.SQLString, 'test"value')).toBe(`'test\\"value'`);
     expect(formatValue(VariableFormatID.SQLString, ['test', "test'value2"])).toBe(`'test','test''value2'`);
-    expect(formatValue(VariableFormatID.SQLString, ['test', "test'value2", "test\"value3"])).toBe(`'test','test''value2','test\\"value3'`);
+    expect(formatValue(VariableFormatID.SQLString, ['test', "test'value2", 'test"value3'])).toBe(
+      `'test','test''value2','test\\"value3'`
+    );
 
     expect(formatValue(VariableFormatID.Date, 1594671549254)).toBe('2020-07-13T20:19:09.254Z');
     expect(formatValue(VariableFormatID.Date, 1594671549254, 'text', ['seconds'])).toBe('1594671549');

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -353,5 +353,5 @@ function sqlStringFormatter(value: VariableValue) {
   }
 
   let strVal = typeof value === 'string' ? value : String(value);
-  return `'${replace(strVal, regExp, "''")}'`;
+  return `'${replace(strVal, regExp, (match) => SQL_ESCAPE_MAP[match] ?? '')}'`;
 }

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -216,20 +216,7 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: VariableFormatID.SQLString,
       name: 'SQL string',
       description: 'SQL string quoting and commas for use in IN statements and other scenarios',
-      formatter: (value) => {
-        // escape single quotes by pairing them
-        const regExp = new RegExp(`'|"`, 'g');
-        const replacements = new Map([
-          ["'", "''"],
-          ['"', '\\"'],
-        ]);
-        if (isArray(value)) {
-          return map(value, (v: string) => `'${replace(v, regExp, function (matched) { return replacements.get(matched) ?? ''; })}'`).join(',');
-        }
-
-        let strVal = typeof value === 'string' ? value : String(value);
-        return `'${replace(strVal, regExp, "''")}'`;
-      },
+      formatter: sqlStringFormatter,
     },
     {
       id: VariableFormatID.Date,
@@ -350,4 +337,21 @@ function formatQueryParameter(name: string, value: VariableValueSingle): string 
 
 export function isAllValue(value: VariableValueSingle) {
   return value === ALL_VARIABLE_VALUE || (Array.isArray(value) && value[0] === ALL_VARIABLE_VALUE);
+}
+
+const SQL_ESCAPE_MAP: Record<string, string> = {
+  "'": "''",
+  '"': '\\"',
+};
+
+function sqlStringFormatter(value: VariableValue) {
+  // escape single quotes by pairing them
+  const regExp = new RegExp(`'|"`, 'g');
+
+  if (isArray(value)) {
+    return map(value, (v: string) => `'${replace(v, regExp, (match) => SQL_ESCAPE_MAP[match] ?? '')}'`).join(',');
+  }
+
+  let strVal = typeof value === 'string' ? value : String(value);
+  return `'${replace(strVal, regExp, "''")}'`;
 }

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -218,9 +218,13 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       description: 'SQL string quoting and commas for use in IN statements and other scenarios',
       formatter: (value) => {
         // escape single quotes by pairing them
-        const regExp = new RegExp(`'`, 'g');
+        const regExp = new RegExp(`'|"`, 'g');
+        const replacements = new Map([
+          ["'", "''"],
+          ['"', '\\"'],
+        ]);
         if (isArray(value)) {
-          return map(value, (v: string) => `'${replace(v, regExp, "''")}'`).join(',');
+          return map(value, (v: string) => `'${replace(v, regExp, function (matched) { return replacements.get(matched) ?? ''; })}'`).join(',');
         }
 
         let strVal = typeof value === 'string' ? value : String(value);


### PR DESCRIPTION
Sqlstring format should escape double quotes since the formatted value is nested in a JSON object sent to query API, see https://github.com/grafana/grafana/blob/main/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts#L193

Without escaping double quotes the JSON gets malformed and we get errors like the following:

![Screenshot from 2023-10-25 11-39-24](https://github.com/grafana/scenes/assets/1173779/e1f2d539-aa14-4039-bbaa-6f744517829a)
