### PR TITLE
Urls: Make sure urls include sub path

### DIFF
--- a/packages/scenes-app/src/demos/withDrilldown/panels.tsx
+++ b/packages/scenes-app/src/demos/withDrilldown/panels.tsx
@@ -69,7 +69,7 @@ export function getRoomsTemperatureTable() {
         .overrideLinks([
           {
             title: 'Go to room overview',
-            url: `${demoUrl('with-drilldowns')}/room/\${__value.text}/temperature`,
+            url: '${__url.path}/room/${__value.text}/temperature',
           },
         ])
         .overrideCustomFieldConfig('width', 250)

--- a/packages/scenes/src/components/SceneApp/utils.ts
+++ b/packages/scenes/src/components/SceneApp/utils.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { RouteComponentProps, useLocation } from 'react-router-dom';
-import { UrlQueryMap, urlUtil } from '@grafana/data';
+import { UrlQueryMap, locationUtil, urlUtil } from '@grafana/data';
 import { locationSearchToObject, locationService } from '@grafana/runtime';
 import { SceneObject } from '../../core/types';
 
@@ -28,7 +28,7 @@ export function getUrlWithAppState(path: string, preserveParams?: string[]): str
     }
   }
 
-  return urlUtil.renderUrl(path, paramsCopy);
+  return urlUtil.renderUrl(locationUtil.assureBaseUrl(path), paramsCopy);
 }
 
 export function renderSceneComponentWithRouteProps(sceneObject: SceneObject, routeProps: RouteComponentProps) {

--- a/packages/scenes/src/variables/macros/urlMacros.test.ts
+++ b/packages/scenes/src/variables/macros/urlMacros.test.ts
@@ -1,7 +1,7 @@
 import { TestScene } from '../TestScene';
 
 import { sceneInterpolator } from '../interpolation/sceneInterpolator';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 
 describe('url macros', () => {
   it('Can get full url via ${__url}', () => {
@@ -16,6 +16,17 @@ describe('url macros', () => {
     locationService.push('/my-plugin/my-page?from=now-5m&to=now');
 
     expect(sceneInterpolator(scene, '${__url.path}')).toBe('/my-plugin/my-page');
+  });
+
+  it('${__url} and ${__url.path} includes grafana sub path', () => {
+    config.appSubUrl = '/grafana';
+
+    const scene = new TestScene({});
+    locationService.push('/my-plugin/my-page?from=now-5m&to=now');
+    expect(sceneInterpolator(scene, '${__url}')).toBe('/grafana/my-plugin/my-page?from=now-5m&to=now');
+    expect(sceneInterpolator(scene, '${__url.path}')).toBe('/grafana/my-plugin/my-page');
+
+    config.appSubUrl = '';
   });
 
   it('Can get only state via ${__url.params}', () => {

--- a/packages/scenes/src/variables/macros/urlMacros.ts
+++ b/packages/scenes/src/variables/macros/urlMacros.ts
@@ -1,4 +1,4 @@
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { SceneObject } from '../../core/types';
 import { FormatVariable } from '../interpolation/formatRegistry';
 import { CustomVariableValue } from '../types';
@@ -12,15 +12,16 @@ export class UrlMacro implements FormatVariable {
 
   public getValue(fieldPath?: string) {
     const location = locationService.getLocation();
+    const subUrl = config.appSubUrl ?? '';
 
     switch (fieldPath ?? '') {
       case 'params':
         return new UrlStateFormatter(location.search);
       case 'path':
-        return location.pathname;
+        return subUrl + location.pathname;
       case '':
       default:
-        return location.pathname + location.search;
+        return subUrl + location.pathname + location.search;
     }
   }
 


### PR DESCRIPTION
I really hate the complexity of the sub path logic where everywhere we have to either add the sub path or remove it :cry: 

Noticed tabs and breadcrumbs built using the scenes app never include the instance sub path. As well as urls coming from `${__url}` 

Wish there was a more centralized way to handle this. The irony is that the sub path is removed in TextLink/Link component (because react-router does not want it), or if we need to use locationServce.push it also needs to be removed 