### PR TITLE
VizPanel: Allow title items configuration

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -14,6 +14,7 @@ import {
   compareDataFrameStructures,
   applyFieldOverrides,
   PluginType,
+  LinkModel,
 } from '@grafana/data';
 import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@grafana/ui';
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
@@ -32,6 +33,10 @@ import { loadPanelPluginSync } from './registerRuntimePanelPlugin';
 import { getCursorSyncScope } from '../../behaviors/CursorSync';
 import { cloneDeep, merge } from 'lodash';
 
+interface VizPanelLinksState extends SceneObjectState {
+  links?: LinkModel[];
+}
+
 export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectState {
   /**
    * This is usually a plugin id that references a core plugin or an external plugin. But this can also reference a
@@ -40,6 +45,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   pluginId: string;
   title: string;
   description?: string;
+  links?: LinkModel[];
   options: DeepPartial<TOptions>;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;
@@ -53,6 +59,10 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
    * So the best way to add dynamic menu actions and links is by adding them in a behavior attached to the menu.
    */
   menu?: VizPanelMenu;
+  /**
+   * Defines a menu that renders panel link.
+   **/
+  panelLinks?: SceneObject<VizPanelLinksState>;
   /**
    * Add action to the top right panel header
    */

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -33,10 +33,6 @@ import { loadPanelPluginSync } from './registerRuntimePanelPlugin';
 import { getCursorSyncScope } from '../../behaviors/CursorSync';
 import { cloneDeep, merge } from 'lodash';
 
-interface VizPanelLinksState extends SceneObjectState {
-  links?: LinkModel[];
-}
-
 export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectState {
   /**
    * This is usually a plugin id that references a core plugin or an external plugin. But this can also reference a
@@ -62,7 +58,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   /**
    * Defines a menu that renders panel link.
    **/
-  panelLinks?: SceneObject<VizPanelLinksState>;
+  titleItems?: React.ReactNode | SceneObject | SceneObject[];
   /**
    * Add action to the top right panel header
    */

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -41,7 +41,6 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   pluginId: string;
   title: string;
   description?: string;
-  links?: LinkModel[];
   options: DeepPartial<TOptions>;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -14,7 +14,6 @@ import {
   compareDataFrameStructures,
   applyFieldOverrides,
   PluginType,
-  LinkModel,
 } from '@grafana/data';
 import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@grafana/ui';
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -23,6 +23,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     hoverHeader,
     menu,
     headerActions,
+    titleItems,
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
   const plugin = model.getPlugin();
@@ -53,16 +54,25 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     $data.setContainerWidth(width);
   }
 
-  const titleItems: React.ReactNode[] = [];
+  let titleItemsElement: React.ReactNode[] = [];
 
-  if (model.state.panelLinks) {
-    const panelLinks = model.state.panelLinks;
-    titleItems.push(<panelLinks.Component model={panelLinks} key={panelLinks.state.key} />);
+  if (titleItems) {
+    if (Array.isArray(titleItems)) {
+      titleItemsElement = titleItemsElement.concat(
+        titleItems.map((titleItem) => {
+          return <titleItem.Component model={titleItem} key={`${titleItem.state.key}`} />;
+        })
+      );
+    } else if (isSceneObject(titleItems)) {
+      titleItemsElement.push(<titleItems.Component model={titleItems} />);
+    } else {
+      titleItemsElement.push(titleItems);
+    }
   }
 
   // If we have local time range show that in panel header
   if (model.state.$timeRange) {
-    titleItems.push(<model.state.$timeRange.Component model={model.state.$timeRange} key={model.state.key} />);
+    titleItemsElement.push(<model.state.$timeRange.Component model={model.state.$timeRange} key={model.state.key} />);
   }
 
   let panelMenu;
@@ -105,7 +115,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             height={height}
             displayMode={displayMode}
             hoverHeader={hoverHeader}
-            titleItems={titleItems}
+            titleItems={titleItemsElement}
             dragClass={dragClass}
             actions={actionsElement}
             dragClassCancel={dragClassCancel}

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -55,6 +55,11 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   const titleItems: React.ReactNode[] = [];
 
+  if (model.state.panelLinks) {
+    const panelLinks = model.state.panelLinks;
+    titleItems.push(<panelLinks.Component model={panelLinks} key={panelLinks.state.key} />);
+  }
+
   // If we have local time range show that in panel header
   if (model.state.$timeRange) {
     titleItems.push(<model.state.$timeRange.Component model={model.state.$timeRange} key={model.state.key} />);


### PR DESCRIPTION
Adds API to VizPanel to allow panel links rendering. There is no component for links rendering in the library, as the dashboard's link renderer heavily depends on core-only code.  https://github.com/grafana/grafana/pull/77295

We may consider adding some generic link renderer, but I would wait with that until we get request for panel links support in the lib.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.20.1--canary.437.6693096080.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.20.1--canary.437.6693096080.0
  # or 
  yarn add @grafana/scenes@1.20.1--canary.437.6693096080.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
