### PR TITLE
SceneTimeRangeCompare: UI improvements proposal

### DIFF
--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
@@ -383,7 +383,7 @@ describe('SceneTimeRangeCompare', () => {
     // Is undefined by default
     expect(comparer.state.compareWith).toBeUndefined();
 
-    let checkbox = screen.getByRole('checkbox');
+    let checkbox = screen.getByLabelText('Enable time frame comparison');
     await userEvent.click(checkbox);
 
     // On checkbox click, previous period gets automatically selected
@@ -398,6 +398,7 @@ describe('SceneTimeRangeCompare', () => {
     // Uncheck checkbox
     await userEvent.click(checkbox);
     expect(comparer.state.compareWith).toBeUndefined();
+    expect(comparer.state.previousCompareWith).toBe('1w');
 
     // Check it again
     await userEvent.click(checkbox);

--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -155,7 +155,6 @@ function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeR
 
   const value = compareOptions.find(({ value }) => value === compareWith);
   const onClick = () => {
-    console.log('onClick', previousCompareWith, compareWith);
     if (enabled) {
       model.onClearCompare();
     } else if (!enabled) {


### PR DESCRIPTION
I think https://github.com/grafana/scenes/pull/415 was prematurely merged, resulting in the scene time range compare picker looking broken (to me maybe) due to the disabled styles usage on the dropdown button: 

![image](https://github.com/grafana/scenes/assets/2376619/a99801c4-f0ab-4334-8ff8-5f5b1a2cca99)

I'm getting back to my proposal of not showing the selected comparison range when the comparison is disabled. I think it makes more sense than the partially disabled button which is a pattern that I can't recall we use anywhere in the product (cc @grafana/design-system .

https://github.com/grafana/scenes/assets/2376619/e2df9149-32f3-40b9-b649-41306f48e682



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.20.2--canary.438.6696445069.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.20.2--canary.438.6696445069.0
  # or 
  yarn add @grafana/scenes@1.20.2--canary.438.6696445069.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
