### PR TITLE
feat: add store field to SceneAppState interface

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
@@ -405,6 +405,27 @@ describe('SceneApp', () => {
     expect(app1).toBe(useSceneApp(getSceneApp1));
     expect(app2).toBe(useSceneApp(getSceneApp2));
   });
+
+  it('SceneAppState should support a key value store', () => {
+    const getSceneApp = () =>
+      new SceneApp({
+        pages: [],
+        store: {
+          foo: 1,
+          bar: 'one',
+          baz: false,
+        }
+      });
+
+    const app = useSceneApp(getSceneApp);
+
+    const { store } = app.useState();
+    const { foo, bar, baz } = store!;
+
+    expect(foo).toBe(1);
+    expect(bar).toBe('one');
+    expect(baz).toBe(false);
+  });
 });
 
 function setupScene(inspectableObject: SceneObject, key?: string) {

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -16,7 +16,7 @@ export interface SceneAppState extends SceneObjectState {
   // Array of SceneAppPage objects that are considered app's top level pages
   pages: SceneAppPageLike[];
   name?: string;
-  store?: Map<string, SceneAppStoreValue>
+  store?: {[key: string]: SceneAppStoreValue};
 }
 
 export interface SceneAppRoute {

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -10,10 +10,13 @@ export interface SceneRouteMatch<Params extends { [K in keyof Params]?: string }
   url: string;
 }
 
+export type SceneAppStoreValue = string | number | boolean;
+
 export interface SceneAppState extends SceneObjectState {
   // Array of SceneAppPage objects that are considered app's top level pages
   pages: SceneAppPageLike[];
   name?: string;
+  store?: Map<string, SceneAppStoreValue>
 }
 
 export interface SceneAppRoute {


### PR DESCRIPTION
Adds a simple key value store to the SceneAppState that allows any nested SceneObject in the graph to access the store data. Useful for adding global data to the scene graph.