### PR TITLE
PanelContext: Eventbus should not filter out local events

### DIFF
--- a/packages/scenes-app/src/demos/cursorSync.tsx
+++ b/packages/scenes-app/src/demos/cursorSync.tsx
@@ -14,7 +14,7 @@ import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './u
 
 export function global() {
   return new SceneAppPage({
-    title: 'Cursor sync test',
+    title: 'Global sync scope',
     url: demoUrl('cursor-sync'),
     getScene: () => {
       return new EmbeddedScene({
@@ -29,7 +29,7 @@ export function global() {
               children: [
                 new SceneFlexItem({
                   body: new VizPanel({
-                    title: 'Panel 1 - syncs tooltip with Panel 2',
+                    title: 'Panel 1',
                     pluginId: 'timeseries',
                     $data: getQueryRunnerWithRandomWalkQuery({
                       scenarioId: 'csv_metric_values',
@@ -58,34 +58,10 @@ export function global() {
               children: [
                 new SceneFlexItem({
                   body: new VizPanel({
-                    title: 'Panel 3 - syncs crosshair with Panel 4',
+                    title: 'Panel 3',
                     pluginId: 'timeseries',
                     $data: getQueryRunnerWithRandomWalkQuery({}),
                   }),
-                }),
-                new SceneFlexItem({
-                  body: PanelBuilders.timeseries()
-                    .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 50 }))
-                    .setTitle('Panel 4')
-                    .build(),
-                }),
-              ],
-            }),
-            new SceneFlexLayout({
-              direction: 'row',
-              children: [
-                new SceneFlexItem({
-                  body: new VizPanel({
-                    title: 'No sync',
-                    pluginId: 'timeseries',
-                    $data: getQueryRunnerWithRandomWalkQuery({}),
-                  }),
-                }),
-                new SceneFlexItem({
-                  body: PanelBuilders.timeseries()
-                    .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 50 }))
-                    .setTitle('No sync')
-                    .build(),
                 }),
               ],
             }),

--- a/packages/scenes/src/behaviors/CursorSync.ts
+++ b/packages/scenes/src/behaviors/CursorSync.ts
@@ -34,9 +34,10 @@ export class CursorSync extends SceneObjectBase<CursorSyncState> {
     if (!this.parent) {
       throw new Error('EnableCursorSync cannot be used as a standalone scene object');
     }
+
     // Since EnableCursorSync is a behavior, it is not a parent to any object in the scene graph.
     // We need to get it's parent in order to provide correct EventBus context to the children.
-    return this.parent.state.key!;
+    return this.state.key!;
   }
 }
 
@@ -45,7 +46,7 @@ class PanelContextEventBus implements EventBus {
   public constructor(private _source: SceneObject, private _eventsOrigin: SceneObject) {}
 
   public publish<T extends BusEvent>(event: T): void {
-    (event as any).origin = this._eventsOrigin;
+    (event as any).origin = this;
     this._eventsOrigin.publishEvent(event, true);
   }
 
@@ -56,6 +57,7 @@ class PanelContextEventBus implements EventBus {
       };
 
       const sub = this._source.subscribeToEvent(eventType, handler);
+
       return () => sub.unsubscribe();
     });
   }

--- a/packages/scenes/src/behaviors/CursorSync.ts
+++ b/packages/scenes/src/behaviors/CursorSync.ts
@@ -1,6 +1,6 @@
 import { BusEvent, BusEventHandler, BusEventType, EventBus, EventFilterOptions } from '@grafana/data';
 import { DashboardCursorSync } from '@grafana/schema';
-import { filter, Observable, Unsubscribable } from 'rxjs';
+import { Observable, Unsubscribable } from 'rxjs';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObject, SceneObjectState } from '../core/types';
@@ -56,9 +56,8 @@ class PanelContextEventBus implements EventBus {
       };
 
       const sub = this._source.subscribeToEvent(eventType, handler);
-
       return () => sub.unsubscribe();
-    }).pipe(filter((event) => (event as any).origin !== this._eventsOrigin));
+    });
   }
 
   public subscribe<T extends BusEvent>(eventType: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {


### PR DESCRIPTION
The pie chart legend hover events are not working. They highlight slices on the same panel and using the standard DataHoverEvent. The panel relies on being able to subscribe to local events. But the scenes PanelContextEventBus filters out any local events. 

Removing this filtering, panels filter out local events they don't care about using:

```ts
 if (eventBus === evt.origin) {
   return;
  }
```

Trying to make the needed changes to get that to work. But when testing the cursor sync demo I am unable to get it to work (with or without these changes). All cursors show on all panels. Think uPlot cursor sync scope key has broken. 

We could also try to revive https://github.com/grafana/grafana/pull/71866 