### PR TITLE
Merge new panel options at the surface level instead of deep merging

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -216,7 +216,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     const { fieldConfig, options } = this.state;
 
     // When replace is true, we want to replace the entire options object. Default will be applied.
-    const nextOptions = replace ? optionsUpdate : merge(cloneDeep(options), optionsUpdate);
+    const nextOptions = replace ? optionsUpdate : Object.assign(cloneDeep(options), optionsUpdate);
 
     const withDefaults = getPanelOptionsWithDefaults({
       plugin: this._plugin!,


### PR DESCRIPTION
Fixes [#595](https://github.com/grafana/app-observability-plugin/issues/595)

By doing a deep merge, we're making it impossible for sorting to reset:
1. ✅ Click on unsorted column name, the `sortBy` key comes with: `[{displayName: 'Name', desc: false}]`, it gets merged with previous options and sorted properly
2. ✅ Click on same column name, the `sortBy` key comes with: `[{displayName: 'Name', desc: true}]`, it gets merged with previous options and sorted properly
3. ❌ Click on same column name, the `sortBy` key comes with `[]`, it doesn't override the previous options, so we can no longer sort by that column, and we're stuck on a descending sort

This solution is a very naive solution, I've tested it and it works, but I'm not sure if we would be missing some potential bug by not doing a deep merge, so very open to suggestions.