### PR TITLE
Variables: Support __org and __user variable macros

### DIFF
--- a/packages/scenes/src/variables/macros/contextMacros.test.ts
+++ b/packages/scenes/src/variables/macros/contextMacros.test.ts
@@ -1,0 +1,41 @@
+import { config } from '@grafana/runtime';
+import { TestScene } from '../TestScene';
+
+import { sceneInterpolator } from '../interpolation/sceneInterpolator';
+import { CurrentUserDTO } from '@grafana/data';
+
+describe('user macro', () => {
+  it('Can interpolate ${__user.*} expressions', () => {
+    const scene = new TestScene({});
+
+    const user: Partial<CurrentUserDTO> = {
+      id: 10,
+      login: 'user_login',
+      email: 'user_email',
+    };
+
+    config.bootData.user = user as CurrentUserDTO;
+
+    expect(sceneInterpolator(scene, '$__user')).toBe('10');
+    expect(sceneInterpolator(scene, '${__user.id}')).toBe('10');
+    expect(sceneInterpolator(scene, '${__user.login}')).toBe('user_login');
+    expect(sceneInterpolator(scene, '${__user.email}')).toBe('user_email');
+  });
+});
+
+describe('org macro', () => {
+  it('Can interpolate ${__org.*} expressions', () => {
+    const scene = new TestScene({});
+
+    const user: Partial<CurrentUserDTO> = {
+      orgId: 15,
+      orgName: 'My cool org',
+    };
+
+    config.bootData.user = user as CurrentUserDTO;
+
+    expect(sceneInterpolator(scene, '$__org')).toBe('15');
+    expect(sceneInterpolator(scene, '${__org.id}')).toBe('15');
+    expect(sceneInterpolator(scene, '${__org.name}')).toBe('My cool org');
+  });
+});

--- a/packages/scenes/src/variables/macros/contextMacros.ts
+++ b/packages/scenes/src/variables/macros/contextMacros.ts
@@ -1,0 +1,59 @@
+import { SceneObject } from '../../core/types';
+import { FormatVariable } from '../interpolation/formatRegistry';
+import { config } from '@grafana/runtime';
+
+/**
+ * Handles expressions like ${__user.login}
+ */
+export class UserMacro implements FormatVariable {
+  public state: { name: string; type: string };
+
+  public constructor(name: string, _: SceneObject) {
+    this.state = { name: name, type: 'user_macro' };
+  }
+
+  public getValue(fieldPath?: string): string {
+    const user = config.bootData.user;
+
+    switch (fieldPath) {
+      case 'login':
+        return user.login;
+      case 'email':
+        return user.email;
+      case 'id':
+      default:
+        return String(user.id);
+    }
+  }
+
+  public getValueText?(): string {
+    return '';
+  }
+}
+
+/**
+ * Handles expressions like ${__org.name}
+ */
+export class OrgMacro implements FormatVariable {
+  public state: { name: string; type: string };
+
+  public constructor(name: string, _: SceneObject) {
+    this.state = { name: name, type: 'org_macro' };
+  }
+
+  public getValue(fieldPath?: string): string {
+    const user = config.bootData.user;
+
+    switch (fieldPath) {
+      case 'name':
+        return user.orgName;
+      case 'id':
+      default:
+        return String(user.orgId);
+    }
+  }
+
+  public getValueText?(): string {
+    return '';
+  }
+}

--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -4,6 +4,7 @@ import { TimeFromAndToMacro, TimezoneMacro, UrlTimeRangeMacro } from './timeMacr
 import { AllVariablesMacro } from './AllVariablesMacro';
 import { DataMacro, FieldMacro, SeriesMacro, ValueMacro } from './dataMacros';
 import { UrlMacro } from './urlMacros';
+import { OrgMacro, UserMacro } from './contextMacros';
 
 export const macrosIndex: Record<string, MacroVariableConstructor> = {
   [DataLinkBuiltInVars.includeVars]: AllVariablesMacro,
@@ -16,4 +17,6 @@ export const macrosIndex: Record<string, MacroVariableConstructor> = {
   ['__from']: TimeFromAndToMacro,
   ['__to']: TimeFromAndToMacro,
   ['__timezone']: TimezoneMacro,
+  ['__user']: UserMacro,
+  ['__org']: OrgMacro,
 };


### PR DESCRIPTION
Closes #448 

* [x] Adds a new __org macro
* [x] Adds a new __user macro 

Question how to implement the `${__dashboard.name}` and `${__dashboard.uid}` macros

* Implement here in scenes lib by going to scene root and look for state properties names `uid` and `name`
* Or provide a way for consumers of the lib to register custom macros (could be very powerful) 