### PR TITLE
Variables: Register variable macro

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -2,6 +2,7 @@ import { getUrlWithAppState } from './components/SceneApp/utils';
 import { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntimePanelPlugin';
 import { cloneSceneObjectState } from './core/sceneGraph/utils';
 import { registerRuntimeDataSource } from './querying/RuntimeDataSource';
+import { registerVariableMacro } from './variables/macros';
 
 export * from './core/types';
 export * from './core/events';
@@ -37,6 +38,7 @@ export { LocalValueVariable } from './variables/variants/LocalValueVariable';
 export { IntervalVariable } from './variables/variants/IntervalVariable';
 export { AdHocFilterSet } from './variables/adhoc/AdHocFiltersSet';
 export { AdHocFiltersVariable } from './variables/adhoc/AdHocFiltersVariable';
+export { type MacroVariableConstructor } from './variables/macros/types';
 
 export { type UrlSyncManagerLike as UrlSyncManager, getUrlSyncManager } from './services/UrlSyncManager';
 export { SceneObjectUrlSyncConfig } from './services/SceneObjectUrlSyncConfig';
@@ -84,5 +86,6 @@ export const sceneUtils = {
   getUrlWithAppState,
   registerRuntimePanelPlugin,
   registerRuntimeDataSource,
+  registerVariableMacro,
   cloneSceneObjectState,
 };

--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -17,3 +17,20 @@ export const macrosIndex: Record<string, MacroVariableConstructor> = {
   ['__to']: TimeFromAndToMacro,
   ['__timezone']: TimezoneMacro,
 };
+
+/**
+ * Allows you to register a variable expression macro that can then be used in strings with syntax ${<macro_name>.<fieldPath>}
+ * Call this on app activation and unregister the macro on deactivation.
+ * @returns a function that unregisters the macro
+ */
+export function registerVariableMacro(name: string, macro: MacroVariableConstructor): () => void {
+  if (macrosIndex[name]) {
+    throw new Error(`Macro already registered ${name}`);
+  }
+
+  macrosIndex[name] = macro;
+
+  return () => {
+    delete macrosIndex[name];
+  };
+}


### PR DESCRIPTION
Exports a `sceneUtils.registerVariableMacro` that makes it possible for scene app plugins to register and unregister custom macros 