### PR TITLE
Variables: Fixes url sync issue for key/value multi value variables

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -105,8 +105,9 @@ describe('MultiValueVariable', () => {
           { label: 'A', value: '1' },
           { label: 'B', value: '2' },
         ],
+        // since we only sync value to URL after URL sync both value and text will have the "value" representation
         value: ['1', '2'],
-        text: ['1'],
+        text: ['1', '2'],
         delayMs: 0,
         isMulti: true,
       });

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -97,6 +97,26 @@ describe('MultiValueVariable', () => {
       expect(variable.state.text).toEqual(['A', 'C']);
     });
 
+    it('Should update text representation if current matched text array values are not valid', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        value: ['1', '2'],
+        text: ['1'],
+        delayMs: 0,
+        isMulti: true,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toEqual(['1', '2']);
+      expect(variable.state.text).toEqual(['A', 'B']);
+    });
+
     it('Should pick first option if none of the current values are valid', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -87,6 +87,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       // If we are a multi valued variable validate the current values are among the options
       const currentValues = Array.isArray(this.state.value) ? this.state.value : [this.state.value];
       const validValues = currentValues.filter((v) => options.find((o) => o.value === v));
+      const validTexts = validValues.map((v) => options.find((o) => o.value === v)!.label);
 
       // If no valid values pick the first option
       if (validValues.length === 0) {
@@ -95,8 +96,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
         stateUpdate.text = defaultState.text;
       }
       // We have valid values, if it's different from current valid values update current values
-      else if (!isEqual(validValues, this.state.value)) {
-        const validTexts = validValues.map((v) => options.find((o) => o.value === v)!.label);
+      else if (!isEqual(validValues, this.state.value) || !isEqual(validTexts, this.state.text)) {
         stateUpdate.value = validValues;
         stateUpdate.text = validTexts;
       }


### PR DESCRIPTION
Noticed that dashboards with variables that have different value / text representation, after a full page reload the panel repeats only showed the "id" (value) representation and was not showing the correct text representation. 

The issue as that we did not compare the text values when deciding to update or not 