### PR TITLE
Variables: Add natural sort from core grafana to query variables

### DIFF
--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -271,6 +271,63 @@ describe('QueryVariable', () => {
     });
   });
 
+  describe('When sort is provided', () => {
+    beforeEach(() => {
+      setCreateQueryVariableRunnerFactory(() => new FakeQueryRunner(fakeDsMock, runRequestMock));
+    });
+
+    it('should return options order by natural sort Desc', async () => {
+      const variable = new QueryVariable({
+        name: 'test',
+        datasource: { uid: 'fake-std', type: 'fake-std' },
+        query: 'query',
+        sort: 8,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.options).toEqual([
+        { label: 'val1', value: 'val1' },
+        { label: 'val2', value: 'val2' },
+        { label: 'val11', value: 'val11' },
+      ]);
+    });
+
+    it('should return options order by natural sort Asc', async () => {
+      const variable = new QueryVariable({
+        name: 'test',
+        datasource: { uid: 'fake-std', type: 'fake-std' },
+        query: 'query',
+        sort: 7,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.options).toEqual([
+        { label: 'val11', value: 'val11' },
+        { label: 'val2', value: 'val2' },
+        { label: 'val1', value: 'val1' },
+      ]);
+    });
+
+    it('should return options order by alphabeticalAsc', async () => {
+      const variable = new QueryVariable({
+        name: 'test',
+        datasource: { uid: 'fake-std', type: 'fake-std' },
+        query: 'query',
+        sort: 1,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.options).toEqual([
+        { label: 'val1', value: 'val1' },
+        { label: 'val2', value: 'val2' },
+        { label: 'val11', value: 'val11' },
+      ]);
+    });
+  });
+
   describe('Query with __searchFilter', () => {
     beforeEach(() => {
       runRequestMock.mockClear();

--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -79,31 +79,23 @@ export const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
     return options;
   }
 
-  const sortType = Math.ceil(sortOrder / 2);
-  const reverseSort = sortOrder % 2 === 0;
+  // @ts-ignore
+  const sortByNumeric = (opt) => {
+    if (!opt.text) {
+      return -1;
+    }
+    const matches = opt.text.match(/.*?(\d+).*/);
+    if (!matches || matches.length < 2) {
+      return -1;
+    } else {
+      return parseInt(matches[1], 10);
+    }
+  };
 
-  if (sortType === 1) {
-    options = sortBy(options, 'text');
-  } else if (sortType === 2) {
-    options = sortBy(options, (opt) => {
-      if (!opt.text) {
-        return -1;
-      }
-
-      const matches = opt.text.match(/.*?(\d+).*/);
-      if (!matches || matches.length < 2) {
-        return -1;
-      } else {
-        return parseInt(matches[1], 10);
-      }
-    });
-  } else if (sortType === 3) {
-    options = sortBy(options, (opt) => {
-      return toLower(opt.text);
-    });
-  } else if (sortType === 4) {
-    // Sort by natural sort
-    options.sort((a, b) => {
+  // @ts-ignore
+  const sortByNaturalSort = (options) => {
+    //@ts-ignore
+    return options.sort((a, b) => {
       if (!a.text) {
         return -1;
       }
@@ -114,11 +106,47 @@ export const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
 
       return a.text.localeCompare(b.text, undefined, { numeric: true });
     });
-  }
+  };
 
-  if (reverseSort) {
-    options = options.reverse();
+  switch (sortOrder) {
+    case VariableSort.alphabeticalAsc:
+      options = sortBy(options, 'text');
+      break;
+    case VariableSort.alphabeticalDesc:
+      options = sortBy(options, 'text').reverse();
+      break;
+    case VariableSort.numericalAsc:
+      options = sortBy(options, sortByNumeric);
+      break;
+    case VariableSort.numericalDesc:
+      options = sortBy(options, sortByNumeric);
+      options = options.reverse();
+      break;
+    case VariableSort.alphabeticalCaseInsensitiveAsc:
+      options = sortBy(options, (opt) => {
+        return toLower(opt.text);
+      });
+      break;
+    case VariableSort.alphabeticalCaseInsensitiveDesc:
+      options = sortBy(options, (opt) => {
+        return toLower(opt.text);
+      });
+      options = options.reverse();
+      break;
+    // TODO remove harcoded value and ts-expect-error when schema package is updated
+    // @ts-expect-error
+    case VariableSort.naturalAsc || 7:
+      // Sort by natural sort
+      options = sortByNaturalSort(options);
+      break;
+    // TODO remove ts-expect-error when schema package is updated
+    // @ts-expect-error
+    case VariableSort.naturalDesc || 8:
+      options = sortByNaturalSort(options);
+      options = options.reverse();
+      break;
+    default:
+      break;
   }
-
   return options;
 };

--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -101,6 +101,19 @@ export const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
     options = sortBy(options, (opt) => {
       return toLower(opt.text);
     });
+  } else if (sortType === 4) {
+    // Sort by natural sort
+    options.sort((a, b) => {
+      if (!a.text) {
+        return -1;
+      }
+
+      if (!b.text) {
+        return 1;
+      }
+
+      return a.text.localeCompare(b.text, undefined, { numeric: true });
+    });
   }
 
   if (reverseSort) {


### PR DESCRIPTION
In core grafana we received a community contribution to implement natural sort. https://github.com/grafana/grafana/pull/78024 

This PR just adds their changes and a few unit tests. 