### PR TITLE
DynamicApp: Demo of a SceneApp with loading phase, a first setup phase and settings page that rebuilds pages

### DIFF
--- a/packages/scenes-app/src/components/Routes/Routes.tsx
+++ b/packages/scenes-app/src/components/Routes/Routes.tsx
@@ -3,12 +3,14 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { prefixRoute } from '../../utils/utils.routing';
 import { ROUTES } from '../../constants';
 import { DemoListPage } from '../../pages/DemoListPage';
+import { DynamicAppPage } from '../../pages/DynamicApp';
 
 export const Routes = () => {
   return (
     <Switch>
       {/* Default page */}
       <Route path={prefixRoute(`${ROUTES.Demos}`)} component={DemoListPage} />
+      <Route path={prefixRoute(`${ROUTES.DynamicApp}`)} component={DynamicAppPage} />
       <Redirect to={prefixRoute(ROUTES.Demos)} />
     </Switch>
   );

--- a/packages/scenes-app/src/constants.ts
+++ b/packages/scenes-app/src/constants.ts
@@ -5,8 +5,7 @@ export const PLUGIN_BASE_URL = `/a/${pluginJson.id}`;
 export enum ROUTES {
   Home = '',
   Demos = 'demos',
-  WithTabs = 'page-with-tabs',
-  WithDrilldown = 'page-with-drilldown',
+  DynamicApp = 'dynamic-app',
 }
 
 export const DATASOURCE_REF = {

--- a/packages/scenes-app/src/pages/DynamicApp.tsx
+++ b/packages/scenes-app/src/pages/DynamicApp.tsx
@@ -1,0 +1,262 @@
+import {
+  EmbeddedScene,
+  SceneApp,
+  SceneAppPage,
+  SceneFlexLayout,
+  SceneFlexItem,
+  SceneReactObject,
+  useSceneApp,
+  SceneObjectState,
+  SceneObjectBase,
+  sceneGraph,
+  PanelBuilders,
+  SceneVariableSet,
+  DataSourceVariable,
+  SceneComponentProps,
+  SceneObject,
+} from '@grafana/scenes';
+import React from 'react';
+import { prefixRoute } from '../utils/utils.routing';
+import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import { Button, Field, Spinner, Switch, VerticalGroup } from '@grafana/ui';
+import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from '../demos/utils';
+import { SceneAppState } from '@grafana/scenes/src/components/SceneApp/types';
+import { DataSourcePicker } from '@grafana/runtime';
+
+interface DynamicAppState extends SceneObjectState {
+  initialDataSource?: string;
+  showPanelDescriptions?: boolean;
+  isInitialized?: boolean;
+  isConfigured?: boolean;
+  settings: DynamicAppSettings;
+}
+
+class DynamicApp extends SceneObjectBase<DynamicAppState> {
+  constructor(state: DynamicAppState) {
+    super(state);
+    this.addActivationHandler(this._activationHandler.bind(this));
+  }
+
+  private _activationHandler() {
+    if (this.state.isInitialized) {
+      return;
+    }
+
+    // Set initializing (loading) page
+    this._updateState({
+      pages: [getInitializingPage()],
+    });
+
+    setTimeout(() => this._initializeCompleted(), 2000);
+  }
+
+  private _updateState(appState: Partial<SceneAppState>, customState?: Partial<DynamicAppState>) {
+    const app = sceneGraph.getAncestor(this, SceneApp);
+    app.setState(appState);
+
+    if (customState) {
+      this.setState(customState);
+    }
+  }
+
+  private _initializeCompleted() {
+    if (!this.state.isConfigured) {
+      this._updateState(
+        {
+          pages: [getInitialSetupPage()],
+        },
+        {
+          isInitialized: true,
+        }
+      );
+    } else {
+      this._updateState(
+        {
+          pages: buildAppPages(this.state),
+        },
+        {
+          isInitialized: true,
+        }
+      );
+    }
+  }
+}
+
+function buildDynamicApp() {
+  return new SceneApp({
+    name: 'dynamic-app',
+    $behaviors: [new DynamicApp({})],
+    pages: [],
+  });
+}
+
+export const DynamicAppPage = () => {
+  const scene = useSceneApp(buildDynamicApp);
+  return <scene.Component model={scene} />;
+};
+
+export function getInitializingPage(): SceneAppPage {
+  return new SceneAppPage({
+    title: 'Dynamic app',
+    url: `${prefixRoute('dynamic-app')}`,
+    getScene: getInitializingScene,
+    getFallbackPage: () => {
+      return new SceneAppPage({
+        title: 'Dynamic app',
+        url: `${prefixRoute('dynamic-app')}`,
+        getScene: getInitializingScene,
+      });
+    },
+  });
+}
+
+export function getInitialSetupPage(): SceneAppPage {
+  return new SceneAppPage({
+    title: 'Initial app setup',
+    subTitle: 'Before using the app you have a few settings to configure',
+    url: `${prefixRoute('dynamic-app')}/settings`,
+    getScene: getSettingsScene,
+  });
+}
+
+function getInitializingScene() {
+  return new EmbeddedScene({
+    body: new SceneFlexLayout({
+      direction: 'column',
+      children: [
+        new SceneFlexItem({
+          body: new SceneReactObject({
+            component: () => {
+              return (
+                <div>
+                  Initalizing app <Spinner />
+                </div>
+              );
+            },
+          }),
+        }),
+      ],
+    }),
+  });
+}
+
+export function buildAppPages(state: DynamicAppState): SceneAppPage[] {
+  return [
+    new SceneAppPage({
+      title: 'Dynamic app',
+      subTitle:
+        'Demo of scene app that has an initializing and setup phases and settings that should cause scenes to rebuilt',
+      url: `${prefixRoute('dynamic-app')}`,
+      tabs: [
+        new SceneAppPage({
+          title: 'Overview',
+          url: `${prefixRoute('dynamic-app')}/overview`,
+          getScene: getOverviewScene,
+        }),
+        new SceneAppPage({
+          title: 'Settings',
+          url: `${prefixRoute('dynamic-app')}/settings`,
+          getScene: getSettingsScene,
+        }),
+      ],
+    }),
+  ];
+}
+
+function getOverviewScene() {
+  return new EmbeddedScene({
+    $variables: getDataSourceVariable(),
+    ...getEmbeddedSceneDefaults(),
+    body: new SceneFlexLayout({
+      direction: 'column',
+      children: [
+        new SceneFlexItem({
+          minWidth: '70%',
+          body: PanelBuilders.timeseries()
+            .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 50 }))
+            .setTitle('Trends')
+            .build(),
+        }),
+      ],
+    }),
+  });
+}
+
+function getSettingsScene() {
+  return new EmbeddedScene({
+    body: new DynamicAppSettings({}),
+  });
+}
+
+class DynamicAppSettings extends SceneObjectBase<SceneObjectState> {
+  public constructor(state: SceneObjectState) {
+    super(state);
+  }
+
+  public onChangeDataSource = (ds: DataSourceInstanceSettings) => {};
+
+  static Component = ({ model }: SceneComponentProps<DynamicAppSettings>) => {
+    const { initialDataSource, isConfigured } = getDynamicApp(model).useState();
+
+    return (
+      <VerticalGroup>
+        <Field label="Data source">
+          <DataSourcePicker
+            current={initialDataSource}
+            pluginId="grafana-testdata-datasource"
+            onChange={model.onChangeDataSource}
+          />
+        </Field>
+
+        <Field label="Show panel descriptions">
+          <Switch />
+        </Field>
+
+        {!isConfigured && <Button>Complete setup</Button>}
+      </VerticalGroup>
+    );
+  };
+}
+
+function getDataSourceVariable() {
+  return new SceneVariableSet({
+    variables: [
+      new DataSourceVariable({
+        name: 'ds',
+        pluginId: 'grafana-testdata-datasource',
+        skipUrlSync: true,
+      }),
+    ],
+  });
+}
+
+function getDynamicApp(model: SceneObject): DynamicApp {
+  let obj = model;
+
+  while (true) {
+    if (obj.parent) {
+      obj = obj.parent;
+    } else if (obj instanceof SceneAppPage && obj.state.getParentPage) {
+      obj = obj.state.getParentPage();
+    } else {
+      break;
+    }
+  }
+
+  if (obj.state.$behaviors?.[0] instanceof DynamicApp) {
+    return obj.state.$behaviors?.[0];
+  }
+
+  throw new Error('DynamicApp behavior not found at scene app root');
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  root: css({
+    display: 'flex',
+    flexGrow: 1,
+    flexDirection: 'column',
+    alignSelf: 'baseline',
+    gap: theme.spacing(2),
+  }),
+});

--- a/packages/scenes-app/src/pages/DynamicApp.tsx
+++ b/packages/scenes-app/src/pages/DynamicApp.tsx
@@ -102,7 +102,7 @@ export function getFirstSetupPage(): SceneAppPage {
   return new SceneAppPage({
     title: 'Initial app setup',
     subTitle: 'Before using the app you have a few settings to configure',
-    url: `${prefixRoute('dynamic-app')}/settings`,
+    url: `${prefixRoute('dynamic-app')}`,
     getScene: getSettingsScene,
   });
 }

--- a/packages/scenes-app/src/pages/DynamicAppSettings.tsx
+++ b/packages/scenes-app/src/pages/DynamicAppSettings.tsx
@@ -20,7 +20,7 @@ export class DynamicAppSettings extends SceneObjectBase<SceneObjectState> {
 
     return (
       <VerticalGroup>
-        <Field label="Data source">
+        <Field label="Default data source">
           <DataSourcePicker
             current={settings?.initialDataSource}
             pluginId="grafana-testdata-datasource"

--- a/packages/scenes-app/src/pages/DynamicAppSettings.tsx
+++ b/packages/scenes-app/src/pages/DynamicAppSettings.tsx
@@ -1,0 +1,39 @@
+import { SceneObjectState, SceneObjectBase, SceneComponentProps } from '@grafana/scenes';
+import React from 'react';
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { Button, Field, Switch, VerticalGroup } from '@grafana/ui';
+import { DataSourcePicker } from '@grafana/runtime';
+import { getDynamicApp } from './shared';
+
+export class DynamicAppSettings extends SceneObjectBase<SceneObjectState> {
+  public onChangeDataSource = (ds: DataSourceInstanceSettings) => {
+    getDynamicApp(this).onChangeSettings({ initialDataSource: ds.uid });
+  };
+
+  public onChangeShowPanelDescriptions = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    getDynamicApp(this).onChangeSettings({ showPanelDescriptions: evt.currentTarget.checked });
+  };
+
+  static Component = ({ model }: SceneComponentProps<DynamicAppSettings>) => {
+    const app = getDynamicApp(model);
+    const { settings } = app.useState();
+
+    return (
+      <VerticalGroup>
+        <Field label="Data source">
+          <DataSourcePicker
+            current={settings?.initialDataSource}
+            pluginId="grafana-testdata-datasource"
+            onChange={model.onChangeDataSource}
+          />
+        </Field>
+
+        <Field label="Show panel descriptions">
+          <Switch value={settings?.showPanelDescriptions ?? false} onChange={model.onChangeShowPanelDescriptions} />
+        </Field>
+
+        {!settings?.isConfigured && <Button onClick={app.onCompleteSetup}>Complete setup</Button>}
+      </VerticalGroup>
+    );
+  };
+}

--- a/packages/scenes-app/src/pages/loadSettings.ts
+++ b/packages/scenes-app/src/pages/loadSettings.ts
@@ -1,0 +1,24 @@
+import { AppSettings } from './shared';
+
+export function loadSettings(): Promise<AppSettings> {
+  let settings: AppSettings = {};
+
+  const settingsJson = localStorage.getItem('dynamic_app');
+  if (settingsJson) {
+    settings = JSON.parse(settingsJson);
+  }
+
+  return new Promise<AppSettings>((resolve) => {
+    setTimeout(() => {
+      resolve(settings);
+    }, 2000);
+  });
+}
+
+export function saveSettings(setting: AppSettings): Promise<boolean> {
+  localStorage.setItem('dynamic_app', JSON.stringify(setting));
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, 2000);
+  });
+}

--- a/packages/scenes-app/src/pages/shared.ts
+++ b/packages/scenes-app/src/pages/shared.ts
@@ -1,0 +1,28 @@
+import { SceneAppPage, SceneObject } from '@grafana/scenes';
+import { DynamicApp } from './DynamicApp';
+
+export interface AppSettings {
+  initialDataSource?: string;
+  showPanelDescriptions?: boolean;
+  isConfigured?: boolean;
+}
+
+export function getDynamicApp(model: SceneObject): DynamicApp {
+  let obj = model;
+
+  while (true) {
+    if (obj.parent) {
+      obj = obj.parent;
+    } else if (obj instanceof SceneAppPage && obj.state.getParentPage) {
+      obj = obj.state.getParentPage();
+    } else {
+      break;
+    }
+  }
+
+  if (obj.state.$behaviors?.[0] instanceof DynamicApp) {
+    return obj.state.$behaviors?.[0];
+  }
+
+  throw new Error('DynamicApp behavior not found at scene app root');
+}

--- a/packages/scenes-app/src/plugin.json
+++ b/packages/scenes-app/src/plugin.json
@@ -32,6 +32,13 @@
       "path": "/a/%PLUGIN_ID%/demos",
       "role": "Admin",
       "addToNav": true
+    },
+    {
+      "type": "page",
+      "name": "Dynamic app",
+      "path": "/a/%PLUGIN_ID%/dynamic-app",
+      "role": "Admin",
+      "addToNav": true
     }
   ],
   "dependencies": {


### PR DESCRIPTION
I have noticed that it's tricky to use SceneApp and SceneAppPages when you need a loading and setup phase where you either need to load settings and/or have the user make some initial configuration before all the pages can be built.  

This is an exploration in how we can solve this. 

Instead of extending SceneApp I am using a behavior attached to the SceneApp. This is because extending SceneObjects is problematic due to Typescript and generics co-variance and problematic from a backward compatible way (makes it hard to make changes to the library). 

* [x] SceneApp that initially starts with no pages
* [x] When activated it will add a loading page that has a fallback (so all urls will show loading page) 
* [x] Once settings are loaded we check if the the app has been configured, if not we show the initial setup page 
* [x] Once the app has been configured we add all the app pages (with app settings being passed around) 
* [x] If settings change we rebuild the app pages (not ideal, as we loose the scene cache, but workable for this scenario I think).

https://github.com/grafana/scenes/assets/10999/c3eda879-1dc7-4f73-8424-72c623205906

## Futher SceneApp exploration 

I think SceneApp could be improved. Maybe support a cleaner way to extend than a behavior like in this PR and a easier way to access it (without having to call getParent on SceneAppPage)

*  Support redirects
*  Allow for more plain pages (that do not implement the full SceneAppPageLike interface) 
*  Support variables or state that can be easily accessed and subscribed to by any part of the app 
