### PR TITLE
fix: compare time ranges using actual unix time vs objects

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -539,7 +539,9 @@ describe('SceneQueryRunner', () => {
 
   describe('when time range changed while in-active', () => {
     it('It should re-issue new query', async () => {
-      const timeRange = new SceneTimeRange();
+      const from = '2000-01-01';
+      const to = '2000-01-02';
+      const timeRange = new SceneTimeRange({from, to});
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A' }],
         $timeRange: timeRange,
@@ -556,6 +558,10 @@ describe('SceneQueryRunner', () => {
 
       deactivateQueryRunner();
 
+      await new Promise((r) => setTimeout(r, 1));
+
+      const differentTo = '2000-01-03'
+      timeRange.setState({from, to: differentTo});
       timeRange.onRefresh();
 
       queryRunner.activate();
@@ -567,6 +573,41 @@ describe('SceneQueryRunner', () => {
     });
   });
 
+  describe('when time range changed to identify range while in-active', () => {
+    it('It should not re-issue new query', async () => {
+      const from = '2000-01-01';
+      const to = '2000-01-02';
+      const timeRange = new SceneTimeRange({from, to});
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        $timeRange: timeRange,
+      });
+
+      expect(queryRunner.state.data).toBeUndefined();
+
+      const deactivateQueryRunner = queryRunner.activate();
+
+      // When consumer viz is rendered with width 1000
+      await new Promise((r) => setTimeout(r, 1));
+      // Should query
+      expect(runRequestMock.mock.calls.length).toEqual(1);
+
+      deactivateQueryRunner();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      timeRange.setState({from, to});
+      timeRange.onRefresh();
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      // Should not any new query
+      expect(runRequestMock.mock.calls.length).toEqual(1);
+    });
+  });
+  
   describe('time frame comparison', () => {
     test('should run query with time range comparison', async () => {
       const timeRange = new SceneTimeRange({

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -573,7 +573,7 @@ describe('SceneQueryRunner', () => {
     });
   });
 
-  describe('when time range changed to identify range while in-active', () => {
+  describe('when time range changed to identical range while in-active', () => {
     it('It should not re-issue new query', async () => {
       const from = '2000-01-01';
       const to = '2000-01-02';
@@ -596,6 +596,7 @@ describe('SceneQueryRunner', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
+      // Setting the state to an equivalent time range
       timeRange.setState({from, to});
       timeRange.onRefresh();
 

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -558,8 +558,6 @@ describe('SceneQueryRunner', () => {
 
       deactivateQueryRunner();
 
-      await new Promise((r) => setTimeout(r, 1));
-
       const differentTo = '2000-01-03'
       timeRange.setState({from, to: differentTo});
       timeRange.onRefresh();
@@ -593,8 +591,6 @@ describe('SceneQueryRunner', () => {
       expect(runRequestMock.mock.calls.length).toEqual(1);
 
       deactivateQueryRunner();
-
-      await new Promise((r) => setTimeout(r, 1));
 
       // Setting the state to an equivalent time range
       timeRange.setState({from, to});

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -247,10 +247,15 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   private _isDataTimeRangeStale(data: PanelData) {
     const timeRange = sceneGraph.getTimeRange(this);
 
-    if (data.timeRange === timeRange.state.value) {
+    const stateTimeRange = timeRange.state.value;
+    const dataTimeRange = data.timeRange;
+
+    if (
+      (stateTimeRange.from.unix() === dataTimeRange.from.unix()) &&
+      (stateTimeRange.to.unix() === dataTimeRange.to.unix()) 
+    ) {
       return false;
     }
-
     writeSceneLog('SceneQueryRunner', 'Data time range is stale');
     return true;
   }


### PR DESCRIPTION
We want to avoid false detection of stale time lines and compare using the underlying `moment.unix()` time stamp for the `from`s and the `to`s, so that we don't accidentally compare object instances.

See:
- https://github.com/grafana/grafana/issues/78185

