### PR TITLE
Adhoc filters: Add tagKeyRegexFilter prop

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
@@ -146,6 +146,15 @@ describe('AdHocFilter', () => {
       { label: 'v', value: '2' },
     ]);
   });
+
+  it('Can filter by regex', async () => {
+    const { filtersSet } = setup({
+      tagKeyRegexFilter: new RegExp('x.*'),
+    });
+
+    const keys = await filtersSet._getKeys(null);
+    expect(keys).toEqual([]);
+  });
 });
 
 const runRequestMock = {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.tsx
@@ -35,6 +35,10 @@ export interface AdHocFilterSetState extends SceneObjectState {
    */
   applyMode?: 'same-datasource' | 'manual';
   /**
+   * Filter out the keys that do not match the regex.
+   */
+  tagKeyRegexFilter?: RegExp;
+  /**
    * Extension hook for customizing the key lookup.
    * Return replace: true if you want to override the default lookup
    * Return replace: false if you want to combine the results with the default lookup
@@ -143,6 +147,11 @@ export class AdHocFilterSet extends SceneObjectBase<AdHocFilterSetState> {
 
     if (override) {
       keys = keys.concat(override.values);
+    }
+
+    const tagKeyRegexFilter = this.state.tagKeyRegexFilter;
+    if (tagKeyRegexFilter) {
+      keys = keys.filter((f) => f.text.match(tagKeyRegexFilter));
     }
 
     return keys.map(toSelectableValue);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -20,7 +20,7 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
 
 export type AdHocFiltersVariableCreateHelperArgs = Pick<
   AdHocFilterSetState,
-  'name' | 'filters' | 'baseFilters' | 'datasource' | 'getTagKeysProvider' | 'getTagValuesProvider' | 'name' | 'layout'
+  'name' | 'filters' | 'baseFilters' | 'datasource' | 'tagKeyRegexFilter' | 'getTagKeysProvider' | 'getTagValuesProvider' | 'name' | 'layout'
 >;
 
 export class AdHocFiltersVariable


### PR DESCRIPTION
This PR adds a new property for adhoc filters, so that the tag keys can be filtered based on a regex