### PR TITLE
Variables: Add type guards for variables

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -3,6 +3,15 @@ import { registerRuntimePanelPlugin } from './components/VizPanel/registerRuntim
 import { cloneSceneObjectState } from './core/sceneGraph/utils';
 import { registerRuntimeDataSource } from './querying/RuntimeDataSource';
 import { registerVariableMacro } from './variables/macros';
+import {
+  isAdHocVariable,
+  isQueryVariable,
+  isTextBoxVariable,
+  isCustomVariable,
+  isDataSourceVariable,
+  isConstantVariable,
+  isIntervalVariable,
+} from './variables/variants/guards';
 
 export * from './core/types';
 export * from './core/events';
@@ -88,4 +97,13 @@ export const sceneUtils = {
   registerRuntimeDataSource,
   registerVariableMacro,
   cloneSceneObjectState,
+
+  // Variable guards
+  isAdHocVariable,
+  isConstantVariable,
+  isCustomVariable,
+  isDataSourceVariable,
+  isIntervalVariable,
+  isQueryVariable,
+  isTextBoxVariable,
 };

--- a/packages/scenes/src/variables/variants/guards.ts
+++ b/packages/scenes/src/variables/variants/guards.ts
@@ -1,0 +1,36 @@
+import { AdHocFiltersVariable } from '../adhoc/AdHocFiltersVariable';
+import { SceneVariable } from '../types';
+import { ConstantVariable } from './ConstantVariable';
+import { CustomVariable } from './CustomVariable';
+import { DataSourceVariable } from './DataSourceVariable';
+import { IntervalVariable } from './IntervalVariable';
+import { TextBoxVariable } from './TextBoxVariable';
+import { QueryVariable } from './query/QueryVariable';
+
+export function isAdHocVariable(variable: SceneVariable): variable is AdHocFiltersVariable {
+  return variable.state.type === 'adhoc';
+}
+
+export function isConstantVariable(variable: SceneVariable): variable is ConstantVariable {
+  return variable.state.type === 'constant';
+}
+
+export function isCustomVariable(variable: SceneVariable): variable is CustomVariable {
+  return variable.state.type === 'custom';
+}
+
+export function isDataSourceVariable(variable: SceneVariable): variable is DataSourceVariable {
+  return variable.state.type === 'datasource';
+}
+
+export function isIntervalVariable(variable: SceneVariable): variable is IntervalVariable {
+  return variable.state.type === 'interval';
+}
+
+export function isQueryVariable(variable: SceneVariable): variable is QueryVariable {
+  return variable.state.type === 'query';
+}
+
+export function isTextBoxVariable(variable: SceneVariable): variable is TextBoxVariable {
+  return variable.state.type === 'textbox';
+}


### PR DESCRIPTION
- Added type guards for scene variables
- Expose guards through `sceneUtils`

Fixes [#78405](https://github.com/grafana/grafana/issues/78405)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.24.0--canary.472.6942909529.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.24.0--canary.472.6942909529.0
  # or 
  yarn add @grafana/scenes@1.24.0--canary.472.6942909529.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
