### PR TITLE
Fix non-null assertion in SceneQueryRunner

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -152,6 +152,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   }
 
   private _onLayersReceived(results: Map<string, PanelData>) {
+    const timeRange = sceneGraph.getTimeRange(this);
     const dataLayers = sceneGraph.getDataLayers(this);
     const { dataLayerFilter } = this.state;
     let annotations: DataFrame[] = [];
@@ -193,7 +194,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       }
     }
 
-    const baseStateUpdate = this.state.data ? this.state.data : emptyPanelData;
+    const baseStateUpdate = this.state.data ? this.state.data : { ...emptyPanelData, timeRange: timeRange.state.value };
 
     this.setState({
       data: {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -193,9 +193,11 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       }
     }
 
+    const baseStateUpdate = this.state.data ? this.state.data : emptyPanelData;
+
     this.setState({
       data: {
-        ...this.state.data!,
+        ...baseStateUpdate,
         annotations,
         alertState: alertState ?? this.state.data?.alertState,
       },
@@ -251,8 +253,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     const dataTimeRange = data.timeRange;
 
     if (
-      (stateTimeRange.from.unix() === dataTimeRange.from.unix()) &&
-      (stateTimeRange.to.unix() === dataTimeRange.to.unix()) 
+      stateTimeRange.from.unix() === dataTimeRange.from.unix() &&
+      stateTimeRange.to.unix() === dataTimeRange.to.unix()
     ) {
       return false;
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/462

Collecting data layers assumed queries have been resolved already. This is not true, layers can definitely finish sooner than queries, there is no guarantee. And using non-null assertions is bad anyway ;)

Fixes:
-  transformation errors we all saw during bug  bash today 
- [data.timeRange](https://github.com/grafana/scenes/blob/main/packages/scenes/src/querying/SceneQueryRunner.ts#L251) being undefined if layers finish sooner than queries 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.24.1--canary.474.6946948769.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.24.1--canary.474.6946948769.0
  # or 
  yarn add @grafana/scenes@1.24.1--canary.474.6946948769.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
