### PR TITLE
Variables: Fixes validation issue where the current saved value only matches text representation

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -61,6 +61,25 @@ describe('MultiValueVariable', () => {
       expect(variable.state.text).toBe('A');
     });
 
+    it('When saved value is same as text representation', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [
+          { label: 'label-A', value: 'value-A' },
+          { label: 'label-B', value: 'value-B' },
+        ],
+        value: 'label-B',
+        text: 'label-B',
+        delayMs: 0,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toBe('value-B');
+      expect(variable.state.text).toBe('label-B');
+    });
+
     it('Should update text representation if current matched option has different text value', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -74,11 +74,14 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
    * Check if current value is valid given new options. If not update the value.
    */
   private updateValueGivenNewOptions(options: VariableValueOption[]) {
+    // Remember current value and text
+    const { value: currentValue, text: currentText } = this.state;
+
     const stateUpdate: Partial<MultiValueVariableState> = {
       options,
       loading: false,
-      value: this.state.value,
-      text: this.state.text,
+      value: currentValue,
+      text: currentText,
     };
 
     if (options.length === 0) {
@@ -90,7 +93,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       // If value is set to All then we keep it set to All but just store the options
     } else if (this.state.isMulti) {
       // If we are a multi valued variable validate the current values are among the options
-      const currentValues = Array.isArray(this.state.value) ? this.state.value : [this.state.value];
+      const currentValues = Array.isArray(currentValue) ? currentValue : [currentValue];
       const validValues = currentValues.filter((v) => options.find((o) => o.value === v));
       const validTexts = validValues.map((v) => options.find((o) => o.value === v)!.label);
 
@@ -101,19 +104,19 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
         stateUpdate.text = defaultState.text;
       }
       // We have valid values, if it's different from current valid values update current values
-      else if (!isEqual(validValues, this.state.value) || !isEqual(validTexts, this.state.text)) {
+      else if (!isEqual(validValues, currentValue) || !isEqual(validTexts, currentText)) {
         stateUpdate.value = validValues;
         stateUpdate.text = validTexts;
       }
     } else {
-      // Single valued variable
-      const foundCurrent = options.find((x) => x.value === this.state.value);
-      if (foundCurrent) {
+      // Try find by value then text
+      let matchingOption = findOptionMatchingCurrent(currentValue, currentText, options);
+      if (matchingOption) {
         // When updating the initial state from URL the text property is set the same as value
         // Here we can correct the text value state
-        if (foundCurrent.label !== this.state.text) {
-          stateUpdate.text = foundCurrent.label;
-        }
+
+        stateUpdate.text = matchingOption.label;
+        stateUpdate.value = matchingOption.value;
       } else {
         // Current value is found in options
         if (this.state.defaultToAll) {
@@ -127,14 +130,11 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       }
     }
 
-    // Remember current value and text
-    const { value: prevValue, text: prevText } = this.state;
-
     // Perform state change
     this.setStateHelper(stateUpdate);
 
     // Publish value changed event only if value changed
-    if (stateUpdate.value !== prevValue || stateUpdate.text !== prevText || this.hasAllValue()) {
+    if (stateUpdate.value !== currentValue || stateUpdate.text !== currentText || this.hasAllValue()) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }
@@ -261,6 +261,30 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
    * Can be used by subclasses to do custom handling of option search based on search input
    */
   public onSearchChange?(searchFilter: string): void;
+}
+
+/**
+ * Looks for matching option, first by value but as a fallback by text (label).
+ */
+function findOptionMatchingCurrent(
+  currentValue: VariableValue,
+  currentText: VariableValue,
+  options: VariableValueOption[]
+) {
+  let textMatch: VariableValueOption | undefined;
+
+  for (const item of options) {
+    if (item.value === currentValue) {
+      return item;
+    }
+
+    // No early return here as want to continue to look a value match
+    if (item.label === currentText) {
+      textMatch = item;
+    }
+  }
+
+  return textMatch;
 }
 
 export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = MultiValueVariableState>


### PR DESCRIPTION
Fixes an issue seen on ops (in bugbash) where variable had an error. The error was caused by
the wrong data source variable to be selected.

The dashboard was saved with the datasource name in the "current.value" property (since data source
variables used to only have the name as both value and text).

The old variable system supports this by validating the current value by looking up option
by both text and value.

https://github.com/grafana/grafana/blob/main/public/app/features/variables/state/actions.ts#L526


I am refining that logic a bit by first looking through all options by value, and if nothing is found
take and option that matches by text.
