### PR TITLE
Variables: Clear error state

### DIFF
--- a/packages/scenes/src/variables/variants/DataSourceVariable.tsx
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.tsx
@@ -73,6 +73,8 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
 
     if (options.length === 0) {
       this.setState({ error: 'No data sources found' });
+    } else if (this.state.error) {
+      this.setState({ error: null });
     }
 
     return of(options);

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -64,7 +64,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       return of([]);
     }
 
-    this.setState({ loading: true });
+    this.setState({ loading: true, error: null });
 
     return from(
       getDataSource(this.state.datasource, {


### PR DESCRIPTION
Noticed that errors that happen on QueryVariables did not go away (once I had switched to correct data source and was getting options) 