### PR TITLE
VizPanelRenderer: Round visualization width pushed to data provider

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -53,7 +53,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   // If we have a query runner on our level inform it of the container width (used to set auto max data points)
   if ($data && $data.setContainerWidth) {
-    $data.setContainerWidth(width);
+    $data.setContainerWidth(Math.round(width));
   }
 
   let titleItemsElement: React.ReactNode[] = [];


### PR DESCRIPTION
Fixes an issue when there was a difference between maxDataPoints passed to SQR and maxDataPoints passed to PanelQueryRunner in the core.

The difference is that we use `useMeasure` in scenes and `AutoSizer` in core to calculate the width of a panel. The version of AutoSizer we use always returns width as [Int](https://github.com/bvaughn/react-virtualized-auto-sizer/blob/1.0.11/src/AutoSizer.ts#L149) while useMeasure return floats. 

Given the testing I performed, `Math.round` is what we want to do here to have parity with core maxDataPoints rounding.

This is easily testable locally. You can i.e. set up gdev-prometheus data source and observe what is the maxDataPoints sent with the request.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.24.4--canary.478.6978980670.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.24.4--canary.478.6978980670.0
  # or 
  yarn add @grafana/scenes@1.24.4--canary.478.6978980670.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
