### PR TITLE
SceneQueryRunner: Fixes issue with waiting for variables

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -210,7 +210,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
    * the query execution on activate was stopped due to VariableSet still not having processed all variables.
    */
   private onVariableUpdatesCompleted(_variablesThatHaveChanged: Set<SceneVariable>, dependencyChanged: boolean) {
-    if (this.state._isWaitingForVariables && this.shouldRunQueriesOnActivate()) {
+    if (this.state._isWaitingForVariables) {
       this.runQueries();
       return;
     }


### PR DESCRIPTION
Fixes an issue where SceneQueryRunner was waiting for variables but shouldRunQueriesOnActivate returned false (due to data layer received and setting this.state.data) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.24.5--canary.481.6981394489.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.24.5--canary.481.6981394489.0
  # or 
  yarn add @grafana/scenes@1.24.5--canary.481.6981394489.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
