### PR TITLE
SceneQueryRunner: Fixes issue with cloned scene query runner would issue new query

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -279,7 +279,7 @@ describe('SceneQueryRunner', () => {
   });
 
   describe('when activated and maxDataPointsFromWidth set to true', () => {
-    it('should run queries', async () => {
+    it('should run queries when container width is received', async () => {
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A' }],
         $timeRange: new SceneTimeRange(),
@@ -301,6 +301,31 @@ describe('SceneQueryRunner', () => {
       await new Promise((r) => setTimeout(r, 1));
 
       expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+    });
+
+    it('should not run queries when container width is received and data has already been fetched', async () => {
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        $timeRange: new SceneTimeRange(),
+        maxDataPointsFromWidth: true,
+      });
+
+      queryRunner.activate();
+      queryRunner.setContainerWidth(1000);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+      expect(runRequestMock.mock.calls.length).toBe(1);
+
+      const clonedQueryRunner = queryRunner.clone();
+      clonedQueryRunner.activate();
+      clonedQueryRunner.setContainerWidth(1000);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      // should not issue new query
+      expect(runRequestMock.mock.calls.length).toBe(1);
     });
   });
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -290,7 +290,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       if (this.state.maxDataPointsFromWidth && !this.state.maxDataPoints) {
         // As this is called from render path we need to wait for next tick before running queries
         setTimeout(() => {
-          if (this.isActive && !this._querySub) {
+          if (this.isActive && !this.state._hasFetchedData) {
             this.runQueries();
           }
         }, 0);


### PR DESCRIPTION

Working on a new way to handle the "View panel" feature in dashboards (where I need to clone the panel). And it's issuing a new query when it gets the containerWidth. 

