### PR TITLE
SceneObject: Allow component rendering to override the "lazy" rendering and render content before activation 

### DIFF
--- a/packages/scenes/src/components/SceneControlsSpacer.tsx
+++ b/packages/scenes/src/components/SceneControlsSpacer.tsx
@@ -4,13 +4,11 @@ import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneComponentProps } from '../core/types';
 
 export class SceneControlsSpacer extends SceneObjectBase {
+  // This component can render right away, it fixes flickering movement of controls
+  static UNSAFE_renderBeforeActive = true;
+
   public constructor() {
     super({});
-  }
-
-  public get Component() {
-    // Skipping wrapper component for this scene object so that it renders right away
-    return SceneControlsSpacer.Component;
   }
 
   public static Component = (_props: SceneComponentProps<SceneControlsSpacer>) => {

--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -27,7 +27,7 @@ export class VizPanelMenu extends SceneObjectBase<VizPanelMenuState> {
 }
 
 function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
-  const { items } = model.useState();
+  const { items = [] } = model.useState();
 
   const renderItems = (items: PanelMenuItem[]) => {
     return items.map((item) =>
@@ -46,9 +46,6 @@ function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
       )
     );
   };
-  if (!items) {
-    return null;
-  }
 
   return <Menu>{renderItems(items)}</Menu>;
 }

--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { PanelMenuItem } from '@grafana/data';
 import { Menu } from '@grafana/ui';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
@@ -10,6 +10,7 @@ interface VizPanelMenuState extends SceneObjectState {
 
 export class VizPanelMenu extends SceneObjectBase<VizPanelMenuState> {
   static Component = VizPanelMenuRenderer;
+  static UNSAFE_renderBeforeActive = true;
 
   // Allows adding menu items dynamically
   public addItem(item: PanelMenuItem) {
@@ -28,13 +29,6 @@ export class VizPanelMenu extends SceneObjectBase<VizPanelMenuState> {
 
 function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
   const { items = [] } = model.useState();
-  const ref = React.useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.focus();
-    }
-  }, []);
 
   const renderItems = (items: PanelMenuItem[]) => {
     return items.map((item) =>
@@ -54,5 +48,5 @@ function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
     );
   };
 
-  return <Menu ref={ref}>{renderItems(items)}</Menu>;
+  return <Menu>{renderItems(items)}</Menu>;
 }

--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { PanelMenuItem } from '@grafana/data';
 import { Menu } from '@grafana/ui';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
@@ -28,6 +28,13 @@ export class VizPanelMenu extends SceneObjectBase<VizPanelMenuState> {
 
 function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
   const { items = [] } = model.useState();
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.focus();
+    }
+  }, []);
 
   const renderItems = (items: PanelMenuItem[]) => {
     return items.map((item) =>
@@ -47,5 +54,5 @@ function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
     );
   };
 
-  return <Menu>{renderItems(items)}</Menu>;
+  return <Menu ref={ref}>{renderItems(items)}</Menu>;
 }

--- a/packages/scenes/src/core/SceneComponentWrapper.tsx
+++ b/packages/scenes/src/core/SceneComponentWrapper.tsx
@@ -3,7 +3,8 @@ import React, { useEffect } from 'react';
 import { SceneComponentProps, SceneObject } from './types';
 
 function SceneComponentWrapperWithoutMemo<T extends SceneObject>({ model, ...otherProps }: SceneComponentProps<T>) {
-  const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
+  const ClassType = model.constructor as SceneObjectType;
+  const Component = ClassType.Component ?? EmptyRenderer;
   const [activated, setActivated] = React.useState(false);
 
   useEffect(() => {
@@ -14,7 +15,7 @@ function SceneComponentWrapperWithoutMemo<T extends SceneObject>({ model, ...oth
   // By not rendering the component until the model is actiavted we make sure that parent models get activated before child models
   // Otherwise child models would be activated before parents as that is the order of React mount effects.
   // This also enables static logic to happen inside activate that can change state before the first render.
-  if (!activated) {
+  if (!activated && !ClassType.UNSAFE_renderBeforeActive) {
     return null;
   }
 
@@ -25,4 +26,9 @@ export const SceneComponentWrapper = React.memo(SceneComponentWrapperWithoutMemo
 
 function EmptyRenderer<T>(_: SceneComponentProps<T>): React.ReactElement | null {
   return null;
+}
+
+interface SceneObjectType {
+  Component?: React.ComponentType<any>;
+  UNSAFE_renderBeforeActive?: boolean;
 }


### PR DESCRIPTION
Alt alt fix :) 
https://github.com/grafana/scenes/pull/483 

The logic that staggers rendering to after activation is useful for higher-level scene objects to make sure that parents activate before children. But for leaf nodes it does not really matter, and so far we have two instances where this has caused issues. 

SceneControlsSpacer and VizPanelMenu. This adds a new property `UNSAFE_renderBeforeActive` to override the condition that renders null on first mount so that the scene object component is rendered before activation. 