### PR TITLE
Variables:  Query - Add optional `definition` prop to state

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -84,6 +84,14 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                   description: 'Auto step count 30, auto min interval 10s',
                   refresh: VariableRefresh.onTimeRangeChanged,
                 }),
+
+                new QueryVariable({
+                  name: 'serverUsingDefinition',
+                  label: 'Server with definition',
+                  query: { query: '*', refId: 'A' },
+                  datasource: { uid: 'gdev-testdata' },
+                  definition: '*',
+                }),
               ],
             }),
             body: new SceneFlexLayout({
@@ -157,6 +165,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                   name: 'server',
                   query: { query: 'A.$__searchFilter', refId: 'A' },
                   datasource: { uid: 'gdev-testdata' },
+                  definition: 'A.$__searchFilter',
                 }),
               ],
             }),
@@ -204,6 +213,7 @@ function getGraphAndTextPanel() {
 * pod: $pod
 * handler: $handler
 * interval: $interval
+* serverUsingDefinition: $serverUsingDefinition
 * [Link that updates pod = AAG and AAH](\${__url.path}\${__url.params:exclude:var-pod}&var-pod=AAG&var-pod=AAH)
 
           `

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -36,6 +36,7 @@ export interface QueryVariableState extends MultiValueVariableState {
   regex: string;
   refresh: VariableRefresh;
   sort: VariableSort;
+  /** @internal Only for use inside core dashboards  */ 
   definition?: string;
 }
 

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -36,7 +36,7 @@ export interface QueryVariableState extends MultiValueVariableState {
   regex: string;
   refresh: VariableRefresh;
   sort: VariableSort;
-  /** @internal Only for use inside core dashboards  */ 
+  /** @internal Only for use inside core dashboards */
   definition?: string;
 }
 
@@ -55,7 +55,6 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       datasource: null,
       regex: '',
       query: { refId: 'A' },
-      definition: '',
       refresh: VariableRefresh.onDashboardLoad,
       sort: VariableSort.disabled,
       ...initialState,

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -36,6 +36,7 @@ export interface QueryVariableState extends MultiValueVariableState {
   regex: string;
   refresh: VariableRefresh;
   sort: VariableSort;
+  definition?: string;
 }
 
 export class QueryVariable extends MultiValueVariable<QueryVariableState> {
@@ -53,6 +54,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       datasource: null,
       regex: '',
       query: { refId: 'A' },
+      definition: '',
       refresh: VariableRefresh.onDashboardLoad,
       sort: VariableSort.disabled,
       ...initialState,


### PR DESCRIPTION
For feature parity in Dashboards Variable Settings migration, we need the `definition` prop defined in query variables. 

This PR adds the prop to the state. Also adds an example, I am not sure if the example is needed as the new prop is not doing anything special here. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.26.0--canary.489.7088562794.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.26.0--canary.489.7088562794.0
  # or 
  yarn add @grafana/scenes@1.26.0--canary.489.7088562794.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
