### PR TITLE
Allow setting initial size on Split Layouts

### DIFF
--- a/packages/scenes-app/src/demos/split.tsx
+++ b/packages/scenes-app/src/demos/split.tsx
@@ -27,6 +27,7 @@ const basicDemo = () =>
         ...getEmbeddedSceneDefaults(),
         key: 'Flex layout embedded scene',
         body: new SplitLayout({
+          initialSize: 0.7,
           direction: 'row',
           primary: PanelBuilders.timeseries()
             .setTitle('Dynamic height and width')

--- a/packages/scenes/src/components/layout/split/SplitLayout.ts
+++ b/packages/scenes/src/components/layout/split/SplitLayout.ts
@@ -7,6 +7,7 @@ interface SplitLayoutState extends SceneObjectState, SceneFlexItemPlacement {
   primary: SceneFlexItemLike;
   secondary: SceneFlexItemLike;
   direction: 'row' | 'column';
+  initialSize?: number;
 }
 
 export class SplitLayout extends SceneObjectBase<SplitLayoutState> {

--- a/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
@@ -6,7 +6,7 @@ import { SplitLayout } from './SplitLayout';
 import { Splitter } from './Splitter';
 
 export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLayout>) {
-  const { primary, secondary, direction, isHidden } = model.useState();
+  const { primary, secondary, direction, isHidden, initialSize } = model.useState();
 
   if (isHidden) {
     return null;
@@ -15,7 +15,7 @@ export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLay
   const Prim = primary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
   const Sec = secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
   return (
-    <Splitter direction={direction}>
+    <Splitter direction={direction} initialSize={initialSize ?? 0.5}>
       <Prim key={primary.state.key} model={primary} parentState={model.state} />
       <Sec key={secondary.state.key} model={secondary} parentState={model.state} />
     </Splitter>


### PR DESCRIPTION
This adds `initialSize` to the SplitLayout state and passes it down.

It doesnt change the API so the default is still going to be `0.5`, where a 70/30 layout would use `0.3` or `0.7` respectively.