### PR TITLE
Make updateValueGivenNewOptions protected

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -73,7 +73,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
   /**
    * Check if current value is valid given new options. If not update the value.
    */
-  private updateValueGivenNewOptions(options: VariableValueOption[]) {
+  protected updateValueGivenNewOptions(options: VariableValueOption[]) {
     // Remember current value and text
     const { value: currentValue, text: currentText } = this.state;
 


### PR DESCRIPTION
One edge case that we encountered during development is that we need to extend `QueryVariable` and override `updateValueGivenNewOptions` in order to auto-select a value based on some custom criteria. The problem is that the named function is private in `MultiValueVariable`, causing TS to complain about incorrectly extending another class.

We suppressed the TS for the time being but it would be nice to avoid having `ts-expect-error` directive.