### PR TITLE
Variables: Fixes issue with chained variable and cascading updates

### DIFF
--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -11,9 +11,6 @@ import {
   SceneComponentProps,
   SceneCSSGridLayout,
   SceneObject,
-  QueryVariable,
-  SceneVariableSet,
-  VariableValueSelectors,
 } from '@grafana/scenes';
 import React from 'react';
 import { demoUrl, prefixRoute } from '../utils/utils.routing';
@@ -24,24 +21,6 @@ import { config } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 
-export const appFilter = new QueryVariable({
-  name: 'app',
-  datasource: { uid: 'gdev-prometheus' },
-  query: 'label_values(app)',
-});
-
-export const server = new QueryVariable({
-  name: 'server',
-  datasource: { uid: 'gdev-prometheus' },
-  query: 'label_values({app="$app"}, server)',
-});
-
-export const geohash = new QueryVariable({
-  name: 'geohash',
-  datasource: { uid: 'gdev-prometheus' },
-  query: 'label_values({server="$server"}, geohash)',
-});
-
 function getDemoSceneApp() {
   return new SceneApp({
     name: 'scenes-demos-app',
@@ -49,10 +28,6 @@ function getDemoSceneApp() {
       new SceneAppPage({
         title: 'Demos',
         key: 'SceneAppPage Demos',
-        $variables: new SceneVariableSet({
-          variables: [appFilter, server, geohash],
-        }), // added
-        controls: [new VariableValueSelectors({})], // added
         url: prefixRoute(ROUTES.Demos),
         getScene: () => {
           return new EmbeddedScene({

--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -11,6 +11,9 @@ import {
   SceneComponentProps,
   SceneCSSGridLayout,
   SceneObject,
+  QueryVariable,
+  SceneVariableSet,
+  VariableValueSelectors,
 } from '@grafana/scenes';
 import React from 'react';
 import { demoUrl, prefixRoute } from '../utils/utils.routing';
@@ -21,6 +24,24 @@ import { config } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 
+export const appFilter = new QueryVariable({
+  name: 'app',
+  datasource: { uid: 'gdev-prometheus' },
+  query: 'label_values(app)',
+});
+
+export const server = new QueryVariable({
+  name: 'server',
+  datasource: { uid: 'gdev-prometheus' },
+  query: 'label_values({app="$app"}, server)',
+});
+
+export const geohash = new QueryVariable({
+  name: 'geohash',
+  datasource: { uid: 'gdev-prometheus' },
+  query: 'label_values({server="$server"}, geohash)',
+});
+
 function getDemoSceneApp() {
   return new SceneApp({
     name: 'scenes-demos-app',
@@ -28,6 +49,10 @@ function getDemoSceneApp() {
       new SceneAppPage({
         title: 'Demos',
         key: 'SceneAppPage Demos',
+        $variables: new SceneVariableSet({
+          variables: [appFilter, server, geohash],
+        }), // added
+        controls: [new VariableValueSelectors({})], // added
         url: prefixRoute(ROUTES.Demos),
         getScene: () => {
           return new EmbeddedScene({

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -98,6 +98,35 @@ describe('SceneVariableList', () => {
       expect(B.state.value).toBe('ABA');
       expect(C.state.loading).toBe(true);
     });
+
+    it('Should start update process of chained dependency', async () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const B = new TestVariable({ name: 'B', query: 'A.$A.*', value: '', text: '', options: [] });
+      const C = new TestVariable({ name: 'C', query: 'value=$B', value: '', text: '', options: [] });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [C, B, A] }),
+      });
+
+      scene.activate();
+
+      A.signalUpdateCompleted();
+      B.signalUpdateCompleted();
+      C.signalUpdateCompleted();
+
+      // When changing A should start B but not C (yet)
+      A.changeValueTo('AB');
+
+      expect(B.state.loading).toBe(true);
+      expect(C.state.loading).toBe(false);
+
+      B.signalUpdateCompleted();
+      expect(B.state.value).toBe('ABA');
+      expect(C.state.loading).toBe(true);
+
+      C.signalUpdateCompleted();
+      expect(C.state.value).toBe('value=ABA');
+    });
   });
 
   describe('When deactivated', () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -102,6 +102,7 @@ describe('SceneVariableList', () => {
     it('Should start update process of chained dependency', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
       const B = new TestVariable({ name: 'B', query: 'A.$A.*', value: '', text: '', options: [] });
+      // Important here that variable C only depends on B
       const C = new TestVariable({ name: 'C', query: 'value=$B', value: '', text: '', options: [] });
 
       const scene = new TestScene({

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -253,14 +253,12 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
 
   private _handleVariableValueChanged(variableThatChanged: SceneVariable) {
     this._variablesThatHaveChanged.add(variableThatChanged);
+    this._addDependentVariablesToUpdateQueue(variableThatChanged);
 
     // Ignore this change if it is currently updating
-    if (this._updating.has(variableThatChanged)) {
-      return;
+    if (!this._updating.has(variableThatChanged)) {
+      this._updateNextBatch();
     }
-
-    this._addDependentVariablesToUpdateQueue(variableThatChanged);
-    this._updateNextBatch();
   }
 
   /**


### PR DESCRIPTION
fixes https://github.com/grafana/scenes/issues/500

Our test cases did not include a case where chained variables did not include the use of the first variable. So we had a test case for variable dependencies like 
B depends on A
C depends on A and B

but we did not have a case for 
B depends on A
C depends on B 

Luckily it was a simple thing to fix :) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.28.1--canary.501.7194502273.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.28.1--canary.501.7194502273.0
  # or 
  yarn add @grafana/scenes@1.28.1--canary.501.7194502273.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
