### PR TITLE
Demos: Adds an example with InteractiveTable with exandable rows that shows sub scenes 

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -29,6 +29,7 @@ import { getNestedScenesAndVariablesDemo } from './nestedVariables';
 import { getCssGridLayoutDemo } from './cssGridLayoutDemo';
 import { getPanelHeaderActions } from './panelHeaderActions';
 import { getVerticalControlsLayoutDemo } from './verticalControlsLayoutDemo';
+import { getInteractiveTableDemo } from './interactiveTableDemo';
 
 export interface DemoDescriptor {
   title: string;
@@ -67,5 +68,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'CSS Grid Layout', getPage: getCssGridLayoutDemo },
     { title: 'Panel header actions', getPage: getPanelHeaderActions },
     { title: 'Vertical controls layout', getPage: getVerticalControlsLayoutDemo },
+    { title: 'Interactive table with expandable rows', getPage: getInteractiveTableDemo },
   ].sort((a, b) => a.title.localeCompare(b.title));
 }

--- a/packages/scenes-app/src/demos/interactiveTableDemo.tsx
+++ b/packages/scenes-app/src/demos/interactiveTableDemo.tsx
@@ -49,10 +49,6 @@ interface TableVizState extends SceneObjectState {
 }
 
 class TableViz extends SceneObjectBase<TableVizState> {
-  public addExpandedRow(row: SceneObject) {
-    this.setState({ expandedRows: [...(this.state.expandedRows ?? []), row] });
-  }
-
   static Component = ({ model }: SceneComponentProps<TableViz>) => {
     const { data } = sceneGraph.getData(model).useState();
 
@@ -102,12 +98,14 @@ interface ExpandedRowProps {
 function TableVizExpandedRow({ tableViz, row }: ExpandedRowProps) {
   const { expandedRows } = tableViz.useState();
 
-  useEffect(() => {
-    const expandedRow = buildExpandedRowScene(row.handler);
-    tableViz.addExpandedRow(expandedRow);
-  }, [row, tableViz]);
-
   const rowScene = expandedRows?.find((scene) => scene.state.key === row.handler);
+
+  useEffect(() => {
+    if (!rowScene) {
+      const newRowScene = buildExpandedRowScene(row.handler);
+      tableViz.setState({ expandedRows: [...(tableViz.state.expandedRows ?? []), newRowScene] });
+    }
+  }, [row, tableViz, rowScene]);
 
   return rowScene ? <rowScene.Component model={rowScene} /> : null;
 }

--- a/packages/scenes-app/src/demos/interactiveTableDemo.tsx
+++ b/packages/scenes-app/src/demos/interactiveTableDemo.tsx
@@ -1,0 +1,134 @@
+import {
+  SceneFlexLayout,
+  SceneFlexItem,
+  SceneAppPage,
+  EmbeddedScene,
+  SceneAppPageState,
+  SceneObjectState,
+  SceneObjectBase,
+  SceneComponentProps,
+  sceneGraph,
+  SceneObject,
+  PanelBuilders,
+} from '@grafana/scenes';
+import {
+  getQueryRunnerWithRandomWalkQuery,
+  getEmbeddedSceneDefaults,
+  getPromQueryInstant,
+  getPromQueryTimeSeries,
+} from './utils';
+import { InteractiveTable } from '@grafana/ui';
+import React, { useMemo, useEffect } from 'react';
+import { DataFrameView } from '@grafana/data';
+
+export function getInteractiveTableDemo(defaults: SceneAppPageState): SceneAppPage {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Interactive table',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        $data: getQueryRunnerWithRandomWalkQuery(),
+        body: new SceneFlexLayout({
+          children: [
+            new SceneFlexItem({
+              $data: getPromQueryInstant({
+                expr: 'sort_desc(avg without(job, instance) (rate(grafana_http_request_duration_seconds_sum[$__rate_interval]) * 1e3))',
+              }),
+              body: new TableViz({}),
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}
+
+interface TableVizState extends SceneObjectState {
+  expandedRows?: SceneObject[];
+}
+
+class TableViz extends SceneObjectBase<TableVizState> {
+  public addExpandedRow(row: SceneObject) {
+    this.setState({ expandedRows: [...(this.state.expandedRows ?? []), row] });
+  }
+
+  static Component = ({ model }: SceneComponentProps<TableViz>) => {
+    const { data } = sceneGraph.getData(model).useState();
+
+    const columns = useMemo(
+      () => [
+        { id: 'handler', header: 'Handler' },
+        { id: 'method', header: 'Method' },
+        { id: 'status_code', header: 'Status code' },
+        { id: 'Value', header: 'Value' },
+      ],
+      []
+    );
+
+    const tableData = useMemo(() => {
+      if (!data || data.series.length === 0) {
+        return [];
+      }
+
+      const frame = data.series[0];
+      const view = new DataFrameView<TableRow>(frame);
+      return view.toArray();
+    }, [data]);
+
+    return (
+      <InteractiveTable
+        columns={columns}
+        getRowId={(row: any) => row.handler}
+        data={tableData}
+        renderExpandedRow={(row) => <TableVizExpandedRow tableViz={model} row={row} />}
+      />
+    );
+  };
+}
+
+interface TableRow {
+  handler: string;
+  method: string;
+  status_code: string;
+  Value: string;
+}
+
+interface ExpandedRowProps {
+  tableViz: TableViz;
+  row: TableRow;
+}
+
+function TableVizExpandedRow({ tableViz, row }: ExpandedRowProps) {
+  const { expandedRows } = tableViz.useState();
+
+  useEffect(() => {
+    const expandedRow = buildExpandedRowScene(row.handler);
+    tableViz.addExpandedRow(expandedRow);
+  }, [row, tableViz]);
+
+  const rowScene = expandedRows?.find((scene) => scene.state.key === row.handler);
+
+  return rowScene ? <rowScene.Component model={rowScene} /> : null;
+}
+
+function buildExpandedRowScene(handler: string) {
+  return new SceneFlexLayout({
+    key: handler,
+    height: 300,
+    children: [
+      new SceneFlexItem({
+        body: PanelBuilders.timeseries()
+          .setTitle('Requests / s')
+          .setCustomFieldConfig('fillOpacity', 6)
+          .setData(
+            getPromQueryTimeSeries({
+              expr: `sum without(job, instance) (rate(grafana_http_request_duration_seconds_count{handler="${handler}"}[$__rate_interval]))`,
+              legendFormat: '{{method}} (status = {{status_code}})',
+            })
+          )
+          .build(),
+      }),
+    ],
+  });
+}

--- a/packages/scenes-app/src/demos/interactiveTableDemo.tsx
+++ b/packages/scenes-app/src/demos/interactiveTableDemo.tsx
@@ -32,10 +32,11 @@ export function getInteractiveTableDemo(defaults: SceneAppPageState): SceneAppPa
         body: new SceneFlexLayout({
           children: [
             new SceneFlexItem({
-              $data: getPromQueryInstant({
-                expr: 'sort_desc(avg without(job, instance) (rate(grafana_http_request_duration_seconds_sum[$__rate_interval]) * 1e3))',
+              body: new TableViz({
+                $data: getPromQueryInstant({
+                  expr: 'sort_desc(avg without(job, instance) (rate(grafana_http_request_duration_seconds_sum[$__rate_interval]) * 1e3))',
+                }),
               }),
-              body: new TableViz({}),
             }),
           ],
         }),

--- a/packages/scenes-app/src/demos/utils.ts
+++ b/packages/scenes-app/src/demos/utils.ts
@@ -10,6 +10,7 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 import { DATASOURCE_REF } from '../constants';
+import { DataQueryExtended } from '@grafana/scenes/src/querying/SceneQueryRunner';
 
 export function getQueryRunnerWithRandomWalkQuery(
   overrides?: Partial<any>,
@@ -47,5 +48,35 @@ export function getRowWithText(text: string) {
       text,
       fontSize: 12,
     }),
+  });
+}
+
+export function getPromQueryInstant(query: Partial<DataQueryExtended>): SceneQueryRunner {
+  return new SceneQueryRunner({
+    datasource: { uid: 'gdev-prometheus' },
+    queries: [
+      {
+        refId: 'A',
+        instant: true,
+        format: 'table',
+        maxDataPoints: 500,
+        ...query,
+      },
+    ],
+  });
+}
+
+export function getPromQueryTimeSeries(query: Partial<DataQueryExtended>): SceneQueryRunner {
+  return new SceneQueryRunner({
+    datasource: { uid: 'gdev-prometheus' },
+    queries: [
+      {
+        refId: 'A',
+        range: true,
+        format: 'time_series',
+        maxDataPoints: 500,
+        ...query,
+      },
+    ],
   });
 }


### PR DESCRIPTION
Adds a demo using InteractiveTable that renders sub scenes in the expandable rows. 

This I think highlights one scenario where scenes lib is making something a bit harder than it should be. 

To render the expanded row scene we need to first attach it it to the scene. It's not too complicated but still feels like there is something here we could do to make this scenario easier. 

![image](https://github.com/grafana/scenes/assets/10999/f389195d-6181-4462-9ca4-9ac39451b983)
