### PR TITLE
SceneQueryRunner: Improve the way to find adhoc filter set

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -224,6 +224,7 @@ describe('SceneQueryRunner', () => {
       expect(queryRunner.state.data).toBeUndefined();
 
       queryRunner.activate();
+      filterSet.activate();
 
       await new Promise((r) => setTimeout(r, 1));
 

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
@@ -1,8 +1,6 @@
 import { getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 import { AdHocFilterSet } from './AdHocFiltersSet';
 import { AdHocVariableFilter } from '@grafana/data';
-import { SceneObject } from '../../core/types';
-import { sceneGraph } from '../../core/sceneGraph';
 
 let originalGetAdhocFilters: any = undefined;
 let allActiveFilterSets = new Set<AdHocFilterSet>();

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
@@ -1,6 +1,8 @@
 import { getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 import { AdHocFilterSet } from './AdHocFiltersSet';
 import { AdHocVariableFilter } from '@grafana/data';
+import { SceneObject } from '../../core/types';
+import { sceneGraph } from '../../core/sceneGraph';
 
 let originalGetAdhocFilters: any = undefined;
 let allActiveFilterSets = new Set<AdHocFilterSet>();
@@ -41,4 +43,14 @@ export function patchGetAdhocFilters(filterSet: AdHocFilterSet) {
 
     return [];
   }.bind(templateSrv);
+}
+
+export function findActiveAdHocFilterSetByUid(dsUid: string | undefined): AdHocFilterSet | undefined {
+  for (const filter of allActiveFilterSets.values()) {
+    if (filter.state.datasource?.uid === dsUid) {
+      return filter;
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
Uses the allActiveFilterSets we already have for a much faster and simpler way to find the adhoc filter set. 

After opening this PR I realized his approach does not allow multiple locally scoped filter sets. 

