### PR TITLE
IntervalVariable: Makes it return the original variable expression when data or request is not present

### DIFF
--- a/packages/scenes/src/variables/macros/timeMacros.test.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.test.ts
@@ -3,6 +3,9 @@ import { TestScene } from '../TestScene';
 
 import { sceneInterpolator } from '../interpolation/sceneInterpolator';
 import { SceneTimeZoneOverride } from '../../core/SceneTimeZoneOverride';
+import { SceneDataNode } from '../../core/SceneDataNode';
+import { LoadingState } from '@grafana/schema';
+import { DataQueryRequest, getDefaultTimeRange } from '@grafana/data';
 
 describe('timeMacros', () => {
   it('Can use use $__url_time_range', () => {
@@ -58,5 +61,39 @@ describe('timeMacros', () => {
     expect(sceneInterpolator(scene1, '$__timezone')).toBe('browser');
     expect(sceneInterpolator(scene2, '$__timezone')).toBe('America/New_York');
     expect(sceneInterpolator(nestedScene, '$__timezone')).toBe('Africa/Abidjan');
+  });
+
+  it('Can use use $__interval when data & request are present', () => {
+    const scene1 = new TestScene({
+      $data: new SceneDataNode({
+        data: {
+          state: LoadingState.Done,
+          timeRange: getDefaultTimeRange(),
+          series: [],
+          request: {
+            intervalMs: 10000,
+            interval: '10s',
+          } as DataQueryRequest,
+        },
+      }),
+    });
+
+    expect(sceneInterpolator(scene1, '$__interval')).toBe('10s');
+    expect(sceneInterpolator(scene1, '$__interval_ms')).toBe('10000');
+  });
+
+  it('$__interval and $__interval_ms should return the variable expression when data request not found', () => {
+    const scene1 = new TestScene({
+      $data: new SceneDataNode({
+        data: {
+          state: LoadingState.Done,
+          timeRange: getDefaultTimeRange(),
+          series: [],
+        },
+      }),
+    });
+
+    expect(sceneInterpolator(scene1, '$__interval')).toBe('${__interval}');
+    expect(sceneInterpolator(scene1, '$__interval_ms')).toBe('${__interval_ms}');
   });
 });

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -99,7 +99,7 @@ export class IntervalMacro implements FormatVariable {
     if (data) {
       const request = data.state.data?.request;
       if (!request) {
-        return '';
+        return `\${${this.state.name}}`;
       }
       if (this.state.name === '__interval_ms') {
         return request.intervalMs;
@@ -107,6 +107,6 @@ export class IntervalMacro implements FormatVariable {
       return request.interval;
     }
 
-    return '';
+    return `\${${this.state.name}}`;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/507 

I think instead of a fix like https://github.com/grafana/grafana/pull/79645  we could change this macro to just return the variable expression when no data or request is found, this way this behavior is not changed for other data sources. 

The variable interpolation engine behaves similarly, in that it returns the variable expression unchanged when a variable cannot be found  

