### PR TITLE
SceneTimeRange: Support delay now to avoid data drops in charts

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -126,7 +126,7 @@ describe('SceneTimeRange', () => {
     });
 
     it('when created should evaluate time range applying the delay value to now', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', nowDelay: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', UNSAFE_nowDelay: '1m' });
       expect(timeRange.state.value.raw.from).toBe('now-1h');
       expect(timeRange.state.value.raw.to).toBe('now');
       expect(timeRange.state.value.to).toEqual(dateMath.parse('now-1m', true));
@@ -136,7 +136,7 @@ describe('SceneTimeRange', () => {
       const timeRange = new SceneTimeRange({
         from: '2021-01-01T10:00:00.000Z',
         to: '2021-02-03T01:20:00.000Z',
-        nowDelay: '1m',
+        UNSAFE_nowDelay: '1m',
       });
       expect(timeRange.state.value.to).toEqual(dateMath.parse('2021-02-03T01:20:00.000Z'));
       expect(timeRange.state.value.from).toEqual(dateMath.parse('2021-01-01T10:00:00.000Z'));
@@ -145,7 +145,7 @@ describe('SceneTimeRange', () => {
     });
 
     it('should apply delay after time range changes', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', nowDelay: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', UNSAFE_nowDelay: '1m' });
       const stateSpy = jest.spyOn(timeRange, 'setState');
 
       timeRange.onTimeRangeChange({
@@ -168,14 +168,14 @@ describe('SceneTimeRange', () => {
     });
 
     it('should apply the delay to the value when time range refreshed', async () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', nowDelay: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', UNSAFE_nowDelay: '1m' });
       timeRange.onRefresh();
       expect(timeRange.state.value.to).toEqual(dateMath.parse('now-1m', true));
       expect(timeRange.state.value.raw.to).toBe('now');
     });
 
     it('should apply the delay to the value when updating from URL', async () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', nowDelay: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', UNSAFE_nowDelay: '1m' });
 
       timeRange.urlSync?.updateFromUrl({
         from: 'now-6h',
@@ -188,7 +188,7 @@ describe('SceneTimeRange', () => {
 
     it('should apply delay when updating time zone from the closest range with time zone specified', () => {
       const outerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'America/New_York' });
-      const innerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', nowDelay: '1m' });
+      const innerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', UNSAFE_nowDelay: '1m' });
       const scene = new SceneFlexLayout({
         $timeRange: outerTimeRange,
         children: [

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -120,7 +120,7 @@ describe('SceneTimeRange', () => {
 
   describe('delay now', () => {
     it('when created should evaluate time range applying the delay value to now', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', delayNow: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', nowDelay: '1m' });
       expect(timeRange.state.value.raw.from).toBe('now-1h');
       expect(timeRange.state.value.raw.to).toBe('now-1m');
     });
@@ -129,14 +129,14 @@ describe('SceneTimeRange', () => {
       const timeRange = new SceneTimeRange({
         from: '2021-01-01T10:00:00.000Z',
         to: '2021-02-03T01:20:00.000Z',
-        delayNow: '1m',
+        nowDelay: '1m',
       });
       expect(timeRange.state.value.raw.from).toBe('2021-01-01T10:00:00.000Z');
       expect(timeRange.state.value.raw.to).toBe('2021-02-03T01:20:00.000Z');
     });
 
     it('should apply delay after time range changes', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', delayNow: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', nowDelay: '1m' });
       const stateSpy = jest.spyOn(timeRange, 'setState');
 
       timeRange.onTimeRangeChange({
@@ -158,13 +158,13 @@ describe('SceneTimeRange', () => {
     });
 
     it('should apply the delay to the value when time range refreshed', async () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', delayNow: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', nowDelay: '1m' });
       timeRange.onRefresh();
       expect(timeRange.state.value.raw.to).toBe('now-1m');
     });
 
     it('should apply the delay to the value when updating from URL', async () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', delayNow: '1m' });
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', nowDelay: '1m' });
 
       timeRange.urlSync?.updateFromUrl({
         from: 'now-6h',
@@ -176,7 +176,7 @@ describe('SceneTimeRange', () => {
 
     it('should apply delay when updating time zone from the closest range with time zone specified', () => {
       const outerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'America/New_York' });
-      const innerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', delayNow: '1m' });
+      const innerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', nowDelay: '1m' });
       const scene = new SceneFlexLayout({
         $timeRange: outerTimeRange,
         children: [
@@ -191,12 +191,12 @@ describe('SceneTimeRange', () => {
       expect(innerTimeRange.state.value.raw.to).toBe('now-1m');
     });
 
-    it('should NOT apply delay from the closest range with time delayNow specified', () => {
+    it('should NOT apply delay from the closest range with time nowDelay specified', () => {
       const outerTimeRange = new SceneTimeRange({
         from: 'now-1h',
         to: 'now',
         timeZone: 'America/New_York',
-        delayNow: '1m',
+        nowDelay: '1m',
       });
       const innerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
       const scene = new SceneFlexLayout({

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -17,7 +17,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     const from = state.from ?? 'now-6h';
     const to = state.to ?? 'now';
     const timeZone = state.timeZone;
-    const value = evaluateTimeRange(from, to, timeZone || getTimeZone(), state.fiscalYearStartMonth, state.delayNow);
+    const value = evaluateTimeRange(from, to, timeZone || getTimeZone(), state.fiscalYearStartMonth, state.nowDelay);
     super({ from, to, timeZone, value, ...state });
 
     this.addActivationHandler(this._onActivate.bind(this));
@@ -37,7 +37,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
                   this.state.to,
                   timeZoneSource.getTimeZone(),
                   this.state.fiscalYearStartMonth,
-                  this.state.delayNow
+                  this.state.nowDelay
                 ),
               });
             }
@@ -123,7 +123,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       updateToEval.to,
       this.getTimeZone(),
       this.state.fiscalYearStartMonth,
-      this.state.delayNow
+      this.state.nowDelay
     );
 
     // Only update if time range actually changed
@@ -143,7 +143,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
         this.state.to,
         this.getTimeZone(),
         this.state.fiscalYearStartMonth,
-        this.state.delayNow
+        this.state.nowDelay
       ),
     });
   };
@@ -175,7 +175,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       update.to ?? this.state.to,
       this.getTimeZone(),
       this.state.fiscalYearStartMonth,
-      this.state.delayNow
+      this.state.nowDelay
     );
     this.setState(update);
   }

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -17,7 +17,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     const from = state.from ?? 'now-6h';
     const to = state.to ?? 'now';
     const timeZone = state.timeZone;
-    const value = evaluateTimeRange(from, to, timeZone || getTimeZone(), state.fiscalYearStartMonth);
+    const value = evaluateTimeRange(from, to, timeZone || getTimeZone(), state.fiscalYearStartMonth, state.delayNow);
     super({ from, to, timeZone, value, ...state });
 
     this.addActivationHandler(this._onActivate.bind(this));
@@ -36,7 +36,8 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
                   this.state.from,
                   this.state.to,
                   timeZoneSource.getTimeZone(),
-                  this.state.fiscalYearStartMonth
+                  this.state.fiscalYearStartMonth,
+                  this.state.delayNow
                 ),
               });
             }
@@ -121,7 +122,8 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       updateToEval.from,
       updateToEval.to,
       this.getTimeZone(),
-      this.state.fiscalYearStartMonth
+      this.state.fiscalYearStartMonth,
+      this.state.delayNow
     );
 
     // Only update if time range actually changed
@@ -136,7 +138,13 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
   public onRefresh = () => {
     this.setState({
-      value: evaluateTimeRange(this.state.from, this.state.to, this.getTimeZone(), this.state.fiscalYearStartMonth),
+      value: evaluateTimeRange(
+        this.state.from,
+        this.state.to,
+        this.getTimeZone(),
+        this.state.fiscalYearStartMonth,
+        this.state.delayNow
+      ),
     });
   };
 
@@ -166,7 +174,8 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       update.from ?? this.state.from,
       update.to ?? this.state.to,
       this.getTimeZone(),
-      this.state.fiscalYearStartMonth
+      this.state.fiscalYearStartMonth,
+      this.state.delayNow
     );
     this.setState(update);
   }

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -17,7 +17,13 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     const from = state.from ?? 'now-6h';
     const to = state.to ?? 'now';
     const timeZone = state.timeZone;
-    const value = evaluateTimeRange(from, to, timeZone || getTimeZone(), state.fiscalYearStartMonth, state.nowDelay);
+    const value = evaluateTimeRange(
+      from,
+      to,
+      timeZone || getTimeZone(),
+      state.fiscalYearStartMonth,
+      state.UNSAFE_nowDelay
+    );
     super({ from, to, timeZone, value, ...state });
 
     this.addActivationHandler(this._onActivate.bind(this));
@@ -37,7 +43,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
                   this.state.to,
                   timeZoneSource.getTimeZone(),
                   this.state.fiscalYearStartMonth,
-                  this.state.nowDelay
+                  this.state.UNSAFE_nowDelay
                 ),
               });
             }
@@ -123,7 +129,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       updateToEval.to,
       this.getTimeZone(),
       this.state.fiscalYearStartMonth,
-      this.state.nowDelay
+      this.state.UNSAFE_nowDelay
     );
 
     // Only update if time range actually changed
@@ -143,7 +149,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
         this.state.to,
         this.getTimeZone(),
         this.state.fiscalYearStartMonth,
-        this.state.nowDelay
+        this.state.UNSAFE_nowDelay
       ),
     });
   };
@@ -175,7 +181,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       update.to ?? this.state.to,
       this.getTimeZone(),
       this.state.fiscalYearStartMonth,
-      this.state.nowDelay
+      this.state.UNSAFE_nowDelay
     );
     this.setState(update);
   }

--- a/packages/scenes/src/core/SceneTimeZoneOverride.tsx
+++ b/packages/scenes/src/core/SceneTimeZoneOverride.tsx
@@ -32,7 +32,7 @@ export class SceneTimeZoneOverride
         timeRange.to,
         this.state.timeZone,
         timeRange.fiscalYearStartMonth,
-        timeRange.delayNow
+        timeRange.nowDelay
       ),
     });
   }
@@ -49,7 +49,7 @@ export class SceneTimeZoneOverride
         this.state.to,
         this.state.timeZone,
         this.getAncestorTimeRange().state.fiscalYearStartMonth,
-        this.state.delayNow
+        this.state.nowDelay
       ),
     });
   }

--- a/packages/scenes/src/core/SceneTimeZoneOverride.tsx
+++ b/packages/scenes/src/core/SceneTimeZoneOverride.tsx
@@ -27,7 +27,13 @@ export class SceneTimeZoneOverride
     this.setState({
       ...timeRange,
       timeZone: this.state.timeZone,
-      value: evaluateTimeRange(timeRange.from, timeRange.to, this.state.timeZone, timeRange.fiscalYearStartMonth),
+      value: evaluateTimeRange(
+        timeRange.from,
+        timeRange.to,
+        this.state.timeZone,
+        timeRange.fiscalYearStartMonth,
+        timeRange.delayNow
+      ),
     });
   }
 
@@ -42,7 +48,8 @@ export class SceneTimeZoneOverride
         this.state.from,
         this.state.to,
         this.state.timeZone,
-        this.getAncestorTimeRange().state.fiscalYearStartMonth
+        this.getAncestorTimeRange().state.fiscalYearStartMonth,
+        this.state.delayNow
       ),
     });
   }

--- a/packages/scenes/src/core/SceneTimeZoneOverride.tsx
+++ b/packages/scenes/src/core/SceneTimeZoneOverride.tsx
@@ -32,7 +32,7 @@ export class SceneTimeZoneOverride
         timeRange.to,
         this.state.timeZone,
         timeRange.fiscalYearStartMonth,
-        timeRange.nowDelay
+        timeRange.UNSAFE_nowDelay
       ),
     });
   }
@@ -49,7 +49,7 @@ export class SceneTimeZoneOverride
         this.state.to,
         this.state.timeZone,
         this.getAncestorTimeRange().state.fiscalYearStartMonth,
-        this.state.nowDelay
+        this.state.UNSAFE_nowDelay
       ),
     });
   }

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -144,6 +144,7 @@ export interface SceneTimeRangeState extends SceneObjectState {
   timeZone?: TimeZone;
   /** weekStart will change the global date locale so having multiple different weekStart values is not supported  */
   weekStart?: string;
+  delayNow?: string;
 }
 
 export interface SceneTimeRangeLike extends SceneObject<SceneTimeRangeState> {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -144,6 +144,7 @@ export interface SceneTimeRangeState extends SceneObjectState {
   timeZone?: TimeZone;
   /** weekStart will change the global date locale so having multiple different weekStart values is not supported  */
   weekStart?: string;
+  /** delayNow will delay the "now" value by the specified duration */
   delayNow?: string;
 }
 

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -144,8 +144,8 @@ export interface SceneTimeRangeState extends SceneObjectState {
   timeZone?: TimeZone;
   /** weekStart will change the global date locale so having multiple different weekStart values is not supported  */
   weekStart?: string;
-  /** delayNow will delay the "now" value by the specified duration */
-  delayNow?: string;
+  /** Override the now time by entering a time delay. Use this option to accommodate known delays in data aggregation to avoid null values. */
+  nowDelay?: string;
 }
 
 export interface SceneTimeRangeLike extends SceneObject<SceneTimeRangeState> {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -144,8 +144,12 @@ export interface SceneTimeRangeState extends SceneObjectState {
   timeZone?: TimeZone;
   /** weekStart will change the global date locale so having multiple different weekStart values is not supported  */
   weekStart?: string;
-  /** Override the now time by entering a time delay. Use this option to accommodate known delays in data aggregation to avoid null values. */
-  nowDelay?: string;
+  /**
+   * @internal
+   * To enable feature parity with the old time range picker, not sure if it will be kept.
+   * Override the now time by entering a time delay. Use this option to accommodate known delays in data aggregation to avoid null values.
+   * */
+  UNSAFE_nowDelay?: string;
 }
 
 export interface SceneTimeRangeLike extends SceneObject<SceneTimeRangeState> {

--- a/packages/scenes/src/utils/evaluateTimeRange.ts
+++ b/packages/scenes/src/utils/evaluateTimeRange.ts
@@ -9,11 +9,10 @@ export function evaluateTimeRange(
   delay?: string
 ): TimeRange {
   const hasDelay = delay && to === 'now';
-  to = hasDelay ? 'now-' + delay : to;
 
   return {
     from: dateMath.parse(from, false, timeZone, fiscalYearStartMonth)!,
-    to: dateMath.parse(to, true, timeZone, fiscalYearStartMonth)!,
+    to: dateMath.parse(hasDelay ? 'now-' + delay : to, true, timeZone, fiscalYearStartMonth)!,
     raw: {
       from: from,
       to: to,

--- a/packages/scenes/src/utils/evaluateTimeRange.ts
+++ b/packages/scenes/src/utils/evaluateTimeRange.ts
@@ -1,12 +1,16 @@
-import { dateMath, TimeRange } from '@grafana/data';
+import { dateMath, DateTime, TimeRange } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 
 export function evaluateTimeRange(
-  from: string,
-  to: string,
+  from: string | DateTime,
+  to: string | DateTime,
   timeZone: TimeZone,
-  fiscalYearStartMonth?: number
+  fiscalYearStartMonth?: number,
+  delay?: string
 ): TimeRange {
+  const hasDelay = delay && to === 'now';
+  to = hasDelay ? 'now-' + delay : to;
+
   return {
     from: dateMath.parse(from, false, timeZone, fiscalYearStartMonth)!,
     to: dateMath.parse(to, true, timeZone, fiscalYearStartMonth)!,


### PR DESCRIPTION
Dashboards PR: https://github.com/grafana/grafana/pull/79703

This enables support for `UNSAFE_nowDelay` in Dashboards. It is prefixed as `UNSAFE` because we don't know how used and useful is this.

This allows us to override the now time by entering a time delay. This option accommodates known delays in data aggregation to avoid null values.

![b2aa17d125dfc0aa8caee873760a8f44ebf2dcab](https://github.com/grafana/scenes/assets/5699976/de771713-92b2-4f46-b467-f4bb358d7f61)
