### PR TITLE
Fix issue with duplicate annotations

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -31,8 +31,45 @@ import { emptyPanelData } from '../core/SceneDataNode';
 const getDataSourceMock = jest.fn().mockReturnValue({
   uid: 'test-uid',
   getRef: () => ({ uid: 'test-uid' }),
-  query: () =>
-    of({
+  query: (request: DataQueryRequest) => {
+    if (request.targets.find((t) => t.refId === 'withAnnotations')) {
+      return of({
+        data: [
+          toDataFrame({
+            refId: 'withAnnotations',
+            datapoints: [
+              [100, 1],
+              [400, 2],
+              [500, 3],
+            ],
+          }),
+          toDataFrame({
+            name: 'exemplar',
+            refId: 'withAnnotations',
+            meta: {
+              typeVersion: [0, 0],
+              custom: {
+                resultType: 'exemplar',
+              },
+              dataTopic: 'annotations',
+            },
+            fields: [
+              {
+                name: 'foo',
+                type: 'string',
+                values: ['foo1', 'foo2', 'foo3'],
+              },
+              {
+                name: 'bar',
+                type: 'string',
+                values: ['bar1', 'bar2', 'bar3'],
+              },
+            ],
+          }),
+        ],
+      });
+    }
+    return of({
       data: [
         toDataFrame({
           refId: 'A',
@@ -43,21 +80,23 @@ const getDataSourceMock = jest.fn().mockReturnValue({
           ],
         }),
       ],
-    }),
+    });
+  },
 });
 
 const runRequestMock = jest.fn().mockImplementation((ds: DataSourceApi, request: DataQueryRequest) => {
   const result: PanelData = {
     state: LoadingState.Loading,
     series: [],
+    annotations: [],
     timeRange: request.range,
   };
 
   return (ds.query(request) as Observable<DataQueryResponse>).pipe(
     map((packet) => {
       result.state = LoadingState.Done;
-      result.series = packet.data;
-
+      result.series = packet.data.filter((d) => d.meta?.dataTopic !== 'annotations');
+      result.annotations = packet.data.filter((d) => d.meta?.dataTopic === 'annotations');
       return result;
     })
   );
@@ -149,6 +188,33 @@ describe('SceneQueryRunner', () => {
           "timezone": "browser",
         }
       `);
+    });
+  });
+
+  describe('when result has annotations', () => {
+    it('should not duplicate annotations when queried repeatedly', async () => {
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'withAnnotations' }],
+        $timeRange: new SceneTimeRange(),
+      });
+
+      expect(queryRunner.state.data).toBeUndefined();
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+
+      expect(queryRunner.state.data?.annotations).toHaveLength(1);
+
+      queryRunner.runQueries();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+
+      expect(queryRunner.state.data?.annotations).toHaveLength(1);
     });
   });
 
@@ -832,6 +898,105 @@ describe('SceneQueryRunner', () => {
         ]
       `);
     });
+
+    it('should merge but not duplicate annotations coming from query result and from layers', async () => {
+      const layer = new TestAnnotationsDataLayer({ name: 'Layer 1' });
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'withAnnotations' }],
+        $timeRange: new SceneTimeRange(),
+        $data: new SceneDataLayers({ layers: [layer] }),
+      });
+
+      const expectedSnapshot = `
+      [
+        {
+          "fields": [
+            {
+              "config": {},
+              "labels": undefined,
+              "name": "foo",
+              "type": "string",
+              "values": [
+                "foo1",
+                "foo2",
+                "foo3",
+              ],
+            },
+            {
+              "config": {},
+              "labels": undefined,
+              "name": "bar",
+              "type": "string",
+              "values": [
+                "bar1",
+                "bar2",
+                "bar3",
+              ],
+            },
+          ],
+          "meta": {
+            "custom": {
+              "resultType": "exemplar",
+            },
+            "dataTopic": "annotations",
+            "typeVersion": [
+              0,
+              0,
+            ],
+          },
+          "name": "exemplar",
+          "refId": "withAnnotations",
+        },
+        {
+          "fields": [
+            {
+              "config": {},
+              "name": "time",
+              "type": "time",
+              "values": [
+                100,
+              ],
+            },
+            {
+              "config": {},
+              "name": "text",
+              "type": "string",
+              "values": [
+                "Layer 1: Test annotation",
+              ],
+            },
+            {
+              "config": {},
+              "name": "tags",
+              "type": "other",
+              "values": [
+                [
+                  "tag1",
+                ],
+              ],
+            },
+          ],
+          "length": 1,
+        },
+      ]
+    `;
+
+      expect(queryRunner.state.data).toBeUndefined();
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+      layer.completeRun();
+
+      expect(queryRunner.state.data?.annotations).toMatchInlineSnapshot(expectedSnapshot);
+
+      queryRunner.runQueries();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(queryRunner.state.data?.annotations).toMatchInlineSnapshot(expectedSnapshot);
+    });
+
     it('should not block queries when layer provides data slower', async () => {
       const layer = new TestAnnotationsDataLayer({ name: 'Layer 1' });
       const queryRunner = new SceneQueryRunner({

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -59,6 +59,8 @@ export interface QueryRunnerState extends SceneObjectState {
   // Private runtime state
   _isWaitingForVariables?: boolean;
   _hasFetchedData?: boolean;
+  _layerAnnotations?: DataFrame[];
+  _resultAnnotations?: DataFrame[];
 }
 
 export interface DataQueryExtended extends DataQuery {
@@ -197,9 +199,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     const baseStateUpdate = this.state.data ? this.state.data : { ...emptyPanelData, timeRange: timeRange.state.value };
 
     this.setState({
+      _layerAnnotations: annotations,
       data: {
         ...baseStateUpdate,
-        annotations,
+        annotations: [...(this.state._resultAnnotations ?? []), ...annotations],
         alertState: alertState ?? this.state.data?.alertState,
       },
     });
@@ -491,12 +494,16 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       hasFetchedData = true;
     }
 
-    this.setState({ data: dataWithLayersApplied, _hasFetchedData: hasFetchedData });
+    this.setState({
+      data: dataWithLayersApplied,
+      _hasFetchedData: hasFetchedData,
+      _resultAnnotations: data.annotations,
+    });
   };
 
   private _combineDataLayers(data: PanelData) {
     if (this.state.data && this.state.data.annotations) {
-      data.annotations = (data.annotations || []).concat(this.state.data.annotations);
+      data.annotations = (data.annotations || []).concat(this.state._layerAnnotations ?? []);
     }
 
     if (this.state.data && this.state.data.alertState) {


### PR DESCRIPTION
In case annotations come with result of query instead of from layers, new annotations would be appended to list of previous annotations instead of replacing them. Eg, when cahnging time range, annotations from previous time range remain visible. If time ranges overlap, annotations get duplicated, triplicated etc. 

This PR refactors query runner to merge annotations from layers and query result without keeping annotations from previous runs.