### PR TITLE
Adhoc filters variable improvements

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { AdHocFilterSet } from './AdHocFiltersSet';
 import { AdHocVariableFilter, GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
@@ -27,8 +27,21 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     isValuesOpen?: boolean;
   }>({});
 
-  const keyValue = filter.key !== '' ? toOption(filter.key) : null;
+  const keyValue =
+    filter.key !== '' ? state?.keys?.find((key) => key.value === filter.key) ?? toOption(filter.key) : null;
   const valueValue = filter.value !== '' ? toOption(filter.value) : null;
+
+  useEffect(() => {
+    async function getKeys() {
+      setState({ ...state, isKeysLoading: true });
+      const keys = await model._getKeys(filter.key);
+      setState({ ...state, isKeysLoading: false, keys });
+    }
+
+    if (state.keys === undefined) {
+      getKeys();
+    }
+  }, [filter.key, model, state]);
 
   const valueSelect = (
     <Select

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -61,7 +61,7 @@ export class AdHocFiltersVariable
     });
   }
 
-  public getValue() {
+  public getValue(): VariableValue | undefined {
     return this.state.filterExpression;
   }
 


### PR DESCRIPTION
We're using `AdHocFiltersVariable` and found a couple of places where we can improve the component/variable:
- Add explicit return type to the `getValue` function, right now it's being narrowed to `string | undefined`
- Expose `renderFilters` class method, it's useful for cases where we want to make some transformation before getting the value of the filters
- When selecting a key from the dropdown, what gets shown as selected is the value instead of the label as one would expect

Related to [this PR](https://github.com/grafana/app-observability-plugin/pull/705)