### PR TITLE
SceneQueryRunner: Fix redundant execution on variable change

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -210,6 +210,11 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
    * the query execution on activate was stopped due to VariableSet still not having processed all variables.
    */
   private onVariableUpdatesCompleted(_variablesThatHaveChanged: Set<SceneVariable>, dependencyChanged: boolean) {
+    // If no maxDataPoints specified we might need to wait for container width to be set from the outside
+    if (!this.state.maxDataPoints && this.state.maxDataPointsFromWidth && !this._containerWidth) {
+      return;
+    }
+
     if (this.state._isWaitingForVariables) {
       this.runQueries();
       return;


### PR DESCRIPTION
Noticed some intermittent unexepcted cancelled queries in network logs.
Found that the problem is that if `SceneQueryRunner` has `maxDataPointsFromWidth=true` and variables change/complete before width is received, it will run queries without waiting for width. Then  width is received immediately after and new execution is triggered.

This PR prevents variable update callback from executing queries if container width has not been received yet.