### PR TITLE
Variables: Checking if a dependency is loading should also check that dependency dependencies

### DIFF
--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -56,7 +56,10 @@ export function interpolate(
 }
 
 /**
- * Checks if the variable is currently loading or waiting to update
+ * Checks if the variable is currently loading or waiting to update.
+ * It also returns true if a dependency of the variable is loading.
+ *
+ * For example if C depends on variable B which depends on variable A and A is loading this returns true for variable C and B.
  */
 export function hasVariableDependencyInLoadingState(sceneObject: SceneObject) {
   if (!sceneObject.variableDependency) {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -322,14 +322,22 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
   }
 
   /**
-   * Return true if variable is waiting to update or currently updating
+   * Return true if variable is waiting to update or currently updating.
+   * It also returns true if a dependency of the variable is loading.
+   *
+   * For example if C depends on variable B which depends on variable A and A is loading this returns true for variable C and B.
    */
   public isVariableLoadingOrWaitingToUpdate(variable: SceneVariable) {
     if (variable.isAncestorLoading && variable.isAncestorLoading()) {
       return true;
     }
 
-    return this._variablesToUpdate.has(variable) || this._updating.has(variable);
+    if (this._variablesToUpdate.has(variable) || this._updating.has(variable)) {
+      return true;
+    }
+
+    // Last scenario is to check the variable's own dependencies as well
+    return sceneGraph.hasVariableDependencyInLoadingState(variable);
   }
 }
 


### PR DESCRIPTION
While investing some variable timing issues with SceneQueryRunner and investigating changing SceneVariableSet to update scene after each variable update is complete (instead of waiting for all variables) I realised one scenario is not handled currently. 

Example:

* var A  (depends on time range)
* var B (depends on B)
* Query Q (depends only on B) 

When time range updates A starts loading, and Query Q also gets the new time range and checks it's dependencies loading state (only B) which is not loading so starts a new query. Later after A completes and starts B and B updates it triggers a new query for Q (So double queries for this time range update). 

We have not hit this in current tests / and manual scenarios as for the initial activation we add both A and B to the update queue so on the first load query Q will wait for A. 

To fix this I think `hasVariableDependencyInLoadingState` should also check the loading state for the dependencies (variables) in a recursive way. 

So if the scenario above if A is loading and you check hasVariableDependencyInLoadingState(B) it would return true as one of it's dependencies is loading. 