### PR TITLE
SceneQueryRunner: Fix for variable & setContainerWidth timing issue 

### DIFF
--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -56,7 +56,10 @@ export function interpolate(
 }
 
 /**
- * Checks if the variable is currently loading or waiting to update
+ * Checks if the variable is currently loading or waiting to update.
+ * It also returns true if a dependency of the variable is loading.
+ *
+ * For example if C depends on variable B which depends on variable A and A is loading this returns true for variable C and B.
  */
 export function hasVariableDependencyInLoadingState(sceneObject: SceneObject) {
   if (!sceneObject.variableDependency) {

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -648,7 +648,7 @@ describe('SceneQueryRunner', () => {
 
     it('Should not issue query when setContainerWidth is called and we are waiting for variables', async () => {
       const varA = new TestVariable({ name: 'A', value: 'AA', query: 'A.*' });
-      const varB = new TestVariable({ name: 'A', value: 'AA', query: 'A.$A.*' });
+      const varB = new TestVariable({ name: 'B', value: 'AA', query: 'A.$A.*' });
 
       // Query only depends on A
       const queryRunner = new SceneQueryRunner({

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -334,11 +334,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   }
 
   private async runWithTimeRange(timeRange: SceneTimeRangeLike) {
-    // If data layers subscription doesn't exist, create one
-    if (!this._dataLayersSub) {
-      this._handleDataLayers();
-    }
-
     // Cancel any running queries
     this._querySub?.unsubscribe();
 
@@ -365,6 +360,11 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     if (!queries?.length) {
       this._setNoDataState();
       return;
+    }
+
+    // If data layers subscription doesn't exist, create one
+    if (!this._dataLayersSub) {
+      this._handleDataLayers();
     }
 
     try {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -322,14 +322,22 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
   }
 
   /**
-   * Return true if variable is waiting to update or currently updating
+   * Return true if variable is waiting to update or currently updating.
+   * It also returns true if a dependency of the variable is loading.
+   *
+   * For example if C depends on variable B which depends on variable A and A is loading this returns true for variable C and B.
    */
   public isVariableLoadingOrWaitingToUpdate(variable: SceneVariable) {
     if (variable.isAncestorLoading && variable.isAncestorLoading()) {
       return true;
     }
 
-    return this._variablesToUpdate.has(variable) || this._updating.has(variable);
+    if (this._variablesToUpdate.has(variable) || this._updating.has(variable)) {
+      return true;
+    }
+
+    // Last scenario is to check the variable's own dependencies as well
+    return sceneGraph.hasVariableDependencyInLoadingState(variable);
   }
 }
 


### PR DESCRIPTION
So this is the quick fix for the scenario of 

* Variables (A, B), Query (depends on A). 
* A completes right away, but SceneVariableSet is still waiting for B to complete to notify scene
* VizPanel get's the container width and calls setContainerWidth, which starts a new query as the scene query runner no longer depends on on any loading variables.
* B completes and SceneVariableSet completes and notifies scene, SceneQueryRunner issues a new query as SceneVariableSet says variable A has changed. 

Resulting in double query on the initial load. 

Fixing this required some minor changes. But ideally, we should figure out a way to avoid this by having SceneVariableSet notify scene as soon as the variable update is complete. Will give this a try, will require some changes I think to variableDependency interface 
