### PR TITLE
Variables: Move handling of "waitingForVariables" to VariableDependencyConfig 

### DIFF
--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -210,9 +210,6 @@ export interface SceneDataLayerProviderState extends SceneObjectState {
   data?: PanelData;
   isEnabled?: boolean;
   isHidden?: boolean;
-
-  // Private runtime state
-  _isWaitingForVariables?: boolean;
 }
 
 export interface SceneDataLayerProvider extends SceneObject<SceneDataLayerProviderState> {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -351,11 +351,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       return;
     }
 
-    // If we were waiting for variables, clear that flag
-    // if (this.state._isWaitingForVariables) {
-    //   this.setState({ _isWaitingForVariables: false });
-    // }
-
     const { queries } = this.state;
 
     // Simple path when no queries exist

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -220,10 +220,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
    * only run if all variables are in a non loading state so in other scenarios where a query depends on many variables this will
    * be called many times until all dependencies are in a non loading state.   *
    */
-  private onVariableUpdatesCompleted(variable: SceneVariable, dependencyChanged: boolean) {
-    if (this.state._isWaitingForVariables || dependencyChanged) {
-      this.runQueries();
-    }
+  private onVariableUpdatesCompleted() {
+    this.runQueries();
   }
 
   private shouldRunQueriesOnActivate() {
@@ -349,16 +347,15 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     this._querySub?.unsubscribe();
 
     // Skip executing queries if variable dependency is in loading state
-    if (sceneGraph.hasVariableDependencyInLoadingState(this)) {
+    if (this._variableDependency.hasDependencyInLoadingState()) {
       writeSceneLog('SceneQueryRunner', 'Variable dependency is in loading state, skipping query execution');
-      this.setState({ _isWaitingForVariables: true });
       return;
     }
 
     // If we were waiting for variables, clear that flag
-    if (this.state._isWaitingForVariables) {
-      this.setState({ _isWaitingForVariables: false });
-    }
+    // if (this.state._isWaitingForVariables) {
+    //   this.setState({ _isWaitingForVariables: false });
+    // }
 
     const { queries } = this.state;
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -57,7 +57,6 @@ export interface QueryRunnerState extends SceneObjectState {
   // Filters to be applied to data layer results before combining them with SQR results
   dataLayerFilter?: DataLayerFilter;
   // Private runtime state
-  _isWaitingForVariables?: boolean;
   _hasFetchedData?: boolean;
 }
 

--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
@@ -123,12 +123,8 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState>
     this._variableValueRecorder.recordCurrentDependencyValuesForSceneObject(this);
   }
 
-  protected onVariableUpdateCompleted(variable: SceneVariable, dependencyChanged: boolean): void {
-    writeSceneLog('SceneDataLayerBase', 'onVariableUpdateCompleted');
-
-    if (this.state._isWaitingForVariables || dependencyChanged) {
-      this.runLayer();
-    }
+  protected onVariableUpdateCompleted(): void {
+    this.runLayer();
   }
 
   public cancelQuery() {

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -57,14 +57,9 @@ export class AnnotationsDataLayer
       this.querySub.unsubscribe();
     }
 
-    if (sceneGraph.hasVariableDependencyInLoadingState(this)) {
+    if (this._variableDependency.hasDependencyInLoadingState()) {
       writeSceneLog('AnnotationsDataLayer', 'Variable dependency is in loading state, skipping query execution');
-      this.setState({ _isWaitingForVariables: true });
       return;
-    }
-
-    if (this.state._isWaitingForVariables) {
-      this.setState({ _isWaitingForVariables: false });
     }
 
     try {

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -24,8 +24,10 @@ interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
   onReferencedVariableValueChanged?: (variable: SceneVariable) => void;
 
   /**
-   * Only called when dependency changed value or after variable update is completed and we are waiting for a variables. There could
-   * still be other dependencies in loading state so a call to hasDependencyInLoadingState is still needed to ensure all dependencies are ready.
+   * Two scenarios trigger this callback to be called.
+   * 1. When any direct dependency changed value
+   * 2. In case hasDependencyInLoadingState was called and returned true we really care about any variable update. So in this scenario this callback is called
+   *    after any variable update completes. This is to cover scenarios where an object is waiting for indirect dependencies to complete.
    */
   onVariableUpdateCompleted?: () => void;
 }

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -73,13 +73,13 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
       this._isWaitingForVariables
     );
 
-    if (this._isWaitingForVariables || dependencyChanged) {
-      // If custom handler is always called to let the scene object know that SceneVariableSet has completed processing variables
-      if (this._options.onVariableUpdateCompleted) {
-        this._options.onVariableUpdateCompleted();
-        return;
-      }
+    // If custom handler called when dependency is changed or when we are waiting for variables
+    if (this._options.onVariableUpdateCompleted && (this._isWaitingForVariables || dependencyChanged)) {
+      this._options.onVariableUpdateCompleted();
+      return;
+    }
 
+    if (dependencyChanged) {
       if (this._options.onReferencedVariableValueChanged) {
         this._options.onReferencedVariableValueChanged(variable);
       } else {
@@ -102,9 +102,7 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
    * Only way to force a re-render is to update state right now
    */
   private defaultHandlerReferencedVariableValueChanged = () => {
-    if (!this.hasDependencyInLoadingState()) {
-      this._sceneObject.forceRender();
-    }
+    this._sceneObject.forceRender();
   };
 
   public getNames(): Set<string> {

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -73,13 +73,13 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
       this._isWaitingForVariables
     );
 
-    // If custom handler is always called to let the scene object know that SceneVariableSet has completed processing variables
-    if (this._options.onVariableUpdateCompleted && (this._isWaitingForVariables || dependencyChanged)) {
-      this._options.onVariableUpdateCompleted();
-      return;
-    }
+    if (this._isWaitingForVariables || dependencyChanged) {
+      // If custom handler is always called to let the scene object know that SceneVariableSet has completed processing variables
+      if (this._options.onVariableUpdateCompleted) {
+        this._options.onVariableUpdateCompleted();
+        return;
+      }
 
-    if (dependencyChanged) {
       if (this._options.onReferencedVariableValueChanged) {
         this._options.onReferencedVariableValueChanged(variable);
       } else {
@@ -102,7 +102,9 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
    * Only way to force a re-render is to update state right now
    */
   private defaultHandlerReferencedVariableValueChanged = () => {
-    this._sceneObject.forceRender();
+    if (!this.hasDependencyInLoadingState()) {
+      this._sceneObject.forceRender();
+    }
   };
 
   public getNames(): Set<string> {


### PR DESCRIPTION
a continuation of https://github.com/grafana/scenes/pull/525  (base) 

Exploration unifying / moving handling of "waitingForVariable" state to VariableDependencyConfig. 

This flag / state is just to know that we wanted to do something but could not, for example: 

* Issue query on activation 
* Issue query on time range change 

But we can't do that as one of the variable dependencies (or a dependency of a dependency) where in a loading state. But this means that we now want to know when any variable update is completed not just a direct dependency as just because a dependency of a dependency where in loading state does not mean any dependency changed value (just that they could have). 

TODO
* Add some more tests to VariableDependencyConfig