### PR TITLE
SceneGridLayout: Support new visualization tooltips

### DIFF
--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -21,6 +21,7 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
         body: new SceneGridLayout({
           isLazy: true,
           isDraggable: true,
+          isResizable: true,
           children: [
             new SceneGridItem({
               x: 0,

--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -19,6 +19,7 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
         ...getEmbeddedSceneDefaults(),
         $data: getQueryRunnerWithRandomWalkQuery(),
         body: new SceneGridLayout({
+          isLazy: true,
           isDraggable: true,
           children: [
             new SceneGridItem({

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useReducer, useRef } from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { SceneComponentProps } from '../../../core/types';
@@ -6,6 +6,8 @@ import { GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, GRID_CELL_HEIGHT } from './consta
 import { LazyLoader } from '../LazyLoader';
 import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
+// @ts-expect-error TODO remove when @grafana/ui is upgraded to 10.4
+import { LayoutItemContext, useTheme2 } from '@grafana/ui';
 
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
   const { children, isLazy, isDraggable, isResizable } = model.useState();
@@ -50,24 +52,16 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
               onLayoutChange={model.onLayoutChange}
               isBounded={false}
             >
-              {layout.map((gridItem) => {
-                const sceneChild = model.getSceneLayoutChild(gridItem.i)!;
-                const className = sceneChild.getClassName?.();
-
-                return isLazy ? (
-                  <LazyLoader
-                    key={sceneChild.state.key!}
-                    data-griditem-key={sceneChild.state.key}
-                    className={className}
-                  >
-                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
-                  </LazyLoader>
-                ) : (
-                  <div key={sceneChild.state.key} data-griditem-key={sceneChild.state.key} className={className}>
-                    <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />
-                  </div>
-                );
-              })}
+              {layout.map((gridItem, index) => (
+                <GridItemWrapper
+                  key={gridItem.i}
+                  grid={model}
+                  layoutItem={gridItem}
+                  index={index}
+                  isLazy={isLazy}
+                  totalCount={layout.length}
+                />
+              ))}
             </ReactGridLayout>
           </div>
         );
@@ -75,6 +69,73 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
     </AutoSizer>
   );
 }
+
+interface GridItemWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+  grid: SceneGridLayout;
+  layoutItem: ReactGridLayout.Layout;
+  index: number;
+  totalCount: number;
+  isLazy?: boolean;
+}
+
+const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((props, ref) => {
+  const { grid, layoutItem, index, totalCount, isLazy, style } = props;
+  const sceneChild = grid.getSceneLayoutChild(layoutItem.i)!;
+  const className = sceneChild.getClassName?.();
+  const theme = useTheme2();
+
+  const boostedCount = useRef(0);
+  const [_, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  const boostZIndex = useCallback(() => {
+    boostedCount.current += 1;
+    forceUpdate();
+
+    return () => {
+      boostedCount.current -= 1;
+      forceUpdate();
+    };
+  }, [forceUpdate]);
+
+  const ctxValue = useMemo(() => ({ boostZIndex }), [boostZIndex]);
+  const descIndex = totalCount - index;
+  const innerContent = <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />;
+  const innerContentWithContext = LayoutItemContext ? (
+    <LayoutItemContext.Provider value={ctxValue}>{innerContent}</LayoutItemContext.Provider>
+  ) : (
+    innerContent
+  );
+
+  style!.zIndex = boostedCount.current === 0 ? descIndex : theme.zIndex.dropdown;
+
+  if (isLazy) {
+    return (
+      <LazyLoader
+        key={sceneChild.state.key!}
+        data-griditem-key={sceneChild.state.key}
+        className={className}
+        style={style}
+        ref={ref}
+      >
+        {innerContentWithContext}
+      </LazyLoader>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      key={sceneChild.state.key}
+      data-griditem-key={sceneChild.state.key}
+      className={className}
+      style={style}
+    >
+      {innerContentWithContext}
+    </div>
+  );
+});
+
+GridItemWrapper.displayName = 'GridItemWrapper';
 
 function validateChildrenSize(children: SceneGridItemLike[]) {
   if (

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -8,6 +8,7 @@ import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
 // @ts-expect-error TODO remove when @grafana/ui is upgraded to 10.4
 import { LayoutItemContext, useTheme2 } from '@grafana/ui';
+import { cx } from '@emotion/css';
 
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
   const { children, isLazy, isDraggable, isResizable } = model.useState();
@@ -113,7 +114,7 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
       <LazyLoader
         key={sceneChild.state.key!}
         data-griditem-key={sceneChild.state.key}
-        className={className}
+        className={cx(className, props.className)}
         style={style}
         ref={ref}
       >
@@ -127,7 +128,7 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
       ref={ref}
       key={sceneChild.state.key}
       data-griditem-key={sceneChild.state.key}
-      className={className}
+      className={cx(className, props.className)}
       style={style}
     >
       {innerContentWithContext}

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -80,7 +80,7 @@ interface GridItemWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((props, ref) => {
-  const { grid, layoutItem, index, totalCount, isLazy, style } = props;
+  const { grid, layoutItem, index, totalCount, isLazy, style, onLoad, onChange, ...divProps } = props;
   const sceneChild = grid.getSceneLayoutChild(layoutItem.i)!;
   const className = sceneChild.getClassName?.();
   const theme = useTheme2();
@@ -107,15 +107,19 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
     innerContent
   );
 
-  style!.zIndex = boostedCount.current === 0 ? descIndex : theme.zIndex.dropdown;
+  const newStyle = {
+    ...style,
+    zIndex: boostedCount.current === 0 ? descIndex : theme.zIndex.dropdown,
+  };
 
   if (isLazy) {
     return (
       <LazyLoader
+        {...divProps}
         key={sceneChild.state.key!}
         data-griditem-key={sceneChild.state.key}
         className={cx(className, props.className)}
-        style={style}
+        style={newStyle}
         ref={ref}
       >
         {innerContentWithContext}
@@ -125,11 +129,12 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
 
   return (
     <div
+      {...divProps}
       ref={ref}
       key={sceneChild.state.key}
       data-griditem-key={sceneChild.state.key}
       className={cx(className, props.className)}
-      style={style}
+      style={newStyle}
     >
       {innerContentWithContext}
     </div>

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -28,7 +28,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
            * in an element that has the calculated size given by the AutoSizer. The AutoSizer
            * has a width of 0 and will let its content overflow its div.
            */
-          <div style={{ width: `${width}px`, height: '100%' }}>
+          <div style={{ width: `${width}px`, height: '100%', position: 'relative', zIndex: 1 }}>
             <ReactGridLayout
               width={width}
               /**


### PR DESCRIPTION
I don't think we need to disable the new tooltips, like proposed in https://github.com/grafana/grafana/pull/80496 

This PR adds all the changes needed to support them
* Decremental z-index 
* Layout context that provides the boostZIndex context method 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.30.0--canary.530.7559055334.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@1.30.0--canary.530.7559055334.0
  # or 
  yarn add @grafana/scenes@1.30.0--canary.530.7559055334.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
