### PR TITLE
SplitLayout: Allow pane style overrides to be passed through

### DIFF
--- a/packages/scenes/src/components/layout/split/SplitLayout.ts
+++ b/packages/scenes/src/components/layout/split/SplitLayout.ts
@@ -1,3 +1,4 @@
+import { CSSProperties } from 'react';
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
 import { SceneObjectState } from '../../../core/types';
 import { SceneFlexItemPlacement, SceneFlexItemLike } from '../SceneFlexLayout';
@@ -8,6 +9,8 @@ interface SplitLayoutState extends SceneObjectState, SceneFlexItemPlacement {
   secondary: SceneFlexItemLike;
   direction: 'row' | 'column';
   initialSize?: number;
+  primaryPaneStyles?: CSSProperties;
+  secondaryPaneStyles?: CSSProperties;
 }
 
 export class SplitLayout extends SceneObjectBase<SplitLayoutState> {

--- a/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
@@ -6,7 +6,8 @@ import { SplitLayout } from './SplitLayout';
 import { Splitter } from './Splitter';
 
 export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLayout>) {
-  const { primary, secondary, direction, isHidden, initialSize } = model.useState();
+  const { primary, secondary, direction, isHidden, initialSize, primaryPaneStyles, secondaryPaneStyles } =
+    model.useState();
 
   if (isHidden) {
     return null;
@@ -15,7 +16,12 @@ export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLay
   const Prim = primary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
   const Sec = secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
   return (
-    <Splitter direction={direction} initialSize={initialSize ?? 0.5}>
+    <Splitter
+      direction={direction}
+      initialSize={initialSize ?? 0.5}
+      primaryPaneStyles={primaryPaneStyles}
+      secondaryPaneStyles={secondaryPaneStyles}
+    >
       <Prim key={primary.state.key} model={primary} parentState={model.state} />
       <Sec key={secondary.state.key} model={secondary} parentState={model.state} />
     </Splitter>


### PR DESCRIPTION
This will allow for fixing the current issue with the panel editor in scenes