### PR TITLE
Chore: Update peer dependencies

### DIFF
--- a/packages/scenes-app/package.json
+++ b/packages/scenes-app/package.json
@@ -60,11 +60,11 @@
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/data": "10.0.3",
-    "@grafana/runtime": "10.0.3",
+    "@grafana/data": "10.2.3",
+    "@grafana/runtime": "10.2.3",
     "@grafana/scenes": "workspace:*",
-    "@grafana/schema": "10.0.3",
-    "@grafana/ui": "10.0.3",
+    "@grafana/schema": "10.2.3",
+    "@grafana/ui": "10.2.3",
     "@types/lodash": "latest",
     "react-router-dom": "^5.2.0"
   },

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -44,10 +44,10 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@grafana/data": "10.0.3",
-    "@grafana/runtime": "10.0.3",
-    "@grafana/schema": "10.0.3",
-    "@grafana/ui": "10.0.3"
+    "@grafana/data": "10.2.3",
+    "@grafana/runtime": "10.2.3",
+    "@grafana/schema": "10.2.3",
+    "@grafana/ui": "10.2.3"
   },
   "devDependencies": {
     "@emotion/css": "11.10.5",


### PR DESCRIPTION
**Related PR:** https://github.com/grafana/scenes/pull/295

### What changed?
Updated the `@grafana/*` peer dependencies to the latest released version (`10.2.3`). (Please let me know if this shouldn't be done yet for some reason. I came across this while trying to update the scaffolded dependencies in the `@grafana/create-plugin` tool.)