### PR TITLE
SceneDataTransformer: Fixes issue with getResultStream not emitting values when there are no transformations

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -24,7 +24,7 @@ export interface SceneDataTransformerState extends SceneDataState {
  */
 export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerState> implements SceneDataProvider {
   private _transformSub?: Unsubscribable;
-  private _results = new ReplaySubject<SceneDataProviderResult>();
+  private _results = new ReplaySubject<SceneDataProviderResult>(1);
   /**
    * Scan transformations for variable usage and re-process transforms when a variable values change
    */
@@ -105,6 +105,10 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
     if (transformations.length === 0 || !data) {
       this.setState({ data });
+
+      if (data) {
+        this._results.next({ origin: this, data });
+      }
       return;
     }
 
@@ -134,12 +138,13 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
             // Combine transformation error with upstream errors
             errors: [...sourceErr, transformationError],
           };
+
           return of(result);
         })
       )
       .subscribe((data) => {
-        this._results.next({ origin: this, data });
         this.setState({ data });
+        this._results.next({ origin: this, data });
       });
   }
 }

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -68,7 +68,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   private _dataLayersSub?: Unsubscribable;
   private _containerWidth?: number;
   private _variableValueRecorder = new VariableValueRecorder();
-  private _results = new ReplaySubject<SceneDataProviderResult>();
+  private _results = new ReplaySubject<SceneDataProviderResult>(1);
   private _scopedVars = { __sceneObject: { value: this, text: '__sceneObject' } };
   private _layerAnnotations?: DataFrame[];
   private _resultAnnotations?: DataFrame[];
@@ -472,8 +472,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   };
 
   private onDataReceived = (data: PanelData) => {
-    this._results.next({ origin: this, data });
-
     // Will combine annotations from SQR queries (frames with meta.dataTopic === DataTopic.Annotations)
     const preProcessedData = preProcessPanelData(data, this.state.data);
 
@@ -487,10 +485,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     }
 
     this._resultAnnotations = data.annotations;
-    this.setState({
-      data: dataWithLayersApplied,
-      _hasFetchedData: hasFetchedData,
-    });
+
+    this.setState({ data: dataWithLayersApplied, _hasFetchedData: hasFetchedData });
+
+    this._results.next({ origin: this, data: dataWithLayersApplied });
   };
 
   private _combineDataLayers(data: PanelData) {


### PR DESCRIPTION
Fixes an issue with the new approach to shared query (DashboardDataSource), this data source now rely on the getResultStream of the data providers and SceneDataTransfomer was not emitting updates on the result stream when no transformations where added. 

@dprokop this fixes the issue with the "Get help" drawer showing a loading panel that never completes.

Also changes the SceneQueryRunner so that the result stream includes the data layers. 