### PR TITLE
AdHocFiltersSet: Pass scene queries to getTagKeys calls

### DIFF
--- a/packages/scenes/src/core/sceneGraph/index.ts
+++ b/packages/scenes/src/core/sceneGraph/index.ts
@@ -2,6 +2,7 @@ import { lookupVariable } from '../../variables/lookupVariable';
 import { getTimeRange } from './getTimeRange';
 import {
   findObject,
+  findAllObjects,
   getData,
   getLayout,
   getVariables,
@@ -21,5 +22,6 @@ export const sceneGraph = {
   lookupVariable,
   hasVariableDependencyInLoadingState,
   findObject,
+  findAllObjects,
   getAncestor,
 };

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -8,6 +8,7 @@ import { SceneCanvasText } from '../../components/SceneCanvasText';
 import { SceneTimePicker } from '../../components/SceneTimePicker';
 import { SceneDataNode } from '../SceneDataNode';
 import { sceneGraph } from '.';
+import { SceneObject } from '../types';
 
 describe('sceneGraph', () => {
   it('Can find object', () => {
@@ -31,6 +32,24 @@ describe('sceneGraph', () => {
     expect(sceneGraph.findObject(data, (s) => s.state.key === 'A')).toBe(item1);
     // from item deep in graph finding control
     expect(sceneGraph.findObject(item2, (s) => s.state.key === 'time-picker')).toBe(timePicker);
+  });
+
+  it('Can find all objects given a predicate', () => {
+    const data = new SceneDataNode();
+    const item1 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A' }), $data: data });
+    const item2 = new SceneFlexItem({ key: 'B', body: new SceneCanvasText({ text: 'B' }) });
+    const timePicker = new SceneTimePicker({ key: 'time-picker' });
+
+    const scene = new EmbeddedScene({
+      controls: [timePicker],
+      body: new SceneFlexLayout({
+        children: [item1, item2],
+      }),
+    });
+
+    const predicate = (o: SceneObject) => o instanceof SceneFlexItem;
+
+    expect(sceneGraph.findAllObjects(scene, predicate)).toEqual([item1, item2]);
   });
 
   describe('getDataLayers', () => {

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -123,6 +123,23 @@ export function findObject(scene: SceneObject, check: (obj: SceneObject) => bool
 }
 
 /**
+ * This will search down the full scene graph, looking for objects that match the provided predicate.
+ */
+export function findAllObjects(scene: SceneObject, check: (obj: SceneObject) => boolean): SceneObject[] {
+  const found: SceneObject[] = [];
+
+  scene.forEachChild((child) => {
+    if (check(child)) {
+      found.push(child);
+    }
+
+    found.push(...findAllObjects(child, check));
+  });
+
+  return found;
+}
+
+/**
  * Will walk up the scene object graph up until the root and collect all SceneDataLayerProvider objects.
  * When localOnly set to true, it will only collect the closest layers.
  */

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.test.tsx
@@ -77,6 +77,23 @@ describe('AdHocFilter', () => {
     expect(filtersSet.state.filters[0].value).toBe('val4');
   });
 
+  it('Should collect and pass respective data source queries to getTagKeys call', async () => {
+    const { getTagKeysSpy } = setup({ filters: [] });
+
+    // Select key
+    await userEvent.click(screen.getByTestId('AdHocFilter-add'));
+    expect(getTagKeysSpy).toBeCalledTimes(1);
+    expect(getTagKeysSpy).toBeCalledWith({
+      filters: [],
+      queries: [
+        {
+          expr: 'my_metric{$filters}',
+          refId: 'A',
+        },
+      ],
+    });
+  });
+
   it('url sync works', async () => {
     const { filtersSet } = setup();
 
@@ -164,10 +181,12 @@ const runRequestMock = {
 let runRequestSet = false;
 
 function setup(overrides?: Partial<AdHocFilterSetState>) {
+  const getTagKeysSpy = jest.fn();
   setDataSourceSrv({
     get() {
       return {
-        getTagKeys() {
+        getTagKeys(options: any) {
+          getTagKeysSpy(options);
           return [{ text: 'key3' }];
         },
         getTagValues() {
@@ -197,6 +216,7 @@ function setup(overrides?: Partial<AdHocFilterSetState>) {
   setTemplateSrv(templateSrv);
 
   const filtersSet = new AdHocFilterSet({
+    datasource: { uid: 'my-ds-uid' },
     name: 'filters',
     filters: [
       {
@@ -225,6 +245,7 @@ function setup(overrides?: Partial<AdHocFilterSetState>) {
       children: [
         new SceneFlexItem({
           $data: new SceneQueryRunner({
+            datasource: { uid: 'my-ds-uid' },
             queries: [
               {
                 refId: 'A',
@@ -244,5 +265,5 @@ function setup(overrides?: Partial<AdHocFilterSetState>) {
 
   const { unmount } = render(<scene.Component model={scene} />);
 
-  return { scene, filtersSet, unmount, runRequest: runRequestMock.fn };
+  return { scene, filtersSet, unmount, runRequest: runRequestMock.fn, getTagKeysSpy };
 }


### PR DESCRIPTION
Depends on https://github.com/grafana/grafana/pull/81071

This passes scene queries to `getTagKeys` calls so that data source can decide which dimensions are applicable in a scene given provided queries context.