### PR TITLE
Make secondary part optional in Splitter

### DIFF
--- a/packages/scenes-app/src/demos/split.tsx
+++ b/packages/scenes-app/src/demos/split.tsx
@@ -147,11 +147,20 @@ const getDynamicSplitScene = () => {
                       })
                     )
                     .setHeaderActions(
-                      <IconButton
-                        name="x"
-                        onClick={() => splitter.setState({ secondary: defaultSecondary })}
-                        aria-label="remove"
-                      />
+                      <label>
+                        <IconButton
+                          name='trash-alt'
+                          type="button"
+                          onClick={() => splitter.setState({ secondary: undefined })}
+                          aria-label="remove right part"
+                        />
+                        <IconButton
+                          name='times'
+                          type="button"
+                          onClick={() => splitter.setState({ secondary: defaultSecondary })}
+                          aria-label="clear right part"
+                        />
+                      </label>
                     )
                     .build(),
                 }),

--- a/packages/scenes/src/components/layout/split/SplitLayout.ts
+++ b/packages/scenes/src/components/layout/split/SplitLayout.ts
@@ -6,7 +6,7 @@ import { SplitLayoutRenderer } from './SplitLayoutRenderer';
 
 interface SplitLayoutState extends SceneObjectState, SceneFlexItemPlacement {
   primary: SceneFlexItemLike;
-  secondary: SceneFlexItemLike;
+  secondary?: SceneFlexItemLike;
   direction: 'row' | 'column';
   initialSize?: number;
   primaryPaneStyles?: CSSProperties;

--- a/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
@@ -14,16 +14,20 @@ export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLay
   }
 
   const Prim = primary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
-  const Sec = secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  const Sec = secondary?.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  let startSize = secondary ? initialSize : 1;
+
   return (
     <Splitter
       direction={direction}
-      initialSize={initialSize ?? 0.5}
+      initialSize={startSize ?? 0.5}
       primaryPaneStyles={primaryPaneStyles}
       secondaryPaneStyles={secondaryPaneStyles}
     >
       <Prim key={primary.state.key} model={primary} parentState={model.state} />
+      { Sec && secondary &&
       <Sec key={secondary.state.key} model={secondary} parentState={model.state} />
+      }
     </Splitter>
   );
 }

--- a/packages/scenes/src/components/layout/split/Splitter.tsx
+++ b/packages/scenes/src/components/layout/split/Splitter.tsx
@@ -283,6 +283,10 @@ export function Splitter({
   const styles = useStyles2(getStyles);
   const id = useUniqueId();
 
+  const secondAvailable = kids.length === 2;
+  const visibilitySecond = secondAvailable ? 'visible' : 'hidden';
+  const visibleHandleSize = secondAvailable ? handleSize : 0;
+
   return (
     <div
       ref={containerRef}
@@ -306,7 +310,7 @@ export function Splitter({
 
       <div
         ref={splitterRef}
-        style={{ [measurementProp]: `${handleSize}px` }}
+        style={{ [measurementProp]: `${visibleHandleSize}px`, visibility: `${visibilitySecond}` }}
         className={cx(styles.handle, { [styles.handleHorizontal]: direction === 'column' })}
         onPointerUp={onPointerUp}
         onPointerDown={onPointerDown}
@@ -330,6 +334,7 @@ export function Splitter({
         style={{
           flexGrow: initialSize === 'auto' ? 0.5 : clamp(1 - initialSize, 0, 1),
           [minDimProp]: 'min-content',
+          visibility: `${visibilitySecond}`,
           ...secondaryPaneStyles,
         }}
         id={`end-panel-${id}`}


### PR DESCRIPTION
With this PR the secondary part is optional.
If it is put as `undefined`, it will be removed. The splitter / handle will not be visible anymore.

I adjusted the example.

Here is a short demo on how it works with both situations
https://github.com/grafana/scenes/assets/255404/a39f59d7-a342-4e08-93cd-c3f1f1865041

