### PR TITLE
LocalValueVariable: Provide backwards compatibility for SQL-ish data source

### DIFF
--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -9,7 +9,6 @@ import { formatRegistry, FormatVariable } from './formatRegistry';
 import { VARIABLE_REGEX } from '../constants';
 import { lookupVariable } from '../lookupVariable';
 import { macrosIndex } from '../macros';
-import { LocalValueVariable } from '../variants/LocalValueVariable';
 
 /**
  * This function will try to parse and replace any variable expression found in the target string. The sceneObject will be used as the source of variables. It will
@@ -91,8 +90,8 @@ function formatValue(
     return formatNameOrFn(value, {
       name: variable.state.name,
       type: variable.state.type as VariableType,
-      multi: variable instanceof LocalValueVariable ? variable.state.UNSAFE_isMulti : variable.state.isMulti,
-      includeAll: variable instanceof LocalValueVariable ? variable.state.UNSAFE_includeAll : variable.state.includeAll,
+      multi: variable.state.isMulti,
+      includeAll: variable.state.includeAll,
     });
   }
 

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -9,6 +9,7 @@ import { formatRegistry, FormatVariable } from './formatRegistry';
 import { VARIABLE_REGEX } from '../constants';
 import { lookupVariable } from '../lookupVariable';
 import { macrosIndex } from '../macros';
+import { LocalValueVariable } from '../variants/LocalValueVariable';
 
 /**
  * This function will try to parse and replace any variable expression found in the target string. The sceneObject will be used as the source of variables. It will
@@ -90,8 +91,8 @@ function formatValue(
     return formatNameOrFn(value, {
       name: variable.state.name,
       type: variable.state.type as VariableType,
-      multi: variable.state.isMulti,
-      includeAll: variable.state.includeAll,
+      multi: variable instanceof LocalValueVariable ? variable.state.UNSAFE_isMulti : variable.state.isMulti,
+      includeAll: variable instanceof LocalValueVariable ? variable.state.UNSAFE_includeAll : variable.state.includeAll,
     });
   }
 

--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -5,6 +5,12 @@ import { SceneVariable, SceneVariableState, VariableValue } from '../types';
 export interface LocalValueVariableState extends SceneVariableState {
   value: VariableValue;
   text: VariableValue;
+
+  // Indicate whether or not this variable is sourced from a multi-value variable.
+  // Introduces for a backwards compatibility with the old variable system, to properly support interpolation in SQL data sources.
+  // Should not be used in new code.
+  UNSAFE_isMulti?: boolean;
+  UNSAFE_includeAll?: boolean;
 }
 
 /**
@@ -15,12 +21,13 @@ export class LocalValueVariable
   extends SceneObjectBase<LocalValueVariableState>
   implements SceneVariable<LocalValueVariableState>
 {
-  public constructor(initialState: Partial<LocalValueVariableState>) {
+  public constructor(initialState: Omit<Partial<LocalValueVariableState>, 'UNSAFE_isMulti'>) {
     super({
       type: 'system',
       value: '',
       text: '',
       name: '',
+      UNSAFE_isMulti: true,
       ...initialState,
       skipUrlSync: true,
     });

--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -8,9 +8,8 @@ export interface LocalValueVariableState extends SceneVariableState {
 
   // Indicate whether or not this variable is sourced from a multi-value variable.
   // Introduces for a backwards compatibility with the old variable system, to properly support interpolation in SQL data sources.
-  // Should not be used in new code.
-  UNSAFE_isMulti?: boolean;
-  UNSAFE_includeAll?: boolean;
+  isMulti?: boolean;
+  includeAll?: boolean;
 }
 
 /**
@@ -21,13 +20,14 @@ export class LocalValueVariable
   extends SceneObjectBase<LocalValueVariableState>
   implements SceneVariable<LocalValueVariableState>
 {
-  public constructor(initialState: Omit<Partial<LocalValueVariableState>, 'UNSAFE_isMulti'>) {
+  public constructor(initialState: Omit<Partial<LocalValueVariableState>, 'isMulti' | 'includeAll'>) {
     super({
       type: 'system',
       value: '',
       text: '',
       name: '',
-      UNSAFE_isMulti: true,
+      isMulti: true,
+      includeAll: true,
       ...initialState,
       skipUrlSync: true,
     });


### PR DESCRIPTION
Provides a fix for SQL data source queries used in a repeated row scenario (discovered when dogfooding dashboard scene for viewers). The root cause problem lies in the `SqlDatasource` implementation which [relies on variable.multi and vairbale.includeAll ](https://github.com/grafana/grafana/blob/main/packages/grafana-sql/src/datasource/SqlDatasource.ts#L80) to format the string correctly. 

This PR brings two  properties to the `LocalValueVariable`. Marking them as ommited in LocalValueVariabel for a reason being LocalValueVariable is used ONLY in the repeats scenatio which assume a variable being a multi one.

@zoltanbedi  I would love to fix this in `SqlDatasource` as the dependency there on the multi/include all sounds not solid - think about a single value variable that has include all option enabled, but not selected. How does formatted the value differs in such a scenario compared to selecting the same option selected from a variable without include all enabled? In the firs scenario the value will be wrapped in `''` while in the other it won't.