### PR TITLE
AdHocFiltersVariable: AdHocFilterSet is not activated when the parent variable is mounted

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@auto-it/omit-commits": "^10.43.0",
     "@auto-it/released": "^10.43.0",
+    "@testing-library/react": "^14.1.2",
     "auto": "^10.43.0",
     "lerna": "^6.5.1",
     "lint-staged": "^13.2.0"

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { render } from '@testing-library/react';
 import { SceneVariableValueChangedEvent } from '../types';
 import { AdHocFiltersVariable } from './AdHocFiltersVariable';
 
@@ -67,5 +69,25 @@ describe('AdHocFiltersVariable', () => {
     variable.state.set.setState({ filters: variable.state.set.state.filters.slice(0) });
 
     expect(evtHandler).not.toHaveBeenCalled();
+  });
+
+  describe('Component', () => {
+    it('should use the model.state.set.Component to ensure the state filterset is activated', () => {
+      const variable = AdHocFiltersVariable.create({
+        datasource: { uid: 'hello' },
+        filters: [
+          {
+            key: 'key1',
+            operator: '=',
+            value: 'val1',
+            condition: '',
+          },
+        ],
+      });
+
+      render(<variable.Component model={variable} />);
+
+      expect(variable.state.set.isActive).toBe(true);
+    });
   });
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -90,6 +90,6 @@ export class AdHocFiltersVariable
 
   // Same UI as the standalone AdHocFilterSet
   public static Component = ({ model }: SceneComponentProps<AdHocFiltersVariable>) => {
-    return <AdHocFilterSet.Component model={model.state.set} />;
+    return <model.state.set.Component model={model.state.set} />;
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6328,6 +6328,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.3.4
+  resolution: "@testing-library/dom@npm:9.3.4"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^5.0.1
+    aria-query: 5.1.3
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.5.0
+    pretty-format: ^27.0.2
+  checksum: dfd6fb0d6c7b4dd716ba3c47309bc9541b4a55772cb61758b4f396b3785efe2dbc75dc63423545c039078c7ffcc5e4b8c67c2db1b6af4799580466036f70026f
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:5.16.5":
   version: 5.16.5
   resolution: "@testing-library/jest-dom@npm:5.16.5"
@@ -6409,6 +6425,20 @@ __metadata:
     react: <18.0.0
     react-dom: <18.0.0
   checksum: 4abd0490405e709a7df584a0db604e508a4612398bb1326e8fa32dd9393b15badc826dcf6d2f7525437886d507871f719f127b9860ed69ddd204d1fa834f576a
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^14.1.2":
+  version: 14.1.2
+  resolution: "@testing-library/react@npm:14.1.2"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@testing-library/dom": ^9.0.0
+    "@types/react-dom": ^18.0.0
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 0269903e53412cf96fddb55c8a97a9987a89c3308d71fa1418fe61c47d275445e7044c5387f57cf39b8cda319a41623dbad2cce7a17016aed3a9e85185aac75a
   languageName: node
   linkType: hard
 
@@ -6974,6 +7004,15 @@ __metadata:
   dependencies:
     "@types/react": ^17
   checksum: 525439fb14a033fc5dbe74711ecc50ec82273a528df9656594066a6219401e975101dafffd15d9a1a57a9442d52ea0c92eaacae09554dde27cd792e773f67467
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18.0.0":
+  version: 18.2.18
+  resolution: "@types/react-dom@npm:18.2.18"
+  dependencies:
+    "@types/react": "*"
+  checksum: 8e3da404c980e2b2a76da3852f812ea6d8b9d0e7f5923fbaf3bfbbbfa1d59116ff91c129de8f68e9b7668a67ae34484fe9df74d5a7518cf8591ec07a0c4dad57
   languageName: node
   linkType: hard
 
@@ -15174,6 +15213,7 @@ __metadata:
   dependencies:
     "@auto-it/omit-commits": ^10.43.0
     "@auto-it/released": ^10.43.0
+    "@testing-library/react": ^14.1.2
     auto: ^10.43.0
     lerna: ^6.5.1
     lint-staged: ^13.2.0


### PR DESCRIPTION
**Problem**
When the `AdHocFilterSet` is activated, this registers the filters into a global object to be findable by the SceneQueryRunner.

When rendering the components for the `AdHocFiltersVariable` because we were not using the component from the model, the `AdHocFilterSet` scene object was not activated, so they were not findable by the SceneQueryRunner.

**Solution**
Use the component from the scene object instead of importing and using the static class property.

_This was found while implementing: https://github.com/grafana/grafana/pull/81318_ 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.1--canary.550.7712757823.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.2.1--canary.550.7712757823.0
  # or 
  yarn add @grafana/scenes@2.2.1--canary.550.7712757823.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
