### PR TITLE
AdHocFiltersVariable: The `create()` factory supports `applyMode` as parameter

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -30,6 +30,7 @@ export type AdHocFiltersVariableCreateHelperArgs = Pick<
   | 'getTagValuesProvider'
   | 'name'
   | 'layout'
+  | 'applyMode'
 >;
 
 export class AdHocFiltersVariable
@@ -43,9 +44,9 @@ export class AdHocFiltersVariable
       hide: VariableHide.hideLabel,
       name: state.name ?? 'Filters',
       set: new AdHocFilterSet({
-        ...state,
-        // Main reason for this helper factory functyion
+        // The applyMode defaults to 'manual' when used through the variable as it is the most frecuent use case
         applyMode: 'manual',
+        ...state,
       }),
     });
   }


### PR DESCRIPTION
**Problem**
When creating a variable using `AdHocFiltersVariable.create()` the `applyMode` state prop was not configurable. This was forcing to use AdHocFiltersVariable in `manual` only. But in the Dashboard use case reflected here https://github.com/grafana/grafana/pull/81318 where we use AdHocFiltersVariable to manage filters for dashboard panels, we need `applyMode: same-dashboard`

**Solution**
Accept `applyMode` as the initial state but default to `manual` if it is not defined. This will avoid breaking changes.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.1--canary.553.7712958297.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.2.1--canary.553.7712958297.0
  # or 
  yarn add @grafana/scenes@2.2.1--canary.553.7712958297.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
