### PR TITLE
Fix dataLayer subscriptions refresh on reactivation

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -119,6 +119,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       this.runQueries();
     }
 
+    if (!this._dataLayersSub) {
+      this._handleDataLayers();
+    }
+
     return () => this._onDeactivate();
   }
 

--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
@@ -172,6 +172,10 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState>
       return true;
     }
 
+    if (!this.querySub) {
+      return true;
+    }
+
     if (this.state.data) {
       return false;
     }


### PR DESCRIPTION
Fixes issues with reactivating annotation dataLayers, where the `SceneQueryRunner` subs would get stale and needed to be refreshed.

`SceneDataLayerBase - querySub` also needs to be reinitialised on dataLayer reactivation.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.2--canary.554.7713830844.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.2.2--canary.554.7713830844.0
  # or 
  yarn add @grafana/scenes@2.2.2--canary.554.7713830844.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
