### PR TITLE
UrlSync: Fixes overwrite issue where later state change overwrites earlier change

### DIFF
--- a/packages/scenes/src/services/UrlSyncManager.ts
+++ b/packages/scenes/src/services/UrlSyncManager.ts
@@ -21,6 +21,7 @@ export class UrlSyncManager implements UrlSyncManagerLike {
   private _stateSub: Unsubscribable | null = null;
   private _locationSub?: UnregisterCallback | null = null;
   private _lastPath?: string;
+  private _ignoreNextLocationUpdate = false;
 
   /**
    * Updates the current scene state to match URL state.
@@ -77,6 +78,11 @@ export class UrlSyncManager implements UrlSyncManagerLike {
   }
 
   private _onLocationUpdate = (location: Location) => {
+    if (this._ignoreNextLocationUpdate) {
+      this._ignoreNextLocationUpdate = false;
+      return;
+    }
+
     if (this._lastPath !== location.pathname) {
       return;
     }
@@ -110,6 +116,7 @@ export class UrlSyncManager implements UrlSyncManagerLike {
       }
 
       if (Object.keys(mappedUpdated).length > 0) {
+        this._ignoreNextLocationUpdate = true;
         locationService.partial(mappedUpdated, true);
       }
     }

--- a/packages/scenes/src/utils/test/activateFullSceneTree.ts
+++ b/packages/scenes/src/utils/test/activateFullSceneTree.ts
@@ -1,0 +1,28 @@
+import { SceneObject, SceneDeactivationHandler } from '../../core/types';
+
+/**
+ * Useful from tests to simulate mounting a full scene. Children are activated before parents to simulate the real order
+ * of React mount order and useEffect ordering.
+ *
+ */
+export function activateFullSceneTree(scene: SceneObject): SceneDeactivationHandler {
+  const deactivationHandlers: SceneDeactivationHandler[] = [];
+
+  scene.forEachChild((child) => {
+    // For query runners which by default use the container width for maxDataPoints calculation we are setting a width.
+    // In real life this is done by the React component when VizPanel is rendered.
+    if ('setContainerWidth' in child) {
+      // @ts-expect-error
+      child.setContainerWidth(500);
+    }
+    deactivationHandlers.push(activateFullSceneTree(child));
+  });
+
+  deactivationHandlers.push(scene.activate());
+
+  return () => {
+    for (const handler of deactivationHandlers) {
+      handler();
+    }
+  };
+}


### PR DESCRIPTION
Finally after being unable to replicate this url overwrite scenario in a unit test I managed to figure out how to replicate it. 

It's when you subscribe to a scene object's state (a scene object that has url sync), and in that subscription you change another object's state (which also has url sync). 

So what was happening was this 

Two scene objects: A (name=A)  B (other=B).   both with url sync for properties name & other respectively 

* Change state of Object A (name=update) -> 
* Triggers state change handler =>
* State change handler changes state of Object B (other=muu)  =>
* UrlSyncManager updates state url with (other=muu) => 
* Url location change triggers sync from URL for Object A as the url as state name=A and state is `name=updated`, so the old value is used to overwrite the new state update 

The fix was to never let a location change trigger a URL => state sync. So that UrlSyncManager will ignore the location update it triggers itself.

Fixes a bug in data trails. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.3--canary.555.7728272785.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.2.3--canary.555.7728272785.0
  # or 
  yarn add @grafana/scenes@2.2.3--canary.555.7728272785.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
