### PR TITLE
SceneVariableSet: Cancel query when dependency changes

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -278,6 +278,11 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       if (otherVariable.variableDependency) {
         if (otherVariable.variableDependency.hasDependencyOn(variableThatChanged.state.name)) {
           writeVariableTraceLog(otherVariable, 'Added to update queue, dependant variable value changed');
+
+          if (this._updating.has(otherVariable) && otherVariable.onCancel) {
+            otherVariable.onCancel();
+          }
+
           this._variablesToUpdate.add(otherVariable);
         }
       }


### PR DESCRIPTION
Fixes #556 

Say you have variable A, and B (B depends on A). If B is very slow and loading and you change A it should cancel B and add it to update queue.