### PR TITLE
Fix empty state adhoc filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -67,7 +67,7 @@ export class AdHocFiltersVariable
         })
       );
 
-      this._updateFilterExpression(this.state.set.state.filters, false);
+      this._updateFilterExpression(this.state.set.state.filters, true);
     });
   }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -23,6 +23,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
     const urlValue = values[this.getKey()];
 
     if (urlValue == null) {
+      this._variable.setState({ filters: [], _wip: undefined });
       return;
     }
 


### PR DESCRIPTION
Problem:
- When having `AdHocFilterSet` in two different views, they sync properly except when removing all filters in one of the views.

Fix: 
- Set filters to empty array when no url value present
- Update filter expression should publish event since filters might've changed from url
