### PR TITLE
VizPanel: Add repeat props to state

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -47,6 +47,10 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;
   displayMode?: 'default' | 'transparent';
+  // Options for repeat panels
+  repeat?: string;
+  repeatDirection?: 'h' | 'v';
+  maxPerRow?: number;
   /**
    * Only shows header on hover, absolutly positioned above the panel.
    */


### PR DESCRIPTION
Context: https://github.com/grafana/grafana/pull/81818

Bit iffy on this tbh, since the repeat state is ultimately represented within the `PanelRepeaterGridItem`, but we need some way to store the state during panel edit and before the changes are committed/applied.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.4.1--canary.565.7757961436.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.4.1--canary.565.7757961436.0
  # or 
  yarn add @grafana/scenes@2.4.1--canary.565.7757961436.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
