### PR TITLE
SceneGridLayout: Fixes missing resize handles

### DIFF
--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -72,55 +72,7 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
               variables: [
                 AdHocFiltersVariable.create({
                   datasource: { uid: 'gdev-prometheus' },
-                  filters: [],
-                }),
-              ],
-            }),
-            body: new SceneFlexLayout({
-              direction: 'column',
-              children: [
-                new SceneFlexItem({
-                  ySizing: 'content',
-                  body: new SceneCanvasText({
-                    text: `Using AdHocFilterSet in manual mode and inside an AdHocFiltersVariable. The query below is interpolated to ALERTS{$Filters}`,
-                    fontSize: 14,
-                  }),
-                }),
-                new SceneFlexItem({
-                  body: PanelBuilders.table()
-                    .setTitle('ALERTS')
-                    .setData(
-                      new SceneQueryRunner({
-                        datasource: { uid: 'gdev-prometheus' },
-                        queries: [
-                          {
-                            refId: 'A',
-                            expr: 'ALERTS{$Filters}',
-                            format: 'table',
-                            instant: true,
-                          },
-                        ],
-                      })
-                    )
-                    .build(),
-                }),
-              ],
-            }),
-            $timeRange: new SceneTimeRange(),
-          });
-        },
-      }),
-      new SceneAppPage({
-        title: 'As variable2',
-        url: `${defaults.url}/manual2`,
-        getScene: () => {
-          return new EmbeddedScene({
-            ...getEmbeddedSceneDefaults(),
-            $variables: new SceneVariableSet({
-              variables: [
-                AdHocFiltersVariable.create({
-                  datasource: { uid: 'gdev-prometheus' },
-                  filters: [],
+                  filters: [{ key: 'job', operator: '=', value: 'grafana', condition: '' }],
                 }),
               ],
             }),

--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -72,7 +72,55 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
               variables: [
                 AdHocFiltersVariable.create({
                   datasource: { uid: 'gdev-prometheus' },
-                  filters: [{ key: 'job', operator: '=', value: 'grafana', condition: '' }],
+                  filters: [],
+                }),
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  ySizing: 'content',
+                  body: new SceneCanvasText({
+                    text: `Using AdHocFilterSet in manual mode and inside an AdHocFiltersVariable. The query below is interpolated to ALERTS{$Filters}`,
+                    fontSize: 14,
+                  }),
+                }),
+                new SceneFlexItem({
+                  body: PanelBuilders.table()
+                    .setTitle('ALERTS')
+                    .setData(
+                      new SceneQueryRunner({
+                        datasource: { uid: 'gdev-prometheus' },
+                        queries: [
+                          {
+                            refId: 'A',
+                            expr: 'ALERTS{$Filters}',
+                            format: 'table',
+                            instant: true,
+                          },
+                        ],
+                      })
+                    )
+                    .build(),
+                }),
+              ],
+            }),
+            $timeRange: new SceneTimeRange(),
+          });
+        },
+      }),
+      new SceneAppPage({
+        title: 'As variable2',
+        url: `${defaults.url}/manual2`,
+        getScene: () => {
+          return new EmbeddedScene({
+            ...getEmbeddedSceneDefaults(),
+            $variables: new SceneVariableSet({
+              variables: [
+                AdHocFiltersVariable.create({
+                  datasource: { uid: 'gdev-prometheus' },
+                  filters: [],
                 }),
               ],
             }),

--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -1,8 +1,6 @@
 import {
   SceneGridLayout,
   SceneGridItem,
-  SceneFlexLayout,
-  SceneFlexItem,
   SceneAppPage,
   EmbeddedScene,
   SceneAppPageState,
@@ -40,26 +38,6 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
               isResizable: false,
               isDraggable: false,
               body: PanelBuilders.timeseries().setTitle('No drag and no resize').build(),
-            }),
-
-            new SceneGridItem({
-              x: 6,
-              y: 11,
-              width: 12,
-              height: 10,
-              isDraggable: false,
-              isResizable: true,
-              body: new SceneFlexLayout({
-                direction: 'column',
-                children: [
-                  new SceneFlexItem({
-                    body: PanelBuilders.timeseries().setTitle('Child of flex layout').build(),
-                  }),
-                  new SceneFlexItem({
-                    body: PanelBuilders.timeseries().setTitle('Child of flex layout').build(),
-                  }),
-                ],
-              }),
             }),
           ],
         }),

--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -1,11 +1,14 @@
 import {
   SceneGridLayout,
   SceneGridItem,
+  SceneFlexLayout,
+  SceneFlexItem,
   SceneAppPage,
   EmbeddedScene,
   SceneAppPageState,
   PanelBuilders,
 } from '@grafana/scenes';
+import { GRID_CELL_HEIGHT } from '@grafana/scenes/src/components/layout/grid/constants';
 import { getQueryRunnerWithRandomWalkQuery, getEmbeddedSceneDefaults } from './utils';
 
 export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
@@ -38,6 +41,27 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
               isResizable: false,
               isDraggable: false,
               body: PanelBuilders.timeseries().setTitle('No drag and no resize').build(),
+            }),
+            new SceneGridItem({
+              x: 0,
+              y: 11,
+              width: 24,
+              height: 10,
+              isDraggable: false,
+              isResizable: true,
+              body: new SceneFlexLayout({
+                direction: 'column',
+                // Auto 100% height for SceneFlexLayout inside grid is not working, need to make grid item display: flex
+                height: 10 * GRID_CELL_HEIGHT,
+                children: [
+                  new SceneFlexItem({
+                    body: PanelBuilders.timeseries().setTitle('Child of flex layout').build(),
+                  }),
+                  new SceneFlexItem({
+                    body: PanelBuilders.timeseries().setTitle('Child of flex layout').build(),
+                  }),
+                ],
+              }),
             }),
           ],
         }),

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -29,7 +29,10 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
            * in an element that has the calculated size given by the AutoSizer. The AutoSizer
            * has a width of 0 and will let its content overflow its div.
            */
-          <div style={{ width: `${width}px`, height: '100%', position: 'relative', zIndex: 1 }}>
+          <div
+            style={{ width: `${width}px`, height: '100%', position: 'relative', zIndex: 1 }}
+            className="scene-grid-layout"
+          >
             <ReactGridLayout
               width={width}
               /**
@@ -80,7 +83,7 @@ interface GridItemWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((props, ref) => {
-  const { grid, layoutItem, index, totalCount, isLazy, style, onLoad, onChange, ...divProps } = props;
+  const { grid, layoutItem, index, totalCount, isLazy, style, onLoad, onChange, children, ...divProps } = props;
   const sceneChild = grid.getSceneLayoutChild(layoutItem.i)!;
   const className = sceneChild.getClassName?.();
   const theme = useTheme2();
@@ -123,6 +126,7 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
         ref={ref}
       >
         {innerContentWithContext}
+        {children}
       </LazyLoader>
     );
   }
@@ -136,6 +140,7 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
       className={cx(className, props.className)}
       style={newStyle}
     >
+      {children}
       {innerContentWithContext}
     </div>
   );


### PR DESCRIPTION
* Fix missing resize handled due to not rendering children in the grid item wrapper
* Add css class name to grid wrapper so we can if we want to style resize handle a bit differently for scenes dashboards 
* fix height issue in demo 