### PR TITLE
implemented preserving tabs logic

### DIFF
--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -60,6 +60,8 @@ export interface SceneAppPageState extends SceneObjectState {
    * The current initialized scene, this is set by the framework after scene url initialization
    **/
   initializedScene?: SceneObject;
+  // Determines whether tabs should be preserved after deactivation of page
+  preserveTab?: boolean
 
   /**
    * Function that returns a fallback scene app page,


### PR DESCRIPTION
So after discovering #559, I thought it would be nice to have a option to preserve the tabs. 
I came up with an idea.

Now the SceneAppPageRenderer always renders the first tab with two urls: the parent page url and the actual tab url.
But if we can remember the last selected tab, we can match the parent page url to any tab. This is what `_lastTabIndex` is for.
And you also have an option to choose not preserving tabs with `preserveTab` property.

Let me know what you think.