### PR TITLE
SplitLayout: Allow undefined secondary split

### DIFF
--- a/packages/scenes-app/src/demos/split.tsx
+++ b/packages/scenes-app/src/demos/split.tsx
@@ -75,14 +75,6 @@ const roomsTemperatureQuery = {
 };
 
 const getDynamicSplitScene = () => {
-  const defaultSecondary = new SceneFlexItem({
-    minWidth: 500,
-    body: new SceneCanvasText({
-      text: 'Select room to see details',
-      fontSize: 20,
-      align: 'center',
-    }),
-  });
   const runner = new SceneQueryRunner({
     datasource: DATASOURCE_REF,
     queries: [roomsTemperatureQuery],
@@ -149,7 +141,7 @@ const getDynamicSplitScene = () => {
                     .setHeaderActions(
                       <IconButton
                         name="x"
-                        onClick={() => splitter.setState({ secondary: defaultSecondary })}
+                        onClick={() => splitter.setState({ secondary: undefined })}
                         aria-label="remove"
                       />
                     )
@@ -169,7 +161,6 @@ const getDynamicSplitScene = () => {
       body: table,
       minWidth: 300,
     }),
-    secondary: defaultSecondary,
   });
 
   return new EmbeddedScene({

--- a/packages/scenes/src/components/layout/split/SplitLayout.ts
+++ b/packages/scenes/src/components/layout/split/SplitLayout.ts
@@ -6,7 +6,7 @@ import { SplitLayoutRenderer } from './SplitLayoutRenderer';
 
 interface SplitLayoutState extends SceneObjectState, SceneFlexItemPlacement {
   primary: SceneFlexItemLike;
-  secondary: SceneFlexItemLike;
+  secondary?: SceneFlexItemLike;
   direction: 'row' | 'column';
   initialSize?: number;
   primaryPaneStyles?: CSSProperties;

--- a/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/split/SplitLayoutRenderer.tsx
@@ -14,16 +14,16 @@ export function SplitLayoutRenderer({ model }: SceneFlexItemRenderProps<SplitLay
   }
 
   const Prim = primary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
-  const Sec = secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>;
+  const Sec = secondary ? (secondary.Component as ComponentType<SceneFlexItemRenderProps<SceneObject>>) : null;
   return (
     <Splitter
       direction={direction}
-      initialSize={initialSize ?? 0.5}
+      initialSize={Sec ? initialSize ?? 0.5 : 1}
       primaryPaneStyles={primaryPaneStyles}
       secondaryPaneStyles={secondaryPaneStyles}
     >
       <Prim key={primary.state.key} model={primary} parentState={model.state} />
-      <Sec key={secondary.state.key} model={secondary} parentState={model.state} />
+      {Sec === null ? null : <Sec key={secondary!.state.key} model={secondary!} parentState={model.state} />}
     </Splitter>
   );
 }

--- a/packages/scenes/src/components/layout/split/Splitter.tsx
+++ b/packages/scenes/src/components/layout/split/Splitter.tsx
@@ -304,38 +304,42 @@ export function Splitter({
         {kids[0]}
       </div>
 
-      <div
-        ref={splitterRef}
-        style={{ [measurementProp]: `${handleSize}px` }}
-        className={cx(styles.handle, { [styles.handleHorizontal]: direction === 'column' })}
-        onPointerUp={onPointerUp}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onDoubleClick={onDoubleClick}
-        onBlur={onBlur}
-        role="separator"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={50}
-        aria-controls={`start-panel-${id}`}
-        aria-label="Pane resize widget"
-        tabIndex={0}
-      ></div>
+      {kids[1] && (
+        <>
+          <div
+            ref={splitterRef}
+            style={{ [measurementProp]: `${handleSize}px` }}
+            className={cx(styles.handle, { [styles.handleHorizontal]: direction === 'column' })}
+            onPointerUp={onPointerUp}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onKeyDown={onKeyDown}
+            onKeyUp={onKeyUp}
+            onDoubleClick={onDoubleClick}
+            onBlur={onBlur}
+            role="separator"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={50}
+            aria-controls={`start-panel-${id}`}
+            aria-label="Pane resize widget"
+            tabIndex={0}
+          ></div>
 
-      <div
-        ref={secondPaneRef}
-        className={styles.panel}
-        style={{
-          flexGrow: initialSize === 'auto' ? 0.5 : clamp(1 - initialSize, 0, 1),
-          [minDimProp]: 'min-content',
-          ...secondaryPaneStyles,
-        }}
-        id={`end-panel-${id}`}
-      >
-        {kids[1]}
-      </div>
+          <div
+            ref={secondPaneRef}
+            className={styles.panel}
+            style={{
+              flexGrow: initialSize === 'auto' ? 0.5 : clamp(1 - initialSize, 0, 1),
+              [minDimProp]: 'min-content',
+              ...secondaryPaneStyles,
+            }}
+            id={`end-panel-${id}`}
+          >
+            {kids[1]}
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Working on an issue with query-less panels in core I've noticed  that `SplitLayout` does not allow empty secondary pane. I think it's a nice addition given that those split panes now become more dynamic and controllable.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.0--canary.568.7785237668.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.6.0--canary.568.7785237668.0
  # or 
  yarn add @grafana/scenes@2.6.0--canary.568.7785237668.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
