### PR TITLE
Variable: Fixes performance issues with variables with many select options

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -25,6 +25,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       width="auto"
       value={value}
       allowCustomValue
+      virtualized
       tabSelectsValue={false}
       onInputChange={onInputChange}
       options={model.getOptionsForSelect()}

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -67,6 +67,7 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       noMultiValueWrap={true}
       maxVisibleValues={maxVisibleValues ?? 5}
       tabSelectsValue={false}
+      virtualized
       allowCustomValue
       options={model.getOptionsForSelect()}
       closeMenuOnSelect={false}

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -366,5 +366,30 @@ describe('QueryVariable', () => {
       expect(runRequestMock).toBeCalledTimes(2);
       expect(runRequestMock.mock.calls[1][1].scopedVars.__searchFilter.value).toEqual('muu!');
     });
+
+    it('Should not trigger new query whern __searchFilter is not present', async () => {
+      const variable = new QueryVariable({
+        name: 'server',
+        datasource: null,
+        query: 'A.*',
+      });
+
+      const scene = new EmbeddedScene({
+        $variables: new SceneVariableSet({ variables: [variable] }),
+        controls: [new VariableValueSelectors({})],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      render(<scene.Component model={scene} />);
+
+      const select = await screen.findByRole('combobox');
+      await userEvent.click(select);
+      await userEvent.type(select, 'muu!');
+
+      // wait for debounce
+      await new Promise((r) => setTimeout(r, 500));
+
+      expect(runRequestMock).toBeCalledTimes(1);
+    });
   });
 });

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -152,5 +152,5 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
 function containsSearchFilter(query: string | DataQuery) {
   const str = safeStringifyValue(query);
-  return str.indexOf(SEARCH_FILTER_VARIABLE);
+  return str.indexOf(SEARCH_FILTER_VARIABLE) > -1;
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/9205

* Makes selects virtualized to handle many options  (Select get's super slow when option count is > 5000) 
* Fixes very bad bug in QueryVariable where every query was thought to contain __searchFilter 

Fixes https://github.com/grafana/grafana/issues/81931

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.1--canary.569.7796550591.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.6.1--canary.569.7796550591.0
  # or 
  yarn add @grafana/scenes@2.6.1--canary.569.7796550591.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
