### PR TITLE
GroupBy variable: Fix variable type

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -121,7 +121,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
       baseFilters: [],
       applyMode: 'same-datasource',
       layout: 'horizontal',
-      type: 'adhoc-aggregation-' as VariableType,
+      type: 'groupby' as VariableType,
       ...initialState,
       noValueOnClear: true,
     });


### PR DESCRIPTION
Required for https://github.com/grafana/grafana/pull/81717

We missed this type rename :( 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.2--canary.571.7799339718.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.6.2--canary.571.7799339718.0
  # or 
  yarn add @grafana/scenes@2.6.2--canary.571.7799339718.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
