### PR TITLE
SceneTimeRange: Support timezone url sync

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -11,7 +11,7 @@ import { evaluateTimeRange } from '../utils/evaluateTimeRange';
 import { config } from '@grafana/runtime';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone'] });
 
   public constructor(state: Partial<SceneTimeRangeState> = {}) {
     const from = state.from ?? 'now-6h';
@@ -155,7 +155,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   };
 
   public getUrlState() {
-    return { from: this.state.from, to: this.state.to };
+    return { from: this.state.from, to: this.state.to, timezone: this.state.timeZone };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
@@ -176,13 +176,18 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       update.to = to;
     }
 
+    if (typeof values.timezone === 'string') {
+      update.timeZone = values.timezone !== '' ? values.timezone : undefined;
+    }
+
     update.value = evaluateTimeRange(
       update.from ?? this.state.from,
       update.to ?? this.state.to,
-      this.getTimeZone(),
+      update.timeZone ?? this.getTimeZone(),
       this.state.fiscalYearStartMonth,
       this.state.UNSAFE_nowDelay
     );
+
     this.setState(update);
   }
 }


### PR DESCRIPTION
Embedded (Solo) page and report page needs to support url timezone sync so instead of doing that via some custom init code I think adding it to SceneTimeRange could make sense. 

It does mean that when users in dashboards (or scene apps) change to a custom / non system/user default timezone that it will be added to URL and included in shared urls. Not sure if this is good or bad. Alt implementation is to only support a one way sync (only check it in updateFromUrl but never return it in getUrlState). 

