### PR TITLE
ByVariableRepeater: Repeat layout for each variable value

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -32,6 +32,7 @@ import { getCssGridLayoutDemo } from './cssGridLayoutDemo';
 import { getPanelHeaderActions } from './panelHeaderActions';
 import { getVerticalControlsLayoutDemo } from './verticalControlsLayoutDemo';
 import { getInteractiveTableDemo } from './interactiveTableDemo';
+import { getVariableRepeaterDemo } from './variableRepeater';
 
 export interface DemoDescriptor {
   title: string;
@@ -45,6 +46,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Panel menu', getPage: getPanelMenuTest },
     { title: 'Panel context', getPage: getPanelContextDemoScene },
     { title: 'Repeat layout by series', getPage: getPanelRepeaterTest },
+    { title: 'Repeat layout by variable', getPage: getVariableRepeaterDemo },
     { title: 'Grid layout', getPage: getGridLayoutTest },
     { title: 'Grid with rows', getPage: getGridWithRowLayoutTest },
     { title: 'Lazy load', getPage: getLazyLoadDemo },

--- a/packages/scenes-app/src/demos/variableRepeater.tsx
+++ b/packages/scenes-app/src/demos/variableRepeater.tsx
@@ -31,6 +31,8 @@ export function getVariableRepeaterDemo(defaults: SceneAppPageState) {
               text: '',
               description: 'Server name',
               delayMs: 1000,
+              includeAll: true,
+              defaultToAll: true,
               isMulti: true,
               options: [],
               //              refresh: VariableRefresh.onTimeRangeChanged,

--- a/packages/scenes-app/src/demos/variableRepeater.tsx
+++ b/packages/scenes-app/src/demos/variableRepeater.tsx
@@ -1,0 +1,71 @@
+import {
+  SceneFlexLayout,
+  SceneTimeRange,
+  SceneVariableSet,
+  TestVariable,
+  EmbeddedScene,
+  SceneFlexItem,
+  SceneAppPage,
+  SceneAppPageState,
+  PanelBuilders,
+  VariableValueSelectors,
+  SceneByVariableRepeater,
+  VariableValueOption,
+} from '@grafana/scenes';
+import { getQueryRunnerWithRandomWalkQuery } from './utils';
+
+export function getVariableRepeaterDemo(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Test of repeating layout by variable',
+    $timeRange: new SceneTimeRange(),
+    getScene: () => {
+      return new EmbeddedScene({
+        controls: [new VariableValueSelectors({})],
+        $variables: new SceneVariableSet({
+          variables: [
+            new TestVariable({
+              name: 'server',
+              query: 'A.*',
+              value: 'server',
+              text: '',
+              description: 'Server name',
+              delayMs: 1000,
+              isMulti: true,
+              options: [],
+              //              refresh: VariableRefresh.onTimeRangeChanged,
+            }),
+          ],
+        }),
+        body: new SceneByVariableRepeater({
+          variableName: 'server',
+          body: new SceneFlexLayout({
+            direction: 'column',
+            children: [],
+          }),
+          getLayoutChild: (option) => getGraphAndTextPanel(option),
+        }),
+      });
+    },
+  });
+}
+
+function getGraphAndTextPanel(option: VariableValueOption) {
+  return new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: PanelBuilders.timeseries()
+          .setTitle(`server: ${option.value}`)
+          .setData(
+            getQueryRunnerWithRandomWalkQuery({
+              alias: `server: ${option.value}`,
+            })
+          )
+          .build(),
+      }),
+      new SceneFlexItem({
+        body: PanelBuilders.stat().setTitle('Max').setData(getQueryRunnerWithRandomWalkQuery({})).build(),
+      }),
+    ],
+  });
+}

--- a/packages/scenes-app/src/demos/variableRepeater.tsx
+++ b/packages/scenes-app/src/demos/variableRepeater.tsx
@@ -35,7 +35,6 @@ export function getVariableRepeaterDemo(defaults: SceneAppPageState) {
               defaultToAll: true,
               isMulti: true,
               options: [],
-              //              refresh: VariableRefresh.onTimeRangeChanged,
             }),
           ],
         }),

--- a/packages/scenes-app/src/demos/variableRepeater.tsx
+++ b/packages/scenes-app/src/demos/variableRepeater.tsx
@@ -54,6 +54,7 @@ export function getVariableRepeaterDemo(defaults: SceneAppPageState) {
 
 function getGraphAndTextPanel(option: VariableValueOption) {
   return new SceneFlexLayout({
+    minHeight: 200,
     children: [
       new SceneFlexItem({
         body: PanelBuilders.timeseries()

--- a/packages/scenes/src/components/SceneByVariableRepeater.tsx
+++ b/packages/scenes/src/components/SceneByVariableRepeater.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneComponentProps, SceneLayout, SceneObject, SceneObjectState } from '../core/types';
+import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
+import { VariableValueOption } from '../variables/types';
+import { MultiValueVariable } from '../variables/variants/MultiValueVariable';
+
+interface SceneByVariableRepeaterState extends SceneObjectState {
+  body: SceneLayout;
+  variableName: string;
+  getLayoutChild(option: VariableValueOption): SceneObject;
+}
+
+export class SceneByVariableRepeater extends SceneObjectBase<SceneByVariableRepeaterState> {
+  protected _variableDependency: VariableDependencyConfig<SceneByVariableRepeaterState> = new VariableDependencyConfig(
+    this,
+    {
+      variableNames: [this.state.variableName],
+      onVariableUpdateCompleted: () => this.performRepeat(),
+    }
+  );
+
+  public constructor(state: SceneByVariableRepeaterState) {
+    super(state);
+
+    this.addActivationHandler(() => this.performRepeat());
+  }
+
+  private performRepeat() {
+    if (this._variableDependency.hasDependencyInLoadingState()) {
+      return;
+    }
+
+    const variable = sceneGraph.lookupVariable(this.state.variableName, this);
+    if (!(variable instanceof MultiValueVariable)) {
+      console.error('SceneByVariableRepeater: variable is not a MultiValueVariable');
+      return;
+    }
+
+    const values = getMultiVariableValues(variable);
+    const newChildren: SceneObject[] = [];
+
+    for (const option of values) {
+      const layoutChild = this.state.getLayoutChild(option);
+      newChildren.push(layoutChild);
+    }
+
+    this.state.body.setState({ children: newChildren });
+  }
+
+  public static Component = ({ model }: SceneComponentProps<SceneByVariableRepeater>) => {
+    const { body } = model.useState();
+    return <body.Component model={body} />;
+  };
+}
+
+export function getMultiVariableValues(variable: MultiValueVariable): VariableValueOption[] {
+  const { value, text, options } = variable.state;
+
+  if (variable.hasAllValue()) {
+    return options;
+  }
+
+  if (Array.isArray(value) && Array.isArray(text)) {
+    return value.map((v, i) => ({ value: v, label: text[i] as string }));
+  }
+
+  return [{ value: value as string, label: text as string }];
+}

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -66,6 +66,7 @@ export { SceneRefreshPicker } from './components/SceneRefreshPicker';
 export { SceneTimeRangeTransformerBase } from './core/SceneTimeRangeTransformerBase';
 export { SceneTimeRangeCompare } from './components/SceneTimeRangeCompare';
 export { SceneByFrameRepeater } from './components/SceneByFrameRepeater';
+export { SceneByVariableRepeater } from './components/SceneByVariableRepeater';
 export { SceneControlsSpacer } from './components/SceneControlsSpacer';
 export {
   SceneFlexLayout,


### PR DESCRIPTION
Closes #528 
Closes #516 

Like with the by frame repeater this could be improved by caching scene objects etc and not doing a repeat on activation when variable value is the same.  But I think it's a an ok start for now. 

https://github.com/grafana/scenes/assets/10999/ab82c27a-45bc-4171-a56f-4c360a940d22




