### PR TITLE
TextBoxVariable: Fixes url sync key when name changes

### DIFF
--- a/packages/scenes/src/services/SceneObjectUrlSyncConfig.ts
+++ b/packages/scenes/src/services/SceneObjectUrlSyncConfig.ts
@@ -1,17 +1,21 @@
 import { SceneObjectUrlSyncHandler, SceneObjectWithUrlSync, SceneObjectUrlValues } from '../core/types';
 
 interface SceneObjectUrlSyncConfigOptions {
-  keys: string[];
+  keys: string[] | (() => string[]);
 }
 
 export class SceneObjectUrlSyncConfig implements SceneObjectUrlSyncHandler {
-  private _keys: string[];
+  private _keys: string[] | (() => string[]);
 
   public constructor(private _sceneObject: SceneObjectWithUrlSync, _options: SceneObjectUrlSyncConfigOptions) {
     this._keys = _options.keys;
   }
 
   public getKeys(): string[] {
+    if (typeof this._keys === 'function') {
+      return this._keys();
+    }
+
     return this._keys;
   }
 

--- a/packages/scenes/src/variables/variants/TextBoxVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/TextBoxVariable.test.tsx
@@ -26,4 +26,14 @@ describe('TextBoxVariable', () => {
     expect(screen.getByText('search')).toBeInTheDocument();
     expect(nestedObj.state.variableValueChanged).toBe(0);
   });
+
+  it('Should change url sync key when name changes', async () => {
+    const variable = new TextBoxVariable({ name: 'search' });
+
+    expect(variable.urlSync?.getKeys()).toEqual(['var-search']);
+
+    variable.setState({ name: 'newName' });
+
+    expect(variable.urlSync?.getKeys()).toEqual(['var-newName']);
+  });
 });

--- a/packages/scenes/src/variables/variants/TextBoxVariable.tsx
+++ b/packages/scenes/src/variables/variants/TextBoxVariable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../../core/types';
+import { SceneComponentProps, SceneObjectUrlValues } from '../../core/types';
 import { SceneObjectUrlSyncConfig } from '../../services/SceneObjectUrlSyncConfig';
 import { VariableValueInput } from '../components/VariableValueInput';
 import { SceneVariable, SceneVariableState, SceneVariableValueChangedEvent, VariableValue } from '../types';
@@ -13,8 +13,6 @@ export class TextBoxVariable
   extends SceneObjectBase<TextBoxVariableState>
   implements SceneVariable<TextBoxVariableState>
 {
-  protected _urlSync: SceneObjectUrlSyncHandler;
-
   public constructor(initialState: Partial<TextBoxVariableState>) {
     super({
       type: 'textbox',
@@ -23,7 +21,7 @@ export class TextBoxVariable
       ...initialState,
     });
 
-    this._urlSync = new SceneObjectUrlSyncConfig(this, { keys: [this.getKey()] });
+    this._urlSync = new SceneObjectUrlSyncConfig(this, { keys: () => [this.getKey()] });
   }
 
   public getValue(): VariableValue {


### PR DESCRIPTION
The key was statically assigned in SceneObjectUrlSyncConfig, update the signature for SceneObjectUrlSyncConfig so that keys can be made into function 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.3--canary.574.7800968870.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.6.3--canary.574.7800968870.0
  # or 
  yarn add @grafana/scenes@2.6.3--canary.574.7800968870.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
