### PR TITLE
query controller wrapps observable

### DIFF
--- a/packages/scenes/src/querying/SceneQueryController.test.ts
+++ b/packages/scenes/src/querying/SceneQueryController.test.ts
@@ -1,0 +1,82 @@
+import { LoadingState } from '@grafana/schema';
+import { Observable } from 'rxjs';
+import { QueryResultWithState, SceneQueryController } from './SceneQueryController';
+
+describe('SceneQueryController', () => {
+  let controller: SceneQueryController;
+
+  beforeEach(() => {
+    controller = new SceneQueryController({});
+  });
+
+  it('Wraps query observable', async () => {
+    const { query, streamFuncs } = registerQuery(controller);
+    let next = jest.fn();
+    let complete = jest.fn();
+
+    const sub1 = query.subscribe({ next, complete });
+
+    next({ state: LoadingState.Loading });
+    complete();
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(streamFuncs.cleanup).toHaveBeenCalledTimes(0);
+
+    sub1.unsubscribe();
+    expect(streamFuncs.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('Last unsubscribe should set running to false', async () => {
+    const { query: query1 } = registerQuery(controller);
+
+    const sub1 = query1.subscribe(() => {});
+
+    expect(controller.state.isRunning).toBe(true);
+
+    const { query: query2 } = registerQuery(controller);
+    const sub2 = query2.subscribe(() => {});
+
+    sub1.unsubscribe();
+    expect(controller.state.isRunning).toBe(true);
+    sub2.unsubscribe();
+    expect(controller.state.isRunning).toBe(false);
+  });
+
+  it('can cancel all', async () => {
+    const { query: query1, streamFuncs: streamFuncs1 } = registerQuery(controller);
+    const sub1 = query1.subscribe(() => {});
+
+    const { query: query2, streamFuncs: streamFuncs2 } = registerQuery(controller);
+    const sub2 = query2.subscribe(() => {});
+
+    controller.cancelAll();
+
+    expect(controller.state.isRunning).toBe(false);
+    expect(streamFuncs1.cleanup).toHaveBeenCalledTimes(1);
+    expect(streamFuncs2.cleanup).toHaveBeenCalledTimes(1);
+    expect(sub1.closed).toBe(true);
+    expect(sub2.closed).toBe(true);
+  });
+});
+
+function registerQuery(controller: SceneQueryController) {
+  let streamFuncs = {
+    next: (data: QueryResultWithState) => {},
+    complete: () => {},
+    cleanup: jest.fn(),
+  };
+
+  const runStream = new Observable<QueryResultWithState>((observer) => {
+    streamFuncs.next = (data) => {
+      observer.next(data);
+    };
+    streamFuncs.complete = () => observer.complete();
+
+    return streamFuncs.cleanup;
+  });
+
+  const query = controller.registerQuery({ type: 'data', runStream });
+
+  return { controller, query, streamFuncs };
+}

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -29,6 +29,7 @@ import { TestSceneWithRequestEnricher } from '../utils/test/TestSceneWithRequest
 import { AdHocFilterSet } from '../variables/adhoc/AdHocFiltersSet';
 import { emptyPanelData } from '../core/SceneDataNode';
 import { GroupByVariable } from '../variables/groupby/GroupByVariable';
+import { SceneQueryController, SceneQueryStateControllerState } from './SceneQueryController';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   uid: 'test-uid',
@@ -71,6 +72,7 @@ const getDataSourceMock = jest.fn().mockReturnValue({
         ],
       });
     }
+    console.log('asd');
     return of({
       data: [
         toDataFrame({
@@ -350,6 +352,31 @@ describe('SceneQueryRunner', () => {
 
       const runRequestCall2 = runRequestMock.mock.calls[1];
       expect(runRequestCall2[1].groupByKeys).toEqual(['C', 'D']);
+    });
+  });
+
+  describe('Query controller', () => {
+    it.only('should register itself', async () => {
+      const queryController = new SceneQueryController({});
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A' }],
+        $behaviors: [queryController],
+        $timeRange: new SceneTimeRange(),
+      });
+
+      const queryControllerStates: SceneQueryStateControllerState[] = [];
+      queryController.subscribeToState((s) => {
+        queryControllerStates.push(s);
+      });
+
+      expect(queryRunner.state.data).toBeUndefined();
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(queryControllerStates[0].isRunning).toEqual(true);
+      expect(queryControllerStates[1].isRunning).toEqual(false);
     });
   });
 


### PR DESCRIPTION
Had a timing issue when I wrote a test for scene query runner and it's registration with the query controller. 

SceneQueryRunner called queryStarted after the subscription was created, and if the query completed right away that happens before queryStarted. 

So wanted to try to make QueryController wrap the request observable and that way it can cancel and know state of query automatically, but not so sure this is a good idea, makes QueryController a bit more complex and requires that all queries we register with it are observables that it can wrap 