### PR TITLE
ResizeHandle: New style

### DIFF
--- a/packages/scenes-app/src/demos/grid.tsx
+++ b/packages/scenes-app/src/demos/grid.tsx
@@ -30,7 +30,10 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
               height: 10,
               isResizable: true,
               isDraggable: true,
-              body: PanelBuilders.timeseries().setTitle('Draggable and resizable').build(),
+              body: PanelBuilders.timeseries()
+                .setTitle('Draggable and resizable')
+                .setOption('legend', { showLegend: false })
+                .build(),
             }),
             new SceneGridItem({
               x: 12,
@@ -39,7 +42,10 @@ export function getGridLayoutTest(defaults: SceneAppPageState): SceneAppPage {
               height: 10,
               isResizable: false,
               isDraggable: false,
-              body: PanelBuilders.timeseries().setTitle('No drag and no resize').build(),
+              body: PanelBuilders.timeseries()
+                .setTitle('No drag and no resize')
+                .setOption('legend', { showLegend: false })
+                .build(),
             }),
 
             new SceneGridItem({

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -8,7 +8,8 @@ import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
 // @ts-expect-error TODO remove when @grafana/ui is upgraded to 10.4
 import { LayoutItemContext, useTheme2 } from '@grafana/ui';
-import { cx } from '@emotion/css';
+import { css, cx } from '@emotion/css';
+import { hover } from '@testing-library/user-event/dist/types/convenience';
 
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
   const { children, isLazy, isDraggable, isResizable } = model.useState();
@@ -112,6 +113,18 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
     zIndex: boostedCount.current === 0 ? descIndex : theme.zIndex.dropdown,
   };
 
+  const styleTest = css({
+    position: 'absolute',
+    bottom: -7,
+    right: -1,
+    zIndex: 999,
+    color: theme.colors.border.strong,
+    cursor: 'se-resize',
+    '&:hover': {
+      color: theme.colors.text.link,
+    },
+  });
+
   if (isLazy) {
     return (
       <LazyLoader
@@ -123,6 +136,22 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
         ref={ref}
       >
         {innerContentWithContext}
+<<<<<<< Updated upstream
+||||||| constructed merge base
+        {children}
+=======
+        <div className={styleTest}>
+          <svg width="16px" height="16x" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M21 15L15 21M21 8L8 21"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+>>>>>>> Stashed changes
       </LazyLoader>
     );
   }

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -192,13 +192,20 @@ ResizeHandle.displayName = 'ResizeHandle';
 function getResizeHandleStyles(theme: GrafanaTheme2) {
   return css({
     position: 'absolute',
-    bottom: -7,
-    right: -1,
+    bottom: 0,
+    right: 0,
     zIndex: 999,
+    padding: theme.spacing(1.5, 0, 0, 1.5),
     color: theme.colors.border.strong,
     cursor: 'se-resize',
     '&:hover': {
       color: theme.colors.text.link,
+    },
+    svg: {
+      display: 'block',
+    },
+    '.react-resizable-hide &': {
+      display: 'none',
     },
   });
 }


### PR DESCRIPTION
With the new custom resize handle styling I don't need any changes in core (can close this https://github.com/grafana/grafana/pull/81856) 

* New custom resize handle (Always visible when dragging enabled)
* Made it a bit bigger than the previous (bigger hit/hover area) so easier to click on 

The cursor that looks stuck is a bug in the recording software 

https://github.com/grafana/scenes/assets/10999/394d2625-ffdf-49f2-a293-4af10346f7c1

