### PR TITLE
AdHoc filter: Don't render label twice when used as a variable

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterBuilder.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterBuilder.tsx
@@ -2,18 +2,29 @@ import React from 'react';
 
 import { AdHocFilterRenderer } from './AdHocFilterRenderer';
 import { AdHocFilterSet } from './AdHocFiltersSet';
-import { Button } from '@grafana/ui';
+import { Button, useTheme2 } from '@grafana/ui';
+import { AdHocFiltersVariable } from './AdHocFiltersVariable';
+import { VariableHide } from '@grafana/schema';
 
 interface Props {
   model: AdHocFilterSet;
 }
 
 export function AdHocFilterBuilder({ model }: Props) {
-  const { _wip } = model.useState();
+  const theme = useTheme2();
+  const { _wip, filters } = model.useState();
+  let fixAddButtonSpacing = false;
+  const noFilterConfigured = filters.length === 0 && !_wip;
+
+  // When using as a variable, we need to accomodate flex gap with a margin when there is no filters configured yet and the label is hidden
+  if (model.parent instanceof AdHocFiltersVariable) {
+    fixAddButtonSpacing = noFilterConfigured && model.parent.state.hide !== VariableHide.hideLabel;
+  }
 
   if (!_wip) {
     return (
       <Button
+        style={{ marginLeft: fixAddButtonSpacing ? theme.spacing(2) : undefined }}
         variant="secondary"
         icon="plus"
         title={'Add filter'}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.tsx
@@ -13,6 +13,7 @@ import { AdHocFilterBuilder } from './AdHocFilterBuilder';
 import { css } from '@emotion/css';
 import { sceneGraph } from '../../core/sceneGraph';
 import { DataQueryExtended, SceneQueryRunner } from '../../querying/SceneQueryRunner';
+import { AdHocFiltersVariable } from './AdHocFiltersVariable';
 
 export interface AdHocFilterSetState extends SceneObjectState {
   /** Defaults to Filters */
@@ -227,10 +228,11 @@ export class AdHocFilterSet extends SceneObjectBase<AdHocFilterSetState> {
 export function AdHocFiltersSetRenderer({ model }: SceneComponentProps<AdHocFilterSet>) {
   const { filters, readOnly, layout, name } = model.useState();
   const styles = useStyles2(getStyles);
+  let skipLabel = model.parent instanceof AdHocFiltersVariable;
 
   return (
     <div className={styles.wrapper}>
-      {layout !== 'vertical' && <ControlsLabel label={name ?? 'Filters'} icon="filter" />}
+      {layout !== 'vertical' && !skipLabel && <ControlsLabel label={name ?? 'Filters'} icon="filter" />}
 
       {filters.map((filter, index) => (
         <React.Fragment key={index}>


### PR DESCRIPTION
A hacky way to make sure filter's control label ain't rendered twice (see https://github.com/grafana/grafana/pull/81318#issuecomment-1932233163). 

This is until we get rid of `AdhocFilterSet` and replace it with only a variable as we did with [group by variable](https://github.com/grafana/scenes/pull/548).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.6.5--canary.580.7828999283.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@2.6.5--canary.580.7828999283.0
  # or 
  yarn add @grafana/scenes@2.6.5--canary.580.7828999283.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
