### PR TITLE
AdHocFiltersSet: Add `hide` property to control controls visibility

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersSet.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersSet.tsx
@@ -1,7 +1,7 @@
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { AdHocVariableFilter, GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
 import { patchGetAdhocFilters } from './patchGetAdhocFilters';
-import { DataSourceRef } from '@grafana/schema';
+import { DataSourceRef, VariableHide } from '@grafana/schema';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectState, SceneObjectUrlSyncHandler, ControlsLayout } from '../../core/types';
 import { AdHocFiltersVariableUrlSyncHandler } from './AdHocFiltersVariableUrlSyncHandler';
@@ -17,6 +17,8 @@ import { DataQueryExtended, SceneQueryRunner } from '../../querying/SceneQueryRu
 export interface AdHocFilterSetState extends SceneObjectState {
   /** Defaults to Filters */
   name?: string;
+  /** The set visibility */
+  hide?: VariableHide;
   /** The visible filters */
   filters: AdHocVariableFilter[];
   /** Base filters to always apply when looking up keys*/
@@ -85,6 +87,7 @@ export class AdHocFilterSet extends SceneObjectBase<AdHocFilterSetState> {
       datasource: null,
       applyMode: 'same-datasource',
       layout: 'horizontal',
+      hide: VariableHide.dontHide,
       ...initialState,
     });
 
@@ -225,12 +228,18 @@ export class AdHocFilterSet extends SceneObjectBase<AdHocFilterSetState> {
 }
 
 export function AdHocFiltersSetRenderer({ model }: SceneComponentProps<AdHocFilterSet>) {
-  const { filters, readOnly, layout, name } = model.useState();
+  const { filters, readOnly, layout, name, hide } = model.useState();
   const styles = useStyles2(getStyles);
+
+  if (hide === VariableHide.hideVariable) {
+    <></>;
+  }
 
   return (
     <div className={styles.wrapper}>
-      {layout !== 'vertical' && <ControlsLabel label={name ?? 'Filters'} icon="filter" />}
+      {hide !== VariableHide.hideLabel && layout !== 'vertical' && (
+        <ControlsLabel label={name ?? 'Filters'} icon="filter" />
+      )}
 
       {filters.map((filter, index) => (
         <React.Fragment key={index}>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -31,6 +31,7 @@ export type AdHocFiltersVariableCreateHelperArgs = Pick<
   | 'name'
   | 'layout'
   | 'applyMode'
+  | 'hide'
 >;
 
 export class AdHocFiltersVariable
@@ -41,11 +42,13 @@ export class AdHocFiltersVariable
   public static create(state: AdHocFiltersVariableCreateHelperArgs): AdHocFiltersVariable {
     return new AdHocFiltersVariable({
       type: 'adhoc',
-      hide: VariableHide.hideLabel,
+      hide: state.hide,
       name: state.name ?? 'Filters',
       set: new AdHocFilterSet({
         // The applyMode defaults to 'manual' when used through the variable as it is the most frecuent use case
         applyMode: 'manual',
+        // The label will be rendered by the AdHocFiltersVariable
+        hide: VariableHide.hideLabel,
         ...state,
       }),
     });


### PR DESCRIPTION
**Problem**
When the AdHocFiltersSet is used as part of AdHocFiltersVariable, the label is rendered twice.

VariableValueSelectors is in charge of rendering the controls, including label and value control. But AdHocFiltersVariable is different since the AdHocFiltersSet can be rendered out of the variable, and it contains its own label and control rendering.

**Solution**
In the same way, every variables has a `hide` property to control the visibility, the AdHocFiltersSet should have its own, so we can decide what part of the control we want to render. This allows when using a AdHocFiltersSet as apart of AdHocFiltersVariable state, hiding the controls to not render them twice.

**Notes**
* I also updated the AdHocFiltersVariable.create to create the filter set as hidden by default but get the hide value from the initial state.

**TODO:**
- [ ] Add tests

Related to #580
Part of https://github.com/grafana/grafana/pull/81318