### PR TITLE
SceneGridLayoutRenderer: fix svg height unit

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -174,7 +174,7 @@ const ResizeHandle = React.forwardRef<HTMLDivElement, ResizeHandleProps>(({ hand
 
   return (
     <div ref={ref} {...divProps} className={`${customCssClass} scene-resize-handle`}>
-      <svg width="16px" height="16x" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
           d="M21 15L15 21M21 8L8 21"
           stroke="currentColor"


### PR DESCRIPTION
Tiny change `16x` to `16px` to resolve:
![Screenshot 2024-02-09 at 11 02 36 AM](https://github.com/grafana/scenes/assets/23087433/8c7d61ef-1237-4441-ab62-90431b074c4f)
