### PR TITLE
AdHoc/GroupBy: Use variable system as way to subscribe to changes

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -30,6 +30,7 @@ import { AdHocFiltersVariable } from '../variables/adhoc/AdHocFiltersVariable';
 import { emptyPanelData } from '../core/SceneDataNode';
 import { GroupByVariable } from '../variables/groupby/GroupByVariable';
 import { SceneQueryController, SceneQueryStateControllerState } from '../behaviors/SceneQueryController';
+import { activateFullSceneTree } from '../utils/test/activateFullSceneTree';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   uid: 'test-uid',
@@ -286,7 +287,7 @@ describe('SceneQueryRunner', () => {
         filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
       });
 
-      new EmbeddedScene({
+      const scene = new EmbeddedScene({
         $data: queryRunner,
         $variables: new SceneVariableSet({ variables: [filtersVar] }),
         body: new SceneCanvasText({ text: 'hello' }),
@@ -294,8 +295,7 @@ describe('SceneQueryRunner', () => {
 
       expect(queryRunner.state.data).toBeUndefined();
 
-      queryRunner.activate();
-      filtersVar.activate();
+      activateFullSceneTree(scene);
 
       await new Promise((r) => setTimeout(r, 1));
 
@@ -325,18 +325,16 @@ describe('SceneQueryRunner', () => {
         defaultOptions: [{ text: 'A' }, { text: 'B' }],
         value: ['A', 'B'],
       });
-      const variables = new SceneVariableSet({ variables: [groupByVariable] });
 
-      new EmbeddedScene({
+      const scene = new EmbeddedScene({
         $data: queryRunner,
-        $variables: variables,
+        $variables: new SceneVariableSet({ variables: [groupByVariable] }),
         body: new SceneCanvasText({ text: 'hello' }),
       });
 
       expect(queryRunner.state.data).toBeUndefined();
 
-      groupByVariable.activate();
-      queryRunner.activate();
+      activateFullSceneTree(scene);
 
       await new Promise((r) => setTimeout(r, 1));
 

--- a/packages/scenes/src/variables/VariableDependencyConfig.test.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.test.ts
@@ -89,6 +89,20 @@ describe('VariableDependencyConfig', () => {
     expect(fn.mock.calls.length).toBe(1);
   });
 
+  it('Can update explicit depenendencies', () => {
+    const sceneObj = new TestObj();
+    const fn = jest.fn();
+    const deps = new VariableDependencyConfig(sceneObj, { onReferencedVariableValueChanged: fn });
+
+    deps.variableUpdateCompleted(new ConstantVariable({ name: 'not-dep', value: '1' }), true);
+    expect(fn.mock.calls.length).toBe(0);
+
+    deps.setVariableNames(['not-dep']);
+    deps.variableUpdateCompleted(new ConstantVariable({ name: 'not-dep', value: '1' }), true);
+
+    expect(fn.mock.calls.length).toBe(1);
+  });
+
   describe('Should remember when an object is waiting for variables', () => {
     it('Should notify as soon as next variable completes', async () => {
       const A = new TestVariable({

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -55,7 +55,7 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
   }
 
   /**
-   * This is called whenever any set of variables have new values. It up to this implementation to check if it's relevant given the current dependencies.
+   * This is called whenever any set of variables have new values. It is up to this implementation to check if it's relevant given the current dependencies.
    */
   public variableUpdateCompleted(variable: SceneVariable, hasChanged: boolean) {
     const deps = this.getNames();
@@ -127,6 +127,14 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
     return this._dependencies;
   }
 
+  /**
+   * Update variableNames
+   */
+  public setVariableNames(varNames: string[]) {
+    this._options.variableNames = varNames;
+    this.scanStateForDependencies(this._state!);
+  }
+
   public setPaths(paths: Array<keyof TState>) {
     this._statePaths = paths;
   }
@@ -139,17 +147,17 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
       for (const name of this._options.variableNames) {
         this._dependencies.add(name);
       }
-    } else {
-      if (this._statePaths) {
-        for (const path of this._statePaths) {
-          const value = state[path];
-          if (value) {
-            this.extractVariablesFrom(value);
-          }
+    }
+
+    if (this._statePaths) {
+      for (const path of this._statePaths) {
+        const value = state[path];
+        if (value) {
+          this.extractVariablesFrom(value);
         }
-      } else {
-        this.extractVariablesFrom(state);
       }
+    } else {
+      this.extractVariablesFrom(state);
     }
   }
 


### PR DESCRIPTION
Builds on https://github.com/grafana/scenes/pull/586 and fixes some bugs in main as well 

* Instead of subscribing to state of adhoc filters and group by (which also triggers when the variable goes into loading state) we now use the variable system. 

Bugfix 
* Currently we do not re-subscribe to adhoc filters nor group by when a query runner re-activates so nothing happens when coming back to a cached scene. 