### PR TITLE
QueryController: Update global window query counter

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -52,6 +52,8 @@ export class SceneQueryController
   public queryStarted(entry: SceneQueryControllerEntry) {
     this.#running.add(entry);
 
+    this.changeRunningQueryCount(1);
+
     if (!this.state.isRunning) {
       this.setState({ isRunning: true });
     }
@@ -60,9 +62,18 @@ export class SceneQueryController
   public queryCompleted(entry: SceneQueryControllerEntry) {
     this.#running.delete(entry);
 
+    this.changeRunningQueryCount(-1);
+
     if (this.#running.size === 0) {
       this.setState({ isRunning: false });
     }
+  }
+
+  private changeRunningQueryCount(dir: 1 | -1) {
+    /**
+     * Used by grafana-image-renderer to know when all queries are completed.
+     */
+    (window as any).__grafanaRunningQueryCount = ((window as any).__grafanaRunningQueryCount ?? 0) + dir;
   }
 
   public cancelAll() {


### PR DESCRIPTION
* First I created the query controller to use it in the image renderer to know when all queries are complete
* Then discovered puppeteer has a built in `page.waitForNetworkIdle({ timeout: options.timeout * 1000 });` that allow you to wait for network requests to finish so[ decided to use that ](https://github.com/grafana/grafana-image-renderer/pull/496/)
* Then I discovered we cannot use that approach as we have async data sources that make requests and then wait up 10 seconds  before fetching the results in a separate request (Athena) 
* Then tried to use a bit of logic inside runRequest to keep a counter of all requests in Loading state but that does not work for template variables (some do not go through runRequest)
* So we do have to use the QueryController 

Instead of grafana-image-renderer using window.__grafanaSceneContext directily (and findining the query controller behavior) I think it's better if the dependency there on a much simpler counter that we set from SceneQueryController  , that way we can change SceneQueryController state/logic without breaking image renderer 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.0--canary.593.7874607283.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.1.0--canary.593.7874607283.0
  # or 
  yarn add @grafana/scenes@3.1.0--canary.593.7874607283.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
