### PR TITLE
Variables: Clear current value when no options are returned

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -39,6 +39,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
 export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, key, maxVisibleValues, noValueOnClear } = model.useState();
   const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
+  const options = model.getOptionsForSelect();
 
   // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
   const [uncommittedValue, setUncommittedValue] = useState(arrayValue);
@@ -56,10 +57,12 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       }
     : undefined;
 
+  const placeholder = options.length > 0 ? 'Select value' : '';
+
   return (
     <MultiSelect<VariableValueSingle>
       id={key}
-      placeholder="Select value"
+      placeholder={placeholder}
       width="auto"
       value={uncommittedValue}
       // TODO remove after grafana/ui upgrade to 10.3

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -61,6 +61,39 @@ describe('MultiValueVariable', () => {
       expect(variable.state.text).toBe('A');
     });
 
+    it('Should set to empty when no options are returned', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [],
+        value: 'A',
+        text: 'A',
+        delayMs: 0,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toBe('');
+      expect(variable.state.text).toBe('');
+    });
+
+    it('Should set to empty arrauy when no options are returned and variable isMulti', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [],
+        value: ['A'],
+        text: ['A'],
+        delayMs: 0,
+        isMulti: true,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toEqual([]);
+      expect(variable.state.text).toEqual([]);
+    });
+
     it('When saved value is same as text representation', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -77,7 +77,7 @@ describe('MultiValueVariable', () => {
       expect(variable.state.text).toBe('');
     });
 
-    it('Should set to empty arrauy when no options are returned and variable isMulti', async () => {
+    it('Should set to empty array when no options are returned and variable isMulti', async () => {
       const variable = new TestVariable({
         name: 'test',
         options: [],

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -89,6 +89,12 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       if (this.state.defaultToAll || this.state.includeAll) {
         stateUpdate.value = ALL_VARIABLE_VALUE;
         stateUpdate.text = ALL_VARIABLE_TEXT;
+      } else if (this.state.isMulti) {
+        stateUpdate.value = [];
+        stateUpdate.text = [];
+      } else {
+        stateUpdate.value = '';
+        stateUpdate.text = '';
       }
     } else if (this.hasAllValue()) {
       // If value is set to All then we keep it set to All but just store the options
@@ -115,7 +121,6 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       if (matchingOption) {
         // When updating the initial state from URL the text property is set the same as value
         // Here we can correct the text value state
-
         stateUpdate.text = matchingOption.label;
         stateUpdate.value = matchingOption.value;
       } else {
@@ -172,8 +177,10 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
   public getDefaultMultiState(options: VariableValueOption[]) {
     if (this.state.defaultToAll) {
       return { value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] };
-    } else {
+    } else if (options.length > 0) {
       return { value: [options[0].value], text: [options[0].label] };
+    } else {
+      return { value: [], text: [] };
     }
   }
 


### PR DESCRIPTION
Replicating the current logic of the old variable system: https://github.com/grafana/grafana/blob/6c42bd31c63d818fe74e50ea4ef684f849a544e0/public/app/features/variables/query/reducer.ts#L168 

Sets the value to `''` and text to 'None' , but I think setting both text and value to `''` is probably best 

# Release notes

All variables that extend from MultValueVariable (Query, DataSource, Custom) now clear the current value if no options / values are returned by query, clears to empty string or array depending on multi or not. 