### PR TITLE
SceneQueryRunner: Improved way to detect changes to adhoc filters and group by variables

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -293,8 +293,6 @@ describe('SceneQueryRunner', () => {
         body: new SceneCanvasText({ text: 'hello' }),
       });
 
-      expect(queryRunner.state.data).toBeUndefined();
-
       activateFullSceneTree(scene);
 
       await new Promise((r) => setTimeout(r, 1));
@@ -312,6 +310,34 @@ describe('SceneQueryRunner', () => {
 
       const runRequestCall2 = runRequestMock.mock.calls[1];
       expect(runRequestCall2[1].filters).toEqual(filtersVar.state.filters);
+    });
+
+    it('Adhoc filter added after first query', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const scene = new EmbeddedScene({ $data: queryRunner, body: new SceneCanvasText({ text: 'hello' }) });
+      activateFullSceneTree(scene);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const filtersVar = new AdHocFiltersVariable({
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [],
+      });
+
+      scene.setState({ $variables: new SceneVariableSet({ variables: [filtersVar] }) });
+      filtersVar.activate();
+
+      filtersVar.setState({ filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }] });
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[1];
+      expect(runRequestCall[1].filters).toEqual(filtersVar.state.filters);
     });
 
     it('should pass group by dimensions via request object', async () => {

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -30,6 +30,11 @@ interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
    *    after any variable update completes. This is to cover scenarios where an object is waiting for indirect dependencies to complete.
    */
   onVariableUpdateCompleted?: () => void;
+
+  /**
+   * Optional way to subscribe to all variable value changes, even to variables that are not dependencies.
+   */
+  onAnyVariableChanged?: (variable: SceneVariable) => void;
 }
 
 export class VariableDependencyConfig<TState extends SceneObjectState> implements SceneVariableDependencyConfigLike {
@@ -72,6 +77,10 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
       dependencyChanged,
       this._isWaitingForVariables
     );
+
+    if (this._options.onAnyVariableChanged) {
+      this._options.onAnyVariableChanged(variable);
+    }
 
     // If custom handler called when dependency is changed or when we are waiting for variables
     if (this._options.onVariableUpdateCompleted && (this._isWaitingForVariables || dependencyChanged)) {


### PR DESCRIPTION
* Now handles adhoc filters / group bys that are added after the first query
* Now handles adhoc filters / group by that are removed and re-added (so different instance) 
* Now handles adhoc filters / group by value changes that happen while inactive 

 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.0--canary.596.7890015712.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.2.0--canary.596.7890015712.0
  # or 
  yarn add @grafana/scenes@3.2.0--canary.596.7890015712.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
