### PR TITLE
VariableDependencyConfig can extract variables from circular structures

### DIFF
--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -11,8 +11,22 @@ export function isVariableValueEqual(a: VariableValue | null | undefined, b: Var
 }
 
 export function safeStringifyValue(value: unknown) {
+  // Avoid circular references ignoring those references
+  const getCircularReplacer = () => {
+    const seen = new WeakSet();
+    return (_: string, value: object | null) => {
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) {
+          return;
+        }
+        seen.add(value);
+      }
+      return value;
+    };
+  };
+
   try {
-    return JSON.stringify(value, null);
+    return JSON.stringify(value, getCircularReplacer());
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
It is hardening the stringifying of the JSON to avoid circular dependencies.

The object can contain circular structures when extracting variables from a value object. For example, references to the parent object. See [this](https://drone.grafana.net/grafana/grafana/160784/1/6).