### PR TITLE
VariableDependencyConfig: do not scan state if `variableNames` is defined

### DIFF
--- a/packages/scenes/src/variables/VariableDependencyConfig.test.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.test.ts
@@ -77,6 +77,16 @@ describe('VariableDependencyConfig', () => {
     expect(deps.scanCount).toBe(2);
   });
 
+  it('Should not scan the state if variable name defined', () => {
+    const sceneObj = new TestObj();
+    sceneObj.setState({ query: 'new query with ${newVar}' });
+    const deps = new VariableDependencyConfig(sceneObj, { variableNames: ['nonExistentVar'] });
+    deps.getNames();
+
+    expect(deps.getNames()).toEqual(new Set(['nonExistentVar']));
+    expect(deps.scanCount).toBe(1);
+  });
+
   it('variableValuesChanged should only call onReferencedVariableValueChanged if dependent variable has changed', () => {
     const sceneObj = new TestObj();
     const fn = jest.fn();

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -156,17 +156,17 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
       for (const name of this._options.variableNames) {
         this._dependencies.add(name);
       }
-    }
-
-    if (this._statePaths) {
-      for (const path of this._statePaths) {
-        const value = state[path];
-        if (value) {
-          this.extractVariablesFrom(value);
-        }
-      }
     } else {
-      this.extractVariablesFrom(state);
+      if (this._statePaths) {
+        for (const path of this._statePaths) {
+          const value = state[path];
+          if (value) {
+            this.extractVariablesFrom(value);
+          }
+        }
+      } else {
+        this.extractVariablesFrom(state);
+      }
     }
   }
 


### PR DESCRIPTION
**Problem:**
If `variableNames` is defined, means the dependencies are explicit, so the state shouldn't be checked. This was causing a circular dependency here https://github.com/grafana/grafana/pull/81318

**Solution**
Do not check the state if `variableNames` is defined 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.1--canary.598.7892152279.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.2.1--canary.598.7892152279.0
  # or 
  yarn add @grafana/scenes@3.2.1--canary.598.7892152279.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
