### PR TITLE
SceneQueryController: Fixes double complete counting

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.test.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.test.ts
@@ -21,17 +21,34 @@ describe('SceneQueryController', () => {
     let next = jest.fn();
     let complete = jest.fn();
 
-    const sub1 = query.subscribe({ next, complete });
+    query.subscribe({ next, complete });
 
-    next({ state: LoadingState.Loading });
-    complete();
+    streamFuncs.next({ state: LoadingState.Loading });
+    streamFuncs.complete();
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(complete).toHaveBeenCalledTimes(1);
-    expect(streamFuncs.cleanup).toHaveBeenCalledTimes(0);
-
-    sub1.unsubscribe();
     expect(streamFuncs.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mark query as complete when packet sent with state != Loading', async () => {
+    const { query, streamFuncs } = registerQuery(scene);
+    let next = jest.fn();
+    let complete = jest.fn();
+
+    query.subscribe({ next, complete });
+
+    expect((window as any).__grafanaRunningQueryCount).toBe(1);
+    expect(controller.state.isRunning).toBe(true);
+
+    streamFuncs.next({ state: LoadingState.Done });
+
+    expect((window as any).__grafanaRunningQueryCount).toBe(0);
+    expect(controller.state.isRunning).toBe(false);
+
+    streamFuncs.complete();
+
+    expect((window as any).__grafanaRunningQueryCount).toBe(0);
   });
 
   it('Last unsubscribe should set running to false', async () => {

--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -60,6 +60,10 @@ export class SceneQueryController
   }
 
   public queryCompleted(entry: SceneQueryControllerEntry) {
+    if (!this.#running.has(entry)) {
+      return;
+    }
+
     this.#running.delete(entry);
 
     this.changeRunningQueryCount(-1);

--- a/packages/scenes/src/querying/registerQueryWithController.ts
+++ b/packages/scenes/src/querying/registerQueryWithController.ts
@@ -19,10 +19,12 @@ export function registerQueryWithController<T extends QueryResultWithState>(entr
       }
 
       queryControler.queryStarted(entry);
+      let markedAsCompleted = false;
 
       const sub = queryStream.subscribe({
         next: (v) => {
-          if (v.state !== LoadingState.Loading) {
+          if (!markedAsCompleted && v.state !== LoadingState.Loading) {
+            markedAsCompleted = true;
             queryControler.queryCompleted(entry);
           }
 
@@ -36,7 +38,10 @@ export function registerQueryWithController<T extends QueryResultWithState>(entr
 
       return () => {
         sub.unsubscribe();
-        queryControler.queryCompleted(entry);
+
+        if (!markedAsCompleted) {
+          queryControler.queryCompleted(entry);
+        }
       };
     });
   };


### PR DESCRIPTION
Fixes a bug in SceneQueryController that resulted in negative __grafanaRunningQueryCount due to double counting completed queries. 

This is caused by wrapper calling queryCompleted on first packet with state != LoadingState.Done (needed for some data sources who's observable never really completes), and we called queryCompleted on observable complete. 

Added a simple check in queryCompleted that the query is part of the running set, now we only try to remove it once and decrement __grafanaRunningQueryCount once 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.3.1--canary.600.7900942701.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.3.1--canary.600.7900942701.0
  # or 
  yarn add @grafana/scenes@3.3.1--canary.600.7900942701.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
