### PR TITLE
SceneQueryRunner: Add query caching options

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -149,6 +149,8 @@ describe('SceneQueryRunner', () => {
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A' }],
         $timeRange: new SceneTimeRange(),
+        cacheTimeout: '30',
+        queryCachingTTL: 300000,
       });
 
       queryRunner.activate();
@@ -168,11 +170,13 @@ describe('SceneQueryRunner', () => {
       expect(request).toMatchInlineSnapshot(`
         {
           "app": "scenes",
+          "cacheTimeout": "30",
           "interval": "30s",
           "intervalMs": 30000,
           "liveStreaming": undefined,
           "maxDataPoints": 500,
           "panelId": 1,
+          "queryCachingTTL": 300000,
           "range": {
             "from": "2023-07-11T02:18:08.000Z",
             "raw": {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -57,6 +57,8 @@ export interface QueryRunnerState extends SceneObjectState {
   maxDataPoints?: number;
   liveStreaming?: boolean;
   maxDataPointsFromWidth?: boolean;
+  cacheTimeout?: DataQueryRequest['cacheTimeout'];
+  queryCachingTTL?: DataQueryRequest['queryCachingTTL'];
   // Filters to be applied to data layer results before combining them with SQR results
   dataLayerFilter?: DataLayerFilter;
   // Private runtime state
@@ -453,6 +455,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
         from: timeRange.state.from,
         to: timeRange.state.to,
       },
+      cacheTimeout: this.state.cacheTimeout,
+      queryCachingTTL: this.state.queryCachingTTL,
       // This asks the scene root to provide context properties like app, panel and dashboardUID
       ...getEnrichedDataRequest(this),
     };


### PR DESCRIPTION
Adds query caching options to the SQR API.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.5.0--canary.603.7902695293.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.5.0--canary.603.7902695293.0
  # or 
  yarn add @grafana/scenes@3.5.0--canary.603.7902695293.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
