### PR TITLE
VizPanel: Fixes issue with non memoizable PanelData

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -421,6 +421,18 @@ describe('VizPanel', () => {
   describe('Data support', () => {
     let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
 
+    it('apply field config should return same data if called multiple times with same data', async () => {
+      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({ pluginId: 'custom-plugin-id' });
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+      await Promise.resolve();
+
+      const data = getTestData();
+      const dataWithFieldConfig1 = panel.applyFieldConfig(data);
+      const dataWithFieldConfig2 = panel.applyFieldConfig(data);
+      expect(dataWithFieldConfig1).toBe(dataWithFieldConfig2);
+    });
+
     it('should not provide alert states and annotations by default', async () => {
       panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({ pluginId: 'custom-plugin-id' });
       pluginToLoad = getTestPlugin1();

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -296,6 +296,11 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       return emptyPanelData;
     }
 
+    // If the data is the same as last time, we can skip the field config apply step and just return same result as last time
+    if (this._prevData === rawData && this._dataWithFieldConfig) {
+      return this._dataWithFieldConfig;
+    }
+
     const pluginDataSupport: PanelPluginDataSupport = plugin.dataSupport || { alertStates: false, annotations: false };
 
     const fieldConfigRegistry = plugin.fieldConfigRegistry;
@@ -343,6 +348,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       this._dataWithFieldConfig.annotations = undefined;
     }
 
+    this._prevData = rawData;
     return this._dataWithFieldConfig;
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/590

Fixes an issue with panels that use the panel data frames or fields as memoizable instance references. Since applyFieldConfig always returned new frames a simple resize invalidated the memoization used by the TracesPanel 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.6.1--canary.609.7970792291.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.6.1--canary.609.7970792291.0
  # or 
  yarn add @grafana/scenes@3.6.1--canary.609.7970792291.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
