### PR TITLE
VizPanel: Pass container width to data provider always

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -17,7 +17,6 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     options,
     fieldConfig,
     _pluginLoadError,
-    $data,
     displayMode,
     hoverHeader,
     menu,
@@ -52,8 +51,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const PanelComponent = plugin.panel;
 
   // If we have a query runner on our level inform it of the container width (used to set auto max data points)
-  if ($data && $data.setContainerWidth) {
-    $data.setContainerWidth(Math.round(width));
+  if (dataObject && dataObject.setContainerWidth) {
+    dataObject.setContainerWidth(Math.round(width));
   }
 
   let titleItemsElement: React.ReactNode[] = [];


### PR DESCRIPTION
For panel edit we need to move data provider to the parent of VizPanel, but still need VizPanel to provider the container width. So changing this logic to always call setContainerWidth on the data provider, not only when it's the data provider is defined on the same level as the VizPanel