### PR TITLE
Variables: Support static keys in AdHocFiltersVariable

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -191,6 +191,28 @@ describe('AdHocFiltersVariable', () => {
     ]);
   });
 
+  it('Can override with static keys', async () => {
+    const { filtersVar } = setup({
+      staticKeys: [{
+        text: 'some',
+        value: '1',
+      }, {
+        text: 'static',
+        value: '2',
+      }, {
+        text: 'keys',
+        value: '3',
+      }],
+    });
+
+    const keys = await filtersVar._getKeys(null);
+    expect(keys).toEqual([
+      { label: 'some', value: '1' },
+      { label: 'static', value: '2' },
+      { label: 'keys', value: '3' },
+    ]);
+  });
+
   it('Can filter by regex', async () => {
     const { filtersVar } = setup({
       tagKeyRegexFilter: new RegExp('x.*'),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -191,9 +191,9 @@ describe('AdHocFiltersVariable', () => {
     ]);
   });
 
-  it('Can override with static keys', async () => {
+  it('Can override with default keys', async () => {
     const { filtersVar } = setup({
-      staticKeys: [{
+      defaultKeys: [{
         text: 'some',
         value: '1',
       }, {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -53,6 +53,12 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   getTagValuesProvider?: getTagValuesProvider;
 
   /**
+   * Optionally provide an array of static keys that override getTagKeys
+   * TODO can we remove this?
+   */
+  staticKeys?: MetricFindValue[];
+
+  /**
    * This is the expression that the filters resulted in. Defaults to
    * Prometheus / Loki compatible label filter expression
    */
@@ -184,6 +190,10 @@ export class AdHocFiltersVariable
 
     if (override && override.replace) {
       return override.values.map(toSelectableValue);
+    }
+
+    if (this.state.staticKeys) {
+      return this.state.staticKeys.map(toSelectableValue);
     }
 
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -54,7 +54,6 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
 
   /**
    * Optionally provide an array of static keys that override getTagKeys
-   * TODO can we remove this?
    */
   staticKeys?: MetricFindValue[];
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -57,7 +57,7 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   /**
    * Optionally provide an array of static keys that override getTagKeys
    */
-  staticKeys?: MetricFindValue[];
+  defaultKeys?: MetricFindValue[];
 
   /**
    * This is the expression that the filters resulted in. Defaults to
@@ -193,8 +193,8 @@ export class AdHocFiltersVariable
       return override.values.map(toSelectableValue);
     }
 
-    if (this.state.staticKeys) {
-      return this.state.staticKeys.map(toSelectableValue);
+    if (this.state.defaultKeys) {
+      return this.state.defaultKeys.map(toSelectableValue);
     }
 
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);


### PR DESCRIPTION
- supports a new optional prop on `AdHocFiltersVariable`: `defaultKeys` 
- these default keys are then returned by `getTagKeys`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.11.0--canary.612.8230146272.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.11.0--canary.612.8230146272.0
  # or 
  yarn add @grafana/scenes@3.11.0--canary.612.8230146272.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
