### PR TITLE
Legend sorting fix

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -410,7 +410,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     this.onOptionsChange({
       ...this.state.options,
       legend: { ...legendOptions, sortBy, sortDesc },
-    } as TOptions);
+    } as TOptions, true);
   };
 
   private buildPanelContext(): PanelContext {


### PR DESCRIPTION
So the legend options get changed based on which sorting should be applied but in case of no sorting the values for `sortBy` and `sortDesc` are undefined. 
This then turns into a problem here:
https://github.com/grafana/scenes/blob/efa082d3c27452f4ad6504d8784cea72c2e62a31/packages/scenes/src/components/VizPanel/VizPanel.tsx#L236

since after  `mergeWIth`  the target properties are used.

I changed the `replace` to true, skipping the `mergeWith` because I did not want to break some other logic in `onOptionsChange`

