### PR TITLE
feat: allow label for adhoc filter add button

### DIFF
--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -1,3 +1,4 @@
+import { VariableHide } from '@grafana/data';
 import {
   SceneFlexLayout,
   SceneTimeRange,
@@ -111,6 +112,80 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
           });
         },
       }),
+
+      new SceneAppPage({
+        title: 'Vertical Variants',
+        url: `${defaults.url}/vertical`,
+        getScene: () => {
+          return new EmbeddedScene({
+            ...getEmbeddedSceneDefaults(),
+            $variables: new SceneVariableSet({
+              variables: [
+                new AdHocFiltersVariable({
+                  name: 'no-button-text',
+                  layout: 'vertical',
+                  label: 'Without add filter button text',
+                  hide: VariableHide.hideLabel,
+                  datasource: { uid: 'gdev-prometheus' },
+                  filters: [{ key: 'job', operator: '=', value: 'has no text', condition: '' }],
+                }),
+                new AdHocFiltersVariable({
+                  name: 'button-text',
+                  layout: 'vertical',
+                  label: 'With add filter button text',
+                  hide: VariableHide.hideLabel,
+                  addFilterButtonText: "Add a filter",
+                  datasource: { uid: 'gdev-prometheus' },
+                  filters: [{ key: 'job', operator: '=', value: 'has text on add button', condition: '' }],
+                }),
+
+                new AdHocFiltersVariable({
+                  name: 'button-text',
+                  layout: 'vertical',
+                  label: 'With add filter button text',
+                  hide: VariableHide.hideLabel,
+                  addFilterButtonText: "Filter",
+                  datasource: { uid: 'gdev-prometheus' },
+                  filters: [{ key: 'job', operator: '=', value: 'also has text on add button', condition: '' }],
+                }),
+
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  ySizing: 'content',
+                  body: new SceneCanvasText({
+                    text: `Using AdHocFilterSet in manual mode allows you to use it as a normal variable. The query below is interpolated to ALERTS{$Filters}`,
+                    fontSize: 14,
+                  }),
+                }),
+                new SceneFlexItem({
+                  body: PanelBuilders.table()
+                    .setTitle('ALERTS')
+                    .setData(
+                      new SceneQueryRunner({
+                        datasource: { uid: 'gdev-prometheus' },
+                        queries: [
+                          {
+                            refId: 'A',
+                            expr: 'ALERTS{$Filters}',
+                            format: 'table',
+                            instant: true,
+                          },
+                        ],
+                      })
+                    )
+                    .build(),
+                }),
+              ],
+            }),
+            $timeRange: new SceneTimeRange(),
+          });
+        },
+      }),
+
     ],
   });
 }

--- a/packages/scenes/src/variables/adhoc/AdHocFilterBuilder.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterBuilder.tsx
@@ -6,9 +6,10 @@ import { Button } from '@grafana/ui';
 
 interface Props {
   model: AdHocFiltersVariable;
+  addFilterButtonText?: string;
 }
 
-export function AdHocFilterBuilder({ model }: Props) {
+export function AdHocFilterBuilder({ model, addFilterButtonText }: Props) {
   const { _wip } = model.useState();
 
   if (!_wip) {
@@ -20,7 +21,7 @@ export function AdHocFilterBuilder({ model }: Props) {
         aria-label="Add filter"
         data-testid={`AdHocFilter-add`}
         onClick={() => model._addWip()}
-      />
+      >{addFilterButtonText}</Button>
     );
   }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -16,6 +16,8 @@ import { AdHocFiltersVariableUrlSyncHandler } from './AdHocFiltersVariableUrlSyn
 import { css } from '@emotion/css';
 
 export interface AdHocFiltersVariableState extends SceneVariableState {
+  /** Optional text to display on the 'add filter' button */
+  addFilterButtonText?: string;
   /** The visible filters */
   filters: AdHocVariableFilter[];
   /** Base filters to always apply when looking up keys*/
@@ -277,7 +279,7 @@ function renderExpression(state: Partial<AdHocFiltersVariableState>) {
 }
 
 export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHocFiltersVariable>) {
-  const { filters, readOnly } = model.useState();
+  const { filters, readOnly, addFilterButtonText } = model.useState();
   const styles = useStyles2(getStyles);
 
   return (
@@ -288,7 +290,7 @@ export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHo
         </React.Fragment>
       ))}
 
-      {!readOnly && <AdHocFilterBuilder model={model} key="'builder" />}
+      {!readOnly && <AdHocFilterBuilder model={model} key="'builder" addFilterButtonText={addFilterButtonText}/>}
     </div>
   );
 }


### PR DESCRIPTION

![image](https://github.com/grafana/scenes/assets/38694490/cf30f60f-bf65-4202-8d95-b443ebd85f33)


- Includes an optional `addFilterButtonText` field
- Added a tab of "vertical variants" to the adhoc filter demo page