### PR TITLE
Style rows to show actions on entire group hover

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -70,8 +70,11 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
 
 export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow>) {
   const styles = useStyles2(getSceneGridRowStyles);
-  const { isCollapsible, isCollapsed, title, isDraggable, actions } = model.useState();
+  const { isCollapsible, isCollapsed, title, isDraggable, actions, children } = model.useState();
   const layoutDragClass = model.getGridLayout().getDragClass();
+
+  const count = children ? children.length : 0;
+  const panels = count === 1 ? 'panel' : 'panels';
 
   return (
     <div className={cx(styles.row, isCollapsed && styles.rowCollapsed)}>
@@ -86,7 +89,14 @@ export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow
             {sceneGraph.interpolate(model, title, undefined, 'text')}
           </span>
         </button>
-        {actions && <actions.Component model={actions} />}
+        <span className={cx(styles.panelCount, isCollapsed && styles.panelCountCollapsed)}>
+          ({count} {panels})
+        </span>
+        {actions && 
+          <div className={styles.rowActions}>
+            <actions.Component model={actions} />
+          </div>
+        }
       </div>
       {isDraggable && isCollapsed && (
         <div className={cx(styles.dragHandle, layoutDragClass)}>
@@ -130,6 +140,21 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
     }),
     rowTitleAndActionsGroup: css({
       display: 'flex',
+
+      '&:hover, &:focus-within': {
+        '& > div': {
+          opacity: 1,
+        }
+      },
+    }),
+    rowActions: css({
+      display: 'flex',
+      opacity: 0,
+      transition: '200ms opacity ease-in 200ms',
+
+      '&:hover, &:focus-within': {
+        opacity: 1,
+      },
     }),
     dragHandle: css({
       display: 'flex',
@@ -141,6 +166,18 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
       '&:hover': {
         color: theme.colors.text.primary,
       },
+    }),
+    panelCount: css({
+      paddingLeft: theme.spacing(2),
+      color: theme.colors.text.secondary,
+      fontStyle: 'italic',
+      fontSize: theme.typography.size.sm,
+      fontWeight: 'normal',
+      display: 'none',
+      lineHeight: '30px',
+    }),
+    panelCountCollapsed: css({
+      display: 'inline-block',
     }),
   };
 };


### PR DESCRIPTION
In the old arch, hovering over the row title area would show the actions. To achieve this we need to refactor some things around the `SceneGridRow`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.8.2--canary.625.8111759979.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.8.2--canary.625.8111759979.0
  # or 
  yarn add @grafana/scenes@3.8.2--canary.625.8111759979.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
