### PR TITLE
Rows are draggable when scene layout is draggable

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -70,8 +70,10 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
 
 export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow>) {
   const styles = useStyles2(getSceneGridRowStyles);
-  const { isCollapsible, isCollapsed, title, isDraggable, actions } = model.useState();
-  const layoutDragClass = model.getGridLayout().getDragClass();
+  const { isCollapsible, isCollapsed, title, actions } = model.useState();
+  const layout = model.getGridLayout();
+  const layoutDragClass = layout.getDragClass();
+  const isDraggable = layout.isDraggable();
 
   return (
     <div className={cx(styles.row, isCollapsed && styles.rowCollapsed)}>


### PR DESCRIPTION
The grid row has a `isDraggable` prop that seems like it's not set anywhere. We can maybe make use of the parent layout to determine whether a row is draggable and remove that prop? Or set that one if it makes more sense. Not sure what approach is better.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.8.2--canary.626.8137562729.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.8.2--canary.626.8137562729.0
  # or 
  yarn add @grafana/scenes@3.8.2--canary.626.8137562729.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
