### PR TITLE
Scenes: Logic for dragging a row within another row

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -292,8 +292,6 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 
     this.setState({ children: sortChildrenByPosition(newChildren) });
     this._skipOnLayoutChange = true;
-
-    console.log(this.state);
   };
 
   private toGridCell(child: SceneGridItemLike): ReactGridLayout.Layout {


### PR DESCRIPTION
This PR fixes the case where a row is dragged in the area of another row. Before this, dragging a row within another row would parent that row to the upper row, which caused the `SceneGridRow` to throw a `SceneGridRow must be a child of SceneGridLayout` error and crashed the dashboard. 

In the old arch, doing this would keep the row at the layout level and split the children panels in the new rows based on where the new row would be dropped (e.g.: if a row would be drag and dropped after the first child panel of another row that contained 3 panels, then the old row would have the one panel below it, until the new panel, and the new row would now hold the other 2 panels)

WIP, I haven't tested it extensively.

TODO: Write some tests for this.


https://github.com/grafana/scenes/assets/36818606/7a960d91-9832-42c2-9b30-9a349ff49fc4

