### PR TITLE
SceneObjectBase: Call self activation handlers before child data, time range and variable handlers

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -125,6 +125,25 @@ describe('SceneObject', () => {
     });
   });
 
+  describe('Should activate itself before child objects', () => {
+    const dataChild = new SceneDataNode({});
+    const scene = new TestScene({
+      $data: dataChild,
+    });
+
+    let parentActive = false;
+
+    scene.addActivationHandler(() => {
+      parentActive = true;
+    });
+
+    dataChild.addActivationHandler(() => {
+      expect(parentActive).toBe(true);
+    });
+
+    scene.activate();
+  });
+
   describe('When deactivated', () => {
     const scene = new TestScene({
       $data: new SceneDataNode({}),
@@ -260,13 +279,15 @@ describe('SceneObject', () => {
       expect(deactivatedCounter).toBe(1);
     });
 
-    it('Cannot call deactivation function twice', () => {
-      const scene = new TestScene({ name: 'nested' });
+    describe('When calling deactivation function twice', () => {
+      it('should throw error', () => {
+        const scene = new TestScene({ name: 'nested' });
 
-      const deactivateScene = scene.activate();
-      deactivateScene();
+        const deactivateScene = scene.activate();
+        deactivateScene();
 
-      expect(() => deactivateScene()).toThrow();
+        expect(() => deactivateScene()).toThrow();
+      });
     });
   });
 });

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -194,6 +194,13 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
 
     const { $data, $variables, $timeRange, $behaviors } = this.state;
 
+    this._activationHandlers.forEach((handler) => {
+      const result = handler();
+      if (result) {
+        this._deactivationHandlers.set(result, result);
+      }
+    });
+
     if ($timeRange && !$timeRange.isActive) {
       this._deactivationHandlers.set($timeRange, $timeRange.activate());
     }
@@ -218,13 +225,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
         }
       }
     }
-
-    this._activationHandlers.forEach((handler) => {
-      const result = handler();
-      if (result) {
-        this._deactivationHandlers.set(result, result);
-      }
-    });
   }
 
   /**
@@ -246,7 +246,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
 
       if (called) {
         const msg = `SceneObject cancelation handler returned by activate() called a second time`;
-        console.error(msg, this);
         throw new Error(msg);
       }
 

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.ts
@@ -1,4 +1,4 @@
-import { arrayToDataFrame, DataTopic, AnnotationQuery } from '@grafana/data';
+import { arrayToDataFrame, DataTopic, AnnotationQuery, ScopedVars } from '@grafana/data';
 import { LoadingState } from '@grafana/schema';
 import { map, Unsubscribable } from 'rxjs';
 import { emptyPanelData } from '../../../core/SceneDataNode';
@@ -20,6 +20,7 @@ export class AnnotationsDataLayer
   extends SceneDataLayerBase<AnnotationsDataLayerState>
   implements SceneDataLayerProvider
 {
+  private _scopedVars: ScopedVars = { __sceneObject: { value: this, text: '__sceneObject' } };
   private _timeRangeSub: Unsubscribable | undefined;
   public topic = DataTopic.Annotations;
 
@@ -99,7 +100,7 @@ export class AnnotationsDataLayer
   }
 
   protected async resolveDataSource(query: AnnotationQuery) {
-    return await getDataSource(query.datasource || undefined, {});
+    return await getDataSource(query.datasource || undefined, this._scopedVars);
   }
 
   protected processEvents(query: AnnotationQuery, events: AnnotationQueryResults) {


### PR DESCRIPTION
I noticed a bug in scenes dashboards with AnnotationDataLayer not working with data source variables, resulting in error `AnnotationsDataLayer.js:95 AnnotationsDataLayer error {message: 'Datasource ${ds} was not found'}` 

I tracked it down to an issue with scene $data, $timeRange and $variables being activated before the local (own) level activation handlers. Resulting in data layers on the top dashboard level being activated before the dashboard scene itself (that sets the window.__grafanaSceneContext without this the variable system is not working (because scopedVars with sceneObject was not passed in AnnotationsDataLayer)

Changes

* Call own local level activation handlers before calling $data, $timeRange, $variables and $behaviors activation handlers
* Pass scopedVars with context when getting data source in AnnotationsDataLayer 

# Release notes

Activation handlers are for a scene object is now called before any direct child activation handlers. Before this release the activation handlers of direction $data, $timeRange, $variables and $behaviors was called before the SceneObjects own activation handlers. 