### PR TITLE
VariableDependencyConfig: Fixes support for explicit dependencies and scanned dependencies

### DIFF
--- a/packages/scenes/src/variables/VariableDependencyConfig.test.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.test.ts
@@ -85,7 +85,7 @@ describe('VariableDependencyConfig', () => {
     expect(deps.scanCount).toBe(2);
   });
 
-  it('Should not scan the state if variable name defined', () => {
+  it('Should not scan the state if no statePaths defined', () => {
     const sceneObj = new TestObj();
     sceneObj.setState({ query: 'new query with ${newVar}' });
     const deps = new VariableDependencyConfig(sceneObj, { variableNames: ['nonExistentVar'] });
@@ -107,18 +107,14 @@ describe('VariableDependencyConfig', () => {
     expect(fn.mock.calls.length).toBe(1);
   });
 
-  it('Can update explicit depenendencies', () => {
+  it('Can update explicit depenendencies and scan for variables', () => {
     const sceneObj = new TestObj();
-    const fn = jest.fn();
-    const deps = new VariableDependencyConfig(sceneObj, { onReferencedVariableValueChanged: fn, statePaths: ['*'] });
+    const deps = new VariableDependencyConfig(sceneObj, { statePaths: ['*'] });
 
-    deps.variableUpdateCompleted(new ConstantVariable({ name: 'not-dep', value: '1' }), true);
-    expect(fn.mock.calls.length).toBe(0);
+    expect(deps.getNames()).toEqual(new Set(['queryVarA', 'queryVarB', 'otherPropA', 'nestedVarA']));
 
-    deps.setVariableNames(['not-dep']);
-    deps.variableUpdateCompleted(new ConstantVariable({ name: 'not-dep', value: '1' }), true);
-
-    expect(fn.mock.calls.length).toBe(1);
+    deps.setVariableNames(['explicitDep']);
+    expect(deps.getNames()).toEqual(new Set(['explicitDep', 'queryVarA', 'queryVarB', 'otherPropA', 'nestedVarA']));
   });
 
   describe('Should remember when an object is waiting for variables', () => {

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -156,17 +156,17 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
       for (const name of this._options.variableNames) {
         this._dependencies.add(name);
       }
-    } else {
-      if (this._statePaths) {
-        for (const path of this._statePaths) {
-          if (path === '*') {
-            this.extractVariablesFrom(state);
-            break;
-          } else {
-            const value = state[path];
-            if (value) {
-              this.extractVariablesFrom(value);
-            }
+    }
+
+    if (this._statePaths) {
+      for (const path of this._statePaths) {
+        if (path === '*') {
+          this.extractVariablesFrom(state);
+          break;
+        } else {
+          const value = state[path];
+          if (value) {
+            this.extractVariablesFrom(value);
           }
         }
       }


### PR DESCRIPTION
Missed the if/else logic in https://github.com/grafana/scenes/pull/598 

We need to support both explicit and scanned dependencies 

Fixes #629