### PR TITLE
Fix bug where SceneQueryRunner ignores variable dependencies if AdHocFilter is present

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -601,7 +601,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       explicitDependencies.push(this._groupByVar.state.name);
     }
 
-    this._variableDependency.setVariableNames(explicitDependencies);
+    this._variableDependency.setExtraVariableNames(explicitDependencies);
   }
 }
 

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -18,6 +18,11 @@ interface VariableDependencyConfigOptions<TState extends SceneObjectState> {
   variableNames?: string[];
 
   /**
+   * Additiona list of variable names to depend on, in addition to those extracted from state.
+   */
+  extraVariableNames?: string[];
+
+  /**
    * Optional way to customize how to handle when a dependent variable changes
    * If not specified the default behavior is to trigger a re-render
    */
@@ -144,6 +149,11 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
     this.scanStateForDependencies(this._state!);
   }
 
+  public setExtraVariableNames(varNames: string[]) {
+    this._options.extraVariableNames = varNames;
+    this.scanStateForDependencies(this._state!);
+  }
+
   public setPaths(paths: Array<keyof TState | '*'>) {
     this._statePaths = paths;
   }
@@ -151,6 +161,12 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
   private scanStateForDependencies(state: TState) {
     this._dependencies.clear();
     this.scanCount += 1;
+
+    if (this._options.extraVariableNames) {
+      for (const name of this._options.extraVariableNames) {
+        this._dependencies.add(name);
+      }
+    }
 
     if (this._options.variableNames) {
       for (const name of this._options.variableNames) {


### PR DESCRIPTION
Fixes bug where `SceneQueryRunner` will not react to variables extracted from query / datasource props if `AdHocFilterVariable` is present in hierarchy. See bug for issue below for details

Fixes #629 