### PR TITLE
Revert "VizPanel: Fixes issue with non memoizable PanelData (#609)"

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -421,18 +421,6 @@ describe('VizPanel', () => {
   describe('Data support', () => {
     let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
 
-    it('apply field config should return same data if called multiple times with same data', async () => {
-      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({ pluginId: 'custom-plugin-id' });
-      pluginToLoad = getTestPlugin1();
-      panel.activate();
-      await Promise.resolve();
-
-      const data = getTestData();
-      const dataWithFieldConfig1 = panel.applyFieldConfig(data);
-      const dataWithFieldConfig2 = panel.applyFieldConfig(data);
-      expect(dataWithFieldConfig1).toBe(dataWithFieldConfig2);
-    });
-
     it('should not provide alert states and annotations by default', async () => {
       panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({ pluginId: 'custom-plugin-id' });
       pluginToLoad = getTestPlugin1();

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -296,11 +296,6 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       return emptyPanelData;
     }
 
-    // If the data is the same as last time, we can skip the field config apply step and just return same result as last time
-    if (this._prevData === rawData && this._dataWithFieldConfig) {
-      return this._dataWithFieldConfig;
-    }
-
     const pluginDataSupport: PanelPluginDataSupport = plugin.dataSupport || { alertStates: false, annotations: false };
 
     const fieldConfigRegistry = plugin.fieldConfigRegistry;
@@ -348,7 +343,6 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       this._dataWithFieldConfig.annotations = undefined;
     }
 
-    this._prevData = rawData;
     return this._dataWithFieldConfig;
   }
 


### PR DESCRIPTION
This reverts commit b6cea5657c9bb83f3cefd80ed7388a246e791472.

Unfortunately this PR was preventing the VizPanel from reflecting changes made to the field config during panel edit.