### PR TITLE
VizPanel: Fixes issue updating field config

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -356,8 +356,8 @@ describe('VizPanel', () => {
 
     test('Can toggle visibility on an off', () => {
       panel.applyFieldConfig(panel.state.$data?.state.data);
-
       panel.getPanelContext().onToggleSeriesVisibility!('B', SeriesVisibilityChangeMode.ToggleSelection);
+      panel.applyFieldConfig(panel.state.$data?.state.data);
       expect(panel.state.fieldConfig.overrides.length).toBe(1);
       panel.getPanelContext().onToggleSeriesVisibility!('B', SeriesVisibilityChangeMode.ToggleSelection);
       expect(panel.state.fieldConfig.overrides.length).toBe(0);
@@ -431,6 +431,20 @@ describe('VizPanel', () => {
       const dataWithFieldConfig1 = panel.applyFieldConfig(data);
       const dataWithFieldConfig2 = panel.applyFieldConfig(data);
       expect(dataWithFieldConfig1).toBe(dataWithFieldConfig2);
+    });
+
+    it('apply field config should return data with latest field config', async () => {
+      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({ pluginId: 'custom-plugin-id' });
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+      await Promise.resolve();
+
+      const data = getTestData();
+      const dataWithFieldConfig1 = panel.applyFieldConfig(data);
+      panel.onFieldConfigChange({ defaults: { unit: 'ms' }, overrides: [] });
+
+      const dataWithFieldConfig2 = panel.applyFieldConfig(data);
+      expect(dataWithFieldConfig1).not.toBe(dataWithFieldConfig2);
     });
 
     it('should not provide alert states and annotations by default', async () => {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -265,9 +265,8 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       isAfterPluginChange: false,
     });
 
-    this.setState({
-      fieldConfig: withDefaults.fieldConfig,
-    });
+    this._dataWithFieldConfig = undefined;
+    this.setState({ fieldConfig: withDefaults.fieldConfig });
   };
 
   public interpolate = ((value: string, scoped?: ScopedVars, format?: string | VariableCustomFormatterFn) => {
@@ -407,10 +406,13 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       sortBy = sortKey;
     }
 
-    this.onOptionsChange({
-      ...this.state.options,
-      legend: { ...legendOptions, sortBy, sortDesc },
-    } as TOptions, true);
+    this.onOptionsChange(
+      {
+        ...this.state.options,
+        legend: { ...legendOptions, sortBy, sortDesc },
+      } as TOptions,
+      true
+    );
   };
 
   private buildPanelContext(): PanelContext {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/83912 

Alternative fix (that does not restore old bug) of https://github.com/grafana/scenes/pull/633
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.9.2--canary.636.8171497001.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.9.2--canary.636.8171497001.0
  # or 
  yarn add @grafana/scenes@3.9.2--canary.636.8171497001.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
