### PR TITLE
LiveNow: Fix broken behavior

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -16,7 +16,6 @@ import {
   PluginType,
   renderMarkdown,
   PanelPluginDataSupport,
-  TimeRange,
 } from '@grafana/data';
 import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@grafana/ui';
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
@@ -214,7 +213,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   public getTimeRange = (data?: PanelData) => {
     const liveNowTimer = sceneGraph.findObject(this, (o) => o instanceof LiveNowTimer);
     const sceneTimeRange = sceneGraph.getTimeRange(this);
-    let timeRangeValue = sceneTimeRange.state.value
+    let timeRangeValue = sceneTimeRange.state.value;
     if (liveNowTimer instanceof LiveNowTimer && liveNowTimer.isEnabled) {
       timeRangeValue = evaluateTimeRange(
         sceneTimeRange.state.from,

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -33,7 +33,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const dataWithFieldConfig = model.applyFieldConfig(rawData.data!);
   const sceneTimeRange = sceneGraph.getTimeRange(model);
   const timeZone = sceneTimeRange.getTimeZone();
-  const timeRange = model.getTimeRange();
+  const timeRange = model.getTimeRange(dataWithFieldConfig);
 
   // Interpolate title
   const titleInterpolated = model.interpolate(title, undefined, 'text');


### PR DESCRIPTION
Forgot to pass `dataWithFieldConfig` when refactoring in https://github.com/grafana/scenes/pull/618