### PR TITLE
PanelMigrations: Fixes incorrect panel.id in migration handler

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -142,6 +142,10 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     }
   }
 
+  public getLegacyPanelId() {
+    return this.getPanelContext().instanceState?.legacyPanelId ?? 1;
+  }
+
   private async _pluginLoaded(plugin: PanelPlugin) {
     const { options, fieldConfig, title, pluginVersion, _UNSAFE_customMigrationHandler } = this.state;
 
@@ -149,7 +153,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       title,
       options,
       fieldConfig,
-      id: 1,
+      id: this.getLegacyPanelId(),
       type: plugin.meta.id,
       pluginVersion: pluginVersion,
     };

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -125,7 +125,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const isReadyToRender = dataObject.isDataReadyToDisplay ? dataObject.isDataReadyToDisplay() : true;
 
   const context = model.getPanelContext();
-  const panelId = context.instanceState?.legacyPanelId ?? 1;
+  const panelId = model.getLegacyPanelId();
 
   return (
     <div className={relativeWrapper}>


### PR DESCRIPTION
Some migrations require panel id (like graph => timeseries migration handler that transforms time regions to annotations) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.11.0--canary.638.8200246516.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.11.0--canary.638.8200246516.0
  # or 
  yarn add @grafana/scenes@3.11.0--canary.638.8200246516.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
