### PR TITLE
Variables: Fixes issue with url sync and key value variables

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -19,6 +19,7 @@ import {
   SceneQueryRunner,
   TextBoxVariable,
   QueryVariable,
+  CustomVariable,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
@@ -66,14 +67,13 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                   options: [],
                   refresh: VariableRefresh.onTimeRangeChanged,
                 }),
-                new TestVariable({
-                  name: 'lonelyOne',
-                  query: 'B.*',
+                new CustomVariable({
+                  name: 'keyValue',
+                  description: 'CustomVariable with key value pairs',
                   value: '',
-                  delayMs: 1000,
                   isMulti: true,
                   text: '',
-                  options: [],
+                  query: 'A : 1, B : 2, C : 3',
                 }),
                 new IntervalVariable({
                   name: 'interval',
@@ -86,8 +86,8 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                 }),
 
                 new QueryVariable({
-                  name: 'serverUsingDefinition',
-                  label: 'Server with definition',
+                  name: 'queryVar',
+                  label: 'QueryVariable with TestData datasource',
                   query: { query: '*', refId: 'A' },
                   datasource: { uid: 'gdev-testdata' },
                   definition: '*',
@@ -96,7 +96,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
             }),
             body: new SceneFlexLayout({
               direction: 'column',
-              $behaviors: [getVariableChangeBehavior('lonelyOne'), getVariableChangeBehavior('server')],
+              $behaviors: [getVariableChangeBehavior('keyValue'), getVariableChangeBehavior('server')],
               children: [
                 getGraphAndTextPanel(),
                 new SceneFlexItem({
@@ -213,7 +213,9 @@ function getGraphAndTextPanel() {
 * pod: $pod
 * handler: $handler
 * interval: $interval
-* serverUsingDefinition: $serverUsingDefinition
+* keyValue: $keyValue
+* keyValue: \${keyValue:text} (text value)
+* queryVar: $queryVar
 * [Link that updates pod = AAG and AAH](\${__url.path}\${__url.params:exclude:var-pod}&var-pod=AAG&var-pod=AAH)
 
           `

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -532,6 +532,26 @@ describe('MultiValueVariable', () => {
       expect(variable.getValue()).toEqual(['1', '2']);
     });
 
+    it('updateFromUrl with key value pair should lookup text representation ', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        isMulti: true,
+        value: ['1'],
+        text: ['A'],
+        delayMs: 0,
+      });
+
+      variable.urlSync?.updateFromUrl({ ['var-test']: ['1', '2'] });
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.getValueText()).toEqual('A + B');
+    });
+
     it('Can disable url sync', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -116,9 +116,13 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
         stateUpdate.text = defaultState.text;
       }
       // We have valid values, if it's different from current valid values update current values
-      else if (!isEqual(validValues, currentValue) || !isEqual(validTexts, currentText)) {
-        stateUpdate.value = validValues;
-        stateUpdate.text = validTexts;
+      else {
+        if (!isEqual(validValues, currentValue)) {
+          stateUpdate.value = validValues;
+        }
+        if (!isEqual(validTexts, currentText)) {
+          stateUpdate.text = validTexts;
+        }
       }
     } else {
       // Try find by value then text
@@ -144,7 +148,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     /**
      * Values set by initial URL sync needs to survive the next validation and update
      */
-    if (this.skipNextValidation) {
+    if (this.skipNextValidation && stateUpdate.value !== currentValue) {
       stateUpdate.value = currentValue;
       stateUpdate.text = currentText;
       this.skipNextValidation = false;


### PR DESCRIPTION
https://github.com/grafana/scenes/pull/632 introduced a minor issue with key value variables.  

Because we skipped validation and always use the value provided via URL this also skipped the lookup of the text representation (when it can be found). So key value variables with valid values lost their text representation value after a full page reload. 