### PR TITLE
VizPanel: Fixes incrementing structureRev

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -441,10 +441,13 @@ describe('VizPanel', () => {
 
       const data = getTestData();
       const dataWithFieldConfig1 = panel.applyFieldConfig(data);
+      expect(dataWithFieldConfig1.structureRev).toBe(1);
+
       panel.onFieldConfigChange({ defaults: { unit: 'ms' }, overrides: [] });
 
       const dataWithFieldConfig2 = panel.applyFieldConfig(data);
-      expect(dataWithFieldConfig1).not.toBe(dataWithFieldConfig2);
+      expect(dataWithFieldConfig2).not.toBe(dataWithFieldConfig1);
+      expect(dataWithFieldConfig2.structureRev).toBe(2);
     });
 
     it('should not provide alert states and annotations by default', async () => {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -16,6 +16,7 @@ import {
   PluginType,
   renderMarkdown,
   PanelPluginDataSupport,
+  DataFrame,
 } from '@grafana/data';
 import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@grafana/ui';
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
@@ -130,7 +131,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       const { importPanelPlugin } = getPluginImportUtils();
 
       try {
-        const result = await importPanelPlugin(pluginId)
+        const result = await importPanelPlugin(pluginId);
         this._pluginLoaded(result);
       } catch (err: unknown) {
         this._pluginLoaded(getPanelPluginNotFound(pluginId));
@@ -231,9 +232,9 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     if (plugin && !plugin.meta.skipDataQuery && data && data.timeRange) {
       return data.timeRange;
     }
-  
+
     return sceneTimeRange.state.value;
-  }
+  };
 
   public onTitleChange = (title: string) => {
     this.setState({ title });
@@ -323,29 +324,24 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     const pluginDataSupport: PanelPluginDataSupport = plugin.dataSupport || { alertStates: false, annotations: false };
 
     const fieldConfigRegistry = plugin.fieldConfigRegistry;
-    const prevFrames = this._prevData?.series;
-    const newFrames = rawData?.series;
+    const prevFrames = this._dataWithFieldConfig?.series ?? [];
+    const newFrames = applyFieldOverrides({
+      data: rawData.series,
+      fieldConfig: this.state.fieldConfig,
+      fieldConfigRegistry,
+      replaceVariables: this.interpolate,
+      theme: config.theme2,
+      timeZone: rawData.request?.timezone,
+    });
 
-    if (
-      rawData.structureRev == null &&
-      newFrames &&
-      prevFrames &&
-      !compareArrayValues(newFrames, prevFrames, compareDataFrameStructures)
-    ) {
+    if (!compareArrayValues(newFrames, prevFrames, compareDataFrameStructures)) {
       this._structureRev++;
     }
 
     this._dataWithFieldConfig = {
       ...rawData,
       structureRev: this._structureRev,
-      series: applyFieldOverrides({
-        data: newFrames,
-        fieldConfig: this.state.fieldConfig,
-        fieldConfigRegistry,
-        replaceVariables: this.interpolate,
-        theme: config.theme2,
-        timeZone: rawData.request?.timezone,
-      }),
+      series: newFrames,
     };
 
     if (this._dataWithFieldConfig.annotations) {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -16,7 +16,6 @@ import {
   PluginType,
   renderMarkdown,
   PanelPluginDataSupport,
-  DataFrame,
 } from '@grafana/data';
 import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@grafana/ui';
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';


### PR DESCRIPTION
Looking at the old code in PanelQuery runner we always increment structureRev when the processed frames differ, so moved the comparison to after apply field config. 

We are still missing some streaming related optimizations in this function (that we have PanelQueryRunner). But leaving that for another future. 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.13.1--canary.643.8277858909.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.13.1--canary.643.8277858909.0
  # or 
  yarn add @grafana/scenes@3.13.1--canary.643.8277858909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
