### PR TITLE
AdHocFilter: Correctly show the label for a matching default key

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { AdHocFiltersVariable, toSelectableValue } from './AdHocFiltersVariable';
 import { AdHocVariableFilter, GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
@@ -27,13 +27,19 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     isValuesOpen?: boolean;
   }>({});
 
-  let keyValue = filter.key !== '' ? toOption(filter.key) : null;
-  if (model.state.defaultKeys) {
-    const matchingDefaultKey = model.state.defaultKeys.find(option => option.value === filter.key);
-    if (matchingDefaultKey) {
-      keyValue = toSelectableValue(matchingDefaultKey);
+  const keyValue = useMemo(() => {
+    if (filter.key !== '') {
+      if (model.state.defaultKeys) {
+        const matchingDefaultKey = model.state.defaultKeys.find(option => option.value === filter.key);
+        if (matchingDefaultKey) {
+          return toSelectableValue(matchingDefaultKey);
+        }
+      } else {
+        return toOption(filter.key);
+      }
     }
-  }
+    return null;
+  }, [filter.key, model.state.defaultKeys])
   const valueValue = filter.value !== '' ? toOption(filter.value) : null;
 
   const valueSelect = (

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { AdHocFiltersVariable } from './AdHocFiltersVariable';
+import { AdHocFiltersVariable, toSelectableValue } from './AdHocFiltersVariable';
 import { AdHocVariableFilter, GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { Button, Field, Select, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -27,7 +27,13 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     isValuesOpen?: boolean;
   }>({});
 
-  const keyValue = filter.key !== '' ? toOption(filter.key) : null;
+  let keyValue = filter.key !== '' ? toOption(filter.key) : null;
+  if (model.state.defaultKeys) {
+    const matchingDefaultKey = model.state.defaultKeys.find(option => option.value === filter.key);
+    if (matchingDefaultKey) {
+      keyValue = toSelectableValue(matchingDefaultKey);
+    }
+  }
   const valueValue = filter.value !== '' ? toOption(filter.value) : null;
 
   const valueSelect = (

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -213,6 +213,26 @@ describe('AdHocFiltersVariable', () => {
     ]);
   });
 
+  it('Selecting a default key correctly shows the label', async () => {
+    const { filtersVar } = setup({
+      defaultKeys: [{
+        text: 'some',
+        value: '1',
+      }, {
+        text: 'static',
+        value: '2',
+      }, {
+        text: 'keys',
+        value: '3',
+      }],
+    });
+    const selects = screen.getAllByRole('combobox');
+    await waitFor(() => select(selects[0], 'some', { container: document.body }));
+
+    expect(screen.getByText('some')).toBeInTheDocument();
+    expect(filtersVar.state.filters[0].key).toBe('1');
+  })
+
   it('Can filter by regex', async () => {
     const { filtersVar } = setup({
       tagKeyRegexFilter: new RegExp('x.*'),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -316,7 +316,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-function toSelectableValue({ text, value }: MetricFindValue): SelectableValue<string> {
+export function toSelectableValue({ text, value }: MetricFindValue): SelectableValue<string> {
   return {
     label: text,
     value: String(value ?? text),


### PR DESCRIPTION
Addresses https://github.com/grafana/grafana/pull/83157#issuecomment-1997271369

in `AdHocFilterRenderer` the selected value for that select is constructed from the filter key [here](https://github.com/grafana/scenes/blob/main/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx#L30). this uses the `toOption` method which just [takes the value and applies it as both the label and value](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/utils/selectUtils.ts#L3)

this changes the behaviour when `defaultKeys` are present to find the matching option from the list of `defaultKeys`, then uses `toSelectableValue` to convert it. that way both the label and internal value are preserved correctly
