### PR TITLE
SceneQueryRunner: Meaningful cloning

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -431,6 +431,19 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     }
   }
 
+  public clone(withState?: Partial<QueryRunnerState>) {
+    const clone = super.clone(withState);
+
+    if (this._resultAnnotations) {
+      clone['_resultAnnotations'] = this._resultAnnotations.map((frame) => ({ ...frame }));
+    }
+
+    if (this._layerAnnotations) {
+      clone['_layerAnnotations'] = this._layerAnnotations.map((frame) => ({ ...frame }));
+    }
+
+    return clone;
+  }
   private prepareRequests = (
     timeRange: SceneTimeRangeLike,
     ds: DataSourceApi


### PR DESCRIPTION
Fixes a bug I have discovered in core Grafana: https://github.com/grafana/grafana/issues/84818

The problem is that in the PanelEditor in core Grafana we are using the cloned version of the data provider. When it's activated, it uses data layers results (via ReplaySubject in the layer) causing the `onLayersReceived` being called. But, this function depends on SQR's private `_resultAnnotations` propert, that is not cloned given it's a instance property, not part of the object state.  Hence we are losing the query-provided annotations.

However, it's actually reflecting a state of an object as it holds annotation results that might have been part of a query response. So, it is technically SQR's state. 

There are alternatives to this approach:
1. Move `_resultAnnotations` / `_layerAnnotations` instance properties into SQR's state. This would be a bigger refactor. Also leaks the implementation details to a public state. This is next scenario when SceneObject private state would beuseful :)
2. Make `_resultAnnotations` / `_layerAnnotations` public properties  or provide setters to allow setting externally. Again, leaking internals. Also would delegate the complexity of remembering about setting those when cloning to the consumer. Sounds like a bad idea.

So I consider the proposed approach quite elegant, as it does not yield an API change while providing the required functionality.


