### PR TITLE
ControlsLabel: style: use info icons for description

### DIFF
--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -47,6 +47,15 @@ export function ControlsLabel(props: ControlsLabelProps) {
     );
   }
 
+  let descriptionIndicator = null;
+  if (props.description) {
+    descriptionIndicator = (
+      <Tooltip content={props.description} placement={isVertical ? 'top' : 'bottom'}>
+        <Icon className={styles.normalIcon} name="info-circle" />
+      </Tooltip>
+    );
+  }
+
   const testId =
     typeof props.label === 'string' ? selectors.pages.Dashboard.SubMenu.submenuItemLabels(props.label) : '';
   let labelElement: JSX.Element;
@@ -57,6 +66,7 @@ export function ControlsLabel(props: ControlsLabelProps) {
     labelElement = (
       <label className={styles.verticalLabel} data-testid={testId} htmlFor={props.htmlFor}>
         {props.label}
+        {descriptionIndicator}
         {errorIndicator}
         {props.icon && <Icon name={props.icon} className={styles.normalIcon} />}
         {loadingIndicator}
@@ -71,16 +81,9 @@ export function ControlsLabel(props: ControlsLabelProps) {
         {errorIndicator}
         {props.icon && <Icon name={props.icon} className={styles.normalIcon} />}
         {props.label}
+        {descriptionIndicator}
         {loadingIndicator}
       </label>
-    );
-  }
-
-  if (props.description) {
-    return (
-      <Tooltip content={props.description} placement={isVertical ? 'top' : 'bottom'}>
-        {labelElement}
-      </Tooltip>
     );
   }
 


### PR DESCRIPTION
There was a UX request to show an explicit info icon whenever a variable had a description.
This PR adds the icon when the description is present, and shows the tooltip when the new icon is on-hover.
The tooltip was removed from the surrounding field component and now will only appear when interacting with the new icon.

![image_360](https://github.com/grafana/scenes/assets/38694490/e011f09c-27d7-46b9-bbbe-972cbb03fb8e)

![image_360](https://github.com/grafana/scenes/assets/38694490/553794b8-9ce4-40c5-bd4a-c9c0943a912b)
