### PR TITLE
Core: Fixes type issue introduced by merge

### DIFF
--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -11,7 +11,7 @@ import {
   PanelData,
   TimeRange,
 } from '@grafana/data';
-import { TimeZone } from '@grafana/schema';
+import { DataTopic, TimeZone } from '@grafana/schema';
 
 import { SceneVariableDependencyConfigLike, SceneVariables } from '../variables/types';
 import { SceneObjectRef } from './SceneObjectRef';


### PR DESCRIPTION
A problem with the ordering of Pr merges I think created this missing import in main 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.14.1--canary.655.8371909776.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@3.14.1--canary.655.8371909776.0
  # or 
  yarn add @grafana/scenes@3.14.1--canary.655.8371909776.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
