### PR TITLE
MultiValueVariable: Fixes issue with initial url sync when using old All url value

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -512,16 +512,20 @@ describe('MultiValueVariable', () => {
       await lastValueFrom(variable.validateAndUpdate());
 
       expect(variable.getValue()).toEqual('Custom value');
+
+      // but a second call to valdiate and update should set default value
+      await lastValueFrom(variable.validateAndUpdate());
+      expect(variable.getValue()).toEqual('1');
     });
 
     it('updateFromUrl with old arch All value', async () => {
       const variable = new TestVariable({
         name: 'test',
-        options: [
+        options: [],
+        optionsToReturn: [
           { label: 'A', value: '1' },
           { label: 'B', value: '2' },
         ],
-        optionsToReturn: [],
         includeAll: true,
         value: ALL_VARIABLE_VALUE,
         text: ALL_VARIABLE_TEXT,
@@ -529,6 +533,9 @@ describe('MultiValueVariable', () => {
       });
 
       variable.urlSync?.updateFromUrl({ ['var-test']: ALL_VARIABLE_TEXT });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
       expect(variable.getValue()).toEqual(['1', '2']);
     });
 


### PR DESCRIPTION
The PR https://github.com/grafana/scenes/pull/632 made it so that we did not support the old URL value for the ALL VALUE. 

This restores the backward compatible support for "All" in URL (changed to $__alll)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.2--canary.656.8387068694.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.0.2--canary.656.8387068694.0
  # or 
  yarn add @grafana/scenes@4.0.2--canary.656.8387068694.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
