### PR TITLE
Autofit: Fit widget in the screen depending on the height

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -187,7 +187,7 @@ describe('SceneGridLayout', () => {
             }),
           ],
           isLazy: false,
-          fitPanels: true,
+          UNSAFE_fitPanels: true,
         }),
       });
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -8,6 +8,7 @@ import { SceneGridItem } from './SceneGridItem';
 
 import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridRow } from './SceneGridRow';
+import * as utils from './utils';
 
 // Mocking AutoSizer to allow testing of the SceneGridLayout component rendering
 jest.mock(
@@ -16,6 +17,11 @@ jest.mock(
     ({ children }: { children: (args: { width: number; height: number }) => React.ReactNode }) =>
       children({ height: 600, width: 600 })
 );
+
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  fitPanelsInHeight: jest.fn().mockImplementation((cells) => cells),
+}));
 
 class TestObject extends SceneObjectBase<SceneObjectState> {
   public static Component = (m: SceneComponentProps<TestObject>) => {
@@ -107,7 +113,7 @@ describe('SceneGridLayout', () => {
       expect(screen.queryAllByTestId('test-object')).toHaveLength(2);
     });
 
-    it('should  render children of an expanded row', async () => {
+    it('should render children of an expanded row', async () => {
       const scene = new EmbeddedScene({
         body: new SceneGridLayout({
           children: [
@@ -155,6 +161,39 @@ describe('SceneGridLayout', () => {
       render(<scene.Component model={scene} />);
 
       expect(screen.queryAllByTestId('test-object')).toHaveLength(3);
+    });
+
+    it('should process the layout when the autofit is enabled', async () => {
+      const scene = new EmbeddedScene({
+        body: new SceneGridLayout({
+          children: [
+            new SceneGridItem({
+              x: 0,
+              y: 0,
+              width: 12,
+              height: 5,
+              isResizable: false,
+              isDraggable: false,
+              body: new TestObject({ key: 'a' }),
+            }),
+            new SceneGridItem({
+              x: 0,
+              y: 5,
+              width: 12,
+              height: 5,
+              isResizable: false,
+              isDraggable: false,
+              body: new TestObject({ key: 'b' }),
+            }),
+          ],
+          isLazy: false,
+          fitPanels: true,
+        }),
+      });
+
+      render(<scene.Component model={scene} />);
+
+      expect(utils.fitPanelsInHeight).toHaveBeenCalled();
     });
   });
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -1,7 +1,7 @@
 import ReactGridLayout from 'react-grid-layout';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
-import { SceneLayout, SceneObjectState, SceneObjectUrlValues } from '../../../core/types';
+import { SceneLayout, SceneObjectState } from '../../../core/types';
 import { DEFAULT_PANEL_SPAN } from './constants';
 import { isSceneGridRow } from './SceneGridItem';
 import { SceneGridLayoutRenderer } from './SceneGridLayoutRenderer';

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -19,7 +19,7 @@ interface SceneGridLayoutState extends SceneObjectState {
   isResizable?: boolean;
   isLazy?: boolean;
   /**
-   * fitPanels panels to height of the grid. This will scale down the panels vertically to fit available height.
+   * Fit panels to height of the grid. This will scale down the panels vertically to fit available height.
    * The row height is not changed, only the y position and height of the panels.
    */
   fitPanels?: boolean;

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -21,8 +21,9 @@ interface SceneGridLayoutState extends SceneObjectState {
   /**
    * Fit panels to height of the grid. This will scale down the panels vertically to fit available height.
    * The row height is not changed, only the y position and height of the panels.
+   * UNSAFE: This feature is experimental and it might change in the future.
    */
-  fitPanels?: boolean;
+  UNSAFE_fitPanels?: boolean;
   children: SceneGridItemLike[];
 }
 
@@ -311,7 +312,7 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
     // Sort by position
     cells = sortGridLayout(cells);
 
-    if (this.state.fitPanels) {
+    if (this.state.UNSAFE_fitPanels) {
       cells = fitPanelsInHeight(cells, height);
     }
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -8,7 +8,6 @@ import { SceneGridLayoutRenderer } from './SceneGridLayoutRenderer';
 
 import { SceneGridRow } from './SceneGridRow';
 import { SceneGridItemLike, SceneGridItemPlacement } from './types';
-import { SceneObjectUrlSyncConfig } from '../../../services/SceneObjectUrlSyncConfig';
 import { fitPanelsInHeight } from './utils';
 
 interface SceneGridLayoutState extends SceneObjectState {
@@ -19,13 +18,16 @@ interface SceneGridLayoutState extends SceneObjectState {
   /** Enable or disable item resizing */
   isResizable?: boolean;
   isLazy?: boolean;
-  autoFit?: boolean;
+  /**
+   * fitPanels panels to height of the grid. This will scale down the panels vertically to fit available height.
+   * The row height is not changed, only the y position and height of the panels.
+   */
+  fitPanels?: boolean;
   children: SceneGridItemLike[];
 }
 
 export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> implements SceneLayout {
   public static Component = SceneGridLayoutRenderer;
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['autofitpanels'] });
 
   private _skipOnLayoutChange = false;
 
@@ -34,22 +36,6 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
       ...state,
       children: sortChildrenByPosition(state.children),
     });
-  }
-
-  public getUrlState() {
-    return {
-      autofitpanels: this.state.autoFit ? '' : undefined,
-    };
-  }
-
-  public updateFromUrl(values: SceneObjectUrlValues) {
-    const autoFit = values.autofitpanels;
-
-    if (typeof autoFit === 'string') {
-      this.setState({
-        autoFit: true,
-      });
-    }
   }
 
   /**
@@ -325,7 +311,7 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
     // Sort by position
     cells = sortGridLayout(cells);
 
-    if (this.state.autoFit) {
+    if (this.state.fitPanels) {
       cells = fitPanelsInHeight(cells, height);
     }
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useReducer, useRef } from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { SceneComponentProps } from '../../../core/types';
-import { GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, GRID_CELL_HEIGHT } from './constants';
+import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from './constants';
 import { LazyLoader } from '../LazyLoader';
 import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
@@ -17,13 +17,13 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
   validateChildrenSize(children);
 
   return (
-    <AutoSizer disableHeight>
-      {({ width }) => {
+    <AutoSizer className="this-is-auto">
+      {({ width, height }) => {
         if (width === 0) {
           return null;
         }
 
-        const layout = model.buildGridLayout(width);
+        const layout = model.buildGridLayout(width, height);
 
         return (
           /**

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -17,7 +17,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
   validateChildrenSize(children);
 
   return (
-    <AutoSizer className="this-is-auto">
+    <AutoSizer>
       {({ width, height }) => {
         if (width === 0) {
           return null;

--- a/packages/scenes/src/components/layout/grid/utils.test.ts
+++ b/packages/scenes/src/components/layout/grid/utils.test.ts
@@ -33,34 +33,70 @@ describe.only('fitPanelsInHeight', () => {
 
   it('should NOT scale down panels if they fit in the given height', () => {
     // ---------------
-    // | a | a | b |
-    // | a | a | b |
-    // | a | a |   |
-    // | a | a |   |
-    // | c | c | c |
-    // | c | c | c |
+    // | a | a |
+    // | a | a |
+    // | b | b |
+    // | b | b |
+    // | c | c |
+    // | c | c |
     // ---------------
     const cells = [
-      { x: 0, y: 0, w: 2, h: 4 },
-      { x: 2, y: 0, w: 1, h: 2 },
-      { x: 0, y: 4, w: 3, h: 2 },
+      { x: 0, y: 0, w: 2, h: 2 },
+      { x: 0, y: 2, w: 2, h: 2 },
+      { x: 0, y: 4, w: 2, h: 2 },
     ] as ReactGridLayout.Layout[];
-    const height = GRID_CELL_HEIGHT * 6 + GRID_CELL_VMARGIN * 4;
+    const height = GRID_CELL_HEIGHT * 6 + GRID_CELL_VMARGIN * 10;
 
     const result = fitPanelsInHeight(cells, height);
 
     // ---------------
-    // | a | a | b |
-    // | a | a | b |
-    // | a | a |   |
-    // | a | a |   |
-    // | c | c | c |
-    // | c | c | c |
+    // 0: | a | a |
+    // 1: | a | a |
+    // 2: | b | b |
+    // 3: | b | b |
+    // 4: | c | c |
+    // 5: | c | c |
     // ---------------
     expect(result).toEqual([
-      { x: 0, y: 0, w: 2, h: 4 },
-      { x: 2, y: 0, w: 1, h: 2 },
-      { x: 0, y: 4, w: 3, h: 2 },
+      { x: 0, y: 0, w: 2, h: 2 },
+      { x: 0, y: 2, w: 2, h: 2 },
+      { x: 0, y: 4, w: 2, h: 2 },
+    ]);
+  });
+
+  it('should scale up panels if they do not fit in the given height', () => {
+    // ---------------
+    // | a | a |
+    // | a | a |
+    // | b | b |
+    // | b | b |
+    // | c | c |
+    // | c | c |
+    // ---------------
+    const cells = [
+      { x: 0, y: 0, w: 2, h: 2 },
+      { x: 0, y: 2, w: 2, h: 2 },
+      { x: 0, y: 4, w: 2, h: 2 },
+    ] as ReactGridLayout.Layout[];
+    const height = GRID_CELL_HEIGHT * 9 + GRID_CELL_VMARGIN * 10;
+
+    const result = fitPanelsInHeight(cells, height);
+
+    // ---------------
+    // | a | a |
+    // | a | a |
+    // | a | a |
+    // | b | b |
+    // | b | b |
+    // | b | b |
+    // | c | c |
+    // | c | c |
+    // | c | c |
+    // ---------------
+    expect(result).toEqual([
+      { x: 0, y: 0, w: 2, h: 3 },
+      { x: 0, y: 3, w: 2, h: 3 },
+      { x: 0, y: 5, w: 2, h: 3 },
     ]);
   });
 });

--- a/packages/scenes/src/components/layout/grid/utils.test.ts
+++ b/packages/scenes/src/components/layout/grid/utils.test.ts
@@ -1,0 +1,66 @@
+import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from './constants';
+import { fitPanelsInHeight } from './utils';
+
+describe.only('fitPanelsInHeight', () => {
+  it('should fit panels to the given height + margins', () => {
+    // ---------------
+    // | a | b |
+    // | a |   |
+    // | c     |
+    // ---------------
+    const cells = [
+      { x: 0, y: 0, w: 2, h: 2 },
+      { x: 2, y: 0, w: 1, h: 1 },
+      { x: 0, y: 2, w: 3, h: 1 },
+      // Total height: 4
+    ] as ReactGridLayout.Layout[];
+
+    // 3 margins: marging top, margin bottom, and some extra margin at the bottom
+    const height = GRID_CELL_HEIGHT * 2 + GRID_CELL_VMARGIN * 3;
+
+    const result = fitPanelsInHeight(cells, height);
+
+    // ---------------
+    // | a | b |
+    // | c     |
+    // ---------------
+    expect(result).toEqual([
+      { x: 0, y: 0, w: 2, h: 1 },
+      { x: 2, y: 0, w: 1, h: 1 },
+      { x: 0, y: 1, w: 3, h: 1 },
+    ]);
+  });
+
+  it('should NOT scale down panels if they fit in the given height', () => {
+    // ---------------
+    // | a | a | b |
+    // | a | a | b |
+    // | a | a |   |
+    // | a | a |   |
+    // | c | c | c |
+    // | c | c | c |
+    // ---------------
+    const cells = [
+      { x: 0, y: 0, w: 2, h: 4 },
+      { x: 2, y: 0, w: 1, h: 2 },
+      { x: 0, y: 4, w: 3, h: 2 },
+    ] as ReactGridLayout.Layout[];
+    const height = GRID_CELL_HEIGHT * 6 + GRID_CELL_VMARGIN * 4;
+
+    const result = fitPanelsInHeight(cells, height);
+
+    // ---------------
+    // | a | a | b |
+    // | a | a | b |
+    // | a | a |   |
+    // | a | a |   |
+    // | c | c | c |
+    // | c | c | c |
+    // ---------------
+    expect(result).toEqual([
+      { x: 0, y: 0, w: 2, h: 4 },
+      { x: 2, y: 0, w: 1, h: 2 },
+      { x: 0, y: 4, w: 3, h: 2 },
+    ]);
+  });
+});

--- a/packages/scenes/src/components/layout/grid/utils.ts
+++ b/packages/scenes/src/components/layout/grid/utils.ts
@@ -2,7 +2,7 @@ import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from './constants';
 
 export function fitPanelsInHeight(cells: ReactGridLayout.Layout[], height: number) {
   // Take into account cell margint top + cell margin bottom + adding some marging at the bottom
-  const visibleHeight = height - GRID_CELL_VMARGIN * 3;
+  const visibleHeight = height - GRID_CELL_VMARGIN * 4;
   const currentGridHeight = Math.max(...cells.map((cell) => cell.h + cell.y));
 
   const visibleGridHeight = Math.floor(visibleHeight / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));

--- a/packages/scenes/src/components/layout/grid/utils.ts
+++ b/packages/scenes/src/components/layout/grid/utils.ts
@@ -1,0 +1,16 @@
+import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from './constants';
+
+export function fitPanelsInHeight(cells: ReactGridLayout.Layout[], height: number) {
+  // Take into account cell margint top + cell margin bottom + adding some marging at the bottom
+  const visibleHeight = height - GRID_CELL_VMARGIN * 3;
+  const currentGridHeight = Math.max(...cells.map((cell) => cell.h + cell.y));
+
+  const visibleGridHeight = Math.floor(visibleHeight / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));
+  const scaleFactor = currentGridHeight / visibleGridHeight;
+
+  return cells.map((cell) => ({
+    ...cell,
+    y: Math.round(cell.y / scaleFactor) || 0,
+    h: Math.round(cell.h / scaleFactor) || 1,
+  }));
+}

--- a/packages/scenes/src/components/layout/grid/utils.ts
+++ b/packages/scenes/src/components/layout/grid/utils.ts
@@ -8,13 +8,7 @@ export function fitPanelsInHeight(cells: ReactGridLayout.Layout[], height: numbe
   const visibleGridHeight = Math.floor(visibleHeight / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));
   const scaleFactor = currentGridHeight / visibleGridHeight;
 
-  console.log('scaleFactor', scaleFactor);
-  console.log('y');
   return cells.map((cell) => {
-    console.log('cell.y', cell.y);
-    console.log('cell.h', cell.h);
-    console.log('Math.round(cell.y / scaleFactor)', Math.round(cell.y / scaleFactor));
-    console.log('Math.round(cell.h / scaleFactor)', Math.round(cell.h / scaleFactor));
     return {
       ...cell,
       y: Math.round(cell.y / scaleFactor) || 0,

--- a/packages/scenes/src/components/layout/grid/utils.ts
+++ b/packages/scenes/src/components/layout/grid/utils.ts
@@ -8,9 +8,17 @@ export function fitPanelsInHeight(cells: ReactGridLayout.Layout[], height: numbe
   const visibleGridHeight = Math.floor(visibleHeight / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));
   const scaleFactor = currentGridHeight / visibleGridHeight;
 
-  return cells.map((cell) => ({
-    ...cell,
-    y: Math.round(cell.y / scaleFactor) || 0,
-    h: Math.round(cell.h / scaleFactor) || 1,
-  }));
+  console.log('scaleFactor', scaleFactor);
+  console.log('y');
+  return cells.map((cell) => {
+    console.log('cell.y', cell.y);
+    console.log('cell.h', cell.h);
+    console.log('Math.round(cell.y / scaleFactor)', Math.round(cell.y / scaleFactor));
+    console.log('Math.round(cell.h / scaleFactor)', Math.round(cell.h / scaleFactor));
+    return {
+      ...cell,
+      y: Math.round(cell.y / scaleFactor) || 0,
+      h: Math.round(cell.h / scaleFactor) || 1,
+    };
+  });
 }


### PR DESCRIPTION
**Problem**
When using Grafana on a TV, the users want to have all the widgets available on the screen. However, the screen size can vary between rooms, so they mark "auto size" when playing a playlist to have the dashboard fit vertically in the screen.

When migrating to the dashboard, this feature stopped working.

**Solution**
To be able to adapt the grid to the available height, we modify the RGL cells height to make sure they don't overflow the bottom of the grid view. 

https://github.com/grafana/scenes/assets/5699976/cdc7eb00-9a9e-417e-888c-eb2edb6414bb


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.2.0--canary.658.8522699461.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.2.0--canary.658.8522699461.0
  # or 
  yarn add @grafana/scenes@4.2.0--canary.658.8522699461.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
