### PR TITLE
VizPanel: Do not apply the visualization's field config to annotation data frames

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -496,6 +496,41 @@ describe('VizPanel', () => {
       expect(dataToRender.alertState).toBe(testData.alertState);
       expect(dataToRender.annotations).toBeDefined();
     });
+
+    it('should not add fieldConfig to annotations', async () => {
+      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+        pluginId: 'custom-plugin-id',
+        fieldConfig: {
+          defaults: {
+            links: [
+              {
+                title: 'some link',
+                url: 'some-valid-url',
+              },
+            ],
+          },
+          overrides: [],
+        },
+      });
+      pluginToLoad = getTestPlugin1({ alertStates: true, annotations: true });
+      panel.activate();
+      await Promise.resolve();
+
+      const testData = getTestData();
+      const dataToRender = panel.applyFieldConfig(testData);
+      expect(
+        dataToRender.series.every((serie) =>
+          serie.fields.every(
+            (field) => field.config.links?.length === 1 && field.config.links.at(0)?.title === 'some link'
+          )
+        )
+      );
+      expect(
+        dataToRender.annotations?.every((annotation) =>
+          annotation.fields.every((field) => field.config.links === undefined)
+        )
+      ).toBe(true);
+    });
   });
 
   describe('VizPanel panel rendering ', () => {

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -497,7 +497,7 @@ describe('VizPanel', () => {
       expect(dataToRender.annotations).toBeDefined();
     });
 
-    it('should not add fieldConfig to annotations', async () => {
+    it('should not add fieldConfig to annotations, and keep annotations config', async () => {
       panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
         pluginId: 'custom-plugin-id',
         fieldConfig: {
@@ -519,15 +519,10 @@ describe('VizPanel', () => {
       const testData = getTestData();
       const dataToRender = panel.applyFieldConfig(testData);
       expect(
-        dataToRender.series.every((serie) =>
-          serie.fields.every(
-            (field) => field.config.links?.length === 1 && field.config.links.at(0)?.title === 'some link'
-          )
-        )
-      );
-      expect(
         dataToRender.annotations?.every((annotation) =>
-          annotation.fields.every((field) => field.config.links === undefined)
+          annotation.fields.every(
+            (field) => field.config.links === undefined || field.config.links.at(0)?.title === 'some annotation link'
+          )
         )
       ).toBe(true);
     });
@@ -628,7 +623,18 @@ function getTestData(): PanelData {
         fields: [
           { name: 'time', values: [1, 2, 2, 5, 5] },
           { name: 'id', values: ['1', '2', '2', '5', '5'] },
-          { name: 'text', values: ['t1', 't2', 't3', 't4', 't5'] },
+          {
+            name: 'text',
+            values: ['t1', 't2', 't3', 't4', 't5'],
+            config: {
+              links: [
+                {
+                  title: 'some annotation link',
+                  url: 'some-valid-annotation-url',
+                },
+              ],
+            },
+          },
         ],
       }),
     ],

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -346,7 +346,10 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     if (this._dataWithFieldConfig.annotations) {
       this._dataWithFieldConfig.annotations = applyFieldOverrides({
         data: this._dataWithFieldConfig.annotations,
-        fieldConfig: this.state.fieldConfig,
+        fieldConfig: {
+          defaults: {},
+          overrides: [],
+        },
         fieldConfigRegistry,
         replaceVariables: this.interpolate,
         theme: config.theme2,


### PR DESCRIPTION
- Avoid adding default `fieldConfig` to annotations, follow what we do in grafana ([link](https://github.com/grafana/grafana/blob/2f5be54252b860925997249163b5f6c4f81acc1c/packages/grafana-data/src/field/fieldOverrides.ts#L600))

Why? When adding links to a panel like so:
```txt
fieldConfig: {
  defaults: {
    ...
    links: [
      {some link}
    ],
  },
},
```

The links were getting added not only to the series, but also to each field in the annotations, resulting in the annotation having repeated links that did not belong there.