### PR TITLE
Check if target datasource is matching the panel ds, if not set the target ds to panel ds.

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -1,7 +1,6 @@
 import { map, of } from 'rxjs';
 
 import {
-  ArrayVector,
   getDefaultTimeRange,
   LoadingState,
   toDataFrame,
@@ -59,7 +58,7 @@ export const getCustomTransformOperator = (spy: jest.Mock): CustomTransformOpera
             fields: frame.fields.map((field) => {
               return {
                 ...field,
-                values: new ArrayVector(field.values.toArray().map((v) => v / 100)),
+                values: field.values.map((v) => v / 100),
               };
             }),
           };
@@ -79,7 +78,7 @@ export const getCustomAnnotationTransformOperator = (spy: jest.Mock): CustomTran
             ...frame,
             fields: frame.fields.map((field) => ({
               ...field,
-              values: new ArrayVector(field.values.toArray().map((v) => v / 10)),
+              values: field.values.map((v) => v / 10),
             })),
           }));
         })
@@ -151,7 +150,7 @@ describe('SceneDataTransformer', () => {
                   fields: frame.fields.map((field) => {
                     return {
                       ...field,
-                      values: new ArrayVector(field.values.toArray().map((v) => v * 2)),
+                      values: field.values.map((v) => v * 2),
                     };
                   }),
                 };
@@ -173,7 +172,7 @@ describe('SceneDataTransformer', () => {
                   fields: frame.fields.map((field) => {
                     return {
                       ...field,
-                      values: new ArrayVector(field.values.toArray().map((v) => v * 3)),
+                      values: field.values.map((v) => v * 3),
                     };
                   }),
                 };
@@ -193,7 +192,7 @@ describe('SceneDataTransformer', () => {
                 fields: frame.fields.map((field) => {
                   return {
                     ...field,
-                    values: new ArrayVector(field.values.toArray().map((v) => v + 4)),
+                    values: field.values.map((v) => v + 4),
                   };
                 }),
               }));

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -14,7 +14,7 @@ import {
   preProcessPanelData,
   rangeUtil,
 } from '@grafana/data';
-import { getRunRequest, toDataQueryError } from '@grafana/runtime';
+import { getRunRequest, toDataQueryError, isExpressionReference} from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
@@ -463,7 +463,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     }
 
     request.targets = request.targets.map((query) => {
-      if (!query.datasource) {
+      if (
+        !query.datasource ||
+        (query.datasource.uid !== ds.uid && !ds.meta?.mixed && !isExpressionReference(query.datasource))
+      ) {
         query.datasource = ds.getRef();
       }
       return query;

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -14,6 +14,9 @@ import {
   preProcessPanelData,
   rangeUtil,
 } from '@grafana/data';
+
+// TODO: Remove this ignore annotation when the grafana runtime dependency has been updated
+// @ts-ignore
 import { getRunRequest, toDataQueryError, isExpressionReference} from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -468,7 +468,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     request.targets = request.targets.map((query) => {
       if (
         !query.datasource ||
-        (query.datasource.uid !== ds.uid && !ds.meta?.mixed && !isExpressionReference(query.datasource))
+        (query.datasource.uid !== ds.uid && !ds.meta?.mixed && isExpressionReference /* TODO: Remove this check when isExpressionReference is properly exported from grafan runtime */ && !isExpressionReference(query.datasource))
       ) {
         query.datasource = ds.getRef();
       }


### PR DESCRIPTION
In some circumstances using datasource variables the target datasource is not matched with the panel datasource. This causes issues for datasources using `DataSourceWithBackend`.

This makes sure we set the target datasource to the correct datasource.