### PR TITLE
LiveNowTimer: The constructor doesn't receive a valid state

### DIFF
--- a/packages/scenes/src/behaviors/LiveNowTimer.test.ts
+++ b/packages/scenes/src/behaviors/LiveNowTimer.test.ts
@@ -1,0 +1,70 @@
+import { EmbeddedScene } from '../components/EmbeddedScene';
+import { VizPanel } from '../components/VizPanel/VizPanel';
+import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
+import { sceneGraph } from '../core/sceneGraph';
+import { LiveNowTimer } from './LiveNowTimer';
+
+jest.useFakeTimers();
+jest.spyOn(global, 'setInterval');
+jest.spyOn(global, 'clearInterval');
+
+describe('LiveNowTimer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([true, false])('should initialize the state correctly to %s', (enabled) => {
+    const { timer } = setup({ enabled });
+
+    expect(timer.isEnabled).toBe(enabled);
+  });
+
+  it('should enable the timer', () => {
+    const { timer } = setup({ enabled: false });
+
+    timer.enable();
+    expect(clearInterval).toHaveBeenCalledTimes(1);
+    expect(setInterval).toHaveBeenCalledTimes(1);
+    expect(timer.isEnabled).toBe(true);
+  });
+
+  it('should disable the timer', () => {
+    const { timer } = setup({ enabled: true });
+
+    timer.disable();
+    expect(timer.isEnabled).toBe(false);
+    expect(clearInterval).toHaveBeenCalledTimes(1);
+  });
+
+  it('should force render all VizPanels', () => {
+    const { timer } = setup({ enabled: false });
+
+    jest.runOnlyPendingTimers();
+
+    timer.enable();
+
+    expect(VizPanel.prototype.forceRender).toHaveBeenCalledTimes(2);
+  });
+});
+
+function setup({ enabled = true } = {}) {
+  const timer = new LiveNowTimer({ enabled });
+
+  jest.spyOn(VizPanel.prototype, 'forceRender');
+
+  const scene = new EmbeddedScene({
+    $behaviors: [timer],
+    body: new SceneFlexLayout({
+      children: [
+        new SceneFlexItem({
+          body: new VizPanel({}),
+        }),
+        new SceneFlexItem({
+          body: new VizPanel({}),
+        }),
+      ],
+    }),
+  });
+
+  return { scene, timer };
+}

--- a/packages/scenes/src/behaviors/LiveNowTimer.ts
+++ b/packages/scenes/src/behaviors/LiveNowTimer.ts
@@ -1,51 +1,51 @@
-import { VizPanel } from "../components/VizPanel/VizPanel";
-import { SceneObjectBase } from "../core/SceneObjectBase";
-import { sceneGraph } from "../core/sceneGraph";
-import { SceneObjectState } from "../core/types";
+import { VizPanel } from '../components/VizPanel/VizPanel';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneObjectState } from '../core/types';
 
 interface LiveNowTimerState extends SceneObjectState {
   enabled: boolean;
 }
 
 export class LiveNowTimer extends SceneObjectBase<LiveNowTimerState> {
-    private timerId: number | undefined = undefined;
-    private static REFRESH_RATE = 100; // ms
+  private timerId: number | undefined = undefined;
+  private static REFRESH_RATE = 100; // ms
 
-    public constructor(enabled = false) {
-      super({ enabled });
-      this.addActivationHandler(this._activationHandler);
-    }
-  
-    private _activationHandler = () => {
-      if (this.state.enabled) {
-        this.enable();
-      }
+  public constructor({ enabled = false }) {
+    super({ enabled });
+    this.addActivationHandler(this._activationHandler);
+  }
 
-      return () => {
-        window.clearInterval(this.timerId);
-        this.timerId = undefined;
-      }
+  private _activationHandler = () => {
+    if (this.state.enabled) {
+      this.enable();
     }
-  
-    public enable() {
+
+    return () => {
       window.clearInterval(this.timerId);
       this.timerId = undefined;
-      this.timerId = window.setInterval(() => {
-        const panels = sceneGraph.findAllObjects(this.getRoot(), (obj) => obj instanceof VizPanel) as VizPanel[];
-        for (const panel of panels) {
-          panel.forceRender();
-        }
-      }, LiveNowTimer.REFRESH_RATE);
-      this.setState({ enabled: true })
-    } 
-  
-    public disable() {
-      window.clearInterval(this.timerId);
-      this.timerId = undefined;
-      this.setState({ enabled: false })
-    }
+    };
+  };
 
-    public get isEnabled() {
-        return this.state.enabled;
-    }
+  public enable() {
+    window.clearInterval(this.timerId);
+    this.timerId = undefined;
+    this.timerId = window.setInterval(() => {
+      const panels = sceneGraph.findAllObjects(this.getRoot(), (obj) => obj instanceof VizPanel) as VizPanel[];
+      for (const panel of panels) {
+        panel.forceRender();
+      }
+    }, LiveNowTimer.REFRESH_RATE);
+    this.setState({ enabled: true });
+  }
+
+  public disable() {
+    window.clearInterval(this.timerId);
+    this.timerId = undefined;
+    this.setState({ enabled: false });
+  }
+
+  public get isEnabled() {
+    return this.state.enabled;
+  }
 }


### PR DESCRIPTION
**Problem**
Using a boolean as a scene object state was causing errors where "enable" in the state was the state itself. This was discovered while creating tests for this PR. This state appears when calling `enable()` method even when using properly the initialization. This is because SceneObjectState expects to receive as parameter always the scene state

![Captura de pantalla 2024-03-29 a las 17 27 01](https://github.com/grafana/scenes/assets/5699976/84683534-a0a8-4408-8e03-d5f754183037)

**Solution**
The constructor parameters should be state timer. Also create some tests
