### PR TITLE
Fix drag and drop panels in rows

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -283,7 +283,7 @@ describe('SceneGridLayout', () => {
               w: 12,
               h: 8,
               x: 0,
-              y: 3,
+              y: 2,
               i: 'a',
           },
           {
@@ -307,7 +307,7 @@ describe('SceneGridLayout', () => {
           w: 12,
           h: 8,
           x: 0,
-          y: 3,
+          y: 2,
           i: 'a',
         },
         {},
@@ -320,6 +320,17 @@ describe('SceneGridLayout', () => {
 
       expect(row.state.children[0].state.key).toEqual('a');
       expect(row.state.children[1].state.key).toEqual('b');
+
+      // layout children should be positioned correctly
+      expect(layout.state.children[0].state.key).toEqual('row-a');
+      expect(layout.state.children[0].state.x).toEqual(0);
+      expect(layout.state.children[0].state.y).toEqual(0);
+      expect((layout.state.children[0] as SceneGridRow).state.children[0].state.key).toEqual('a');
+      expect((layout.state.children[0] as SceneGridRow).state.children[0].state.x).toEqual(0);
+      expect((layout.state.children[0] as SceneGridRow).state.children[0].state.y).toEqual(2);
+      expect((layout.state.children[0] as SceneGridRow).state.children[1].state.key).toEqual('b');
+      expect((layout.state.children[0] as SceneGridRow).state.children[1].state.x).toEqual(0);
+      expect((layout.state.children[0] as SceneGridRow).state.children[1].state.y).toEqual(10);
     });
   });
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -159,7 +159,7 @@ describe('SceneGridLayout', () => {
   });
 
   describe('when moving a panel', () => {
-    it('shoud update layout children placement and order ', () => {
+    it('should update layout children placement and order ', () => {
       const layout = new SceneGridLayout({
         children: [
           new SceneGridItem({
@@ -236,6 +236,90 @@ describe('SceneGridLayout', () => {
       expect(layout.state.children[2].state.y).toEqual(2);
       expect(layout.state.children[2].state.width).toEqual(1);
       expect(layout.state.children[2].state.height).toEqual(1);
+    });
+
+    it('should update row children placement and order as well', () => {
+      const layout = new SceneGridLayout({
+        children: [
+          new SceneGridItem({
+            key: 'a',
+            x: 0,
+            y: 0,
+            width: 1,
+            height: 1,
+            isResizable: false,
+            isDraggable: false,
+            body: new TestObject({}),
+          }),
+          new SceneGridRow({
+            title: 'Row A',
+            key: 'row-a',
+            isCollapsed: false,
+            y: 1,
+            children: [
+              new SceneGridItem({
+                key: 'b',
+                x: 0,
+                y: 2,
+                width: 1,
+                height: 1,
+                isResizable: false,
+                isDraggable: false,
+                body: new TestObject({}),
+              }),
+            ],
+          }),
+        ],
+        isLazy: false,
+      });
+
+      // move panel a to be the first child of the row:
+      // row
+      //  - a
+      //  - b
+      layout.onDragStop(
+        [
+          {
+              w: 12,
+              h: 8,
+              x: 0,
+              y: 3,
+              i: 'a',
+          },
+          {
+              w: 24,
+              h: 1,
+              x: 0,
+              y: 0,
+              i: 'row-a',
+          },
+          {
+              w: 12,
+              h: 8,
+              x: 0,
+              y: 10,
+              i: 'b',
+          }
+      ],
+        // @ts-expect-error
+        {},
+        {
+          w: 12,
+          h: 8,
+          x: 0,
+          y: 3,
+          i: 'a',
+        },
+        {},
+        {},
+        {}
+      );
+
+      // after sorting by position, the row should have the children in the correct order [a,b]
+      const row = layout.state.children[0] as SceneGridRow;
+
+      expect(row.state.children[0].state.key).toEqual('a');
+      expect(row.state.children[1].state.key).toEqual('b');
     });
   });
 

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -208,8 +208,9 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 
     // Remove from current parent row
     if (currentParent instanceof SceneGridRow) {
-      const newRow = currentParent.clone({
-        children: currentParent.state.children.filter((c) => c.state.key !== child.state.key),
+      const newRow = currentParent.clone();
+      newRow.setState({
+        children: newRow.state.children.filter((c) => c.state.key !== child.state.key),
       });
 
       // new children with new row
@@ -217,7 +218,8 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 
       // if target is also a row
       if (target instanceof SceneGridRow) {
-        const targetRow = target.clone({ children: [...target.state.children, newChild] });
+        const targetRow = target.clone();
+        targetRow.setState({ children: [...targetRow.state.children, newChild] });
         rootChildren = rootChildren.map((c) => (c === target ? targetRow : c));
       } else {
         // target is the main grid
@@ -228,7 +230,8 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
         // current parent is the main grid remove it from there
         rootChildren = rootChildren.filter((c) => c.state.key !== child.state.key);
         // Clone the target row and add the child
-        const targetRow = target.clone({ children: [...target.state.children, newChild] });
+        const targetRow = target.clone();
+        targetRow.setState({ children: [...targetRow.state.children, newChild] });
         // Replace row with new row
         rootChildren = rootChildren.map((c) => (c === target ? targetRow : c));
       }
@@ -240,7 +243,7 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
   public onDragStop: ReactGridLayout.ItemCallback = (gridLayout, o, updatedItem) => {
     const sceneChild = this.getSceneLayoutChild(updatedItem.i)!;
 
-    // Need to resort the grid layout based on new position (needed to to find the new parent)
+    // Need to resort the grid layout based on new position (needed to find the new parent)
     gridLayout = sortGridLayout(gridLayout);
 
     // Update children positions if they have changed
@@ -322,6 +325,12 @@ function isItemSizeEqual(a: SceneGridItemPlacement, b: SceneGridItemPlacement) {
 }
 
 function sortChildrenByPosition(children: SceneGridItemLike[]) {
+  children.forEach((child) => {
+    if (child instanceof SceneGridRow) {
+      child.setState({ children: sortChildrenByPosition(child.state.children) });
+    }
+  });
+
   return [...children].sort((a, b) => {
     return a.state.y! - b.state.y! || a.state.x! - b.state.x!;
   });


### PR DESCRIPTION
This fixes panel positioning glitching when drag/dropping a panel into a row.

There were 2 issues:
- Moving panels into/out of rows caused a existing parent warning
- After moving a panel into a row, when calling `toggleRow` the `firstPanelYPos` [here](https://github.com/grafana/scenes/blob/main/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx#L72) would be wrongly selected because `sortChildrenByPosition` would not sort row children also, thus causing a glitch.

Fixes https://github.com/grafana/grafana/issues/83292
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.1--canary.663.8521906375.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.1.1--canary.663.8521906375.0
  # or 
  yarn add @grafana/scenes@4.1.1--canary.663.8521906375.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
