### PR TITLE
AdHocFiltersVariable: Pass scene queries to getTagValues calls

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -239,7 +239,9 @@ export class AdHocFiltersVariable
     const otherFilters = this.state.filters.filter((f) => f.key !== filter.key).concat(this.state.baseFilters ?? []);
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    let values = await ds.getTagValues({ key: filter.key, filters: otherFilters, timeRange });
+    const queries = this._getSceneQueries();
+    // @ts-expect-error TODO: remove this once 10.4.2 is released
+    let values = await ds.getTagValues({ key: filter.key, filters: otherFilters, timeRange, queries });
 
     if (override) {
       values = values.concat(override.values);
@@ -299,7 +301,7 @@ export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHo
         </React.Fragment>
       ))}
 
-      {!readOnly && <AdHocFilterBuilder model={model} key="'builder" addFilterButtonText={addFilterButtonText}/>}
+      {!readOnly && <AdHocFilterBuilder model={model} key="'builder" addFilterButtonText={addFilterButtonText} />}
     </div>
   );
 }


### PR DESCRIPTION
Depends on https://github.com/grafana/grafana/pull/85436

This passes scene queries to getTagValues calls so that data source can decide which dimensions are applicable in a scene given provided queries context.