### PR TITLE
Fix issue where curly braces are always added to IntervalMacro. 

### DIFF
--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -203,4 +203,21 @@ describe('sceneInterpolator', () => {
 
     expect(sceneInterpolator(scene, '$__url_time_range')).toBe('from=now-5m&to=now');
   });
+
+  describe('Interval variables', () => {
+    it('Does not add curly braces to unbraced variables', () => {
+      const scene = new TestScene({
+        $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now' }),
+      });
+
+      expect(sceneInterpolator(scene, '$__interval')).toBe('$__interval');
+    });
+    it('Does not remove curly braces from braced variables', () => {
+      const scene = new TestScene({
+        $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now' }),
+      });
+
+      expect(sceneInterpolator(scene, '${__interval}')).toBe('${__interval}');
+    });
+  });
 });

--- a/packages/scenes/src/variables/macros/timeMacros.test.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.test.ts
@@ -93,7 +93,9 @@ describe('timeMacros', () => {
       }),
     });
 
-    expect(sceneInterpolator(scene1, '$__interval')).toBe('${__interval}');
-    expect(sceneInterpolator(scene1, '$__interval_ms')).toBe('${__interval_ms}');
+    expect(sceneInterpolator(scene1, '${__interval}')).toBe('${__interval}');
+    expect(sceneInterpolator(scene1, '$__interval')).toBe('$__interval');
+    expect(sceneInterpolator(scene1, '${__interval_ms}')).toBe('${__interval_ms}');
+    expect(sceneInterpolator(scene1, '$__interval_ms')).toBe('$__interval_ms');
   });
 });

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -85,11 +85,11 @@ export class TimezoneMacro implements FormatVariable {
  * Handles $__interval and $__intervalMs expression.
  */
 export class IntervalMacro implements FormatVariable {
-  public state: { name: string; type: string };
+  public state: { name: string; type: string, match: string };
   private _sceneObject: SceneObject;
 
-  public constructor(name: string, sceneObject: SceneObject) {
-    this.state = { name: name, type: 'time_macro' };
+  public constructor(name: string, sceneObject: SceneObject, match: string) {
+    this.state = { name: name, type: 'time_macro', match: match };
     this._sceneObject = sceneObject;
   }
 
@@ -99,7 +99,7 @@ export class IntervalMacro implements FormatVariable {
     if (data) {
       const request = data.state.data?.request;
       if (!request) {
-        return `\${${this.state.name}}`;
+        return this.state.match;
       }
       if (this.state.name === '__interval_ms') {
         return request.intervalMs;
@@ -107,6 +107,6 @@ export class IntervalMacro implements FormatVariable {
       return request.interval;
     }
 
-    return `\${${this.state.name}}`;
+    return this.state.match;
   }
 }


### PR DESCRIPTION
In the old architecture `$__interval` was passed to the backend as `$__interval`. With scenes this changed so that we're always adding curly braces e.g. `${__interval}`. The Influx db datasource does not handle this well. So for backwards compatibility we should probably keep the variable as is, without the braces.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.1.1--canary.666.8521778570.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.1.1--canary.666.8521778570.0
  # or 
  yarn add @grafana/scenes@4.1.1--canary.666.8521778570.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
