### PR TITLE
Disallow drag and drop a row inside another uncollapsed row

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -36,6 +36,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
             className={cx('react-grid-layout', isDraggable && 'react-grid-layout--enable-move-animations')}
           >
             <ReactGridLayout
+              key={model.getLayoutKey()}
               width={width}
               /**
                 Disable draggable if mobile device, solving an issue with unintentionally


### PR DESCRIPTION
https://github.com/grafana/scenes/assets/36818606/62a14da1-dd64-4a4f-87cc-05ce0405666a

This PR fixes the dashboard crashing when a row is dragged within the area of another uncollapsed row. It's not the most elegant solution, so I'm open to feedback if there is a better way to achieve this, but I think this is the simplest way to fix the bug without adding a lot of complexity, knowing that this will need to be revisited having invalidation in mind.

I think this needs to be further worked on, especially on UX side of things to let users know that they can't have nested rows (e.g.: highlight the uncollapsed row area, similar to how we do to repeated panels and disallow dropping if dragged element is a row). My knowledge of RGL is limited and I couldn't find a proper way to invalidate a drop, which makes me believe that the only way to do it would be to update the layout with the invalid state and then re-update with the old state.

The idea here is to return early if we detect after a drag and drop that we are in a row within a row scenario and force render the grid layout with the old layout. Since there is no actual layout change in the grid props, we need to force the render through the grid layout key prop.

TODO: tests