### PR TITLE
AdHoc Filters: Allow custom value

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -44,6 +44,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
 
   const valueSelect = (
     <Select
+      allowCustomValue
       disabled={model.state.readOnly}
       className={state.isKeysOpen ? styles.widthWhenOpen : undefined}
       width="auto"

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -84,6 +84,24 @@ describe('AdHocFiltersVariable', () => {
     expect(filtersVar.state.filters[0].value).toBe('val4');
   });
 
+  it('can set a custom value', async () => {
+    const { filtersVar, runRequest } = setup();
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    await userEvent.type(selects[2], 'myVeryCustomValue{enter}');
+
+    // should run new query when filter changed
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
+  });
+
   it('Should collect and pass respective data source queries to getTagKeys call', async () => {
     const { getTagKeysSpy, timeRange } = setup({ filters: [] });
 


### PR DESCRIPTION
- allow specifying a custom value as the adhoc filter value
- adds a unit test to ensure we preserve this behaviour

![image](https://github.com/grafana/scenes/assets/20999846/0c27c583-b06d-49af-8d80-79afb2e2cd51)

Fixes https://github.com/grafana/grafana/issues/85070