### PR TITLE
Disallow drag and drop rows within uncollapsed rows

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -197,7 +197,7 @@ describe('SceneGridLayout', () => {
     });
   });
 
-  describe('when moving a panel', () => {
+  describe('when moving a panel or row', () => {
     it('should update layout children placement and order ', () => {
       const layout = new SceneGridLayout({
         children: [
@@ -371,6 +371,121 @@ describe('SceneGridLayout', () => {
       expect((layout.state.children[0] as SceneGridRow).state.children[1].state.x).toEqual(0);
       expect((layout.state.children[0] as SceneGridRow).state.children[1].state.y).toEqual(10);
     });
+
+    it('should disallow dropping a row within another row', () => {
+      const layout = new SceneGridLayout({
+        children: [
+          new SceneGridRow({
+            title: 'Row B',
+            key: 'row-b',
+            isCollapsed: true,
+            y: 0
+          }),
+          new SceneGridRow({
+            title: 'Row A',
+            key: 'row-a',
+            isCollapsed: false,
+            y: 1,
+            children: [
+              new SceneGridItem({
+                key: 'b',
+                x: 0,
+                y: 2,
+                width: 1,
+                height: 1,
+                isResizable: false,
+                isDraggable: false,
+                body: new TestObject({}),
+              }),
+            ],
+          }),
+        ],
+        isLazy: false,
+      });
+
+      layout.onDragStart([
+        {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 0,
+            i: 'row-b',
+        },
+        {
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 1,
+            i: 'row-a',
+        },
+        {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 2,
+            i: 'b',
+        }
+      // @ts-expect-error
+    ], {}, {}, {}, {}, {})
+
+      // move row-b to be the first child of the row-a:
+      // row-a
+      //  - row-b
+      //  - b
+      // this is an invalid state, we cannot have a row within another row
+      layout.onDragStop(
+        [
+          {
+              w: 12,
+              h: 8,
+              x: 0,
+              y: 2,
+              i: 'row-b',
+          },
+          {
+              w: 24,
+              h: 1,
+              x: 0,
+              y: 0,
+              i: 'row-a',
+          },
+          {
+              w: 12,
+              h: 8,
+              x: 0,
+              y: 10,
+              i: 'b',
+          }
+      ],
+        // @ts-expect-error
+        {},
+        {
+          w: 12,
+          h: 8,
+          x: 0,
+          y: 2,
+          i: 'row-b',
+        },
+        {},
+        {},
+        {}
+      );
+
+      //first call is skipped because onDragStop sets _skipOnLayoutChange
+      layout.onLayoutChange([])
+      // layout argument is irrelevant because we are in an invalid state and will load the old layout in this func
+      layout.onLayoutChange([])
+
+      // children state should be the same as in the beginning
+      expect(layout.state.children[0].state.key).toEqual('row-b');
+      expect(layout.state.children[0].state.y).toEqual(0);
+      expect(layout.state.children[0].parent).toBeInstanceOf(SceneGridLayout);
+      expect(layout.state.children[1].state.key).toEqual('row-a');
+      expect(layout.state.children[1].state.y).toEqual(1);
+      expect(layout.state.children[1].parent).toBeInstanceOf(SceneGridLayout);
+      expect((layout.state.children[1] as SceneGridRow).state.children[0].state.key).toEqual('b');
+      expect((layout.state.children[1] as SceneGridRow).state.children[0].state.y).toEqual(2);
+    })
   });
 
   describe('when using rows', () => {

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -372,7 +372,7 @@ describe('SceneGridLayout', () => {
       expect((layout.state.children[0] as SceneGridRow).state.children[1].state.y).toEqual(10);
     });
 
-    it('should disallow dropping a row within another row', () => {
+    it('should disallow dropping a row within another row and revert to initial layout', () => {
       const layout = new SceneGridLayout({
         children: [
           new SceneGridRow({
@@ -403,6 +403,7 @@ describe('SceneGridLayout', () => {
         isLazy: false,
       });
 
+      // we save the initial layout here, if a state is invalid we will revert to this layout
       layout.onDragStart([
         {
             w: 12,

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -36,6 +36,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
             className={cx('react-grid-layout', isDraggable && 'react-grid-layout--enable-move-animations')}
           >
             <ReactGridLayout
+              key={model.getLayoutKey()}
               width={width}
               /**
                 Disable draggable if mobile device, solving an issue with unintentionally

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -36,7 +36,6 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
             className={cx('react-grid-layout', isDraggable && 'react-grid-layout--enable-move-animations')}
           >
             <ReactGridLayout
-              key={model.getLayoutKey()}
               width={width}
               /**
                 Disable draggable if mobile device, solving an issue with unintentionally
@@ -54,6 +53,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
               draggableCancel=".grid-drag-cancel"
               // @ts-ignore: ignoring for now until we make the size type numbers-only
               layout={layout}
+              onDragStart={model.onDragStart}
               onDragStop={model.onDragStop}
               onResizeStop={model.onResizeStop}
               onLayoutChange={model.onLayoutChange}


### PR DESCRIPTION
https://github.com/grafana/scenes/assets/36818606/7487da9c-bc39-4992-98bc-95c96dc9c7d8

This is a different approach to https://github.com/grafana/scenes/pull/669 that fixes https://github.com/grafana/grafana/issues/83916.  

It involves saving the initial layout when a drag action starts and checks on drag stop if the state is invalid (e.g.: a row is within a row). If layout is invalid we flag it so that when `onLayoutChange` is called we load the old layout and revert to it. I'm not entirely happy with this solution but think this is the best approach for now to get this to the finish line.

- In the future, I think we can try to wrap the entire uncollapsed row with the `GridItemWrapper` to clearly highlight it for row dragging, although I'm not sure how panels dragging would work in this case. It would need to resize and allow dropping a panel in the row layout, but not another row. Maybe a grid within a grid? I'll look into this when I have some spare time

- Another option would be similar to the old architecture where we always keep `SceneGridRow`s parent as the layout and move the children below it from the old row to the new one. In the old arch everything is at the same level so you can easily drag and drop a row anywhere.
For the following layout:
```
-- row-a
   -- panel-a
   -- panel-b
   -- panel-c
--row-b
```

If we drag `row-b` before `panel-c`:
```
-- row-a
   -- panel-a
   -- panel-b
-- row-b
   -- panel-c
```
When we uncollapse `row-b`, `panel-c` gets picked up as a child of `row-b`. Although this UX feels a bit confusing.