### PR TITLE
feat: function `clearSceneApp` to de-cache initialized scene apps so that they can be fully reinitialized

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
@@ -8,7 +8,7 @@ import { SceneObject } from '../../core/types';
 import { EmbeddedScene } from '../EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../layout/SceneFlexLayout';
 import { SceneCanvasText } from '../SceneCanvasText';
-import { SceneApp, useSceneApp } from './SceneApp';
+import { clearSceneApp, SceneApp, useSceneApp } from './SceneApp';
 import { SceneAppPage } from './SceneAppPage';
 import { SceneRouteMatch } from './types';
 import { SceneReactObject } from '../SceneReactObject';
@@ -403,6 +403,29 @@ describe('SceneApp', () => {
     const app2 = useSceneApp(getSceneApp2);
 
     expect(app1).toBe(useSceneApp(getSceneApp1));
+    expect(app2).toBe(useSceneApp(getSceneApp2));
+  });
+
+  it('clearSceneApp should clear instances cached by useSceneApp', () => {
+    const getSceneApp1 = () =>
+      new SceneApp({
+        pages: [],
+      });
+
+    const getSceneApp2 = () =>
+      new SceneApp({
+        pages: [],
+      });
+
+    const app1 = useSceneApp(getSceneApp1);
+    const app2 = useSceneApp(getSceneApp2);
+
+    expect(app1).toBe(useSceneApp(getSceneApp1));
+    expect(app2).toBe(useSceneApp(getSceneApp2));
+
+    clearSceneApp(getSceneApp1);
+
+    expect(app1).not.toBe(useSceneApp(getSceneApp1));
     expect(app2).toBe(useSceneApp(getSceneApp2));
   });
 });

--- a/packages/scenes/src/components/SceneApp/SceneApp.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.tsx
@@ -51,3 +51,10 @@ export function useSceneApp(factory: () => SceneApp) {
 
   return newApp;
 }
+
+/**
+ * Deliberately remove a SceneApp from the cache to ensure that it is completely reinitialized, e.g., after a high-impact configuration change.
+ */
+export function clearSceneApp(factory: () => SceneApp) {
+  sceneAppCache.delete(factory);
+}


### PR DESCRIPTION
This supports a use case to completely refresh a scene app when in the event of an app plugin configuration change.
There are many ways to solve this problem, but this may be a useful option to speed up developer experience, to be used when a complete re-init of a scene app is acceptable UX.
