### PR TITLE
Chore: Remove viz panel tooltip related code that is no longer needed

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useReducer, useRef } from 'react';
+import React from 'react';
 import ReactGridLayout from 'react-grid-layout';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { SceneComponentProps } from '../../../core/types';
@@ -6,8 +6,7 @@ import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from './consta
 import { LazyLoader } from '../LazyLoader';
 import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridItemLike } from './types';
-// @ts-expect-error TODO remove when @grafana/ui is upgraded to 10.4
-import { LayoutItemContext, useStyles2, useTheme2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 
@@ -89,34 +88,8 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
   const { grid, layoutItem, index, totalCount, isLazy, style, onLoad, onChange, children, ...divProps } = props;
   const sceneChild = grid.getSceneLayoutChild(layoutItem.i)!;
   const className = sceneChild.getClassName?.();
-  const theme = useTheme2();
 
-  const boostedCount = useRef(0);
-  const [_, forceUpdate] = useReducer((x) => x + 1, 0);
-
-  const boostZIndex = useCallback(() => {
-    boostedCount.current += 1;
-    forceUpdate();
-
-    return () => {
-      boostedCount.current -= 1;
-      forceUpdate();
-    };
-  }, [forceUpdate]);
-
-  const ctxValue = useMemo(() => ({ boostZIndex }), [boostZIndex]);
-  const descIndex = totalCount - index;
   const innerContent = <sceneChild.Component model={sceneChild} key={sceneChild.state.key} />;
-  const innerContentWithContext = LayoutItemContext ? (
-    <LayoutItemContext.Provider value={ctxValue}>{innerContent}</LayoutItemContext.Provider>
-  ) : (
-    innerContent
-  );
-
-  const newStyle = {
-    ...style,
-    zIndex: boostedCount.current === 0 ? descIndex : theme.zIndex.dropdown,
-  };
 
   if (isLazy) {
     return (
@@ -125,10 +98,10 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
         key={sceneChild.state.key!}
         data-griditem-key={sceneChild.state.key}
         className={cx(className, props.className)}
-        style={newStyle}
+        style={style}
         ref={ref}
       >
-        {innerContentWithContext}
+        {innerContent}
         {children}
       </LazyLoader>
     );
@@ -141,9 +114,9 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
       key={sceneChild.state.key}
       data-griditem-key={sceneChild.state.key}
       className={cx(className, props.className)}
-      style={newStyle}
+      style={style}
     >
-      {innerContentWithContext}
+      {innerContent}
       {children}
     </div>
   );


### PR DESCRIPTION
This used to be needed for the new viz tooltips, but should no longer be needed now that they're [portaled](https://github.com/grafana/grafana/pull/81986).

This also fixes an issue where panels lower down a page always appeared beneath ones above when being moved around.

See also: https://github.com/grafana/grafana/pull/85563

Closes #622 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.3.1--canary.675.8546552145.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.3.1--canary.675.8546552145.0
  # or 
  yarn add @grafana/scenes@4.3.1--canary.675.8546552145.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
