### PR TITLE
AdHocFiltersVariable: Fixes issue updating hide state causing variable to be deactivated and prevent it from being shown again

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -326,19 +326,25 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
  * This hook is always returning model.state instead of a useState that remembers the last state emitted on the subject
  * The reason for this is so that if the model instance change this function will always return the latest state.
  */
-function useSceneObjectState<TState extends SceneObjectState>(model: SceneObjectBase<TState>): TState {
+export function useSceneObjectState<TState extends SceneObjectState>(model: SceneObjectBase<TState>): TState {
   const [_, setState] = useState<TState>(model.state);
   const stateAtFirstRender = model.state;
 
   useEffect(() => {
-    const s = model.subscribeToState(setState);
+    const unactivate = model.activate();
+    const s = model.subscribeToState((state) => {
+      setState(state);
+    });
 
     // Re-render component if the state changed between first render and useEffect (mount)
     if (model.state !== stateAtFirstRender) {
       setState(model.state);
     }
 
-    return () => s.unsubscribe();
+    return () => {
+      s.unsubscribe();
+      unactivate();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model]);
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -299,24 +299,34 @@ describe('AdHocFiltersVariable', () => {
         datasource: { uid: 'hello' },
         applyMode: 'manual',
         filters: [
-          {
-            key: 'key1',
-            operator: '=',
-            value: 'val1',
-            condition: '',
-          },
-          {
-            key: 'key2',
-            operator: '=~',
-            value: '[val2]',
-            condition: '',
-          },
+          { key: 'key1', operator: '=', value: 'val1' },
+          { key: 'key2', operator: '=~', value: '[val2]' },
         ],
       });
 
       variable.activate();
 
       expect(variable.getValue()).toBe(`key1="val1",key2=~"\\\\[val2\\\\]"`);
+    });
+
+    it('Updates filterExpression on setState', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+      });
+
+      variable.activate();
+
+      const stateUpdates: AdHocFiltersVariableState[] = [];
+      variable.subscribeToState((state) => stateUpdates.push(state));
+
+      expect(stateUpdates.length).toBe(0);
+
+      variable.setState({ filters: [{ key: 'key1', operator: '=', value: 'val2' }] });
+
+      expect(stateUpdates).toHaveLength(1);
+      expect(stateUpdates[0].filterExpression).toBe('key1="val2"');
     });
 
     it('Renders correct expression when passed an expression builder', () => {
@@ -329,18 +339,8 @@ describe('AdHocFiltersVariable', () => {
         applyMode: 'manual',
         expressionBuilder,
         filters: [
-          {
-            key: 'key1',
-            operator: '=',
-            value: 'val1',
-            condition: '',
-          },
-          {
-            key: 'key2',
-            operator: '=~',
-            value: '[val2]',
-            condition: '',
-          },
+          { key: 'key1', operator: '=', value: 'val1' },
+          { key: 'key2', operator: '=~', value: '[val2]' },
         ],
       });
 
@@ -353,14 +353,7 @@ describe('AdHocFiltersVariable', () => {
       const variable = new AdHocFiltersVariable({
         applyMode: 'manual',
         datasource: { uid: 'hello' },
-        filters: [
-          {
-            key: 'key1',
-            operator: '=',
-            value: 'val1',
-            condition: '',
-          },
-        ],
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
       });
 
       const evtHandler = jest.fn();
@@ -374,14 +367,7 @@ describe('AdHocFiltersVariable', () => {
       const variable = new AdHocFiltersVariable({
         applyMode: 'manual',
         datasource: { uid: 'hello' },
-        filters: [
-          {
-            key: 'key1',
-            operator: '=',
-            value: 'val1',
-            condition: '',
-          },
-        ],
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
       });
 
       const evtHandler = jest.fn();
@@ -395,14 +381,7 @@ describe('AdHocFiltersVariable', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
         applyMode: 'manual',
-        filters: [
-          {
-            key: 'key1',
-            operator: '=',
-            value: 'val1',
-            condition: '',
-          },
-        ],
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
       });
 
       variable.activate();
@@ -439,14 +418,7 @@ describe('AdHocFiltersVariable', () => {
     it('should use the model.state.set.Component to ensure the state filterset is activated', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
-        filters: [
-          {
-            key: 'key1',
-            operator: '=',
-            value: 'val1',
-            condition: '',
-          },
-        ],
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
       });
 
       render(<variable.Component model={variable} />);
@@ -503,18 +475,8 @@ function setup(overrides?: Partial<AdHocFiltersVariableState>) {
     datasource: { uid: 'my-ds-uid' },
     name: 'filters',
     filters: [
-      {
-        key: 'key1',
-        operator: '=',
-        value: 'val1',
-        condition: '',
-      },
-      {
-        key: 'key2',
-        operator: '=',
-        value: 'val2',
-        condition: '',
-      },
+      { key: 'key1', operator: '=', value: 'val1' },
+      { key: 'key2', operator: '=', value: 'val2' },
     ],
     ...overrides,
   });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -69,13 +69,15 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
    * The default builder creates a Prometheus/Loki compatible filter expression,
    * this can be overridden to create a different expression based on the current filters.
    */
-  expressionBuilder?: (filters: AdHocVariableFilter[]) => string;
+  expressionBuilder?: AdHocVariableExpressionBuilderFn;
 
   /**
    * @internal state of the new filter being added
    */
   _wip?: AdHocVariableFilter;
 }
+
+export type AdHocVariableExpressionBuilderFn = (filters: AdHocVariableFilter[]) => string;
 
 export type getTagKeysProvider = (
   variable: AdHocFiltersVariable,
@@ -107,44 +109,32 @@ export class AdHocFiltersVariable
       filters: [],
       datasource: null,
       applyMode: 'auto',
-      filterExpression: state.filterExpression ?? renderExpression(state),
+      filterExpression: state.filterExpression ?? renderExpression(state.expressionBuilder, state.filters),
       ...state,
     });
 
     if (this.state.applyMode === 'auto') {
       patchGetAdhocFilters(this);
     }
+  }
 
-    // Subscribe to filter changes and up the variable value (filterExpression)
-    this.addActivationHandler(() => {
-      this._subs.add(
-        this.subscribeToState((newState, prevState) => {
-          if (newState.filters !== prevState.filters) {
-            this._updateFilterExpression(newState, true);
-          }
-        })
-      );
+  public setState(update: Partial<AdHocFiltersVariableState>): void {
+    let filterExpressionChanged = false;
 
-      this._updateFilterExpression(this.state, false);
-    });
+    if (update.filters !== this.state.filters && !update.filterExpression) {
+      update.filterExpression = renderExpression(this.state.expressionBuilder, update.filters);
+      filterExpressionChanged = update.filterExpression !== this.state.filterExpression;
+    }
+
+    super.setState(update);
+
+    if (filterExpressionChanged) {
+      this.publishEvent(new SceneVariableValueChangedEvent(this), true);
+    }
   }
 
   public getValue(): VariableValue | undefined {
     return this.state.filterExpression;
-  }
-
-  private _updateFilterExpression(state: Partial<AdHocFiltersVariableState>, publishEvent: boolean) {
-    let expr = renderExpression(state);
-
-    if (expr === this.state.filterExpression) {
-      return;
-    }
-
-    this.setState({ filterExpression: expr });
-
-    if (publishEvent) {
-      this.publishEvent(new SceneVariableValueChangedEvent(this), true);
-    }
   }
 
   public _updateFilter(filter: AdHocVariableFilter, prop: keyof AdHocVariableFilter, value: string | undefined | null) {
@@ -286,8 +276,11 @@ export class AdHocFiltersVariable
   }
 }
 
-function renderExpression(state: Partial<AdHocFiltersVariableState>) {
-  return (state.expressionBuilder ?? renderPrometheusLabelFilters)(state.filters ?? []);
+function renderExpression(
+  builder: AdHocVariableExpressionBuilderFn | undefined,
+  filters: AdHocVariableFilter[] | undefined
+) {
+  return (builder ?? renderPrometheusLabelFilters)(filters ?? []);
 }
 
 export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHocFiltersVariable>) {


### PR DESCRIPTION
While troubleshooting the problem of clearing adhoc filters and setting hide: VariableHide.hideVariable and then adding filters and setting variable hide back to Variable.dontHide I discovered some fundamental issues with useState and AdHocFiltersVariable

Problem with useState.
* calling the useState hook from a component does not actually guarantee state updates as useState does not activate the source scene object. So what this means is that useState only works if there is something else keeping the object active (like the scene objects own Component). The VariableValueSelectWrapper uses variable.useState  but when the variable was hidden it was deactivated (since it was only it's component that counted in the refCount). 

Solution: 
* useState should also count as "refCount" activation and keep the source scene object alive. 



Problem with AdHocFiltersVariable 
* It updated filterExpression inside a subscribeToState (subscribing to it's own state). This could then trigger another state update if the expression had changed. But this can cause a problem as the state update that updates filterExpression happens inside the subscribeToState callback the order of state updates could be mangled for other objects subscribing to the variable state. 

Example.
1.  setState (update filters)  (state update A)
2. State change handler 1 triggers for update A (this is its own handler), it causes another setState with updated filterExpression (state update B)
3. State change handler 1 triggers for update B (does nothing as filters has not changed only filterExpression)
4. State change handler 2 triggers for update B (for some other component that subscribes to state)
5. State change handler 2 triggers for update A (for some other component that subscribes to state)

As you can see the other component subscribing to the variable state will get the first state change (with old filterExpression) as the last value. Could be fixed with updating filterExpresion inside a setTimeout but opted to update filterExpression inside an overridden setState function as this eliminates two state updates when updating filters. 

# Release notes 

SceneObject useState will now cause the scene object whose state is subscribed to to be activated. The same is not true for sceneObject.subscribeToState, which still does not cause the source object to be activated. 
