### PR TITLE
SceneRefreshPicker: Show the auto calculated value when auto is selected

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -200,7 +200,7 @@ describe('SceneRefreshPicker', () => {
       expect(calculateIntervalSpy).not.toHaveBeenCalled();
     });
 
-    xit('does not recalculate auto interval when a tick happens', () => {
+    it('does not recalculate auto interval when a tick happens', () => {
       const autoInterval = 20000;
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true, autoInterval);
 
@@ -231,7 +231,7 @@ describe('SceneRefreshPicker', () => {
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('debounces recalculation of auto interval when window is resized', async () => {
+    xit('debounces recalculation of auto interval when window is resized', async () => {
       Object.assign(window, { innerWidth: 1024 });
 
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);

--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -3,6 +3,7 @@ import { SceneTimeRange } from '../core/SceneTimeRange';
 import { SceneFlexItem, SceneFlexLayout } from './layout/SceneFlexLayout';
 import { SceneRefreshPicker } from './SceneRefreshPicker';
 import { RefreshPicker } from '@grafana/ui';
+import { fireEvent } from '@testing-library/dom';
 
 jest.mock('@grafana/data', () => {
   const originalModule = jest.requireActual('@grafana/data');
@@ -214,33 +215,37 @@ describe('SceneRefreshPicker', () => {
     });
 
     it('recalculates auto interval when window is resized', () => {
+      Object.assign(window, { innerWidth: 1024 });
+
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);
 
       // The initial calculation
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
 
       // A resize triggers
-      window.dispatchEvent(new Event('resize'));
+      fireEvent(window, new Event('resize'));
 
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(500);
 
       // The interval is recalculated
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
     });
 
     it('debounces recalculation of auto interval when window is resized', async () => {
+      Object.assign(window, { innerWidth: 1024 });
+
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);
 
       // The initial calculation
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
 
       // Multiple resize triggers
-      global.dispatchEvent(new Event('resize'));
-      global.dispatchEvent(new Event('resize'));
-      global.dispatchEvent(new Event('resize'));
-      global.dispatchEvent(new Event('resize'));
+      fireEvent(window, new Event('resize'));
+      fireEvent(window, new Event('resize'));
+      fireEvent(window, new Event('resize'));
+      fireEvent(window, new Event('resize'));
 
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(500);
 
       // The interval is recalculated
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);

--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -19,7 +19,7 @@ jest.mock('@grafana/data', () => {
 
 function setupScene(refresh: string, intervals?: string[], autoEnabled?: boolean, autoInterval = 20000) {
   // We need to mock this on every run otherwise we can't rely on the spy value
-  const calculateIntervalSpy = jest.fn(() => ({ interval: '', intervalMs: autoInterval }));
+  const calculateIntervalSpy = jest.fn(() => ({ interval: `${autoInterval / 1000}s`, intervalMs: autoInterval }));
 
   rangeUtil.calculateInterval = calculateIntervalSpy;
 
@@ -177,7 +177,7 @@ describe('SceneRefreshPicker', () => {
       expect(refreshPicker.state.autoEnabled).toBe(false);
     });
 
-    it('recalculates auto interval when time range changes and auto is selected', async () => {
+    it('recalculates auto interval when time range changes and auto is selected', () => {
       const { timeRange, calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value);
 
       // The initial calculation
@@ -191,14 +191,14 @@ describe('SceneRefreshPicker', () => {
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('does not recalculate auto interval when time range changes and auto is not selected', async () => {
+    it('does not recalculate auto interval when time range changes and auto is not selected', () => {
       const { timeRange, calculateIntervalSpy } = setupScene('5s');
       timeRange.setState({ from: 'now-30d', to: 'now-29d' });
       timeRange.onRefresh();
       expect(calculateIntervalSpy).not.toHaveBeenCalled();
     });
 
-    it('does not recalculate auto interval when a tick happens', async () => {
+    it('does not recalculate auto interval when a tick happens', () => {
       const autoInterval = 20000;
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true, autoInterval);
 
@@ -210,6 +210,39 @@ describe('SceneRefreshPicker', () => {
 
       // There is no additional calculation
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('recalculates auto interval when window is resized', () => {
+      const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);
+
+      // The initial calculation
+      expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
+
+      // A resize triggers
+      window.dispatchEvent(new Event('resize'));
+
+      jest.advanceTimersByTime(2000);
+
+      // The interval is recalculated
+      expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('debounces recalculation of auto interval when window is resized', async () => {
+      const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);
+
+      // The initial calculation
+      expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
+
+      // Multiple resize triggers
+      global.dispatchEvent(new Event('resize'));
+      global.dispatchEvent(new Event('resize'));
+      global.dispatchEvent(new Event('resize'));
+      global.dispatchEvent(new Event('resize'));
+
+      jest.advanceTimersByTime(2000);
+
+      // The interval is recalculated
+      expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -3,7 +3,6 @@ import { SceneTimeRange } from '../core/SceneTimeRange';
 import { SceneFlexItem, SceneFlexLayout } from './layout/SceneFlexLayout';
 import { SceneRefreshPicker } from './SceneRefreshPicker';
 import { RefreshPicker } from '@grafana/ui';
-import { fireEvent } from '@testing-library/dom';
 
 jest.mock('@grafana/data', () => {
   const originalModule = jest.requireActual('@grafana/data');
@@ -212,43 +211,6 @@ describe('SceneRefreshPicker', () => {
 
       // There is no additional calculation
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
-    });
-
-    xit('recalculates auto interval when window is resized', () => {
-      Object.assign(window, { innerWidth: 1024 });
-
-      const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);
-
-      // The initial calculation
-      expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
-
-      // A resize triggers
-      fireEvent(window, new Event('resize'));
-
-      jest.advanceTimersByTime(500);
-
-      // The interval is recalculated
-      expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
-    });
-
-    xit('debounces recalculation of auto interval when window is resized', async () => {
-      Object.assign(window, { innerWidth: 1024 });
-
-      const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);
-
-      // The initial calculation
-      expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
-
-      // Multiple resize triggers
-      fireEvent(window, new Event('resize'));
-      fireEvent(window, new Event('resize'));
-      fireEvent(window, new Event('resize'));
-      fireEvent(window, new Event('resize'));
-
-      jest.advanceTimersByTime(500);
-
-      // The interval is recalculated
-      expect(calculateIntervalSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -28,6 +28,7 @@ function setupScene(refresh: string, intervals?: string[], autoEnabled?: boolean
     autoEnabled,
     refresh,
     intervals,
+    autoMinInterval: '20s',
   });
 
   const scene = new SceneFlexLayout({

--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -200,7 +200,7 @@ describe('SceneRefreshPicker', () => {
       expect(calculateIntervalSpy).not.toHaveBeenCalled();
     });
 
-    it('does not recalculate auto interval when a tick happens', () => {
+    xit('does not recalculate auto interval when a tick happens', () => {
       const autoInterval = 20000;
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true, autoInterval);
 
@@ -214,7 +214,7 @@ describe('SceneRefreshPicker', () => {
       expect(calculateIntervalSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('recalculates auto interval when window is resized', () => {
+    xit('recalculates auto interval when window is resized', () => {
       Object.assign(window, { innerWidth: 1024 });
 
       const { calculateIntervalSpy } = setupScene(RefreshPicker.autoOption.value, undefined, true);

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -152,7 +152,7 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
   const { refresh, intervals, autoEnabled, autoValue, isOnCanvas, primary, withText } = model.useState();
   const isRunning = useQueryControllerState(model);
 
-  let text = autoEnabled ? autoValue : withText ? 'Refresh' : undefined;
+  let text = refresh === RefreshPicker.autoOption.value ? autoValue : withText ? 'Refresh' : undefined;
   let tooltip: string | undefined;
 
   if (isRunning) {


### PR DESCRIPTION
Show the computed auto value when auto is selected.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.5.3--canary.680.8568953297.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.5.3--canary.680.8568953297.0
  # or 
  yarn add @grafana/scenes@4.5.3--canary.680.8568953297.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
