### PR TITLE
Clone SceneQueryRunner together with _results

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -2009,6 +2009,32 @@ describe('SceneQueryRunner', () => {
       });
     });
   });
+
+  describe('when cloning', () => {
+    it('should clone query runner with necessary private members', async () => {
+      const layer = new TestAnnotationsDataLayer({ name: 'Layer 1' });
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'withAnnotations' }],
+        $timeRange: new SceneTimeRange(),
+        $data: new SceneDataLayerSet({ layers: [layer] }),
+      });
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+      layer.completeRun();
+
+      const clone = queryRunner.clone();
+
+      expect(clone['_resultAnnotations']).not.toBeUndefined();
+      expect(clone['_resultAnnotations'].length).toBe(1);
+      expect(clone['_resultAnnotations']).toStrictEqual(queryRunner['_resultAnnotations']);
+      expect(clone['_layerAnnotations']).not.toBeUndefined();
+      expect(clone['_layerAnnotations'].length).toBe(1);
+      expect(clone['_layerAnnotations']).toStrictEqual(queryRunner['_layerAnnotations']);
+      expect(clone['_results']['_buffer']).not.toEqual([]);
+    });
+  })
 });
 
 class CustomDataSource extends RuntimeDataSource {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -425,6 +425,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
     return clone;
   }
+
   private prepareRequests = (
     timeRange: SceneTimeRangeLike,
     ds: DataSourceApi

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -421,6 +421,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       clone['_layerAnnotations'] = this._layerAnnotations.map((frame) => ({ ...frame }));
     }
 
+    clone['_results'].next({ origin: this, data: this.state.data });
+
     return clone;
   }
   private prepareRequests = (

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -421,7 +421,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       clone['_layerAnnotations'] = this._layerAnnotations.map((frame) => ({ ...frame }));
     }
 
-    clone['_results'].next({ origin: this, data: this.state.data });
+    clone['_results'].next({ origin: this, data: this.state.data ?? emptyPanelData });
 
     return clone;
   }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/84575

Fixes an issue where the DashboardDS would not get the correct data from the source panels `SceneQueryRunner._results` because the source panel `_results` buffer would be empty. This affected the dashboard DS in various scenarios but was observed consistently when creating a new dashboard.

In a new dashboard, if you would create a new panel, it's `_results` buffer in the query runner would be empty. As soon as you saved the dashboard and refreshed the page the buffer would populate and thus the DashboardDS would also work.

The problem was in `SceneQueryRunner` cloning where we now emit the data in the clone so it can be picked up by the DashboardDS.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.5.4--canary.681.8570869587.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.5.4--canary.681.8570869587.0
  # or 
  yarn add @grafana/scenes@4.5.4--canary.681.8570869587.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
