### PR TITLE
Filters/GroupBy: Resolve queries only from active query runners

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -2,13 +2,13 @@ import { AdHocVariableFilter, DataSourceApi, MetricFindValue } from '@grafana/da
 import { allActiveGroupByVariables } from './findActiveGroupByVariablesByUid';
 import { DataSourceRef, VariableType } from '@grafana/schema';
 import { SceneComponentProps, ControlsLayout } from '../../core/types';
-import { DataQueryExtended, SceneQueryRunner } from '../../querying/SceneQueryRunner';
 import { sceneGraph } from '../../core/sceneGraph';
 import { ValidateAndUpdateResult, VariableValueOption, VariableValueSingle } from '../types';
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from '../variants/MultiValueVariable';
 import { from, map, mergeMap, Observable, of, take } from 'rxjs';
 import { getDataSource } from '../../utils/getDataSource';
 import { renderSelectForVariable } from '../components/VariableValueSelect';
+import { getQueriesForVariables } from '../utils';
 
 export interface GroupByVariableState extends MultiValueVariableState {
   /** Defaults to "Group" */
@@ -152,7 +152,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
       return [];
     }
 
-    const queries = this._getSceneQueries();
+    const queries = getQueriesForVariables(this);
     const otherFilters = this.state.baseFilters || [];
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     // @ts-expect-error TODO: remove this once 10.4.0 is released
@@ -176,31 +176,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
   public getDefaultMultiState(options: VariableValueOption[]): { value: VariableValueSingle[]; text: string[] } {
     return { value: [], text: [] };
   }
-
-  /**
-   * Get all queries in the scene that have the same datasource as this AggregationsSet
-   */
-  private _getSceneQueries(): DataQueryExtended[] {
-    const runners = sceneGraph.findAllObjects(
-      this.getRoot(),
-      (o) => o instanceof SceneQueryRunner
-    ) as SceneQueryRunner[];
-
-    const applicableRunners = runners.filter((r) => r.state.datasource?.uid === this.state.datasource?.uid);
-
-    if (applicableRunners.length === 0) {
-      return [];
-    }
-
-    const result: DataQueryExtended[] = [];
-    applicableRunners.forEach((r) => {
-      result.push(...r.state.queries);
-    });
-
-    return result;
-  }
 }
-
 export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValueVariable>) {
   return renderSelectForVariable(model);
 }

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -1,0 +1,83 @@
+import { DataSourceRef } from '@grafana/schema';
+import { EmbeddedScene } from '../components/EmbeddedScene';
+import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneObjectState } from '../core/types';
+import { SceneQueryRunner } from '../querying/SceneQueryRunner';
+import { getQueriesForVariables } from './utils';
+
+describe('getQueriesForVariables', () => {
+  it('should resolve queries', () => {
+    const runner1 = new SceneQueryRunner({
+      datasource: {
+        uid: 'test-uid',
+      },
+      queries: [{ refId: 'A' }],
+    });
+
+    const runner2 = new SceneQueryRunner({
+      datasource: {
+        uid: 'test-uid',
+      },
+      queries: [{ refId: 'B' }],
+    });
+
+    const source = new TestObject({ datasource: { uid: 'test-uid' } });
+    const _ = new EmbeddedScene({
+      $data: runner1,
+      body: new SceneFlexLayout({
+        children: [
+          new SceneFlexItem({
+            $data: runner2,
+            body: source,
+          }),
+        ],
+      }),
+    });
+
+    runner1.activate();
+    runner2.activate();
+    source.activate();
+    expect(getQueriesForVariables(source)).toEqual([{ refId: 'A' }, { refId: 'B' }]);
+  });
+
+  it('should ignore queries from inactive runners', () => {
+    const runner1 = new SceneQueryRunner({
+      datasource: {
+        uid: 'test-uid',
+      },
+      queries: [{ refId: 'A' }],
+    });
+
+    const runner2 = new SceneQueryRunner({
+      datasource: {
+        uid: 'test-uid',
+      },
+      queries: [{ refId: 'B' }],
+    });
+
+    const source = new TestObject({ datasource: { uid: 'test-uid' } });
+    const _ = new EmbeddedScene({
+      $data: runner1,
+      body: new SceneFlexLayout({
+        children: [
+          new SceneFlexItem({
+            $data: runner2,
+            body: source,
+          }),
+        ],
+      }),
+    });
+
+    runner1.activate();
+    source.activate();
+
+    expect(getQueriesForVariables(source)).toEqual([{ refId: 'A' }]);
+  });
+});
+
+interface TestObjectState extends SceneObjectState {
+  datasource?: DataSourceRef;
+}
+
+class TestObject extends SceneObjectBase<TestObjectState> {}

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -23,7 +23,7 @@ describe('getQueriesForVariables', () => {
     });
 
     const source = new TestObject({ datasource: { uid: 'test-uid' } });
-    const _ = new EmbeddedScene({
+    new EmbeddedScene({
       $data: runner1,
       body: new SceneFlexLayout({
         children: [
@@ -57,7 +57,8 @@ describe('getQueriesForVariables', () => {
     });
 
     const source = new TestObject({ datasource: { uid: 'test-uid' } });
-    const _ = new EmbeddedScene({
+
+    new EmbeddedScene({
       $data: runner1,
       body: new SceneFlexLayout({
         children: [
@@ -77,7 +78,7 @@ describe('getQueriesForVariables', () => {
 });
 
 interface TestObjectState extends SceneObjectState {
-  datasource?: DataSourceRef;
+  datasource: DataSourceRef | null;
 }
 
 class TestObject extends SceneObjectBase<TestObjectState> {}

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -85,7 +85,9 @@ function escapeLokiRegexp(value: string): string {
 /**
  * Get all queries in the scene that have the same datasource as provided source object
  */
-export function getQueriesForVariables(sourceObject: SceneObject<SceneObjectState & { datasource?: DataSourceRef }>) {
+export function getQueriesForVariables(
+  sourceObject: SceneObject<SceneObjectState & { datasource: DataSourceRef | null }>
+) {
   const runners = sceneGraph.findAllObjects(
     sourceObject.getRoot(),
     (o) => o instanceof SceneQueryRunner && o.isActive


### PR DESCRIPTION
This addresses a problem with `getTagValues` being called with queries from all runners in a scene, including inactive ones. 

This is problematic i.e. in a panel edit scenario in Grafana core. When one goes to panel edit all other panels are de-activated, but `getTagValues` for filters would still be executed with queries from runners of those inactive panels.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.5.7--canary.685.8631031033.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.5.7--canary.685.8631031033.0
  # or 
  yarn add @grafana/scenes@4.5.7--canary.685.8631031033.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
