### PR TITLE
GroupBy: Fetch options when opening menu

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -1045,7 +1045,6 @@ describe('SceneQueryRunner', () => {
 
       expect(runRequestMock.mock.calls.length).toEqual(2);
       const comaprisonRunRequestCall = runRequestMock.mock.calls[1];
-      console.log([comaprisonRunRequestCall]);
       expect(comaprisonRunRequestCall[1].targets.length).toEqual(1);
       expect(comaprisonRunRequestCall[1].targets[0].refId).toEqual('B');
     });
@@ -2034,7 +2033,7 @@ describe('SceneQueryRunner', () => {
       expect(clone['_layerAnnotations']).toStrictEqual(queryRunner['_layerAnnotations']);
       expect(clone['_results']['_buffer']).not.toEqual([]);
     });
-  })
+  });
 });
 
 class CustomDataSource extends RuntimeDataSource {

--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -1,6 +1,6 @@
 import { DataQueryRequest, DataSourceApi, getDefaultTimeRange, LoadingState, PanelData } from '@grafana/data';
 import { DataSourceSrv, locationService, setDataSourceSrv, setRunRequest } from '@grafana/runtime';
-import { act, render } from '@testing-library/react';
+import { act, getAllByRole, render, screen } from '@testing-library/react';
 import { lastValueFrom, Observable, of } from 'rxjs';
 import React from 'react';
 import { GroupByVariable, GroupByVariableState } from './GroupByVariable';
@@ -11,6 +11,7 @@ import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 import { VariableValueSelectors } from '../components/VariableValueSelectors';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
+import userEvent from '@testing-library/user-event';
 
 describe('GroupByVariable', () => {
   it('should not resolve values from the data source if default options provided', async () => {
@@ -131,6 +132,20 @@ describe('GroupByVariable', () => {
       timeRange: timeRange.state.value,
     });
   });
+
+  describe('component', () => {
+    it('should fetch dimensions when Select is opened', async () => {
+      const { variable, getTagKeysSpy } = setupTest();
+
+      expect(variable.isActive).toBe(true);
+      expect(getTagKeysSpy).not.toHaveBeenCalled();
+
+      const selects = getAllByRole(screen.getByTestId('GroupBySelect-testGroupBy'), 'combobox');
+      await userEvent.click(selects[0]);
+
+      expect(getTagKeysSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 const runRequestMock = {
@@ -171,6 +186,7 @@ export function setupTest(overrides?: Partial<GroupByVariableState>) {
 
   const variable = new GroupByVariable({
     name: 'test',
+    key: 'testGroupBy',
     value: '',
     text: '',
     datasource: { uid: 'my-ds-uid' },

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useMemo, useState } from 'react';
 import { AdHocVariableFilter, DataSourceApi, MetricFindValue } from '@grafana/data';
 import { allActiveGroupByVariables } from './findActiveGroupByVariablesByUid';
 import { DataSourceRef, VariableType } from '@grafana/schema';
@@ -6,9 +7,10 @@ import { DataQueryExtended, SceneQueryRunner } from '../../querying/SceneQueryRu
 import { sceneGraph } from '../../core/sceneGraph';
 import { ValidateAndUpdateResult, VariableValueOption, VariableValueSingle } from '../types';
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from '../variants/MultiValueVariable';
-import { from, map, mergeMap, Observable, of, take } from 'rxjs';
+import { from, lastValueFrom, map, mergeMap, Observable, of, take } from 'rxjs';
 import { getDataSource } from '../../utils/getDataSource';
-import { renderSelectForVariable } from '../components/VariableValueSelect';
+import { InputActionMeta, MultiSelect } from '@grafana/ui';
+import { isArray } from 'lodash';
 
 export interface GroupByVariableState extends MultiValueVariableState {
   /** Defaults to "Group" */
@@ -202,5 +204,64 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
 }
 
 export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValueVariable>) {
-  return renderSelectForVariable(model);
+  const { value, key, maxVisibleValues, noValueOnClear } = model.useState();
+  const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
+  const options = model.getOptionsForSelect();
+  const [isFetchingOptions, setIsFetchingOptions] = useState(false);
+  const [isOptionsOpen, setIsOptionsOpen] = useState(false);
+
+  // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
+  const [uncommittedValue, setUncommittedValue] = useState(arrayValue);
+
+  // Detect value changes outside
+  useEffect(() => {
+    setUncommittedValue(arrayValue);
+  }, [arrayValue]);
+
+  const onInputChange = model.onSearchChange
+    ? (value: string, meta: InputActionMeta) => {
+        if (meta.action === 'input-change') {
+          model.onSearchChange!(value);
+        }
+      }
+    : undefined;
+
+  const placeholder = options.length > 0 ? 'Select value' : '';
+  return (
+    <MultiSelect<VariableValueSingle>
+      id={key}
+      placeholder={placeholder}
+      width="auto"
+      value={uncommittedValue}
+      noMultiValueWrap={true}
+      maxVisibleValues={maxVisibleValues ?? 5}
+      tabSelectsValue={false}
+      virtualized
+      allowCustomValue
+      options={model.getOptionsForSelect()}
+      closeMenuOnSelect={false}
+      isOpen={isOptionsOpen}
+      isClearable={true}
+      isLoading={isFetchingOptions}
+      onInputChange={onInputChange}
+      onBlur={() => {
+        model.changeValueTo(uncommittedValue);
+      }}
+      onChange={(newValue, action) => {
+        if (action.action === 'clear' && noValueOnClear) {
+          model.changeValueTo([]);
+        }
+        setUncommittedValue(newValue.map((x) => x.value!));
+      }}
+      onOpenMenu={async () => {
+        setIsFetchingOptions(true);
+        await lastValueFrom(model.validateAndUpdate());
+        setIsFetchingOptions(false);
+        setIsOptionsOpen(true);
+      }}
+      onCloseMenu={() => {
+        setIsOptionsOpen(false);
+      }}
+    />
+  );
 }

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -54,6 +54,7 @@ export type getTagKeysProvider = (
 
 export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
   static Component = GroupByVariableRenderer;
+  isLazy = true;
 
   public validateAndUpdate(): Observable<ValidateAndUpdateResult> {
     return this.getValueOptions({}).pipe(
@@ -125,7 +126,6 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
       layout: 'horizontal',
       type: 'groupby' as VariableType,
       ...initialState,
-      isLazy: true,
       noValueOnClear: true,
     });
 

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -125,6 +125,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
       layout: 'horizontal',
       type: 'groupby' as VariableType,
       ...initialState,
+      isLazy: true,
       noValueOnClear: true,
     });
 
@@ -155,6 +156,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
     }
 
     const queries = getQueriesForVariables(this);
+
     const otherFilters = this.state.baseFilters || [];
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     // @ts-expect-error TODO: remove this once 10.4.0 is released
@@ -182,7 +184,6 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
 export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, key, maxVisibleValues, noValueOnClear } = model.useState();
   const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
-  const options = model.getOptionsForSelect();
   const [isFetchingOptions, setIsFetchingOptions] = useState(false);
   const [isOptionsOpen, setIsOptionsOpen] = useState(false);
 
@@ -202,9 +203,11 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
       }
     : undefined;
 
-  const placeholder = options.length > 0 ? 'Select value' : '';
+  const placeholder = 'Select value';
+
   return (
     <MultiSelect<VariableValueSingle>
+      data-testid={`GroupBySelect-${key}`}
       id={key}
       placeholder={placeholder}
       width="auto"

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -72,7 +72,7 @@ describe('SceneVariableList', () => {
     });
 
     it('should not start lazy variable', () => {
-      const A = new TestVariable({ isLazy: true, name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] }, true);
 
       const scene = new TestScene({
         $variables: new SceneVariableSet({ variables: [A] }),

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -70,6 +70,18 @@ describe('SceneVariableList', () => {
       C.signalUpdateCompleted();
       expect(C.state.issuedQuery).toBe('A.AA.AAA.*');
     });
+
+    it('should not start lazy variable', () => {
+      const A = new TestVariable({ isLazy: true, name: 'A', query: 'A.*', value: '', text: '', options: [] });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [A] }),
+      });
+
+      scene.activate();
+
+      expect(A.state.loading).toBe(undefined);
+    });
   });
 
   describe('When variable changes value', () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -67,7 +67,7 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
 
     // Add all variables that need updating to queue
     for (const variable of this.state.variables) {
-      if (!variable.state.isLazy && this._variableNeedsUpdate(variable)) {
+      if (this._variableNeedsUpdate(variable)) {
         this._variablesToUpdate.add(variable);
       }
     }
@@ -161,6 +161,10 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
   }
 
   private _variableNeedsUpdate(variable: SceneVariable): boolean {
+    if (variable.isLazy) {
+      return false;
+    }
+
     if (!variable.validateAndUpdate) {
       return false;
     }

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -67,7 +67,7 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
 
     // Add all variables that need updating to queue
     for (const variable of this.state.variables) {
-      if (this._variableNeedsUpdate(variable)) {
+      if (!variable.state.isLazy && this._variableNeedsUpdate(variable)) {
         this._variablesToUpdate.add(variable);
       }
     }

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -14,7 +14,6 @@ export interface SceneVariableState extends SceneObjectState {
   loading?: boolean;
   error?: any | null;
   description?: string | null;
-  isLazy?: boolean;
 }
 
 export interface SceneVariable<TState extends SceneVariableState = SceneVariableState> extends SceneObject<TState> {
@@ -44,6 +43,12 @@ export interface SceneVariable<TState extends SceneVariableState = SceneVariable
    * Allows cancelling variable execution.
    */
   onCancel?(): void;
+
+  /**
+   * @experimental
+   * Indicates that a variable loads values lazily when user interacts with the variable dropdown.
+   */
+  isLazy?: boolean;
 }
 
 export type VariableValue = VariableValueSingle | VariableValueSingle[];

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -14,6 +14,7 @@ export interface SceneVariableState extends SceneObjectState {
   loading?: boolean;
   error?: any | null;
   description?: string | null;
+  isLazy?: boolean;
 }
 
 export interface SceneVariable<TState extends SceneVariableState = SceneVariableState> extends SceneObject<TState> {

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -117,10 +117,12 @@ function filterOutInactiveRunnerDuplicates(runners: SceneQueryRunner[]) {
   const groupedItems: { [key: string]: SceneQueryRunner[] } = {};
 
   for (const item of runners) {
-    if (!(item.state.key in groupedItems)) {
-      groupedItems[item.state.key] = [];
+    if (item.state.key) {
+      if (!(item.state.key in groupedItems)) {
+        groupedItems[item.state.key] = [];
+      }
+      groupedItems[item.state.key].push(item);
     }
-    groupedItems[item.state.key].push(item);
   }
 
   // Filter out inactive items and concatenate active items

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -90,10 +90,12 @@ export function getQueriesForVariables(
 ) {
   const runners = sceneGraph.findAllObjects(
     sourceObject.getRoot(),
-    (o) => o instanceof SceneQueryRunner && o.isActive
+    (o) => o instanceof SceneQueryRunner
   ) as SceneQueryRunner[];
 
-  const applicableRunners = runners.filter((r) => r.state.datasource?.uid === sourceObject.state.datasource?.uid);
+  const applicableRunners = filterOutInactiveRunnerDuplicates(runners).filter((r) => {
+    return r.state.datasource?.uid === sourceObject.state.datasource?.uid;
+  });
 
   if (applicableRunners.length === 0) {
     return [];
@@ -105,4 +107,29 @@ export function getQueriesForVariables(
   });
 
   return result;
+}
+
+// Filters out inactive runner duplicates, keeping only the ones that are currently active.
+// This is needed for scnearios whan a query runner is cloned and the original is not removed but de-activated.
+// Can happen i.e. when editing a panel in Grafana Core dashboards.
+function filterOutInactiveRunnerDuplicates(runners: SceneQueryRunner[]) {
+  // Group items by key
+  const groupedItems: { [key: string]: SceneQueryRunner[] } = {};
+
+  for (const item of runners) {
+    if (!(item.state.key in groupedItems)) {
+      groupedItems[item.state.key] = [];
+    }
+    groupedItems[item.state.key].push(item);
+  }
+
+  // Filter out inactive items and concatenate active items
+  return Object.values(groupedItems).flatMap((group) => {
+    const activeItems = group.filter((item) => item.isActive);
+    // Keep inactive items if there's only one item with the key
+    if (activeItems.length === 0 && group.length === 1) {
+      return group;
+    }
+    return activeItems;
+  });
 }

--- a/packages/scenes/src/variables/variants/TestVariable.tsx
+++ b/packages/scenes/src/variables/variants/TestVariable.tsx
@@ -29,12 +29,13 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
   private completeUpdate = new Subject<number>();
   public isGettingValues = true;
   public getValueOptionsCount = 0;
+  isLazy = false;
 
   protected _variableDependency = new VariableDependencyConfig(this, {
     statePaths: ['query'],
   });
 
-  public constructor(initialState: Partial<TestVariableState>) {
+  public constructor(initialState: Partial<TestVariableState>, isLazy = false) {
     super({
       type: 'custom',
       name: 'Test',
@@ -45,6 +46,7 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
       refresh: VariableRefresh.onDashboardLoad,
       ...initialState,
     });
+    this.isLazy = isLazy;
   }
 
   public getValueOptions(args: VariableGetOptionsArgs): Observable<VariableValueOption[]> {


### PR DESCRIPTION
i think this does what we want, but leaving as draft for now to check the approach before adding tests etc

what this does:
- takes the rendering logic from `VariableValueSelectMulti`
- enhances with `isFetchingOptions` and `isOptionsOpen` logic controlled by `onOpenMenu`/`onCloseMenu`
- fetches and waits for new options when opening the menu via `model.validateAndUpdate()`

some questions:
- does this logic only apply to group by, or would we want it for any multi value variable?
  - if so, could move this new logic back into `VariableValueSelectMulti` 🤔 

Fixes #686 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.11.2--canary.687.8737546972.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.11.2--canary.687.8737546972.0
  # or 
  yarn add @grafana/scenes@4.11.2--canary.687.8737546972.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
