### PR TITLE
AdhocFilters: Show label for selected key

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -312,7 +312,7 @@ describe('SceneQueryRunner', () => {
       expect(runRequestCall[1].filters).toEqual(filtersVar.state.filters);
 
       // Verify updating filter re-triggers query
-      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', 'newValue');
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue' });
 
       await new Promise((r) => setTimeout(r, 1));
 

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -14,7 +14,7 @@ interface Props {
 function keyLabelToOption(key: string, label?: string): SelectableValue | null {
   return key !== ''
     ? {
-        key: key,
+        value: key,
         label: label || key,
       }
     : null;

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -1,14 +1,23 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
-import { AdHocFiltersVariable } from './AdHocFiltersVariable';
-import { AdHocVariableFilter, GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
+import { AdHocFiltersVariable, AdHocFilterWithLabels } from './AdHocFiltersVariable';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Button, Field, Select, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { ControlsLabel } from '../../utils/ControlsLabel';
 
 interface Props {
-  filter: AdHocVariableFilter;
+  filter: AdHocFilterWithLabels;
   model: AdHocFiltersVariable;
+}
+
+function keyLabelToOption(key: string, label?: string): SelectableValue | null {
+  return key !== ''
+    ? {
+        key: key,
+        label: label || key,
+      }
+    : null;
 }
 
 export function AdHocFilterRenderer({ filter, model }: Props) {
@@ -27,17 +36,8 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     isValuesOpen?: boolean;
   }>({});
 
-  const keyValue = useMemo(() => {
-    if (filter.key !== '') {
-      if (state.keys) {
-        return state.keys.find(option => option.value === filter.key);
-      } else {
-        return toOption(filter.key);
-      }
-    }
-    return null;
-  }, [filter.key, state.keys])
-  const valueValue = filter.value !== '' ? toOption(filter.value) : null;
+  const keyValue = keyLabelToOption(filter.key, filter.keyLabel);
+  const valueValue = keyLabelToOption(filter.value, filter.valueLabel);
 
   const valueSelect = (
     <Select
@@ -49,7 +49,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       value={valueValue}
       placeholder={'Select value'}
       options={state.values}
-      onChange={(v) => model._updateFilter(filter, 'value', v.value)}
+      onChange={(v) => model._updateFilter(filter, 'value', v)}
       isOpen={state.isValuesOpen}
       isLoading={state.isValuesLoading}
       autoFocus={filter.key !== '' && filter.value === ''}
@@ -76,7 +76,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       value={keyValue}
       placeholder={'Select label'}
       options={state.keys}
-      onChange={(v) => model._updateFilter(filter, 'key', v.value)}
+      onChange={(v) => model._updateFilter(filter, 'key', v)}
       autoFocus={filter.key === ''}
       isOpen={state.isKeysOpen}
       isLoading={state.isKeysLoading}
@@ -125,7 +125,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
         disabled={model.state.readOnly}
         options={model._getOperators()}
         width="auto"
-        onChange={(v) => model._updateFilter(filter, 'operator', v.value)}
+        onChange={(v) => model._updateFilter(filter, 'operator', v)}
       />
       {valueSelect}
       <Button

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 
-import { AdHocFiltersVariable, toSelectableValue } from './AdHocFiltersVariable';
+import { AdHocFiltersVariable } from './AdHocFiltersVariable';
 import { AdHocVariableFilter, GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { Button, Field, Select, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -29,17 +29,14 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
 
   const keyValue = useMemo(() => {
     if (filter.key !== '') {
-      if (model.state.defaultKeys) {
-        const matchingDefaultKey = model.state.defaultKeys.find(option => option.value === filter.key);
-        if (matchingDefaultKey) {
-          return toSelectableValue(matchingDefaultKey);
-        }
+      if (state.keys) {
+        return state.keys.find(option => option.value === filter.key);
       } else {
         return toOption(filter.key);
       }
     }
     return null;
-  }, [filter.key, model.state.defaultKeys])
+  }, [filter.key, state.keys])
   const valueValue = filter.value !== '' ? toOption(filter.value) : null;
 
   const valueSelect = (

--- a/packages/scenes/src/variables/adhoc/AdHocFilterValue.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterValue.tsx
@@ -21,7 +21,7 @@ export function AdHocFilterValue({ filter, placeHolder, model }: Props) {
         disabled={model.state.readOnly}
         placeholder={placeHolder}
         value={filter.value}
-        onChange={(v) => model._updateFilter(filter, 'value', v.value)}
+        onChange={(v) => model._updateFilter(filter, 'value', v)}
         loadOptions={loadValues}
       />
     </div>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -148,7 +148,7 @@ describe('AdHocFiltersVariable', () => {
     const { filtersVar } = setup();
 
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', 'newValue');
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue', label: 'newValue' });
     });
 
     expect(locationService.getLocation().search).toBe(
@@ -159,8 +159,22 @@ describe('AdHocFiltersVariable', () => {
       locationService.push('/?var-filters=key1|=|valUrl&var-filters=keyUrl|=~|urlVal');
     });
 
-    expect(filtersVar.state.filters[0]).toEqual({ key: 'key1', operator: '=', value: 'valUrl', condition: '' });
-    expect(filtersVar.state.filters[1]).toEqual({ key: 'keyUrl', operator: '=~', value: 'urlVal', condition: '' });
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'key1',
+      keyLabel: 'key1',
+      operator: '=',
+      value: 'valUrl',
+      valueLabel: 'valUrl',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'keyUrl',
+      keyLabel: 'keyUrl',
+      operator: '=~',
+      value: 'urlVal',
+      valueLabel: 'urlVal',
+      condition: '',
+    });
   });
 
   it('overrides state when url has empty key', () => {
@@ -191,6 +205,214 @@ describe('AdHocFiltersVariable', () => {
     });
 
     expect(filtersVar.state.filters.length).toEqual(2);
+  });
+
+  it('url sync with both key and value labels', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey', label: 'New Key' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue', label: 'New Value' });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=newKey,New%20Key%7C%3D%7CnewValue,New%20Value&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.push(
+        '/?var-filters=newKey,New Key|=|newValue,New Value&var-filters=newKey2,New Key 2|=~|newValue2,New Value 2'
+      );
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'newKey',
+      keyLabel: 'New Key',
+      operator: '=',
+      value: 'newValue',
+      valueLabel: 'New Value',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'newKey2',
+      keyLabel: 'New Key 2',
+      operator: '=~',
+      value: 'newValue2',
+      valueLabel: 'New Value 2',
+      condition: '',
+    });
+  });
+
+  it('url sync with key label and no value label', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey', label: 'New Key' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue' });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=newKey,New%20Key%7C%3D%7CnewValue&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.push('/?var-filters=newKey,New Key|=|newValue&var-filters=newKey2,New Key 2|=~|newValue2');
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'newKey',
+      keyLabel: 'New Key',
+      operator: '=',
+      value: 'newValue',
+      valueLabel: 'newValue',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'newKey2',
+      keyLabel: 'New Key 2',
+      operator: '=~',
+      value: 'newValue2',
+      valueLabel: 'newValue2',
+      condition: '',
+    });
+  });
+
+  it('url sync with no key label and value label', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue', label: 'New Value' });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=newKey%7C%3D%7CnewValue,New%20Value&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.push('/?var-filters=newKey|=|newValue,New Value&var-filters=newKey2|=~|newValue2,New Value 2');
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'newKey',
+      keyLabel: 'newKey',
+      operator: '=',
+      value: 'newValue',
+      valueLabel: 'New Value',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'newKey2',
+      keyLabel: 'newKey2',
+      operator: '=~',
+      value: 'newValue2',
+      valueLabel: 'New Value 2',
+      condition: '',
+    });
+  });
+
+  it('url sync with no key and value labels', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue' });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=newKey%7C%3D%7CnewValue&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.push('/?var-filters=newKey|=|newValue&var-filters=newKey2|=~|newValue2');
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'newKey',
+      keyLabel: 'newKey',
+      operator: '=',
+      value: 'newValue',
+      valueLabel: 'newValue',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'newKey2',
+      keyLabel: 'newKey2',
+      operator: '=~',
+      value: 'newValue2',
+      valueLabel: 'newValue2',
+      condition: '',
+    });
+  });
+
+  it('url sync with both key and value labels with commas', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey', label: 'New,Key' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue', label: 'New,Value' });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=newKey,New__gfc__Key%7C%3D%7CnewValue,New__gfc__Value&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.push(
+        '/?var-filters=newKey,New__gfc__Key|=|newValue,New__gfc__Value&var-filters=newKey2,New__gfc__Key__gfc__2|=~|newValue2,New__gfc__Value__gfc__2'
+      );
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'newKey',
+      keyLabel: 'New,Key',
+      operator: '=',
+      value: 'newValue',
+      valueLabel: 'New,Value',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'newKey2',
+      keyLabel: 'New,Key,2',
+      operator: '=~',
+      value: 'newValue2',
+      valueLabel: 'New,Value,2',
+      condition: '',
+    });
+  });
+
+  it('url sync with identical key and value labels', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey', label: 'newKey' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue', label: 'newValue' });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=newKey%7C%3D%7CnewValue&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.push('/?var-filters=newKey|=|newValue&var-filters=newKey2,newKey2|=~|newValue2,newValue2');
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'newKey',
+      keyLabel: 'newKey',
+      operator: '=',
+      value: 'newValue',
+      valueLabel: 'newValue',
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'newKey2',
+      keyLabel: 'newKey2',
+      operator: '=~',
+      value: 'newValue2',
+      valueLabel: 'newValue2',
+      condition: '',
+    });
   });
 
   it('Can override and replace getTagKeys and getTagValues', async () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -52,7 +52,7 @@ describe('AdHocFiltersVariable', () => {
 
     const selects = getAllByRole(wrapper, 'combobox');
 
-    await waitFor(() => select(selects[0], 'key3', { container: document.body }));
+    await waitFor(() => select(selects[0], 'Key 3', { container: document.body }));
     await waitFor(() => select(selects[2], 'val3', { container: document.body }));
 
     expect(filtersVar.state.filters.length).toBe(3);
@@ -124,7 +124,7 @@ describe('AdHocFiltersVariable', () => {
     const { getTagValuesSpy, timeRange } = setup({ filters: [] });
 
     // Select key
-    const key = 'key3';
+    const key = 'Key 3';
     await userEvent.click(screen.getByTestId('AdHocFilter-add'));
     const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
     await waitFor(() => select(selects[0], key, { container: document.body }));
@@ -133,7 +133,7 @@ describe('AdHocFiltersVariable', () => {
     expect(getTagValuesSpy).toBeCalledTimes(1);
     expect(getTagValuesSpy).toBeCalledWith({
       filters: [],
-      key,
+      key: 'key3',
       queries: [
         {
           expr: 'my_metric{}',
@@ -222,7 +222,7 @@ describe('AdHocFiltersVariable', () => {
 
     const keys = await filtersVar._getKeys(null);
     expect(keys).toEqual([
-      { label: 'key3', value: 'key3' },
+      { label: 'Key 3', value: 'key3' },
       { label: 'hello', value: '1' },
     ]);
 
@@ -258,6 +258,30 @@ describe('AdHocFiltersVariable', () => {
       { label: 'static', value: '2' },
       { label: 'keys', value: '3' },
     ]);
+  });
+
+  it('Selecting a key correctly shows the label', async () => {
+    const { filtersVar } = setup({
+      defaultKeys: [
+        {
+          text: 'some',
+          value: '1',
+        },
+        {
+          text: 'static',
+          value: '2',
+        },
+        {
+          text: 'keys',
+          value: '3',
+        },
+      ],
+    });
+    const selects = screen.getAllByRole('combobox');
+    await waitFor(() => select(selects[0], 'some', { container: document.body }));
+
+    expect(screen.getByText('some')).toBeInTheDocument();
+    expect(filtersVar.state.filters[0].key).toBe('1');
   });
 
   it('Selecting a default key correctly shows the label', async () => {
@@ -442,7 +466,7 @@ function setup(overrides?: Partial<AdHocFiltersVariableState>) {
       return {
         getTagKeys(options: any) {
           getTagKeysSpy(options);
-          return [{ text: 'key3' }];
+          return [{ text: 'Key 3', value: 'key3' }];
         },
         getTagValues(options: any) {
           getTagValuesSpy(options);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -349,33 +349,33 @@ describe('AdHocFiltersVariable', () => {
     const { filtersVar } = setup();
 
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'newKey', label: 'New,Key' });
-      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'newValue', label: 'New,Value' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'key', { value: 'new,Key', label: 'New,Key' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], 'value', { value: 'new,Value', label: 'New,Value' });
     });
 
     expect(locationService.getLocation().search).toBe(
-      '?var-filters=newKey,New__gfc__Key%7C%3D%7CnewValue,New__gfc__Value&var-filters=key2%7C%3D%7Cval2'
+      '?var-filters=new__gfc__Key,New__gfc__Key%7C%3D%7Cnew__gfc__Value,New__gfc__Value&var-filters=key2%7C%3D%7Cval2'
     );
 
     act(() => {
       locationService.push(
-        '/?var-filters=newKey,New__gfc__Key|=|newValue,New__gfc__Value&var-filters=newKey2,New__gfc__Key__gfc__2|=~|newValue2,New__gfc__Value__gfc__2'
+        '/?var-filters=new__gfc__Key,New__gfc__Key|=|new__gfc__Value,New__gfc__Value&var-filters=new__gfc__Key__gfc__2,New__gfc__Key__gfc__2|=~|new__gfc__Value__gfc__2,New__gfc__Value__gfc__2'
       );
     });
 
     expect(filtersVar.state.filters[0]).toEqual({
-      key: 'newKey',
+      key: 'new,Key',
       keyLabel: 'New,Key',
       operator: '=',
-      value: 'newValue',
+      value: 'new,Value',
       valueLabel: 'New,Value',
       condition: '',
     });
     expect(filtersVar.state.filters[1]).toEqual({
-      key: 'newKey2',
+      key: 'new,Key,2',
       keyLabel: 'New,Key,2',
       operator: '=~',
-      value: 'newValue2',
+      value: 'new,Value,2',
       valueLabel: 'New,Value,2',
       condition: '',
     });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -82,7 +82,7 @@ function toArray(filter: AdHocFilterWithLabels): string[] {
   ];
 }
 
-function toCommaDelimitedString(key: string, label: string): string {
+function toCommaDelimitedString(key: string, label?: string): string {
   // Omit for identical key/label or when label is not set at all
   if (!label || key === label) {
     return escapeCommaDelimiters(key);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -88,7 +88,7 @@ function toCommaDelimitedString(key: string, label?: string): string {
     return escapeCommaDelimiters(key);
   }
 
-  return [key, label].map(escapeCommaDelimiters).map(escapeCommaDelimiters).join(',');
+  return [key, label].map(escapeCommaDelimiters).join(',');
 }
 
 function toFilter(urlValue: string | number | boolean | undefined | null): AdHocFilterWithLabels | null {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -1,6 +1,5 @@
-import { AdHocVariableFilter } from '@grafana/data';
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValue, SceneObjectUrlValues } from '../../core/types';
-import { AdHocFiltersVariable } from './AdHocFiltersVariable';
+import { AdHocFiltersVariable, AdHocFilterWithLabels } from './AdHocFiltersVariable';
 
 export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _variable: AdHocFiltersVariable) {}
@@ -20,7 +19,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       return { [this.getKey()]: [''] };
     }
 
-    const value = filters.map((filter) => toArray(filter).map(escapeDelimiter).join('|'));
+    const value = filters.map((filter) => toArray(filter).map(escapePipeDelimiters).join('|'));
     return { [this.getKey()]: value };
   }
 
@@ -36,7 +35,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
   }
 }
 
-function deserializeUrlToFilters(value: SceneObjectUrlValue): AdHocVariableFilter[] {
+function deserializeUrlToFilters(value: SceneObjectUrlValue): AdHocFilterWithLabels[] {
   if (Array.isArray(value)) {
     const values = value;
     return values.map(toFilter).filter(isFilter);
@@ -46,41 +45,78 @@ function deserializeUrlToFilters(value: SceneObjectUrlValue): AdHocVariableFilte
   return filter === null ? [] : [filter];
 }
 
-function escapeDelimiter(value: string | undefined): string {
+function escapePipeDelimiters(value: string | undefined): string {
   if (value === null || value === undefined) {
     return '';
   }
 
-  return /\|/g[Symbol.replace](value, '__gfp__');
+  // Replace the pipe due to using it as a filter separator
+  return (value = /\|/g[Symbol.replace](value, '__gfp__'));
 }
 
-function unescapeDelimiter(value: string | undefined): string {
+function escapeCommaDelimiters(value: string | undefined): string {
   if (value === null || value === undefined) {
     return '';
   }
 
-  return /__gfp__/g[Symbol.replace](value, '|');
+  // Replace the comma due to using it as a value/label separator
+  return /,/g[Symbol.replace](value, '__gfc__');
 }
 
-function toArray(filter: AdHocVariableFilter): string[] {
-  return [filter.key, filter.operator, filter.value];
+function unescapeDelimiters(value: string | undefined): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  value = /__gfp__/g[Symbol.replace](value, '|');
+  value = /__gfc__/g[Symbol.replace](value, ',');
+
+  return value;
 }
 
-function toFilter(value: string | number | boolean | undefined | null): AdHocVariableFilter | null {
-  if (typeof value !== 'string' || value.length === 0) {
+function toArray(filter: AdHocFilterWithLabels): string[] {
+  return [
+    toCommaDelimitedString(filter.key, filter.keyLabel),
+    filter.operator,
+    toCommaDelimitedString(filter.value, filter.valueLabel),
+  ];
+}
+
+function toCommaDelimitedString(key: string, label: string): string {
+  // Omit for identical key/label or when label is not set at all
+  if (!label || key === label) {
+    return escapeCommaDelimiters(key);
+  }
+
+  return [key, label].map(escapeCommaDelimiters).map(escapeCommaDelimiters).join(',');
+}
+
+function toFilter(urlValue: string | number | boolean | undefined | null): AdHocFilterWithLabels | null {
+  if (typeof urlValue !== 'string' || urlValue.length === 0) {
     return null;
   }
 
-  const parts = value.split('|').map(unescapeDelimiter);
+  const [key, keyLabel, operator, _operatorLabel, value, valueLabel] = urlValue
+    .split('|')
+    .reduce<string[]>((acc, v) => {
+      const [key, label] = v.split(',');
+
+      acc.push(key, label ?? key);
+
+      return acc;
+    }, [])
+    .map(unescapeDelimiters);
 
   return {
-    key: parts[0],
-    operator: parts[1],
-    value: parts[2],
+    key,
+    keyLabel,
+    operator,
+    value,
+    valueLabel,
     condition: '',
   };
 }
 
-function isFilter(filter: AdHocVariableFilter | null): filter is AdHocVariableFilter {
+function isFilter(filter: AdHocFilterWithLabels | null): filter is AdHocFilterWithLabels {
   return filter !== null && typeof filter.key === 'string' && typeof filter.value === 'string';
 }


### PR DESCRIPTION
Ensures we find the selected option from the list and get the full key/value object instead of creating a new object from just the key
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.11.3--canary.690.8783271240.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.11.3--canary.690.8783271240.0
  # or 
  yarn add @grafana/scenes@4.11.3--canary.690.8783271240.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
