### PR TITLE
LocalValueVariable: Do not throw when missing parent variable

### DIFF
--- a/packages/scenes/src/variables/variants/LocalValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.test.ts
@@ -1,0 +1,49 @@
+import { SceneVariableSet } from '../sets/SceneVariableSet';
+import { TestScene } from '../TestScene';
+import { LocalValueVariable } from './LocalValueVariable';
+import { TestVariable } from './TestVariable';
+
+describe('LocalValueVariable', () => {
+  describe('isAncestorLoading', () => {
+    it('Should return ancestor state', async () => {
+      const { scene, localVar } = setup();
+
+      scene.activate();
+      expect(localVar.isAncestorLoading()).toBe(true);
+    });
+
+    it('Should handle missing parent var', async () => {
+      const { scene, localVar } = setup();
+
+      scene.setState({ $variables: new SceneVariableSet({ variables: [] }) });
+      scene.activate();
+
+      expect(localVar.isAncestorLoading()).toBe(false);
+    });
+  });
+});
+
+function setup() {
+  const localVar = new LocalValueVariable({
+    name: 'test',
+    value: 'nestedValue',
+  });
+
+  const scene = new TestScene({
+    $variables: new SceneVariableSet({
+      variables: [
+        new TestVariable({
+          name: 'test',
+          options: [],
+          optionsToReturn: [{ label: 'B', value: 'B' }],
+        }),
+      ],
+    }),
+    nested: new TestScene({
+      $variables: new SceneVariableSet({
+        variables: [localVar],
+      }),
+    }),
+  });
+  return { scene, localVar };
+}

--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -58,6 +58,6 @@ export class LocalValueVariable
       return set.isVariableLoadingOrWaitingToUpdate(parentVar);
     }
 
-    throw new Error('LocalValueVariable requires a parent SceneVariableSet that has an ancestor SceneVariableSet');
+    return false;
   }
 }


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/85934 

I think if we have to do that try catch there, might just be simpler to support this scenario in LocalValueVariable 