### PR TITLE
SceneComponentWrapper: More robust activation

### DIFF
--- a/packages/scenes/src/core/SceneComponentWrapper.tsx
+++ b/packages/scenes/src/core/SceneComponentWrapper.tsx
@@ -1,20 +1,21 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { SceneComponentProps, SceneObject } from './types';
 
 function SceneComponentWrapperWithoutMemo<T extends SceneObject>({ model, ...otherProps }: SceneComponentProps<T>) {
   const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
-  const [activated, setActivated] = React.useState(false);
+  const [_, setValue] = useState(0);
 
   useEffect(() => {
-    setActivated(true);
-    return model.activate();
+    const unsub = model.activate();
+    setValue((prevState) => prevState + 1);
+    return unsub;
   }, [model]);
 
   // By not rendering the component until the model is actiavted we make sure that parent models get activated before child models
   // Otherwise child models would be activated before parents as that is the order of React mount effects.
   // This also enables static logic to happen inside activate that can change state before the first render.
-  if (!activated) {
+  if (!model.isActive) {
     return null;
   }
 


### PR DESCRIPTION
This is a companion fix to https://github.com/grafana/grafana/pull/86093 to make sure bugs like that cannot happen again by fixing the issue in SceneComponentWrapper so that we never render model components before they are activated. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.7.0--canary.692.8683393495.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.7.0--canary.692.8683393495.0
  # or 
  yarn add @grafana/scenes@4.7.0--canary.692.8683393495.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
