### PR TITLE
SceneGridLayout: Fix issue with grid taking 0 height

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -9,20 +9,22 @@ import { SceneGridItemLike } from './types';
 import { useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
+import { useMeasure } from 'react-use';
 
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
   const { children, isLazy, isDraggable, isResizable } = model.useState();
+  const [ref, { height }] = useMeasure();
 
   validateChildrenSize(children);
 
   return (
-    <AutoSizer>
-      {({ width, height }) => {
+    <AutoSizer disableHeight>
+      {({ width }) => {
         if (width === 0) {
           return null;
         }
 
-        const layout = model.buildGridLayout(width, height);
+        const layout = model.buildGridLayout(width, Math.round(height));
 
         return (
           /**
@@ -33,6 +35,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
           <div
             style={{ width: `${width}px`, height: '100%', position: 'relative', zIndex: 1 }}
             className={cx('react-grid-layout', isDraggable && 'react-grid-layout--enable-move-animations')}
+            ref={ref}
           >
             <ReactGridLayout
               width={width}


### PR DESCRIPTION
**Problem**
Autosizer forces the consumer to have a parent with height or with flex layout.

This was causing the issue of having grid with height 0.

**Approach**
We can avoid that by not giving control to Autosizer and leaving the height to be the content.

We need the height from `Autosizer` to know the space available to fill all panels for the autofit feature. However, we don't need to let the component manage it, so we can use `useMeasure` to get the height.

This approach can be improved to do the measurement only if the autofit is enabled.

**TODO**
It gets into an infinite loop. In case someone have time to take a look, feel free to take it