### PR TITLE
Remove sceneObject from scoped vars

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -162,7 +162,6 @@ describe('SceneQueryRunner', () => {
 
       expect(Object.keys(scopedVars)).toMatchInlineSnapshot(`
         [
-          "__sceneObject",
           "__interval",
           "__interval_ms",
         ]
@@ -278,9 +277,7 @@ describe('SceneQueryRunner', () => {
       await new Promise((r) => setTimeout(r, 1));
 
       const getDataSourceCall = getDataSourceMock.mock.calls[0];
-      const runRequestCall = runRequestMock.mock.calls[0];
 
-      expect(runRequestCall[1].scopedVars.__sceneObject).toEqual({ value: queryRunner, text: '__sceneObject' });
       expect(getDataSourceCall[1].__sceneObject).toEqual({ value: queryRunner, text: '__sceneObject' });
     });
 
@@ -2034,7 +2031,7 @@ describe('SceneQueryRunner', () => {
       expect(clone['_layerAnnotations']).toStrictEqual(queryRunner['_layerAnnotations']);
       expect(clone['_results']['_buffer']).not.toEqual([]);
     });
-  })
+  });
 });
 
 class CustomDataSource extends RuntimeDataSource {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -17,7 +17,7 @@ import {
 
 // TODO: Remove this ignore annotation when the grafana runtime dependency has been updated
 // @ts-ignore
-import { getRunRequest, toDataQueryError, isExpressionReference} from '@grafana/runtime';
+import { getRunRequest, toDataQueryError, isExpressionReference } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
@@ -445,7 +445,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       intervalMs: 1000,
       targets: cloneDeep(queries),
       maxDataPoints: this.getMaxDataPoints(),
-      scopedVars: this._scopedVars,
+      scopedVars: {
+        ...this._scopedVars,
+        __sceneObject: undefined,
+      },
       startTime: Date.now(),
       liveStreaming: this.state.liveStreaming,
       rangeRaw: {
@@ -471,7 +474,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     request.targets = request.targets.map((query) => {
       if (
         !query.datasource ||
-        (query.datasource.uid !== ds.uid && !ds.meta?.mixed && isExpressionReference /* TODO: Remove this check when isExpressionReference is properly exported from grafan runtime */ && !isExpressionReference(query.datasource))
+        (query.datasource.uid !== ds.uid &&
+          !ds.meta?.mixed &&
+          isExpressionReference /* TODO: Remove this check when isExpressionReference is properly exported from grafan runtime */ &&
+          !isExpressionReference(query.datasource))
       ) {
         query.datasource = ds.getRef();
       }

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -220,14 +220,11 @@ describe('AnnotationsDataLayer', () => {
         expect(runRequestMock).toBeCalledTimes(2);
         const { scopedVars } = sentRequest!;
 
-        expect(scopedVars['__sceneObject']).toBeDefined();
-        expect(scopedVars['__sceneObject']?.value).toBe(layer);
         expect(Object.keys(scopedVars)).toMatchInlineSnapshot(`
           [
             "__interval",
             "__interval_ms",
             "__annotation",
-            "__sceneObject",
           ]
         `);
       });

--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -97,7 +97,6 @@ export function executeAnnotationQuery(
     __interval: { text: interval.interval, value: interval.interval },
     __interval_ms: { text: interval.intervalMs.toString(), value: interval.intervalMs },
     __annotation: { text: annotation.name, value: annotation },
-    __sceneObject: { text: '__sceneObject', value: layer },
   };
 
   const queryRequest: DataQueryRequest = {

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -172,9 +172,7 @@ describe('QueryVariable', () => {
       await lastValueFrom(variable.validateAndUpdate());
 
       const getDataSourceCall = getDataSourceMock.mock.calls[0];
-      const runRequestCall = runRequestMock.mock.calls[0];
 
-      expect(runRequestCall[1].scopedVars.__sceneObject).toEqual({ value: variable, text: '__sceneObject' });
       expect(getDataSourceCall[1].__sceneObject).toEqual({ value: variable, text: '__sceneObject' });
     });
 

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -112,9 +112,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
   }
 
   private getRequest(target: DataQuery | string, searchFilter?: string) {
-    const scopedVars: ScopedVars = {
-      __sceneObject: { text: '__sceneObject', value: this },
-    };
+    const scopedVars: ScopedVars = {};
 
     if (searchFilter) {
       scopedVars.__searchFilter = { value: searchFilter, text: searchFilter };


### PR DESCRIPTION
Remove `__sceneObject` from `scopedVars`. This is causing various issues with datasources that are stringifing the request object for various reasons.