### PR TITLE
Fix ${__all_variables} not updating their value in panels

### DIFF
--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -1,3 +1,4 @@
+import { DataLinkBuiltInVars } from '@grafana/data';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObject, SceneObjectState } from '../core/types';
 import { writeSceneLog } from '../utils/writeSceneLog';

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -66,7 +66,11 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
     const deps = this.getNames();
     let dependencyChanged = false;
 
-    if (deps.has(variable.state.name) && hasChanged) {
+    // if the panel is dependant on __all_ variables, it means any variable update should force a re-render
+    // TODO: I noticed there is a variable macro called ALLVariablesMacro, is there a way to use that here?
+    const ALL_VARIABLES = '__all_variables';
+
+    if ((deps.has(variable.state.name) || deps.has(ALL_VARIABLES)) && hasChanged) {
       dependencyChanged = true;
     }
 

--- a/packages/scenes/src/variables/VariableDependencyConfig.ts
+++ b/packages/scenes/src/variables/VariableDependencyConfig.ts
@@ -66,11 +66,7 @@ export class VariableDependencyConfig<TState extends SceneObjectState> implement
     const deps = this.getNames();
     let dependencyChanged = false;
 
-    // if the panel is dependant on __all_ variables, it means any variable update should force a re-render
-    // TODO: I noticed there is a variable macro called ALLVariablesMacro, is there a way to use that here?
-    const ALL_VARIABLES = '__all_variables';
-
-    if ((deps.has(variable.state.name) || deps.has(ALL_VARIABLES)) && hasChanged) {
+    if ((deps.has(variable.state.name) || deps.has(DataLinkBuiltInVars.includeVars)) && hasChanged) {
       dependencyChanged = true;
     }
 


### PR DESCRIPTION
Issue reported here [Dashboard Migration: ${__all_variables} not updating their value in panels #86296](https://github.com/grafana/grafana/issues/86296)

I noticed that `$__all_variables` is not being updated when a variable changes. I lack context in this area, and this is my attempt to understand it. 

Is there a better way to fix this issue?


https://github.com/grafana/scenes/assets/239999/81570ceb-3650-44af-8339-498a3b90f4d4

