### PR TITLE
Add method to get ancestor for localValueVariable

### DIFF
--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -60,4 +60,19 @@ export class LocalValueVariable
 
     return false;
   }
+
+  public getAncestorVariable(): SceneVariable | null {
+    // Parent (SceneVariableSet) -> Parent (The object that has our parent set) -> Parent (scope we need to access our sets ancestor)
+    const ancestorScope = this.parent?.parent?.parent;
+    if (!ancestorScope) {
+      throw new Error('LocalValueVariable requires a parent SceneVariableSet that has an ancestor SceneVariableSet');
+    }
+
+    const parentVar = sceneGraph.lookupVariable(this.state.name, ancestorScope);
+    if (!parentVar) {
+      return null;
+    }
+
+    return parentVar;
+  }
 }


### PR DESCRIPTION
In certain scenarios (e.g.: https://github.com/grafana/grafana/issues/84915) where we repeat a panel under a repeated row using the same variable, the `DashboardGridItem._performRepeat` looks up and finds the variable in the grid row, since they have the same name, and since that is a `LocalValueVariable` it cannot perform the repeat with it. 

With this method we can get the parent variable of the `LocalValueVariable` and use that to repeat.

Needed by https://github.com/grafana/grafana/pull/86425

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.11.1--canary.699.8720696583.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.11.1--canary.699.8720696583.0
  # or 
  yarn add @grafana/scenes@4.11.1--canary.699.8720696583.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
