### PR TITLE
Interval variable: Make interval variable properly update on name change

### DIFF
--- a/packages/scenes/src/variables/variants/IntervalVariable.tsx
+++ b/packages/scenes/src/variables/variants/IntervalVariable.tsx
@@ -42,7 +42,7 @@ export class IntervalVariable
       ...initialState,
     });
 
-    this._urlSync = new SceneObjectUrlSyncConfig(this, { keys: [this.getKey()] });
+    this._urlSync = new SceneObjectUrlSyncConfig(this, { keys: () => [this.getKey()] });
   }
 
   private getKey(): string {


### PR DESCRIPTION
The interval variable was not correctly changing when the name was updated. This is because the url sync config option `keys` property was set statically to whatever the name was when the variable object was created. This PR changes the property to a function, so the key is looked up when `getKeys` is called