### PR TITLE
VizPanel: Fixes issue updating instanceState

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -219,6 +219,16 @@ describe('VizPanel', () => {
     });
   });
 
+  describe('getLegacyPanelId', () => {
+    it('should return panel id', () => {
+      const panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+        key: 'panel-12',
+      });
+
+      expect(panel.getLegacyPanelId()).toBe(12);
+    });
+  });
+
   describe('updating options', () => {
     let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
 

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -406,7 +406,10 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     if (this._panelContext) {
       this._panelContext = {
         ...this._panelContext,
-        instanceState: this.state._pluginInstanceState,
+        instanceState: {
+          ...this._panelContext.instanceState,
+          ...state,
+        },
       };
     }
 

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -147,7 +147,12 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   }
 
   public getLegacyPanelId() {
-    return this.getPanelContext().instanceState?.legacyPanelId ?? 1;
+    const panelId = parseInt(this.state.key!.replace('panel-', ''), 10);
+    if (isNaN(panelId)) {
+      return 0;
+    }
+
+    return panelId;
   }
 
   private async _pluginLoaded(plugin: PanelPlugin) {
@@ -406,10 +411,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     if (this._panelContext) {
       this._panelContext = {
         ...this._panelContext,
-        instanceState: {
-          ...this._panelContext.instanceState,
-          ...state,
-        },
+        instanceState: state,
       };
     }
 

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -203,6 +203,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
   public getPanelContext(): PanelContext {
     this._panelContext ??= this.buildPanelContext();
+
     return this._panelContext!;
   }
 
@@ -402,6 +403,13 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   };
 
   private _onInstanceStateChange = (state: any) => {
+    if (this._panelContext) {
+      this._panelContext = {
+        ...this._panelContext,
+        instanceState: this.state._pluginInstanceState,
+      };
+    }
+
     this.setState({ _pluginInstanceState: state });
   };
 


### PR DESCRIPTION
Trying to fix https://github.com/grafana/grafana/issues/86554 

Also changing / skipping using instanceState for legacyPanelId as this is a bit problematic as this state is really reserved to only be used by the panel plugin so for Grafana to use it causes issues (we have to make sure we preserve legacyPanelId when we handle onInstanceStateChange. 


I am tempted to just add legacyPanelId to VizPanel state (instead of parsing it from key) but not sure. 



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.12.0--canary.702.8784713837.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.12.0--canary.702.8784713837.0
  # or 
  yarn add @grafana/scenes@4.12.0--canary.702.8784713837.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
