### PR TITLE
Fix how the submenus appear for menus of type group

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -45,7 +45,7 @@ function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
           case 'group':
             return (
               <Menu.Group key={item.text} label={item.text}>
-                {renderItems(item.subMenu)}
+                {item.subMenu ? renderItems(item.subMenu) : undefined}
               </Menu.Group>
             );
           default:

--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -38,19 +38,30 @@ function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
 
   const renderItems = (items: PanelMenuItem[]) => {
     return items.map((item) =>
-      item.type === 'divider' ? (
-        <Menu.Divider key={item.text} />
-      ) : (
-        <Menu.Item
-          key={item.text}
-          label={item.text}
-          icon={item.iconClassName}
-          childItems={item.subMenu ? renderItems(item.subMenu) : undefined}
-          url={item.href}
-          onClick={item.onClick}
-          shortcut={item.shortcut}
-        />
-      )
+      {
+        switch (item.type) {
+          case 'divider':
+            return <Menu.Divider key={item.text} />;
+          case 'group':
+            return (
+              <Menu.Group key={item.text} label={item.text}>
+                {renderItems(item.subMenu)}
+              </Menu.Group>
+            );
+          default:
+            return (
+              <Menu.Item
+                key={item.text}
+                label={item.text}
+                icon={item.iconClassName}
+                childItems={item.subMenu ? renderItems(item.subMenu) : undefined}
+                url={item.href}
+                onClick={item.onClick}
+                shortcut={item.shortcut}
+              />
+            );
+        }
+      }
     );
   };
 


### PR DESCRIPTION
Show group menus correctly in scenes dashboards.

Fixes https://github.com/grafana/grafana/issues/84807
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.12.1--canary.704.8799450327.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.12.1--canary.704.8799450327.0
  # or 
  yarn add @grafana/scenes@4.12.1--canary.704.8799450327.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
