### PR TITLE
GroupByVariable: Sync label to URL

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -1,5 +1,6 @@
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValue, SceneObjectUrlValues } from '../../core/types';
 import { AdHocFiltersVariable, AdHocFilterWithLabels, isFilterComplete } from './AdHocFiltersVariable';
+import { escapeUrlPipeDelimiters, toUrlCommaDelimitedString, unescapeUrlDelimiters } from '../utils';
 
 export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _variable: AdHocFiltersVariable) {}
@@ -19,7 +20,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       return { [this.getKey()]: [''] };
     }
 
-    const value = filters.filter(isFilterComplete).map((filter) => toArray(filter).map(escapePipeDelimiters).join('|'));
+    const value = filters.filter(isFilterComplete).map((filter) => toArray(filter).map(escapeUrlPipeDelimiters).join('|'));
     return { [this.getKey()]: value };
   }
 
@@ -45,50 +46,12 @@ function deserializeUrlToFilters(value: SceneObjectUrlValue): AdHocFilterWithLab
   return filter === null ? [] : [filter];
 }
 
-function escapePipeDelimiters(value: string | undefined): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  // Replace the pipe due to using it as a filter separator
-  return (value = /\|/g[Symbol.replace](value, '__gfp__'));
-}
-
-function escapeCommaDelimiters(value: string | undefined): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  // Replace the comma due to using it as a value/label separator
-  return /,/g[Symbol.replace](value, '__gfc__');
-}
-
-function unescapeDelimiters(value: string | undefined): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  value = /__gfp__/g[Symbol.replace](value, '|');
-  value = /__gfc__/g[Symbol.replace](value, ',');
-
-  return value;
-}
-
 function toArray(filter: AdHocFilterWithLabels): string[] {
   return [
-    toCommaDelimitedString(filter.key, filter.keyLabel),
+    toUrlCommaDelimitedString(filter.key, filter.keyLabel),
     filter.operator,
-    toCommaDelimitedString(filter.value, filter.valueLabel),
+    toUrlCommaDelimitedString(filter.value, filter.valueLabel),
   ];
-}
-
-function toCommaDelimitedString(key: string, label?: string): string {
-  // Omit for identical key/label or when label is not set at all
-  if (!label || key === label) {
-    return escapeCommaDelimiters(key);
-  }
-
-  return [key, label].map(escapeCommaDelimiters).join(',');
 }
 
 function toFilter(urlValue: string | number | boolean | undefined | null): AdHocFilterWithLabels | null {
@@ -105,7 +68,7 @@ function toFilter(urlValue: string | number | boolean | undefined | null): AdHoc
 
       return acc;
     }, [])
-    .map(unescapeDelimiters);
+    .map(unescapeUrlDelimiters);
 
   return {
     key,

--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -46,27 +46,109 @@ describe('GroupByVariable', () => {
     });
   });
 
-  it('url sync works', async () => {
-    const { variable } = setupTest({
-      defaultOptions: [
-        { text: 'a', value: 'a' },
-        { text: 'b', value: 'b' },
-      ],
+  describe('url sync', () => {
+    it('should work with default options', () => {
+      const { variable } = setupTest({
+        defaultOptions: [
+          { text: 'a', value: 'a' },
+          { text: 'b', value: 'b' },
+        ],
+      });
+
+      expect(variable.state.value).toEqual('');
+
+      act(() => {
+        variable.changeValueTo(['a']);
+      });
+
+      expect(locationService.getLocation().search).toBe('?var-test=a');
+
+      act(() => {
+        locationService.push('/?var-test=a&var-test=b');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b']);
+
+      act(() => {
+        locationService.push('/?var-test=a&var-test=b&var-test=c');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b', 'c']);
     });
 
-    expect(variable.state.value).toEqual('');
+    it('should work with received options', async () => {
+      const { variable } = setupTest({
+        getTagKeysProvider: () => {
+          return Promise.resolve({
+            replace: true,
+            values: [
+              { text: 'A', value: 'a' },
+              { text: 'b', value: 'b' },
+              { text: 'C', value: 'c' },
+            ],
+          });
+        },
+      });
 
-    act(() => {
-      variable.changeValueTo(['a']);
+      await act(async () => {
+        await lastValueFrom(variable.validateAndUpdate());
+      });
+
+      expect(variable.state.value).toEqual('');
+
+      act(() => {
+        variable.changeValueTo(['a']);
+      });
+
+      expect(locationService.getLocation().search).toBe('?var-test=a,A');
+
+      act(() => {
+        locationService.push('/?var-test=a,A&var-test=b');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b']);
+
+      act(() => {
+        locationService.push('/?var-test=a,A&var-test=b&var-test=c');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b', 'c']);
     });
 
-    expect(locationService.getLocation().search).toBe('?var-test=a');
+    it('should work with commas', async () => {
+      const { variable } = setupTest({
+        defaultOptions: [
+          { text: 'A,something', value: 'a' },
+          { text: 'B', value: 'b,something' },
+        ],
+      });
 
-    act(() => {
-      locationService.push('/?var-test=a&var-test=b');
+      expect(variable.state.value).toEqual('');
+
+      await act(async () => {
+        await lastValueFrom(variable.validateAndUpdate());
+      });
+
+      act(() => {
+        variable.changeValueTo(['a']);
+      });
+
+      expect(locationService.getLocation().search).toBe('?var-test=a,A__gfc__something');
+
+      act(() => {
+        locationService.push('/?var-test=a,A__gfc__something&var-test=b__gfc__something');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b,something']);
+
+      act(() => {
+        locationService.push(
+          '/?var-test=a,A__gfc__something&var-test=b__gfc__something&var-test=c__gfc__something,C__gfc__something'
+        );
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b,something', 'c,something']);
     });
-
-    expect(variable.state.value).toEqual(['a', 'b']);
   });
 
   it('Can override and replace getTagKeys', async () => {

--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -56,6 +56,7 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual('');
+      expect(variable.state.text).toEqual('');
 
       act(() => {
         variable.changeValueTo(['a']);
@@ -68,12 +69,14 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual(['a', 'b']);
+      expect(variable.state.text).toEqual(['a', 'b']);
 
       act(() => {
         locationService.push('/?var-test=a&var-test=b&var-test=c');
       });
 
       expect(variable.state.value).toEqual(['a', 'b', 'c']);
+      expect(variable.state.text).toEqual(['a', 'b', 'c']);
     });
 
     it('should work with received options', async () => {
@@ -95,6 +98,7 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual('');
+      expect(variable.state.text).toEqual('');
 
       act(() => {
         variable.changeValueTo(['a']);
@@ -107,12 +111,14 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual(['a', 'b']);
+      expect(variable.state.text).toEqual(['A', 'b']);
 
       act(() => {
         locationService.push('/?var-test=a,A&var-test=b&var-test=c');
       });
 
       expect(variable.state.value).toEqual(['a', 'b', 'c']);
+      expect(variable.state.text).toEqual(['A', 'b', 'c']);
     });
 
     it('should work with commas', async () => {
@@ -124,6 +130,7 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual('');
+      expect(variable.state.text).toEqual('');
 
       await act(async () => {
         await lastValueFrom(variable.validateAndUpdate());
@@ -140,6 +147,7 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual(['a', 'b,something']);
+      expect(variable.state.text).toEqual(['A,something', 'b,something']);
 
       act(() => {
         locationService.push(
@@ -148,6 +156,7 @@ describe('GroupByVariable', () => {
       });
 
       expect(variable.state.value).toEqual(['a', 'b,something', 'c,something']);
+      expect(variable.state.text).toEqual(['A,something', 'b,something', 'C,something']);
     });
   });
 

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -252,7 +252,7 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
       components={{ Option: OptionWithCheckbox }}
       onInputChange={onInputChange}
       onBlur={() => {
-        model.changeValueTo(uncommittedValue.map((x) => x.value));
+        model.changeValueTo(uncommittedValue.map((x) => x.value!));
       }}
       onChange={(newValue, action) => {
         if (action.action === 'clear' && noValueOnClear) {

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -66,7 +66,7 @@ function toUrlValues(values: VariableValue, texts: VariableValue): string[] {
 function fromUrlValues(urlValues: string | string[]): { values: string[]; texts: string[] } {
   urlValues = Array.isArray(urlValues) ? urlValues : [urlValues];
 
-  return urlValues.reduce(
+  return urlValues.reduce<{ values: string[]; texts: string[] }>(
     (acc, urlValue) => {
       const [value, label] = (urlValue ?? '').split(',');
 

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -1,7 +1,7 @@
 import { unzip, zip } from 'lodash';
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../../core/types';
 import { GroupByVariable } from './GroupByVariable';
-import { toUrlCommaDelimitedString } from '../utils';
+import { toUrlCommaDelimitedString, unescapeUrlDelimiters } from '../utils';
 
 export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _sceneObject: GroupByVariable) {}
@@ -46,11 +46,11 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
       }
 
       urlValue = Array.isArray(urlValue) ? urlValue : [urlValue];
-      let [values, labels] = unzip(urlValue.map((value) => (value ? value.split(',') : [value])));
+      const valuesLabelsPairs = urlValue.map((value) => (value ? value.split(',') : [value]));
+      let [values, labels] = unzip(valuesLabelsPairs);
 
-      // Fail-safe as this cannot be type-checked properly
-      values = values ?? [];
-      labels = labels ?? [];
+      values = (values ?? []).map(unescapeUrlDelimiters);
+      labels = (labels ?? []).map(unescapeUrlDelimiters);
 
       this._sceneObject.setState({
         urlOptions: values.map((value, idx) => ({

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -1,0 +1,76 @@
+import { unzip, zip } from 'lodash';
+import { SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../../core/types';
+import { GroupByVariable } from './GroupByVariable';
+import { toUrlCommaDelimitedString } from '../utils';
+
+export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
+  public constructor(private _sceneObject: GroupByVariable) {}
+
+  private getKey(): string {
+    return `var-${this._sceneObject.state.name}`;
+  }
+
+  public getKeys(): string[] {
+    if (this._sceneObject.state.skipUrlSync) {
+      return [];
+    }
+
+    return [this.getKey()];
+  }
+
+  public getUrlState(): SceneObjectUrlValues {
+    if (this._sceneObject.state.skipUrlSync) {
+      return {};
+    }
+
+    let { value: values, text: texts } = this._sceneObject.state;
+
+    values = Array.isArray(values) ? values : [values];
+    texts = Array.isArray(texts) ? texts : [texts];
+
+    const urlValue = zip(values, texts).map(toUrlValues);
+
+    return { [this.getKey()]: urlValue };
+  }
+
+  public updateFromUrl(values: SceneObjectUrlValues): void {
+    let urlValue = values[this.getKey()];
+
+    if (urlValue != null) {
+      /**
+       * Initial URL Sync happens before scene objects are activated.
+       * We need to skip validation in this case to make sure values set via URL are maintained.
+       */
+      if (!this._sceneObject.isActive) {
+        this._sceneObject.skipNextValidation = true;
+      }
+
+      urlValue = Array.isArray(urlValue) ? urlValue : [urlValue];
+      let [values, labels] = unzip(urlValue.map((value) => (value ? value.split(',') : [value])));
+
+      // Fail-safe as this cannot be type-checked properly
+      values = values ?? [];
+      labels = labels ?? [];
+
+      this._sceneObject.setState({
+        urlOptions: values.map((value, idx) => ({
+          value,
+          text: labels[idx],
+        })),
+      });
+
+      this._sceneObject.changeValueTo(values, labels);
+    }
+  }
+}
+
+function toUrlValues([value, label]: [string, string]) {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  value = String(value);
+  label = label === undefined || label === null ? value : String(label);
+
+  return toUrlCommaDelimitedString(value, label);
+}

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -2,6 +2,7 @@ import { unzip, zip } from 'lodash';
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../../core/types';
 import { GroupByVariable } from './GroupByVariable';
 import { toUrlCommaDelimitedString, unescapeUrlDelimiters } from '../utils';
+import { VariableValueSingle } from '../types';
 
 export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _sceneObject: GroupByVariable) {}
@@ -64,9 +65,11 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
   }
 }
 
-function toUrlValues([value, label]: [string, string]) {
+function toUrlValues([value, label]: [VariableValueSingle | undefined, VariableValueSingle | undefined]):
+  | string
+  | undefined {
   if (value === undefined || value === null) {
-    return value;
+    return undefined;
   }
 
   value = String(value);

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -65,11 +65,9 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
   }
 }
 
-function toUrlValues([value, label]: [VariableValueSingle | undefined, VariableValueSingle | undefined]):
-  | string
-  | undefined {
+function toUrlValues([value, label]: [VariableValueSingle | undefined, VariableValueSingle | undefined]): string {
   if (value === undefined || value === null) {
-    return undefined;
+    return '';
   }
 
   value = String(value);

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -135,3 +135,41 @@ function filterOutInactiveRunnerDuplicates(runners: SceneQueryRunner[]) {
     return activeItems;
   });
 }
+
+export function escapeUrlPipeDelimiters(value: string | undefined): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  // Replace the pipe due to using it as a filter separator
+  return (value = /\|/g[Symbol.replace](value, '__gfp__'));
+}
+
+export function escapeUrlCommaDelimiters(value: string | undefined): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  // Replace the comma due to using it as a value/label separator
+  return /,/g[Symbol.replace](value, '__gfc__');
+}
+
+export function unescapeUrlDelimiters(value: string | undefined): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  value = /__gfp__/g[Symbol.replace](value, '|');
+  value = /__gfc__/g[Symbol.replace](value, ',');
+
+  return value;
+}
+
+export function toUrlCommaDelimitedString(key: string, label?: string): string {
+  // Omit for identical key/label or when label is not set at all
+  if (!label || key === label) {
+    return escapeUrlCommaDelimiters(key);
+  }
+
+  return [key, label].map(escapeUrlCommaDelimiters).join(',');
+}


### PR DESCRIPTION
This PR syncs labels of the values in the group by variable similarly to what we introduced for ad-hoc filters.

Unlike ad-hoc filters, group by is a little bit more of a special case hence the reason why some of the changes below. The solution might not be optimal, so please feel free to suggested changes and improvements.

Changes:
- introduced custom URL sync handler
   - it works similarly to the ad-hoc filters one
   - this is needed as currently we use the one multi-value variable one and we don't want this changed for all variables
- the state of group by variable received a new prop: `urlOptions` where we store the options that we received via the URL
   - when fetching the options, we concat the `urlOptions` with what we receive from the datasource (or with the `defaultOptions`)
   - this is needed because of `validateAndUpdate` and also because `changeValueTo` is sometimes called without the texts array
- we leverage the fact that the value of the `MultiSelect` can be a `SelectableValue` hence we can enforce the labels on values
- moved some common functions to variables utils

The gotcha: let's assume we pass a value via URL. This value is not returned by the datasource hence we consider it a custom value. We then remove the custom value using the UI button. When opening the dropdown again, the custom value can be found in the dropdown. Is this a behavior we want to keep? You can also see this behavior in the demo below.

PS: tests will come in a subsequent push. For the time being I'm trying to decide upon edge cases.

Demo:

https://github.com/grafana/scenes/assets/9215315/54ca86b9-9db9-4ac1-ac8e-144a8cd576f2


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.20.0--canary.705.9031064372.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.20.0--canary.705.9031064372.0
  # or 
  yarn add @grafana/scenes@4.20.0--canary.705.9031064372.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
