### PR TITLE
Adjust VariableValueSelect(ors) styles to allow shrinking

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -1,16 +1,18 @@
 import { isArray } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { InputActionMeta, MultiSelect, Select } from '@grafana/ui';
+import { InputActionMeta, MultiSelect, Select, useStyles2 } from '@grafana/ui';
 
 import { SceneComponentProps } from '../../core/types';
 import { MultiValueVariable } from '../variants/MultiValueVariable';
 import { VariableValue, VariableValueSingle } from '../types';
 import { selectors } from '@grafana/e2e-selectors';
+import { css } from '@emotion/css';
 
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, key } = model.useState();
 
+  const styles = useStyles2(getStyles);
   const onInputChange = model.onSearchChange
     ? (value: string, meta: InputActionMeta) => {
         if (meta.action === 'input-change') {
@@ -34,6 +36,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);
       }}
+      className={styles.overflow}
     />
   );
 }
@@ -61,6 +64,8 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
 
   const placeholder = options.length > 0 ? 'Select value' : '';
 
+  const styles = useStyles2(getStyles);
+
   return (
     <MultiSelect<VariableValueSingle>
       id={key}
@@ -86,6 +91,7 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
         }
         setUncommittedValue(newValue.map((x) => x.value!));
       }}
+      className={styles.overflow}
     />
   );
 }
@@ -97,3 +103,9 @@ export function renderSelectForVariable(model: MultiValueVariable) {
     return <VariableValueSelect model={model} />;
   }
 }
+
+const getStyles = (() => ({
+  overflow: css({
+    overflow: 'hidden',
+  })
+}));

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -7,7 +7,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { ControlsLayout, SceneComponentProps, SceneObjectState } from '../../core/types';
 import { SceneVariable, SceneVariableState } from '../types';
 import { ControlsLabel } from '../../utils/ControlsLabel';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { selectors } from '@grafana/e2e-selectors';
 
 export interface VariableValueSelectorsState extends SceneObjectState {
@@ -44,18 +44,9 @@ export function VariableValueSelectWrapper({ variable, layout, showAlways }: Var
     return null;
   }
 
-  if (layout === 'vertical') {
-    return (
-      <div className={verticalContainer} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
-        <VariableLabel variable={variable} layout={layout} />
-        <variable.Component model={variable} />
-      </div>
-    );
-  }
-
   return (
-    <div className={containerStyle} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
-      <VariableLabel variable={variable} />
+    <div className={cx(containerStyle, { [verticalContainer]: layout === 'vertical' })} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
+      <VariableLabel variable={variable} layout={layout} />
       <variable.Component model={variable} />
     </div>
   );
@@ -75,7 +66,7 @@ function VariableLabel({ variable, layout }: VariableSelectProps) {
     <ControlsLabel
       htmlFor={elementId}
       isLoading={state.loading}
-      onCancel={() => variable.onCancel?.()}
+      onCancel={variable.onCancel}
       label={labelOrName}
       error={state.error}
       layout={layout}
@@ -84,5 +75,5 @@ function VariableLabel({ variable, layout }: VariableSelectProps) {
   );
 }
 
-const containerStyle = css({ display: 'flex' });
-const verticalContainer = css({ display: 'flex', flexDirection: 'column' });
+const containerStyle = css({ display: 'flex', overflow: 'hidden' });
+const verticalContainer = css({ flexDirection: 'column' });


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/87051 together with https://github.com/grafana/grafana/pull/87085
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.13.1--canary.711.8884688944.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.13.1--canary.711.8884688944.0
  # or 
  yarn add @grafana/scenes@4.13.1--canary.711.8884688944.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
