### PR TITLE
MultiValueVariable: Fixes support for legacy All url value

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -539,6 +539,28 @@ describe('MultiValueVariable', () => {
       expect(variable.getValue()).toEqual(['1', '2']);
     });
 
+    it('updateFromUrl with old arch All value and isMulti: true', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        includeAll: true,
+        isMulti: true,
+        value: '',
+        text: '',
+        delayMs: 0,
+      });
+
+      variable.urlSync?.updateFromUrl({ ['var-test']: [ALL_VARIABLE_TEXT] });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.getValue()).toEqual(['1', '2']);
+    });
+
     it('updateFromUrl with key value pair should lookup text representation ', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -4,7 +4,7 @@ import { map, Observable } from 'rxjs';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneObjectUrlSyncHandler, SceneObjectUrlValue, SceneObjectUrlValues } from '../../core/types';
+import { SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../../core/types';
 import {
   SceneVariable,
   SceneVariableValueChangedEvent,

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -381,7 +381,7 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
   }
 }
 
-function handleLegacyUrlAllValue(value: SceneObjectUrlValue) {
+function handleLegacyUrlAllValue(value: string | string[]) {
   if (isArray(value) && value[0] === ALL_VARIABLE_TEXT) {
     return [ALL_VARIABLE_VALUE];
   } else if (value === ALL_VARIABLE_TEXT) {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -1,10 +1,10 @@
-import { isEqual } from 'lodash';
+import { isArray, isEqual } from 'lodash';
 import { map, Observable } from 'rxjs';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 
 import { SceneObjectBase } from '../../core/SceneObjectBase';
-import { SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../../core/types';
+import { SceneObjectUrlSyncHandler, SceneObjectUrlValue, SceneObjectUrlValues } from '../../core/types';
 import {
   SceneVariable,
   SceneVariableValueChangedEvent,
@@ -364,8 +364,8 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
 
     if (urlValue != null) {
       // This is to be backwards compatible with old url all value
-      if (this._sceneObject.state.includeAll && urlValue === ALL_VARIABLE_TEXT) {
-        urlValue = ALL_VARIABLE_VALUE;
+      if (this._sceneObject.state.includeAll) {
+        urlValue = handleLegacyUrlAllValue(urlValue);
       }
 
       /**
@@ -379,6 +379,16 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
       this._sceneObject.changeValueTo(urlValue);
     }
   }
+}
+
+function handleLegacyUrlAllValue(value: SceneObjectUrlValue) {
+  if (isArray(value) && value[0] === ALL_VARIABLE_TEXT) {
+    return [ALL_VARIABLE_VALUE];
+  } else if (value === ALL_VARIABLE_TEXT) {
+    return ALL_VARIABLE_VALUE;
+  }
+
+  return value;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/87167 

A previous fix for this https://github.com/grafana/scenes/pull/656 only added a unit test for the scenario where includeAll and isMulti was false (so not truly multi value). when isMulti is true the URL value is an array and so the comparison that checked for the old legacy ALL URL value did not pass as the urlValue was an array with "All" 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.13.2--canary.712.8910747975.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.13.2--canary.712.8910747975.0
  # or 
  yarn add @grafana/scenes@4.13.2--canary.712.8910747975.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
