### PR TITLE
AdHocFiltersVariable: create an opt-in state variable for using queries to filter the options

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -102,47 +102,87 @@ describe('AdHocFiltersVariable', () => {
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
   });
 
-  it('Should collect and pass respective data source queries to getTagKeys call', async () => {
-    const { getTagKeysSpy, timeRange } = setup({ filters: [] });
+  describe('By default, Without altering `useQueriesAsFilterForOptions`', ()=>{
 
-    // Select key
-    await userEvent.click(screen.getByTestId('AdHocFilter-add'));
-    expect(getTagKeysSpy).toBeCalledTimes(1);
-    expect(getTagKeysSpy).toBeCalledWith({
-      filters: [],
-      queries: [
-        {
-          expr: 'my_metric{}',
-          refId: 'A',
-        },
-      ],
-      timeRange: timeRange.state.value,
+    it('Should not collect and pass respective data source queries to getTagKeys call', async () => {
+      const { getTagKeysSpy, timeRange } = setup({ filters: [] });
+  
+      // Select key
+      await userEvent.click(screen.getByTestId('AdHocFilter-add'));
+      expect(getTagKeysSpy).toBeCalledTimes(1);
+      expect(getTagKeysSpy).toBeCalledWith({
+        filters: [],
+        queries: undefined,
+        timeRange: timeRange.state.value,
+      });
+    });
+  
+    it('Should not collect and pass respective data source queries to getTagValues call', async () => {
+      const { getTagValuesSpy, timeRange } = setup({ filters: [] });
+  
+      // Select key
+      const key = 'Key 3';
+      await userEvent.click(screen.getByTestId('AdHocFilter-add'));
+      const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
+      await waitFor(() => select(selects[0], key, { container: document.body }));
+      await userEvent.click(selects[2]);
+  
+      expect(getTagValuesSpy).toBeCalledTimes(1);
+      expect(getTagValuesSpy).toBeCalledWith({
+        filters: [],
+        key: 'key3',
+        queries: undefined,
+        timeRange: timeRange.state.value,
+      });
     });
   });
 
-  it('Should collect and pass respective data source queries to getTagValues call', async () => {
-    const { getTagValuesSpy, timeRange } = setup({ filters: [] });
+  describe('When `useQueriesAsFilterForOptions` is set to `true`', ()=>{
 
-    // Select key
-    const key = 'Key 3';
-    await userEvent.click(screen.getByTestId('AdHocFilter-add'));
-    const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
-    await waitFor(() => select(selects[0], key, { container: document.body }));
-    await userEvent.click(selects[2]);
-
-    expect(getTagValuesSpy).toBeCalledTimes(1);
-    expect(getTagValuesSpy).toBeCalledWith({
-      filters: [],
-      key: 'key3',
-      queries: [
-        {
-          expr: 'my_metric{}',
-          refId: 'A',
-        },
-      ],
-      timeRange: timeRange.state.value,
+    it('Should collect and pass respective data source queries to getTagKeys call', async () => {
+      const { getTagKeysSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
+  
+      // Select key
+      await userEvent.click(screen.getByTestId('AdHocFilter-add'));
+      expect(getTagKeysSpy).toBeCalledTimes(1);
+      expect(getTagKeysSpy).toBeCalledWith({
+        filters: [],
+        queries: [
+          {
+            expr: 'my_metric{}',
+            refId: 'A',
+          },
+        ],
+        timeRange: timeRange.state.value,
+      });
     });
+  
+    it('Should collect and pass respective data source queries to getTagValues call', async () => {
+      const { getTagValuesSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
+  
+      // Select key
+      const key = 'Key 3';
+      await userEvent.click(screen.getByTestId('AdHocFilter-add'));
+      const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
+      await waitFor(() => select(selects[0], key, { container: document.body }));
+      await userEvent.click(selects[2]);
+  
+      expect(getTagValuesSpy).toBeCalledTimes(1);
+      expect(getTagValuesSpy).toBeCalledWith({
+        filters: [],
+        key: 'key3',
+        queries: [
+          {
+            expr: 'my_metric{}',
+            refId: 'A',
+          },
+        ],
+        timeRange: timeRange.state.value,
+      });
+    });
+  
   });
+
 
   it('url sync works', async () => {
     const { filtersVar } = setup();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -76,6 +76,14 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   expressionBuilder?: AdHocVariableExpressionBuilderFn;
 
   /**
+   * When querying the datasource for label names and values to determine keys and values 
+   * for this ad hoc filter, consider the queries in the scene and use them as a filter.
+   * This queries filter can be used to ensure that only ad hoc filter options that would
+   * impact the current queries are presented to the user.
+   */
+  useQueriesAsFilterForOptions?: boolean
+
+  /**
    * @internal state of the new filter being added
    */
   _wip?: AdHocFilterWithLabels;
@@ -204,7 +212,7 @@ export class AdHocFiltersVariable
 
     const otherFilters = this.state.filters.filter((f) => f.key !== currentKey).concat(this.state.baseFilters ?? []);
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    const queries = getQueriesForVariables(this);
+    const queries = this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined;
     let keys = await ds.getTagKeys({ filters: otherFilters, queries, timeRange });
 
     if (override) {
@@ -239,7 +247,7 @@ export class AdHocFiltersVariable
     const otherFilters = this.state.filters.filter((f) => f.key !== filter.key).concat(this.state.baseFilters ?? []);
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    const queries = getQueriesForVariables(this);
+    const queries = this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined;
     // @ts-expect-error TODO: remove this once 11.1.x is released
     let values = await ds.getTagValues({ key: filter.key, filters: otherFilters, timeRange, queries });
 


### PR DESCRIPTION
Instead of using queries by default to filter the options for the `AdHocFiltersVariable`, make it an opt-in option.

Adds `useQueriesAsFilterForOptions` to state definition.

Notes:
- When updating grafana to use this new version, we need to ensure that the dashboards opt-in
  - https://github.com/grafana/grafana/pull/87244 

Related:
- https://github.com/grafana/grafana/pull/85674
- https://github.com/grafana/scenes/pull/685