### PR TITLE
Allow filter selectors to wrap

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -291,8 +291,10 @@ export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHo
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({
     display: 'flex',
-    gap: theme.spacing(2),
+    flexWrap: 'wrap',
     alignItems: 'flex-end',
+    columnGap: theme.spacing(2),
+    rowGap: theme.spacing(1),
   }),
   filterIcon: css({
     color: theme.colors.text.secondary,


### PR DESCRIPTION
Closes https://github.com/grafana/hyperion-planning/issues/38

Before:
<img width="1467" alt="image" src="https://github.com/grafana/scenes/assets/45561153/f5468c0b-00ed-423d-a3f2-4347266e615c">

After:
<img width="1470" alt="image" src="https://github.com/grafana/scenes/assets/45561153/101c6506-2355-4bc6-9ed9-bea892e156bf">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.13.3--canary.715.8927266597.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.13.3--canary.715.8927266597.0
  # or 
  yarn add @grafana/scenes@4.13.3--canary.715.8927266597.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
