### PR TITLE
VizPanelRenderer: Emit SetPanelAttention event

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -136,8 +136,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
       <div
         ref={ref as RefCallback<HTMLDivElement>}
         className={absoluteWrapper}
-        onFocus={() => panelAttentionService.setPanelWithAttention(model)}
-        onMouseMove={() => panelAttentionService.setPanelWithAttention(model)}
+        onFocus={() => panelAttentionService.setPanelWithAttention(model.state.key)}
+        onMouseMove={() => panelAttentionService.setPanelWithAttention(model.state.key)}
         data-viz-panel-key={model.state.key}
       >
         {width > 0 && height > 0 && (

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { RefCallback } from 'react';
+import React, { RefCallback, useCallback, useMemo } from 'react';
 import { useMeasure } from 'react-use';
 
 // @ts-ignore
@@ -29,10 +29,13 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     description,
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
-  const appEvents = getAppEvents();
+  const appEvents = useMemo(() => getAppEvents(), []);
 
-  const setPanelAttention = () => appEvents.publish(new SetPanelAttentionEvent({ panelId: model.state.key }));
-  const debouncedMouseMove = debounce(() => setPanelAttention(), 100);
+  const setPanelAttention = useCallback(
+    () => appEvents.publish(new SetPanelAttentionEvent({ panelId: model.state.key })),
+    [model.state.key, appEvents]
+  );
+  const debouncedMouseMove = useMemo(() => debounce(setPanelAttention, 100), [setPanelAttention]);
 
   const plugin = model.getPlugin();
 
@@ -159,9 +162,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             padding={plugin.noPadding ? 'none' : 'md'}
             menu={panelMenu}
             onCancelQuery={model.onCancelQuery}
-            //@ts-ignore
             onFocus={() => setPanelAttention()}
-            onMouseMove={debouncedMouseMove}
+            onMouseMove={() => debouncedMouseMove()}
           >
             {(innerWidth, innerHeight) => (
               <>

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -136,8 +136,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
       <div
         ref={ref as RefCallback<HTMLDivElement>}
         className={absoluteWrapper}
-        onFocus={() => panelAttentionService.setPanelWithAttention(model.state.key)}
-        onMouseMove={() => panelAttentionService.setPanelWithAttention(model.state.key)}
+        onFocus={() => panelAttentionService?.setPanelWithAttention(model.state.key)}
+        onMouseMove={() => panelAttentionService?.setPanelWithAttention(model.state.key)}
         data-viz-panel-key={model.state.key}
       >
         {width > 0 && height > 0 && (

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -163,8 +163,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             menu={panelMenu}
             onCancelQuery={model.onCancelQuery}
             // @ts-ignore
-            onFocus={() => setPanelAttention()}
-            onMouseMove={() => debouncedMouseMove()}
+            onFocus={setPanelAttention}
+            onMouseMove={debouncedMouseMove}
           >
             {(innerWidth, innerHeight) => (
               <>

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -162,6 +162,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             padding={plugin.noPadding ? 'none' : 'md'}
             menu={panelMenu}
             onCancelQuery={model.onCancelQuery}
+            // @ts-ignore
             onFocus={() => setPanelAttention()}
             onMouseMove={() => debouncedMouseMove()}
           >

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { RefCallback } from 'react';
+import React, { RefCallback, useMemo } from 'react';
 import { useMeasure } from 'react-use';
 
 import { AlertState, GrafanaTheme2, PanelData, PluginContextProvider } from '@grafana/data';
@@ -11,6 +11,7 @@ import { isSceneObject, SceneComponentProps, SceneLayout, SceneObject } from '..
 
 import { VizPanel } from './VizPanel';
 import { css, cx } from '@emotion/css';
+import { debounce } from 'lodash';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -27,7 +28,9 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     description,
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
-  const panelAttentionService = getPanelAttentionSrv();
+  const panelAttentionService = useMemo(() => getPanelAttentionSrv(), []);
+  const debouncedMouseMove = debounce(() => panelAttentionService.setPanelWithAttention(model.state.key), 100);
+
   const plugin = model.getPlugin();
 
   const { dragClass, dragClassCancel } = getDragClasses(model);
@@ -137,7 +140,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
         ref={ref as RefCallback<HTMLDivElement>}
         className={absoluteWrapper}
         onFocus={() => panelAttentionService?.setPanelWithAttention(model.state.key)}
-        onMouseMove={() => panelAttentionService?.setPanelWithAttention(model.state.key)}
+        onMouseMove={debouncedMouseMove}
         data-viz-panel-key={model.state.key}
       >
         {width > 0 && height > 0 && (

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -2,7 +2,8 @@ import React, { RefCallback } from 'react';
 import { useMeasure } from 'react-use';
 
 import { AlertState, GrafanaTheme2, PanelData, PluginContextProvider } from '@grafana/data';
-import { getAppEvents } from '@grafana/runtime';
+// @ts-ignore
+import { getAppEvents, getPanelAttentionSrv } from '@grafana/runtime';
 import { PanelChrome, ErrorBoundaryAlert, PanelContextProvider, Tooltip, useStyles2, Icon } from '@grafana/ui';
 
 import { sceneGraph } from '../../core/sceneGraph';
@@ -26,10 +27,12 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     description,
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
+  const panelAttentionService = getPanelAttentionSrv();
   const plugin = model.getPlugin();
 
   const { dragClass, dragClassCancel } = getDragClasses(model);
   const dataObject = sceneGraph.getData(model);
+
   const rawData = dataObject.useState();
   const dataWithFieldConfig = model.applyFieldConfig(rawData.data!);
   const sceneTimeRange = sceneGraph.getTimeRange(model);
@@ -130,7 +133,13 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   return (
     <div className={relativeWrapper}>
-      <div ref={ref as RefCallback<HTMLDivElement>} className={absoluteWrapper} data-viz-panel-key={model.state.key}>
+      <div
+        ref={ref as RefCallback<HTMLDivElement>}
+        className={absoluteWrapper}
+        onFocus={() => panelAttentionService.setPanelWithAttention(model)}
+        onMouseMove={() => panelAttentionService.setPanelWithAttention(model)}
+        data-viz-panel-key={model.state.key}
+      >
         {width > 0 && height > 0 && (
           <PanelChrome
             title={titleInterpolated}

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -13,9 +13,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
   const { children, isLazy, isDraggable, isResizable } = model.useState();
 
-  // Attention to handle keyboard and hover shortcuts
-  const [attention, setAttention] = React.useState<string | undefined>();
-
   validateChildrenSize(children);
 
   return (
@@ -69,8 +66,6 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
                   index={index}
                   isLazy={isLazy}
                   totalCount={layout.length}
-                  hasAttention={attention === gridItem.i}
-                  setAttention={() => setAttention(gridItem.i)}
                 />
               ))}
             </ReactGridLayout>
@@ -87,25 +82,10 @@ interface GridItemWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
   index: number;
   totalCount: number;
   isLazy?: boolean;
-  hasAttention: boolean;
-  setAttention: () => void;
 }
 
 const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((props, ref) => {
-  const {
-    grid,
-    layoutItem,
-    index,
-    totalCount,
-    isLazy,
-    style,
-    onLoad,
-    onChange,
-    children,
-    hasAttention,
-    setAttention,
-    ...divProps
-  } = props;
+  const { grid, layoutItem, index, totalCount, isLazy, style, onLoad, onChange, children, ...divProps } = props;
   const sceneChild = grid.getSceneLayoutChild(layoutItem.i)!;
   const className = sceneChild.getClassName?.();
 
@@ -117,9 +97,6 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
         {...divProps}
         key={sceneChild.state.key!}
         data-griditem-key={sceneChild.state.key}
-        data-attention={hasAttention}
-        onFocus={() => !hasAttention && setAttention()}
-        onMouseMove={() => !hasAttention && setAttention()}
         className={cx(className, props.className)}
         style={style}
         ref={ref}
@@ -136,9 +113,6 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
       ref={ref}
       key={sceneChild.state.key}
       data-griditem-key={sceneChild.state.key}
-      data-attention={hasAttention}
-      onFocus={() => !hasAttention && setAttention()}
-      onMouseMove={() => !hasAttention && setAttention()}
       className={cx(className, props.className)}
       style={style}
     >

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -13,6 +13,9 @@ import { GrafanaTheme2 } from '@grafana/data';
 export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGridLayout>) {
   const { children, isLazy, isDraggable, isResizable } = model.useState();
 
+  // Attention to handle keyboard and hover shortcuts
+  const [attention, setAttention] = React.useState<string | undefined>();
+
   validateChildrenSize(children);
 
   return (
@@ -66,6 +69,8 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
                   index={index}
                   isLazy={isLazy}
                   totalCount={layout.length}
+                  hasAttention={attention === gridItem.i}
+                  setAttention={() => setAttention(gridItem.i)}
                 />
               ))}
             </ReactGridLayout>
@@ -82,10 +87,25 @@ interface GridItemWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
   index: number;
   totalCount: number;
   isLazy?: boolean;
+  hasAttention: boolean;
+  setAttention: () => void;
 }
 
 const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((props, ref) => {
-  const { grid, layoutItem, index, totalCount, isLazy, style, onLoad, onChange, children, ...divProps } = props;
+  const {
+    grid,
+    layoutItem,
+    index,
+    totalCount,
+    isLazy,
+    style,
+    onLoad,
+    onChange,
+    children,
+    hasAttention,
+    setAttention,
+    ...divProps
+  } = props;
   const sceneChild = grid.getSceneLayoutChild(layoutItem.i)!;
   const className = sceneChild.getClassName?.();
 
@@ -97,6 +117,9 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
         {...divProps}
         key={sceneChild.state.key!}
         data-griditem-key={sceneChild.state.key}
+        data-attention={hasAttention}
+        onFocus={() => !hasAttention && setAttention()}
+        onMouseMove={() => !hasAttention && setAttention()}
         className={cx(className, props.className)}
         style={style}
         ref={ref}
@@ -113,6 +136,9 @@ const GridItemWrapper = React.forwardRef<HTMLDivElement, GridItemWrapperProps>((
       ref={ref}
       key={sceneChild.state.key}
       data-griditem-key={sceneChild.state.key}
+      data-attention={hasAttention}
+      onFocus={() => !hasAttention && setAttention()}
+      onMouseMove={() => !hasAttention && setAttention()}
       className={cx(className, props.className)}
       style={style}
     >


### PR DESCRIPTION
Addresses this issue https://github.com/grafana/grafana/issues/47005#issuecomment-2089912829

Related PR in the Grafana repo: https://github.com/grafana/grafana/pull/87317

Is this a good place to add this? Also, are there some drawbacks that may cause performance issues?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.24.4--canary.716.9299472214.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.24.4--canary.716.9299472214.0
  # or 
  yarn add @grafana/scenes@4.24.4--canary.716.9299472214.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
