### PR TITLE
Types: Export `FieldConfigOverridesBuilder`

### DIFF
--- a/packages/scenes/src/core/PanelBuilders/index.ts
+++ b/packages/scenes/src/core/PanelBuilders/index.ts
@@ -181,3 +181,4 @@ export const PanelBuilders = {
 
 export { PanelOptionsBuilders } from './PanelOptionsBuilders';
 export { FieldConfigBuilders } from './FieldConfigBuilders';
+export { FieldConfigOverridesBuilder } from './FieldConfigOverridesBuilder';

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -98,7 +98,12 @@ export { SceneApp, useSceneApp } from './components/SceneApp/SceneApp';
 export { SceneAppPage } from './components/SceneApp/SceneAppPage';
 export { SceneReactObject } from './components/SceneReactObject';
 export { SceneObjectRef } from './core/SceneObjectRef';
-export { PanelBuilders, PanelOptionsBuilders, FieldConfigBuilders } from './core/PanelBuilders';
+export {
+  PanelBuilders,
+  PanelOptionsBuilders,
+  FieldConfigBuilders,
+  FieldConfigOverridesBuilder,
+} from './core/PanelBuilders';
 export { VizPanelBuilder } from './core/PanelBuilders/VizPanelBuilder';
 export { SceneDebugger } from './components/SceneDebugger/SceneDebugger';
 


### PR DESCRIPTION
I wanted to use `FieldConfigOverridesBuilder` but that type/class is not exported. I didn't see any obvious reason to not export it.