### PR TITLE
SceneDataTransformer: Fixes transformer emitting untransformed series

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -1,23 +1,6 @@
-import {
-  DataFrame,
-  DataTopic,
-  DataTransformerConfig,
-  LoadingState,
-  PanelData,
-  transformDataFrame,
-} from '@grafana/data';
+import { DataTopic, DataTransformerConfig, LoadingState, PanelData, transformDataFrame } from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
-import {
-  catchError,
-  forkJoin,
-  map,
-  merge,
-  Observable,
-  of,
-  OperatorFunction,
-  ReplaySubject,
-  Unsubscribable,
-} from 'rxjs';
+import { catchError, forkJoin, map, of, ReplaySubject, Unsubscribable } from 'rxjs';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { CustomTransformerDefinition, SceneDataProvider, SceneDataProviderResult, SceneDataState } from '../core/types';

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -1,6 +1,23 @@
-import { DataTopic, DataTransformerConfig, LoadingState, PanelData, transformDataFrame } from '@grafana/data';
+import {
+  DataFrame,
+  DataTopic,
+  DataTransformerConfig,
+  LoadingState,
+  PanelData,
+  transformDataFrame,
+} from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
-import { catchError, map, merge, of, ReplaySubject, Unsubscribable } from 'rxjs';
+import {
+  catchError,
+  forkJoin,
+  map,
+  merge,
+  Observable,
+  of,
+  OperatorFunction,
+  ReplaySubject,
+  Unsubscribable,
+} from 'rxjs';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { CustomTransformerDefinition, SceneDataProvider, SceneDataProviderResult, SceneDataState } from '../core/types';
@@ -25,6 +42,7 @@ export interface SceneDataTransformerState extends SceneDataState {
 export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerState> implements SceneDataProvider {
   private _transformSub?: Unsubscribable;
   private _results = new ReplaySubject<SceneDataProviderResult>(1);
+
   /**
    * Scan transformations for variable usage and re-process transforms when a variable values change
    */
@@ -140,20 +158,23 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
       },
     };
 
-    const seriesStream = transformDataFrame(seriesTransformations, data.series, ctx);
-    const annotationsStream = transformDataFrame(annotationsTransformations, data.annotations ?? [], ctx);
+    let streams = [transformDataFrame(seriesTransformations, data.series, ctx)];
 
-    let transformedData = { ...data };
+    if (data.annotations && data.annotations.length > 0 && annotationsTransformations.length > 0) {
+      streams.push(transformDataFrame(annotationsTransformations, data.annotations ?? []));
+    }
 
-    this._transformSub = merge(annotationsStream, seriesStream)
+    this._transformSub = forkJoin(streams)
       .pipe(
-        map((frames) => {
-          const isAnnotations = frames.some((f) => f.meta?.dataTopic === DataTopic.Annotations);
-          const transformed = isAnnotations ? { annotations: frames } : { series: frames };
+        map((values) => {
+          const transformedSeries = values[0];
+          const transformedAnnotations = values[1];
 
-          transformedData = { ...transformedData, ...transformed };
-
-          return transformedData;
+          return {
+            ...data,
+            series: transformedSeries,
+            annotations: transformedAnnotations ?? data.annotations,
+          };
         }),
         catchError((err) => {
           console.error('Error transforming data: ', err);

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -542,6 +542,9 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     // Will combine annotations from SQR queries (frames with meta.dataTopic === DataTopic.Annotations)
     const preProcessedData = preProcessPanelData(data, this.state.data);
 
+    // Save query annotations
+    this._resultAnnotations = data.annotations;
+
     // Will combine annotations & alert state from data layer providers
     const dataWithLayersApplied = this._combineDataLayers(preProcessedData);
 
@@ -551,16 +554,14 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       hasFetchedData = true;
     }
 
-    this._resultAnnotations = data.annotations;
-
     this.setState({ data: dataWithLayersApplied, _hasFetchedData: hasFetchedData });
 
     this._results.next({ origin: this, data: dataWithLayersApplied });
   };
 
   private _combineDataLayers(data: PanelData) {
-    if (this.state.data && this.state.data.annotations) {
-      data.annotations = (data.annotations || []).concat(this._layerAnnotations ?? []);
+    if (this._layerAnnotations && this._layerAnnotations.length > 0) {
+      data.annotations = (data.annotations || []).concat(this._layerAnnotations);
     }
 
     if (this.state.data && this.state.data.alertState) {


### PR DESCRIPTION
Fixes an issue in SceneDataTransformer where it would emit untransformed series when annotations where present. 

Because the two transformation observables where done in parallel the annotations one can complete before the series one and this cause the untransformed series data to be emitted. 

Now I wait for both series + annotation transforms to be completed before emitting anything, this also greatly reduces state updates. 

Also an unrelated change in SceneQueryRunner that is most just a cleaner logic change  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.15.0--canary.720.8986092576.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.15.0--canary.720.8986092576.0
  # or 
  yarn add @grafana/scenes@4.15.0--canary.720.8986092576.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
