### PR TITLE
AdHoc filters: Allow adding custom value while loading

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -42,6 +42,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueSelect = (
     <Select
       allowCustomValue
+      allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
       disabled={model.state.readOnly}
       className={state.isKeysOpen ? styles.widthWhenOpen : undefined}
@@ -55,9 +56,9 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       autoFocus={filter.key !== '' && filter.value === ''}
       openMenuOnFocus={true}
       onOpenMenu={async () => {
-        setState({ ...state, isValuesLoading: true });
+        setState({ ...state, isValuesLoading: true, isValuesOpen: true });
         const values = await model._getValuesFor(filter);
-        setState({ ...state, isValuesLoading: false, isValuesOpen: true, values });
+        setState({ ...state, isValuesLoading: false, values });
       }}
       onCloseMenu={() => {
         setState({ ...state, isValuesOpen: false });


### PR DESCRIPTION
- adds the `allowCreateWhileLoading` option to the value select
- adjusts when `isValuesOpen` is set to true to be as soon as the `onClick` is fired. otherwise the menu will reopen once the options finally resolve even if you've already selected and added a custom value

Fixes https://github.com/grafana/hyperion-planning/issues/23
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.14.2--canary.721.8986239090.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.14.2--canary.721.8986239090.0
  # or 
  yarn add @grafana/scenes@4.14.2--canary.721.8986239090.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
