### PR TITLE
AdHoc filters: Apply `isKeysOpen` state changes synchronously

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -82,9 +82,9 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       isOpen={state.isKeysOpen}
       isLoading={state.isKeysLoading}
       onOpenMenu={async () => {
-        setState({ ...state, isKeysLoading: true });
+        setState({ ...state, isKeysLoading: true, isKeysOpen: true });
         const keys = await model._getKeys(filter.key);
-        setState({ ...state, isKeysLoading: false, isKeysOpen: true, keys });
+        setState({ ...state, isKeysLoading: false, keys });
       }}
       onCloseMenu={() => {
         setState({ ...state, isKeysOpen: false });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -123,16 +123,14 @@ describe('AdHocFiltersVariable', () => {
 
     const wrapper = screen.getByTestId('AdHocFilter-key1');
     const selects = getAllByRole(wrapper, 'combobox');
-    await userEvent.type(selects[2], 'myVeryCustomValue{enter}');
-
-    // check the value has been set 
-    expect(runRequest.mock.calls.length).toBe(2);
-    expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
+    await userEvent.type(selects[2], 'myVeryCustomValue');
 
     // resolve the delaying promise
     await act(resolveCallback);
 
-    // check the calls and values are the same
+    await userEvent.type(selects[2], '{enter}');
+
+    // check the value has been set 
     expect(runRequest.mock.calls.length).toBe(2);
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
 


### PR DESCRIPTION
- changes `keySelect` to set `isKeysOpen` synchronously as soon as the `onOpenMenu`/`onCloseMenu` callbacks are called
- if this is set asynchronously once the options are resolved, can potentially cause issues with slow connections. example:
  - throttle connection to slooooooow
  - take a configured filter (with key + value)
  - open the key dropdown
  - click outside to close the key dropdown
  - open the value dropdown
  - click outside to close the value dropdown
  - wait for everything to resolve
  - expected: dropdowns remain closed
  - (haven't tested this, but) i think actually both dropdowns will be open, which shouldn't be possible and could cause any manner of issues

Fixes https://github.com/grafana/hyperion-planning/issues/28
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.14.3--canary.722.8989150174.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.14.3--canary.722.8989150174.0
  # or 
  yarn add @grafana/scenes@4.14.3--canary.722.8989150174.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
