### PR TITLE
AdHoc filters: Allow typing the same custom value

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -36,6 +36,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueSelect = (
     <Select
       allowCustomValue
+      isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
       disabled={model.state.readOnly}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -102,6 +102,34 @@ describe('AdHocFiltersVariable', () => {
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
   });
 
+  it('can set the same custom value again', async () => {
+    const { filtersVar, runRequest } = setup();
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    await userEvent.type(selects[2], 'myVeryCustomValue{enter}');
+
+    // should run new query when filter changed
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
+
+    await userEvent.type(selects[2], 'myVeryCustomValue');
+
+    expect(screen.getByText('Use custom value: myVeryCustomValue')).toBeInTheDocument();
+
+    await userEvent.type(selects[2], '{enter}');
+
+    // should not run a new query since the value is the same
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
+  });
+
   it('Can set a custom value before the list of values returns', async () => {
     let resolveCallback;
     const delayingPromise = new Promise((resolve) => resolveCallback = resolve);


### PR DESCRIPTION
- passes a custom `isValidNewOption` function to the valueSelect
  - allows any non-zero-length string as a valid option
  - this prevents showing a `No options found` message when entering the same custom value as was initially present
- adds a unit test to prevent regressions 

Fixes https://github.com/grafana/hyperion-planning/issues/25
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.17.2--canary.723.8999827741.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.17.2--canary.723.8999827741.0
  # or 
  yarn add @grafana/scenes@4.17.2--canary.723.8999827741.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
