### PR TITLE
Variables: Do not update value when value and text are the same

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -15,7 +15,7 @@ import {
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 
 import { SceneDataNode } from '../core/SceneDataNode';
-import { SceneDataTransformer, SceneDataTransformerState } from './SceneDataTransformer';
+import { SceneDataTransformer } from './SceneDataTransformer';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import { CustomTransformOperator, CustomTransformerDefinition, SceneObjectState } from '../core/types';

--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -22,6 +22,7 @@ import { CustomTransformOperator, CustomTransformerDefinition, SceneObjectState 
 import { mockTransformationsRegistry } from '../utils/mockTransformationsRegistry';
 import { SceneQueryRunner } from './SceneQueryRunner';
 import { SceneTimeRange } from '../core/SceneTimeRange';
+import { subscribeToStateUpdates } from '../../utils/test/utils';
 
 class TestSceneObject extends SceneObjectBase<{}> {}
 
@@ -529,8 +530,7 @@ describe('SceneDataTransformer', () => {
 
     transformationNode.activate();
 
-    const stateUpdates: SceneDataTransformerState[] = [];
-    transformationNode.subscribeToState((state) => stateUpdates.push(state));
+    const stateUpdates = subscribeToStateUpdates(transformationNode);
 
     sourceDataNode.setState({
       data: {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -21,6 +21,7 @@ import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { select } from 'react-select-event';
 import { VariableValueSelectors } from '../components/VariableValueSelectors';
+import { subscribeToStateUpdates } from '../../../utils/test/utils';
 
 const templateSrv = {
   getAdhocFilters: jest.fn().mockReturnValue([{ key: 'origKey', operator: '=', value: '' }]),
@@ -104,16 +105,16 @@ describe('AdHocFiltersVariable', () => {
 
   it('Can set a custom value before the list of values returns', async () => {
     let resolveCallback;
-    const delayingPromise = new Promise((resolve) => resolveCallback = resolve);
+    const delayingPromise = new Promise((resolve) => (resolveCallback = resolve));
 
     const { filtersVar, runRequest } = setup({
       getTagValuesProvider: async () => {
         await delayingPromise;
         return {
           replace: true,
-          values: [{ text: 'Value 3', value: 'value3' }]
-        }
-      }
+          values: [{ text: 'Value 3', value: 'value3' }],
+        };
+      },
     });
 
     await new Promise((r) => setTimeout(r, 1));
@@ -130,7 +131,7 @@ describe('AdHocFiltersVariable', () => {
 
     await userEvent.type(selects[2], '{enter}');
 
-    // check the value has been set 
+    // check the value has been set
     expect(runRequest.mock.calls.length).toBe(2);
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
 
@@ -138,11 +139,10 @@ describe('AdHocFiltersVariable', () => {
     expect(screen.queryByText('Value 3')).not.toBeInTheDocument();
   });
 
-  describe('By default, Without altering `useQueriesAsFilterForOptions`', ()=>{
-
+  describe('By default, Without altering `useQueriesAsFilterForOptions`', () => {
     it('Should not collect and pass respective data source queries to getTagKeys call', async () => {
       const { getTagKeysSpy, timeRange } = setup({ filters: [] });
-  
+
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       expect(getTagKeysSpy).toBeCalledTimes(1);
@@ -152,17 +152,17 @@ describe('AdHocFiltersVariable', () => {
         timeRange: timeRange.state.value,
       });
     });
-  
+
     it('Should not collect and pass respective data source queries to getTagValues call', async () => {
       const { getTagValuesSpy, timeRange } = setup({ filters: [] });
-  
+
       // Select key
       const key = 'Key 3';
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
       await waitFor(() => select(selects[0], key, { container: document.body }));
       await userEvent.click(selects[2]);
-  
+
       expect(getTagValuesSpy).toBeCalledTimes(1);
       expect(getTagValuesSpy).toBeCalledWith({
         filters: [],
@@ -173,11 +173,10 @@ describe('AdHocFiltersVariable', () => {
     });
   });
 
-  describe('When `useQueriesAsFilterForOptions` is set to `true`', ()=>{
-
+  describe('When `useQueriesAsFilterForOptions` is set to `true`', () => {
     it('Should collect and pass respective data source queries to getTagKeys call', async () => {
       const { getTagKeysSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
-  
+
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       expect(getTagKeysSpy).toBeCalledTimes(1);
@@ -192,17 +191,17 @@ describe('AdHocFiltersVariable', () => {
         timeRange: timeRange.state.value,
       });
     });
-  
+
     it('Should collect and pass respective data source queries to getTagValues call', async () => {
       const { getTagValuesSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
-  
+
       // Select key
       const key = 'Key 3';
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
       await waitFor(() => select(selects[0], key, { container: document.body }));
       await userEvent.click(selects[2]);
-  
+
       expect(getTagValuesSpy).toBeCalledTimes(1);
       expect(getTagValuesSpy).toBeCalledWith({
         filters: [],
@@ -216,9 +215,7 @@ describe('AdHocFiltersVariable', () => {
         timeRange: timeRange.state.value,
       });
     });
-  
   });
-
 
   it('url sync works', async () => {
     const { filtersVar } = setup();
@@ -640,8 +637,7 @@ describe('AdHocFiltersVariable', () => {
 
       variable.activate();
 
-      const stateUpdates: AdHocFiltersVariableState[] = [];
-      variable.subscribeToState((state) => stateUpdates.push(state));
+      const stateUpdates = subscribeToStateUpdates(variable);
 
       expect(stateUpdates.length).toBe(0);
 

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -5,7 +5,7 @@ import { VariableFormatID } from '@grafana/schema';
 
 import { SceneVariableValueChangedEvent } from '../types';
 import { CustomAllValue } from '../variants/MultiValueVariable';
-import { TestVariable, TestVariableState } from './TestVariable';
+import { TestVariable } from './TestVariable';
 import { subscribeToStateUpdates } from '../../../utils/test/utils';
 
 describe('MultiValueVariable', () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -5,7 +5,8 @@ import { VariableFormatID } from '@grafana/schema';
 
 import { SceneVariableValueChangedEvent } from '../types';
 import { CustomAllValue } from '../variants/MultiValueVariable';
-import { TestVariable } from './TestVariable';
+import { TestVariable, TestVariableState } from './TestVariable';
+import { subscribeToStateUpdates } from '../../../utils/test/utils';
 
 describe('MultiValueVariable', () => {
   describe('When validateAndUpdate is called', () => {
@@ -307,6 +308,30 @@ describe('MultiValueVariable', () => {
       variable.changeValueTo([ALL_VARIABLE_VALUE, '1']);
       // Should remove the all value so only the new value is present
       expect(variable.state.value).toEqual(['1']);
+    });
+
+    it('When value is the same', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        isMulti: true,
+        defaultToAll: true,
+        optionsToReturn: [],
+        delayMs: 0,
+        value: ['1', '2'],
+        text: ['A', 'B'],
+      });
+
+      variable.activate();
+
+      const stateUpdates = subscribeToStateUpdates(variable);
+
+      variable.changeValueTo(['1', '2']);
+
+      expect(stateUpdates).toHaveLength(0);
     });
   });
 

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -250,6 +250,11 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       }
     }
 
+    // Do nothing if value and text are the same
+    if (isEqual(value, this.state.value) && isEqual(text, this.state.text)) {
+      return;
+    }
+
     this.setStateHelper({ value, text, loading: false });
     this.publishEvent(new SceneVariableValueChangedEvent(this), true);
   }

--- a/packages/scenes/utils/test/utils.tsx
+++ b/packages/scenes/utils/test/utils.tsx
@@ -5,6 +5,7 @@ import { History } from 'history';
 import { render } from '@testing-library/react';
 import { SceneApp } from '../../src/components/SceneApp/SceneApp';
 import { Router } from 'react-router-dom';
+import { SceneObject, SceneObjectState } from '../../src';
 
 export const OBSERVABLE_TEST_TIMEOUT_IN_MS = 1000;
 
@@ -74,4 +75,10 @@ export function renderAppInsideRouterWithStartingUrl(history: History, app: Scen
       <app.Component model={app} />
     </Router>
   );
+}
+
+export function subscribeToStateUpdates<T extends SceneObjectState>(obj: SceneObject<T>): T[] {
+  const stateUpdates: T[] = [];
+  obj.subscribeToState((state) => stateUpdates.push(state));
+  return stateUpdates;
 }


### PR DESCRIPTION
Fixes an annoying issue where a multi-value variable would trigger a cascading update even when the value did not change, for example when just opening the variable multi select and closing it without changing anything 