### PR TITLE
SceneVariableSet: Do not propagate variable value changes when a local variable has the same name

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -15,6 +15,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { LocalValueVariable } from '../variants/LocalValueVariable';
 import { TestObjectWithVariableDependency, TestScene } from '../TestScene';
+import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 
 interface SceneTextItemState extends SceneObjectState {
   text: string;
@@ -680,6 +681,35 @@ describe('SceneVariableList', () => {
       // Now change variable A
       A.changeValueTo('AB');
       expect(B.state.loading).toBe(true);
+    });
+
+    describe('When local value overrides parent variable changes on top level should not propagate', () => {
+      const topLevelVar = new TestVariable({
+        name: 'test',
+        options: [],
+        value: 'B',
+        optionsToReturn: [{ label: 'B', value: 'B' }],
+        delayMs: 0,
+      });
+
+      const nestedScene = new TestObjectWithVariableDependency({
+        title: '$test',
+        $variables: new SceneVariableSet({
+          variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
+        }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [topLevelVar] }),
+        nested: nestedScene,
+      });
+
+      activateFullSceneTree(scene);
+
+      topLevelVar.changeValueTo('E');
+
+      expect(nestedScene.state.didSomethingCount).toBe(0);
+      expect(nestedScene.state.variableValueChanged).toBe(0);
     });
   });
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -324,6 +324,14 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
+    // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
+    if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
+      const localVar = sceneObject.state.$variables.getByName(variable.state.name);
+      if (localVar) {
+        return;
+      }
+    }
+
     if (sceneObject.variableDependency) {
       sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
     }


### PR DESCRIPTION
Part of row repeat fixes https://github.com/grafana/grafana/pull/87539

So we have this problem in row repeats that when the variable changes (that you repeat by). All the panel query runners inside all the repeated rows were notified that their variable dependency changed and started issuing a new queries (even when their local value did not change) . 

So figured that this notification (via variableDependency) should not happen if there is a local SceneVariableSet with a local variable of the same name. 

Created a test case for this scenario all is fine. This logic make sense, the variable has not changed for the local scope (as there is a local variable with the same name that has not changed).

The only really hard puzzle piece to solve is that his completely breaks the RowRepeatBehavior in core as it relies on this notification to process repeats. 

So the problem here is that the first row (which we use as template / source of repeats) also get's a locally scoped value (the first variable value), so after the first repeat process this local value on the first row will block any updates the variable, which logically is correct the local value is not changing. ARHHHHfasFASDSDASFA S FQ"!° going to go for a walk. 

Think the only solution is to the notification of variable changes from the behavior itself to the dashboard scene, this is now done in https://github.com/grafana/grafana/pull/87539 



