### PR TITLE
Default `hoverHeaderOffset` to 0

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -19,7 +19,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     _pluginLoadError,
     displayMode,
     hoverHeader,
-    hoverHeaderOffset,
+    hoverHeaderOffset = 0,
     menu,
     headerActions,
     titleItems,


### PR DESCRIPTION
This PR is part of alternative approach to https://github.com/grafana/grafana/issues/87495 that maked `hoverHeaderOffset` always 0
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.17.4--canary.730.9018441703.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.17.4--canary.730.9018441703.0
  # or 
  yarn add @grafana/scenes@4.17.4--canary.730.9018441703.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
