### PR TITLE
All row repeat fixes (Just for testing in core repo PR) 

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -229,6 +229,7 @@ describe('SceneObject', () => {
         $variables: new SceneVariableSet({ variables: [] }),
         $data: new SceneDataNode({}),
         $timeRange: new SceneTimeRange({}),
+        $behaviors: [],
       });
 
       scene.activate();
@@ -239,6 +240,7 @@ describe('SceneObject', () => {
         $variables: new SceneVariableSet({ variables: [] }),
         $data: new SceneDataNode({}),
         $timeRange: new SceneTimeRange({}),
+        $behaviors: [],
       });
 
       const newState = scene.state;
@@ -252,6 +254,40 @@ describe('SceneObject', () => {
       expect(newState.$variables!.isActive).toBe(true);
       expect(newState.$data!.isActive).toBe(true);
       expect(newState.$timeRange!.isActive).toBe(true);
+    });
+
+    it('Call activation handlers for new behaviors in state', () => {
+      const behavior1Deactivate = jest.fn();
+      const behavior1 = jest.fn().mockReturnValue(behavior1Deactivate);
+      const behavior2Deactivate = jest.fn();
+      const behavior2 = jest.fn().mockReturnValue(behavior2Deactivate);
+      const behavior3Deactivate = jest.fn();
+      const behavior3 = jest.fn().mockReturnValue(behavior3Deactivate);
+
+      const scene = new TestScene({
+        name: 'root',
+        $behaviors: [behavior1, behavior2],
+      });
+
+      const deactivate = scene.activate();
+
+      // Remove behavior 2 and and behavior 3
+      scene.setState({ $behaviors: [behavior1, behavior3] });
+
+      // 1 should have been called 1 times and not deactivated
+      expect(behavior1Deactivate).toHaveBeenCalledTimes(0);
+      expect(behavior1).toHaveBeenCalledTimes(1);
+
+      // 2 should have been deactivated
+      expect(behavior2Deactivate).toHaveBeenCalledTimes(1);
+
+      // 3 should have been activated
+      expect(behavior3).toHaveBeenCalledTimes(1);
+
+      deactivate();
+      expect(behavior1Deactivate).toHaveBeenCalledTimes(1);
+      expect(behavior2Deactivate).toHaveBeenCalledTimes(1); // just to check it's not deactivated again
+      expect(behavior3Deactivate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -15,13 +15,14 @@ import {
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 
 import { SceneDataNode } from '../core/SceneDataNode';
-import { SceneDataTransformer, SceneDataTransformerState } from './SceneDataTransformer';
+import { SceneDataTransformer } from './SceneDataTransformer';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import { CustomTransformOperator, CustomTransformerDefinition, SceneObjectState } from '../core/types';
 import { mockTransformationsRegistry } from '../utils/mockTransformationsRegistry';
 import { SceneQueryRunner } from './SceneQueryRunner';
 import { SceneTimeRange } from '../core/SceneTimeRange';
+import { subscribeToStateUpdates } from '../../utils/test/utils';
 
 class TestSceneObject extends SceneObjectBase<{}> {}
 
@@ -529,8 +530,7 @@ describe('SceneDataTransformer', () => {
 
     transformationNode.activate();
 
-    const stateUpdates: SceneDataTransformerState[] = [];
-    transformationNode.subscribeToState((state) => stateUpdates.push(state));
+    const stateUpdates = subscribeToStateUpdates(transformationNode);
 
     sourceDataNode.setState({
       data: {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -439,6 +439,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       clone['_layerAnnotations'] = this._layerAnnotations.map((frame) => ({ ...frame }));
     }
 
+    clone['_variableValueRecorder'] = this._variableValueRecorder.cloneAndRecordCurrentValuesForSceneObject(this);
+    clone['_containerWidth'] = this._containerWidth;
     clone['_results'].next({ origin: this, data: this.state.data ?? emptyPanelData });
 
     return clone;

--- a/packages/scenes/src/variables/VariableValueRecorder.ts
+++ b/packages/scenes/src/variables/VariableValueRecorder.ts
@@ -7,7 +7,7 @@ import { isVariableValueEqual } from './utils';
  * Useful for remembering variable values to know if they have changed
  **/
 export class VariableValueRecorder {
-  private _values = new Map<SceneVariable, VariableValue | undefined | null>();
+  private _values = new Map<string, VariableValue | undefined | null>();
 
   public recordCurrentDependencyValuesForSceneObject(sceneObject: SceneObject) {
     this.clearValues();
@@ -19,9 +19,15 @@ export class VariableValueRecorder {
     for (const variableName of sceneObject.variableDependency.getNames()) {
       const variable = sceneGraph.lookupVariable(variableName, sceneObject);
       if (variable) {
-        this._values.set(variable, variable.getValue());
+        this._values.set(variable.state.name, variable.getValue());
       }
     }
+  }
+
+  public cloneAndRecordCurrentValuesForSceneObject(sceneObject: SceneObject) {
+    const clone = new VariableValueRecorder();
+    clone.recordCurrentDependencyValuesForSceneObject(sceneObject);
+    return clone;
   }
 
   public clearValues() {
@@ -33,16 +39,16 @@ export class VariableValueRecorder {
   }
 
   public recordCurrentValue(variable: SceneVariable) {
-    this._values.set(variable, variable.getValue());
+    this._values.set(variable.state.name, variable.getValue());
   }
 
   public hasRecordedValue(variable: SceneVariable): boolean {
-    return this._values.has(variable);
+    return this._values.has(variable.state.name);
   }
 
   public hasValueChanged(variable: SceneVariable): boolean {
-    if (this._values.has(variable)) {
-      const value = this._values.get(variable);
+    if (this._values.has(variable.state.name)) {
+      const value = this._values.get(variable.state.name);
       if (!isVariableValueEqual(value, variable.getValue())) {
         return true;
       }
@@ -62,8 +68,14 @@ export class VariableValueRecorder {
 
     for (const variableName of sceneObject.variableDependency.getNames()) {
       const variable = sceneGraph.lookupVariable(variableName, sceneObject);
-      if (variable && this._values.has(variable)) {
-        const value = this._values.get(variable);
+      if (!variable) {
+        continue;
+      }
+
+      const name = variable.state.name;
+
+      if (variable && this._values.has(name)) {
+        const value = this._values.get(name);
         if (!isVariableValueEqual(value, variable.getValue())) {
           return true;
         }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -21,6 +21,7 @@ import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { select } from 'react-select-event';
 import { VariableValueSelectors } from '../components/VariableValueSelectors';
+import { subscribeToStateUpdates } from '../../../utils/test/utils';
 
 const templateSrv = {
   getAdhocFilters: jest.fn().mockReturnValue([{ key: 'origKey', operator: '=', value: '' }]),
@@ -143,16 +144,16 @@ describe('AdHocFiltersVariable', () => {
 
   it('Can set a custom value before the list of values returns', async () => {
     let resolveCallback;
-    const delayingPromise = new Promise((resolve) => resolveCallback = resolve);
+    const delayingPromise = new Promise((resolve) => (resolveCallback = resolve));
 
     const { filtersVar, runRequest } = setup({
       getTagValuesProvider: async () => {
         await delayingPromise;
         return {
           replace: true,
-          values: [{ text: 'Value 3', value: 'value3' }]
-        }
-      }
+          values: [{ text: 'Value 3', value: 'value3' }],
+        };
+      },
     });
 
     await new Promise((r) => setTimeout(r, 1));
@@ -169,7 +170,7 @@ describe('AdHocFiltersVariable', () => {
 
     await userEvent.type(selects[2], '{enter}');
 
-    // check the value has been set 
+    // check the value has been set
     expect(runRequest.mock.calls.length).toBe(2);
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
 
@@ -177,11 +178,10 @@ describe('AdHocFiltersVariable', () => {
     expect(screen.queryByText('Value 3')).not.toBeInTheDocument();
   });
 
-  describe('By default, Without altering `useQueriesAsFilterForOptions`', ()=>{
-
+  describe('By default, Without altering `useQueriesAsFilterForOptions`', () => {
     it('Should not collect and pass respective data source queries to getTagKeys call', async () => {
       const { getTagKeysSpy, timeRange } = setup({ filters: [] });
-  
+
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       expect(getTagKeysSpy).toBeCalledTimes(1);
@@ -191,17 +191,17 @@ describe('AdHocFiltersVariable', () => {
         timeRange: timeRange.state.value,
       });
     });
-  
+
     it('Should not collect and pass respective data source queries to getTagValues call', async () => {
       const { getTagValuesSpy, timeRange } = setup({ filters: [] });
-  
+
       // Select key
       const key = 'Key 3';
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
       await waitFor(() => select(selects[0], key, { container: document.body }));
       await userEvent.click(selects[2]);
-  
+
       expect(getTagValuesSpy).toBeCalledTimes(1);
       expect(getTagValuesSpy).toBeCalledWith({
         filters: [],
@@ -212,11 +212,10 @@ describe('AdHocFiltersVariable', () => {
     });
   });
 
-  describe('When `useQueriesAsFilterForOptions` is set to `true`', ()=>{
-
+  describe('When `useQueriesAsFilterForOptions` is set to `true`', () => {
     it('Should collect and pass respective data source queries to getTagKeys call', async () => {
       const { getTagKeysSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
-  
+
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       expect(getTagKeysSpy).toBeCalledTimes(1);
@@ -231,17 +230,17 @@ describe('AdHocFiltersVariable', () => {
         timeRange: timeRange.state.value,
       });
     });
-  
+
     it('Should collect and pass respective data source queries to getTagValues call', async () => {
       const { getTagValuesSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
-  
+
       // Select key
       const key = 'Key 3';
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       const selects = getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox');
       await waitFor(() => select(selects[0], key, { container: document.body }));
       await userEvent.click(selects[2]);
-  
+
       expect(getTagValuesSpy).toBeCalledTimes(1);
       expect(getTagValuesSpy).toBeCalledWith({
         filters: [],
@@ -255,9 +254,7 @@ describe('AdHocFiltersVariable', () => {
         timeRange: timeRange.state.value,
       });
     });
-  
   });
-
 
   it('url sync works', async () => {
     const { filtersVar } = setup();
@@ -692,8 +689,7 @@ describe('AdHocFiltersVariable', () => {
 
       variable.activate();
 
-      const stateUpdates: AdHocFiltersVariableState[] = [];
-      variable.subscribeToState((state) => stateUpdates.push(state));
+      const stateUpdates = subscribeToStateUpdates(variable);
 
       expect(stateUpdates.length).toBe(0);
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -15,6 +15,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { LocalValueVariable } from '../variants/LocalValueVariable';
 import { TestObjectWithVariableDependency, TestScene } from '../TestScene';
+import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 
 interface SceneTextItemState extends SceneObjectState {
   text: string;
@@ -680,6 +681,35 @@ describe('SceneVariableList', () => {
       // Now change variable A
       A.changeValueTo('AB');
       expect(B.state.loading).toBe(true);
+    });
+
+    describe('When local value overrides parent variable changes on top level should not propagate', () => {
+      const topLevelVar = new TestVariable({
+        name: 'test',
+        options: [],
+        value: 'B',
+        optionsToReturn: [{ label: 'B', value: 'B' }],
+        delayMs: 0,
+      });
+
+      const nestedScene = new TestObjectWithVariableDependency({
+        title: '$test',
+        $variables: new SceneVariableSet({
+          variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
+        }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [topLevelVar] }),
+        nested: nestedScene,
+      });
+
+      activateFullSceneTree(scene);
+
+      topLevelVar.changeValueTo('E');
+
+      expect(nestedScene.state.didSomethingCount).toBe(0);
+      expect(nestedScene.state.variableValueChanged).toBe(0);
     });
   });
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -324,6 +324,14 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
+    // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
+    if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
+      const localVar = sceneObject.state.$variables.getByName(variable.state.name);
+      if (localVar) {
+        return;
+      }
+    }
+
     if (sceneObject.variableDependency) {
       sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
     }

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -6,6 +6,7 @@ import { VariableFormatID } from '@grafana/schema';
 import { SceneVariableValueChangedEvent } from '../types';
 import { CustomAllValue } from '../variants/MultiValueVariable';
 import { TestVariable } from './TestVariable';
+import { subscribeToStateUpdates } from '../../../utils/test/utils';
 
 describe('MultiValueVariable', () => {
   describe('When validateAndUpdate is called', () => {
@@ -307,6 +308,30 @@ describe('MultiValueVariable', () => {
       variable.changeValueTo([ALL_VARIABLE_VALUE, '1']);
       // Should remove the all value so only the new value is present
       expect(variable.state.value).toEqual(['1']);
+    });
+
+    it('When value is the same', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        isMulti: true,
+        defaultToAll: true,
+        optionsToReturn: [],
+        delayMs: 0,
+        value: ['1', '2'],
+        text: ['A', 'B'],
+      });
+
+      variable.activate();
+
+      const stateUpdates = subscribeToStateUpdates(variable);
+
+      variable.changeValueTo(['1', '2']);
+
+      expect(stateUpdates).toHaveLength(0);
     });
   });
 

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -250,6 +250,11 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       }
     }
 
+    // Do nothing if value and text are the same
+    if (isEqual(value, this.state.value) && isEqual(text, this.state.text)) {
+      return;
+    }
+
     this.setStateHelper({ value, text, loading: false });
     this.publishEvent(new SceneVariableValueChangedEvent(this), true);
   }

--- a/packages/scenes/utils/test/utils.tsx
+++ b/packages/scenes/utils/test/utils.tsx
@@ -5,6 +5,7 @@ import { History } from 'history';
 import { render } from '@testing-library/react';
 import { SceneApp } from '../../src/components/SceneApp/SceneApp';
 import { Router } from 'react-router-dom';
+import { SceneObject, SceneObjectState } from '../../src';
 
 export const OBSERVABLE_TEST_TIMEOUT_IN_MS = 1000;
 
@@ -74,4 +75,10 @@ export function renderAppInsideRouterWithStartingUrl(history: History, app: Scen
       <app.Component model={app} />
     </Router>
   );
+}
+
+export function subscribeToStateUpdates<T extends SceneObjectState>(obj: SceneObject<T>): T[] {
+  const stateUpdates: T[] = [];
+  obj.subscribeToState((state) => stateUpdates.push(state));
+  return stateUpdates;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,17 +5,10 @@
     "declarationDir": "./compiled",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
-    "rootDirs": [
-      "."
-    ]
+    "rootDirs": ["."]
   },
-  "exclude": [
-    "dist/**/*"
-  ],
-  "include": [
-    "utils/**/*.ts*",
-    "src/**/*.ts*"
-  ],
+  "exclude": ["dist/**/*"],
+  "include": ["utils/**/*.ts*", "src/**/*.ts*"],
   "ts-node": {
     "compilerOptions": {
       "isolatedModules": false,


### PR DESCRIPTION
- Variables: Do not update value when value and text are the same
- SceneVariableSet: Do not propagate variable value changes when a local variable has the same name
- Update
- SceneObject: Handle new or removed behaviors

This is just to test a canary build with all these fixes 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.17.4--canary.732.9028593616.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.17.4--canary.732.9028593616.0
  # or 
  yarn add @grafana/scenes@4.17.4--canary.732.9028593616.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
