### PR TITLE
NestedScene: Don't show `cursor: pointer;` for everything

### DIFF
--- a/packages/scenes/src/components/NestedScene.tsx
+++ b/packages/scenes/src/components/NestedScene.tsx
@@ -88,7 +88,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flexDirection: 'column',
     flexGrow: 1,
     gap: theme.spacing(1),
-    cursor: 'pointer',
   }),
   row: css({
     width: '100%',


### PR DESCRIPTION
- removes `cursor: pointer;` from the `NestedScene` wrapper
- might be missing something, but i don't think this is necessary
- most obvious place to spot the problems this causes is the [alerting landing page in ops](https://ops.grafana-ops.net/alerting)
- everything under `Insights` shows a pointer cursor 🤯 
- this means it can look like something is clickable when it's not (e.g. try clicking in the gap to the right of `Grafana-managed alert rules`)