### PR TITLE
Group by: Do not allow custom options

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -238,7 +238,6 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
       maxVisibleValues={maxVisibleValues ?? 5}
       tabSelectsValue={false}
       virtualized
-      allowCustomValue
       options={model.getOptionsForSelect()}
       closeMenuOnSelect={false}
       isOpen={isOptionsOpen}


### PR DESCRIPTION
Custom options do not make sense in the group by variable which is supposed to provide source of aggregations based on the data source provided dimensions.

Ref https://github.com/grafana/hyperion-planning/issues/46

