### PR TITLE
MultiValueVariable: Fixes setting value from url when url value is a custom all value

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -586,6 +586,26 @@ describe('MultiValueVariable', () => {
       expect(variable.getValue()).toEqual(['1', '2']);
     });
 
+    it('updateFromUrl with the custom all value should set value to ALL_VARIABLE_VALUE', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        optionsToReturn: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        includeAll: true,
+        isMulti: true,
+        value: ALL_VARIABLE_VALUE,
+        text: ALL_VARIABLE_TEXT,
+        allValue: '.*',
+        delayMs: 0,
+      });
+
+      variable.urlSync?.updateFromUrl({ ['var-test']: '.*' });
+      expect(variable.state.value).toEqual(ALL_VARIABLE_VALUE);
+      expect(variable.state.text).toEqual(ALL_VARIABLE_TEXT);
+    });
+
     it('updateFromUrl with key value pair should lookup text representation ', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -260,6 +260,10 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
   }
 
   private findLabelTextForValue(value: VariableValueSingle): VariableValueSingle {
+    if (value === ALL_VARIABLE_VALUE) {
+      return ALL_VARIABLE_TEXT;
+    }
+
     const option = this.state.options.find((x) => x.value === value);
     if (option) {
       return option.label;
@@ -371,6 +375,12 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
       // This is to be backwards compatible with old url all value
       if (this._sceneObject.state.includeAll) {
         urlValue = handleLegacyUrlAllValue(urlValue);
+      }
+
+      // For edge cases where data links include variables with custom all value.
+      // We want the variable to maintain the "All" meta value not the actual custom vall value. (Fixes https://github.com/grafana/grafana/issues/28635)
+      if (this._sceneObject.state.allValue && this._sceneObject.state.allValue === urlValue) {
+        urlValue = ALL_VARIABLE_VALUE;
       }
 
       /**


### PR DESCRIPTION
Ran across this if statement in the old variable system a few weeks ago, https://github.com/grafana/grafana/blob/main/public/app/features/variables/state/actions.ts#L423 , I have had it on my todo to fix this in the new variable system. 

The condition fixes this issue https://github.com/grafana/grafana/issues/28635 

It's for variables with custom all value, when we interpolate a datalink with `${varName}` we do not use the URL state for all value (`$__all`) as we do not really know if the link is targeting Grafana or an external system, so that will always interpolate to the real value, so if the value is `All` then it would be all values or if a custom value is defined (say `.*`) the URL value will be `.*` . 

This new code (condition) will translate the URL value back to our meta All value (`$__all`) when it matches the custom all value. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.23.0--canary.738.9107827139.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.23.0--canary.738.9107827139.0
  # or 
  yarn add @grafana/scenes@4.23.0--canary.738.9107827139.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
