### PR TITLE
VariableValueSelect: Add missing data-testids for e2e

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -137,6 +137,9 @@ export const OptionWithCheckbox = ({
       className={cx(selectStyles.option, isFocused && selectStyles.optionFocused)}
       {...rest}
       aria-label="Select option"
+      data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts(
+        data.label || String(data.value)
+      )}
       title={data.title}
     >
       <div className={optionStyles.checkbox}>


### PR DESCRIPTION
Add missing `data-testid` in variable value select
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.23.1--canary.742.9178393475.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.23.1--canary.742.9178393475.0
  # or 
  yarn add @grafana/scenes@4.23.1--canary.742.9178393475.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
