### PR TITLE
SceneFlexLayout: Min width/height option was ignored

### DIFF
--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -174,12 +174,15 @@ function useLayoutStyle(state: SceneFlexLayoutState, parentState?: SceneFlexItem
     } else {
       style.display = 'flex';
       style.flexGrow = 1;
+      style.minWidth = state.minWidth;
+      style.minHeight = state.minHeight;
     }
 
     style.flexDirection = direction;
     style.gap = '8px';
     style.flexWrap = wrap || 'nowrap';
     style.alignContent = 'baseline';
+    style.minWidth = style.minWidth || 0;
     style.minHeight = style.minHeight || 0;
 
     style[theme.breakpoints.down('md')] = {


### PR DESCRIPTION
Discovered that the `SceneFlexLayout` component was not respecting the `minWidth` and `minHeight` options if it doesn't have a parent, this pr fixes so that they are applied without having to have a parent.

The reason why it works when there is a parent is that `applyItemStyles` function is called with both the own `state` and `parentState` and there the `minWidth` and `minHeight` options are applied.