### PR TITLE
Variables: Prioritize showing adhoc variable key and operator

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -196,7 +196,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flexShrink: 1,
   }),
   key: css({
-    flexShrink: 0,
+    minWidth: '90px',
+    flexShrink: 1,
   }),
   operator: css({
     flexShrink: 0,
@@ -205,6 +206,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     paddingLeft: theme.spacing(3 / 2),
     paddingRight: theme.spacing(3 / 2),
     borderLeft: 'none',
+    width: theme.spacing(3),
+    marginRight: theme.spacing(1),
+    boxSizing: 'border-box',
     // To not have button background and last select border intersect
     position: 'relative',
     left: '1px',

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { AdHocFiltersVariable, AdHocFilterWithLabels } from './AdHocFiltersVariable';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Button, Field, Select, useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { ControlsLabel } from '../../utils/ControlsLabel';
 
 interface Props {
@@ -40,7 +40,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
       disabled={model.state.readOnly}
-      className={isKeysOpen ? styles.widthWhenOpen : undefined}
+      className={cx(styles.value, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
       value={valueValue}
       placeholder={'Select value'}
@@ -72,7 +72,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       // to ensure that the loaded values are shown after they are loaded
       key={`${isValuesLoading ? 'loading' : 'loaded'}`}
       disabled={model.state.readOnly}
-      className={isKeysOpen ? styles.widthWhenOpen : undefined}
+      className={cx(styles.key, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
       value={keyValue}
       placeholder={'Select label'}
@@ -127,6 +127,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     <div className={styles.wrapper} data-testid={`AdHocFilter-${filter.key}`}>
       {keySelect}
       <Select
+        className={styles.operator}
         value={filter.operator}
         disabled={model.state.readOnly}
         options={model._getOperators()}
@@ -190,6 +191,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   widthWhenOpen: css({
     minWidth: theme.spacing(16),
+  }),
+  value: css({
+    flexShrink: 1,
+  }),
+  key: css({
+    flexShrink: 0,
+  }),
+  operator: css({
+    flexShrink: 0,
   }),
   removeButton: css({
     paddingLeft: theme.spacing(3 / 2),


### PR DESCRIPTION
When the value of the adhoc filter gets long, you can't see the key and operator, which are arguably more important than showing a few more characters of the already truncated value.

Before: 
![image](https://github.com/grafana/scenes/assets/468940/b56bd2ad-367b-4d08-98d2-0da1fb62edfb)

After:
![image](https://github.com/grafana/scenes/assets/468940/1c4eae9c-6110-46d2-ae4e-12d7de71cb75)


Fixes: https://github.com/grafana/grafana/issues/88328