### PR TITLE
fix: undefined check on RefreshPicker.autoOption

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -152,7 +152,7 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
   const { refresh, intervals, autoEnabled, autoValue, isOnCanvas, primary, withText } = model.useState();
   const isRunning = useQueryControllerState(model);
 
-  let text = refresh === RefreshPicker.autoOption.value ? autoValue : withText ? 'Refresh' : undefined;
+  let text = refresh === RefreshPicker.autoOption?.value ? autoValue : withText ? 'Refresh' : undefined;
   let tooltip: string | undefined;
   let width: string | undefined;
 


### PR DESCRIPTION
When `autoOption` is undefined, the error prevents some of the demos from displaying.

Moved the fix out of:
- https://github.com/grafana/scenes/pull/744/files#r1611931529
so it can be merged earlier.