### PR TITLE
Update docker-compose.yaml to include latest grafana

### DIFF
--- a/packages/scenes-app/docker-compose.yaml
+++ b/packages/scenes-app/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_version: ${GRAFANA_VERSION:-9.5.0-105543pre}
+        grafana_version: ${GRAFANA_VERSION:latest}
     ports:
       - 3001:3000/tcp
     volumes:

--- a/packages/scenes-app/docker-compose.yaml
+++ b/packages/scenes-app/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_version: ${GRAFANA_VERSION:latest}
+        grafana_version: ${GRAFANA_VERSION:-11.1.0-179671}
     ports:
       - 3001:3000/tcp
     volumes:


### PR DESCRIPTION
When I was testing https://github.com/grafana/scenes/pull/734 using `./scripts/demo.sh`, I got React import error. The grafana version used was old + had older React and didn't have `useId` from it. So I updated it to -11.1.0-179671. 


Broken with `~9.5`: 
<img width="1482" alt="image" src="https://github.com/grafana/scenes/assets/30407135/63486a7d-afac-4e82-aaa5-e06860c9566a">

Fixed with `-11.1.0-179671` (grafana-dev does not have latest): 

<img width="1511" alt="image" src="https://github.com/grafana/scenes/assets/30407135/3fb16cb7-c8ac-47f3-b5a5-e479fdee7dc0">

 