### PR TITLE
feat: sceneGraph.findByKey(AndType)

### DIFF
--- a/packages/scenes/src/core/sceneGraph/index.ts
+++ b/packages/scenes/src/core/sceneGraph/index.ts
@@ -1,6 +1,8 @@
 import { lookupVariable } from '../../variables/lookupVariable';
 import { getTimeRange } from './getTimeRange';
 import {
+  findByKey,
+  findByKeyAndType,
   findObject,
   findAllObjects,
   getData,
@@ -22,6 +24,8 @@ export const sceneGraph = {
   interpolate,
   lookupVariable,
   hasVariableDependencyInLoadingState,
+  findByKey,
+  findByKeyAndType,
   findObject,
   findAllObjects,
   getAncestor,

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -208,4 +208,34 @@ describe('sceneGraph', () => {
       }).toThrow();
     });
   });
+
+  describe('can find by key (and type)', ()=>{
+    const data = new SceneDataNode();
+    const item1 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A' }), $data: data });
+    const item2 = new SceneFlexItem({ key: 'B', body: new SceneCanvasText({ text: 'B' }) });
+    const timePicker = new SceneTimePicker({ key: 'time-picker' });
+
+    const scene = new EmbeddedScene({
+      controls: [timePicker],
+      body: new SceneFlexLayout({
+        children: [item1, item2],
+      }),
+    });
+
+    // from root
+    expect(sceneGraph.findByKey(scene, 'A')).toBe(item1);
+    // from sibling
+    expect(sceneGraph.findByKey(item2, 'A')).toBe(item1);
+    // from data
+    expect(sceneGraph.findByKey(data, 'A')).toBe(item1);
+    // from item deep in graph finding control
+    expect(sceneGraph.findByKey(item2, 'time-picker')).toBe(timePicker);
+    // By type
+    expect(sceneGraph.findByKeyAndType(scene, 'A', SceneFlexItem)).toBe(item1);
+    // By wrong type
+    expect(()=>sceneGraph.findByKeyAndType(scene, 'A', SceneDataNode)).toThrow();
+    // By wrong key
+    expect(()=>sceneGraph.findByKey(scene, 'NOT A KEY')).toThrow();
+    expect(()=>sceneGraph.findByKey(scene, 'NOT A KEY', SceneFlexItem)).toThrow();
+  })
 });

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -236,6 +236,6 @@ describe('sceneGraph', () => {
     expect(()=>sceneGraph.findByKeyAndType(scene, 'A', SceneDataNode)).toThrow();
     // By wrong key
     expect(()=>sceneGraph.findByKey(scene, 'NOT A KEY')).toThrow();
-    expect(()=>sceneGraph.findByKey(scene, 'NOT A KEY', SceneFlexItem)).toThrow();
+    expect(()=>sceneGraph.findByKeyAndType(scene, 'NOT A KEY', SceneFlexItem)).toThrow();
   })
 });

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -128,7 +128,7 @@ function findObjectInternal(
  * 
  * Throws error if no key-matching scene object found.
  */
-export function findByKey<TargetType extends SceneObject>(sceneObject: SceneObject, key: string, targetType?: { new(...args: never[]): TargetType }) {
+export function findByKey(sceneObject: SceneObject, key: string) {
   const found = findObject(sceneObject, (sceneToCheck) => {
     return sceneToCheck.state.key === key;
   });

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -124,6 +124,41 @@ function findObjectInternal(
 }
 
 /**
+ * Returns a scene object from the scene graph with the requested key.
+ * 
+ * Throws error if no key-matching scene object found.
+ */
+export function findByKey<TargetType extends SceneObject>(sceneObject: SceneObject, key: string, targetType?: { new(...args: never[]): TargetType }) {
+  const found = findObject(sceneObject, (sceneToCheck) => {
+    return sceneToCheck.state.key === key;
+  });
+  if (!found) {
+    throw new Error('Unable to find scene with key ' + key);
+  }
+  return found;
+}
+
+/**
+ * Returns a scene object from the scene graph with the requested key.
+ * 
+ * Throws error if no key-matching scene object found.
+ * Throws error if the given type does not match.
+ */
+export function findByKeyAndType<TargetType extends SceneObject>(sceneObject: SceneObject, key: string, targetType: { new(...args: never[]): TargetType }) {
+  const found = findObject(sceneObject, (sceneToCheck) => {
+    return sceneToCheck.state.key === key;
+  });
+  if (!found) {
+    throw new Error('Unable to find scene with key ' + key);
+  }
+  if (!(found instanceof targetType)) {
+    throw new Error(`Found scene object with key ${key} does not match type ${targetType.name}`) 
+  }
+  return found;
+}
+
+
+/**
  * This will search the full scene graph, starting with the scene node passed in, then walking up the parent chain. *
  */
 export function findObject(scene: SceneObject, check: (obj: SceneObject) => boolean): SceneObject | null {

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -139,7 +139,7 @@ export function findByKey<TargetType extends SceneObject>(sceneObject: SceneObje
 }
 
 /**
- * Returns a scene object from the scene graph with the requested key.
+ * Returns a scene object from the scene graph with the requested key and type.
  * 
  * Throws error if no key-matching scene object found.
  * Throws error if the given type does not match.


### PR DESCRIPTION
Additional functions on sceneGraph to search for a single scene object by its key (and optionally to check it matches a specific type).

Based on feedback here:
- https://github.com/grafana/scenes/pull/744#discussion_r1612215386

Please check the suitability of the labels.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.25.0--canary.753.9269482662.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.25.0--canary.753.9269482662.0
  # or 
  yarn add @grafana/scenes@4.25.0--canary.753.9269482662.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
