### PR TITLE
Allow drag and dropping rows in valid states

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -227,8 +227,12 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 
     // if the next child after the updated item is a scene grid row, then we are either at the top
     // of the dashboard, or between rows
+    // if it's not a grid row, but it's parent is the layout, it means we are not in between a
+    // rows children, so also valid state
     const nextSceneChild = this.getSceneLayoutChild(gridLayout[indexOfUpdatedItem + 1].i);
     if (nextSceneChild instanceof SceneGridRow) {
+      return true;
+    } else if (nextSceneChild.parent instanceof SceneGridLayout) {
       return true;
     }
 


### PR DESCRIPTION
We should be able to drag and drop rows across the dashboard if we are not dragging a row within another row. If we try to drag and drop a row after an uncollapsed row and all its panels, this should be a valid state.

Currently if we drop a row after an uncollapsed row it will become a child of that row, since we do not properly delimit between dropping an item in or outside the area of an uncollapsed row.

This PR changes that and checks whether the dragged row is dropped after all the previous rows children, in which case it will assume the layout as parent and allow the drop. If the row is dragged and dropped in between children of another row, it's parent will be considered the row that holds the children, this being an invalid state. We cannot have rows within rows.


https://github.com/grafana/scenes/assets/36818606/f20849c8-fa91-4d80-bdb0-c9c6ff3a8f97



Fixes https://github.com/grafana/grafana-org/issues/106
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.24.1--canary.756.9268571916.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.24.1--canary.756.9268571916.0
  # or 
  yarn add @grafana/scenes@4.24.1--canary.756.9268571916.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
