### PR TITLE
MultiValueVariable: Fixes issue when value is all value but all value is not enabled

### DIFF
--- a/packages/scenes/src/components/VizPanel/seriesVisibilityConfigFactory.test.ts
+++ b/packages/scenes/src/components/VizPanel/seriesVisibilityConfigFactory.test.ts
@@ -1,4 +1,4 @@
-import { ArrayVector, DataFrame, FieldConfigSource, FieldMatcherID, FieldType } from '@grafana/data';
+import { DataFrame, FieldConfigSource, FieldMatcherID, FieldType } from '@grafana/data';
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
 
 import { seriesVisibilityConfigFactory } from './seriesVisibilityConfigFactory';
@@ -6,9 +6,9 @@ import { seriesVisibilityConfigFactory } from './seriesVisibilityConfigFactory';
 describe('seriesVisibilityConfigFactory', () => {
   const frame1: DataFrame = {
     fields: [
-      { name: 'field1', values: new ArrayVector(), config: {}, type: FieldType.string },
-      { name: 'field2', values: new ArrayVector(), config: {}, type: FieldType.string },
-      { name: 'field3', values: new ArrayVector(), config: {}, type: FieldType.string },
+      { name: 'field1', values: [], config: {}, type: FieldType.string },
+      { name: 'field2', values: [], config: {}, type: FieldType.string },
+      { name: 'field3', values: [], config: {}, type: FieldType.string },
     ],
     length: 0,
   };

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -319,27 +319,27 @@ describe('SceneGridLayout', () => {
       layout.onDragStop(
         [
           {
-              w: 12,
-              h: 8,
-              x: 0,
-              y: 2,
-              i: 'a',
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 2,
+            i: 'a',
           },
           {
-              w: 24,
-              h: 1,
-              x: 0,
-              y: 0,
-              i: 'row-a',
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 0,
+            i: 'row-a',
           },
           {
-              w: 12,
-              h: 8,
-              x: 0,
-              y: 10,
-              i: 'b',
-          }
-      ],
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 10,
+            i: 'b',
+          },
+        ],
         // @ts-expect-error
         {},
         {
@@ -379,7 +379,7 @@ describe('SceneGridLayout', () => {
             title: 'Row B',
             key: 'row-b',
             isCollapsed: true,
-            y: 0
+            y: 0,
           }),
           new SceneGridRow({
             title: 'Row A',
@@ -404,30 +404,37 @@ describe('SceneGridLayout', () => {
       });
 
       // we save the initial layout here, if a state is invalid we will revert to this layout
-      layout.onDragStart([
-        {
+      layout.onDragStart(
+        [
+          {
             w: 12,
             h: 8,
             x: 0,
             y: 0,
             i: 'row-b',
-        },
-        {
+          },
+          {
             w: 24,
             h: 1,
             x: 0,
             y: 1,
             i: 'row-a',
-        },
-        {
+          },
+          {
             w: 12,
             h: 8,
             x: 0,
             y: 2,
             i: 'b',
-        }
-      // @ts-expect-error
-    ], {}, {}, {}, {}, {})
+          },
+          // @ts-expect-error
+        ],
+        {},
+        {},
+        {},
+        {},
+        {}
+      );
 
       // move row-b to be the first child of the row-a:
       // row-a
@@ -437,27 +444,27 @@ describe('SceneGridLayout', () => {
       layout.onDragStop(
         [
           {
-              w: 12,
-              h: 8,
-              x: 0,
-              y: 2,
-              i: 'row-b',
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 2,
+            i: 'row-b',
           },
           {
-              w: 24,
-              h: 1,
-              x: 0,
-              y: 0,
-              i: 'row-a',
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 0,
+            i: 'row-a',
           },
           {
-              w: 12,
-              h: 8,
-              x: 0,
-              y: 10,
-              i: 'b',
-          }
-      ],
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 10,
+            i: 'b',
+          },
+        ],
         // @ts-expect-error
         {},
         {
@@ -473,9 +480,9 @@ describe('SceneGridLayout', () => {
       );
 
       //first call is skipped because onDragStop sets _skipOnLayoutChange
-      layout.onLayoutChange([])
+      layout.onLayoutChange([]);
       // layout argument is irrelevant because we are in an invalid state and will load the old layout in this func
-      layout.onLayoutChange([])
+      layout.onLayoutChange([]);
 
       // children state should be the same as in the beginning
       expect(layout.state.children[0].state.key).toEqual('row-b');
@@ -486,385 +493,404 @@ describe('SceneGridLayout', () => {
       expect(layout.state.children[1].parent).toBeInstanceOf(SceneGridLayout);
       expect((layout.state.children[1] as SceneGridRow).state.children[0].state.key).toEqual('b');
       expect((layout.state.children[1] as SceneGridRow).state.children[0].state.y).toEqual(2);
-    })
-
-  it('should allow dropping a row around another uncollapsed row if state is valid', () => {
-    const layout = new SceneGridLayout({
-      children: [
-        new SceneGridRow({
-          title: 'Row B',
-          key: 'row-b',
-          isCollapsed: false,
-          y: 0,
-          children: [
-            new SceneGridItem({
-              key: 'b',
-              x: 0,
-              y: 1,
-              width: 1,
-              height: 1,
-              isResizable: false,
-              isDraggable: false,
-              body: new TestObject({}),
-            }),
-          ],
-        }),
-        new SceneGridRow({
-          title: 'Row A',
-          key: 'row-a',
-          isCollapsed: false,
-          y: 2,
-        }),
-      new SceneGridRow({
-          title: 'Row C',
-          key: 'row-c',
-          isCollapsed: true,
-          y: 3,
-        }),
-      ],
-      isLazy: false,
     });
 
-    // we save the initial layout here, if a state is invalid we will revert to this layout
-    layout.onDragStart([
-      {
-          w: 12,
-          h: 8,
-          x: 0,
-          y: 0,
-          i: 'row-b',
-      },
-      {
-          w: 24,
-          h: 1,
-          x: 0,
-          y: 1,
-          i: 'row-a',
-      },
-      {
-          w: 12,
-          h: 8,
-          x: 0,
-          y: 2,
-          i: 'b',
-      },
-      {
-        w: 24,
-        h: 9,
-        x: 0,
-        y: 3,
-        i: 'row-c'
-      }
-    // @ts-expect-error
-  ], {}, {}, {}, {}, {})
+    it('should allow dropping a row around another uncollapsed row if state is valid', () => {
+      const layout = new SceneGridLayout({
+        children: [
+          new SceneGridRow({
+            title: 'Row B',
+            key: 'row-b',
+            isCollapsed: false,
+            y: 0,
+            children: [
+              new SceneGridItem({
+                key: 'b',
+                x: 0,
+                y: 1,
+                width: 1,
+                height: 1,
+                isResizable: false,
+                isDraggable: false,
+                body: new TestObject({}),
+              }),
+            ],
+          }),
+          new SceneGridRow({
+            title: 'Row A',
+            key: 'row-a',
+            isCollapsed: false,
+            y: 2,
+          }),
+          new SceneGridRow({
+            title: 'Row C',
+            key: 'row-c',
+            isCollapsed: true,
+            y: 3,
+          }),
+        ],
+        isLazy: false,
+      });
 
-    // move row-c to be between 2 uncollapsed rows:
-    // row-b
-    //  - b
-    // row-c
-    // row-a
-    const gridLayout = [
-      {
+      // we save the initial layout here, if a state is invalid we will revert to this layout
+      layout.onDragStart(
+        [
+          {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 0,
+            i: 'row-b',
+          },
+          {
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 1,
+            i: 'row-a',
+          },
+          {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 2,
+            i: 'b',
+          },
+          {
+            w: 24,
+            h: 9,
+            x: 0,
+            y: 3,
+            i: 'row-c',
+          },
+          // @ts-expect-error
+        ],
+        {},
+        {},
+        {},
+        {},
+        {}
+      );
+
+      // move row-c to be between 2 uncollapsed rows:
+      // row-b
+      //  - b
+      // row-c
+      // row-a
+      const gridLayout = [
+        {
           w: 12,
           h: 8,
           x: 0,
           y: 0,
           i: 'row-b',
-      },
-      {
+        },
+        {
           w: 12,
           h: 8,
           x: 0,
           y: 8,
           i: 'b',
-      },
-      {
+        },
+        {
           w: 24,
           h: 1,
           x: 0,
           y: 10,
           i: 'row-a',
-      },
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 9,
-        i: 'row-c'
-      }
-    ]
-
-    layout.onDragStop(
-      gridLayout,
-      // @ts-expect-error
-      {},
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 9,
-        i: 'row-c',
-      },
-      {},
-      {},
-      {}
-    );
-
-    //first call is skipped because onDragStop sets _skipOnLayoutChange
-    layout.onLayoutChange([])
-    layout.onLayoutChange(gridLayout)
-
-    expect(layout.state.children[0].state.key).toEqual('row-b');
-    expect(layout.state.children[1].state.key).toEqual('row-c');
-    expect(layout.state.children[2].state.key).toEqual('row-a');
-  })
-
-  it('should allow dropping a row at the end of a dashboard, after a uncollapsed row', () => {
-    const layout = new SceneGridLayout({
-      children: [
-        new SceneGridRow({
-          title: 'Row B',
-          key: 'row-b',
-          isCollapsed: false,
-          y: 0,
-          children: [
-            new SceneGridItem({
-              key: 'b',
-              x: 0,
-              y: 1,
-              width: 1,
-              height: 1,
-              isResizable: false,
-              isDraggable: false,
-              body: new TestObject({}),
-            }),
-          ],
-        }),
-        new SceneGridRow({
-          title: 'Row A',
-          key: 'row-a',
-          isCollapsed: true,
-          y: 2,
-        }),
-      ],
-      isLazy: false,
-    });
-
-    // we save the initial layout here, if a state is invalid we will revert to this layout
-    layout.onDragStart([
-      {
+        },
+        {
           w: 24,
           h: 1,
           x: 0,
-          y: 0,
-          i: 'row-a',
-      },
-      {
-          w: 12,
-          h: 8,
-          x: 0,
-          y: 1,
-          i: 'row-b',
-      },
-      {
-          w: 12,
-          h: 8,
-          x: 0,
-          y: 2,
-          i: 'b',
-      },
-    // @ts-expect-error
-  ], {}, {}, {}, {}, {})
+          y: 9,
+          i: 'row-c',
+        },
+      ];
 
-    // move row-a to be after an uncollapsed row:
-    // row-b
-    //  - b
-    // row-a
-    const gridLayout = [
-      {
+      layout.onDragStop(
+        gridLayout,
+        // @ts-expect-error
+        {},
+        {
+          w: 24,
+          h: 1,
+          x: 0,
+          y: 9,
+          i: 'row-c',
+        },
+        {},
+        {},
+        {}
+      );
+
+      //first call is skipped because onDragStop sets _skipOnLayoutChange
+      layout.onLayoutChange([]);
+      layout.onLayoutChange(gridLayout);
+
+      expect(layout.state.children[0].state.key).toEqual('row-b');
+      expect(layout.state.children[1].state.key).toEqual('row-c');
+      expect(layout.state.children[2].state.key).toEqual('row-a');
+    });
+
+    it('should allow dropping a row at the end of a dashboard, after a uncollapsed row', () => {
+      const layout = new SceneGridLayout({
+        children: [
+          new SceneGridRow({
+            title: 'Row B',
+            key: 'row-b',
+            isCollapsed: false,
+            y: 0,
+            children: [
+              new SceneGridItem({
+                key: 'b',
+                x: 0,
+                y: 1,
+                width: 1,
+                height: 1,
+                isResizable: false,
+                isDraggable: false,
+                body: new TestObject({}),
+              }),
+            ],
+          }),
+          new SceneGridRow({
+            title: 'Row A',
+            key: 'row-a',
+            isCollapsed: true,
+            y: 2,
+          }),
+        ],
+        isLazy: false,
+      });
+
+      // we save the initial layout here, if a state is invalid we will revert to this layout
+      layout.onDragStart(
+        [
+          {
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 0,
+            i: 'row-a',
+          },
+          {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 1,
+            i: 'row-b',
+          },
+          {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 2,
+            i: 'b',
+          },
+          // @ts-expect-error
+        ],
+        {},
+        {},
+        {},
+        {},
+        {}
+      );
+
+      // move row-a to be after an uncollapsed row:
+      // row-b
+      //  - b
+      // row-a
+      const gridLayout = [
+        {
           w: 12,
           h: 8,
           x: 0,
           y: 0,
           i: 'row-b',
-      },
-      {
+        },
+        {
           w: 12,
           h: 8,
           x: 0,
           y: 8,
           i: 'b',
-      },
-      {
+        },
+        {
           w: 24,
           h: 1,
           x: 0,
           y: 9,
           i: 'row-a',
-      },
-    ]
+        },
+      ];
 
-    layout.onDragStop(
-      gridLayout,
-      // @ts-expect-error
-      {},
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 9,
-        i: 'row-a',
-      },
-      {},
-      {},
-      {}
-    );
-
-    //first call is skipped because onDragStop sets _skipOnLayoutChange
-    layout.onLayoutChange([])
-    layout.onLayoutChange(gridLayout)
-
-    expect(layout.state.children[0].state.key).toEqual('row-b');
-    expect(layout.state.children[1].state.key).toEqual('row-a');
-  })
-
-  it('should allow dropping a row between an uncollapsed row and a grid item that is not part of the row', () => {
-    const layout = new SceneGridLayout({
-      children: [
-        new SceneGridRow({
-          title: 'Row B',
-          key: 'row-b',
-          isCollapsed: false,
-          y: 0,
-          children: [
-            new SceneGridItem({
-              key: 'b',
-              x: 0,
-              y: 1,
-              width: 1,
-              height: 1,
-              isResizable: false,
-              isDraggable: false,
-              body: new TestObject({}),
-            }),
-          ],
-        }),
-        new SceneGridItem({
-          key: 'c',
+      layout.onDragStop(
+        gridLayout,
+        // @ts-expect-error
+        {},
+        {
+          w: 24,
+          h: 1,
           x: 0,
-          y: 2,
-          width: 1,
-          height: 1,
-          isResizable: false,
-          isDraggable: false,
-          body: new TestObject({}),
-        }),
-        new SceneGridRow({
-          title: 'Row A',
-          key: 'row-a',
-          isCollapsed: true,
-          y: 3,
-        }),
-      ],
-      isLazy: false,
+          y: 9,
+          i: 'row-a',
+        },
+        {},
+        {},
+        {}
+      );
+
+      //first call is skipped because onDragStop sets _skipOnLayoutChange
+      layout.onLayoutChange([]);
+      layout.onLayoutChange(gridLayout);
+
+      expect(layout.state.children[0].state.key).toEqual('row-b');
+      expect(layout.state.children[1].state.key).toEqual('row-a');
     });
 
-    // we save the initial layout here, if a state is invalid we will revert to this layout
-    layout.onDragStart([
-      {
-          w: 12,
-          h: 8,
-          x: 0,
-          y: 0,
-          i: 'row-b',
-      },
-      {
-          w: 12,
-          h: 8,
-          x: 0,
-          y: 1,
-          i: 'b',
-      },
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 2,
-        i: 'c',
-    },
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 3,
-        i: 'row-a',
-    },
-    // @ts-expect-error
-  ], {}, {}, {}, {}, {})
+    it('should allow dropping a row between an uncollapsed row and a grid item that is not part of the row', () => {
+      const layout = new SceneGridLayout({
+        children: [
+          new SceneGridRow({
+            title: 'Row B',
+            key: 'row-b',
+            isCollapsed: false,
+            y: 0,
+            children: [
+              new SceneGridItem({
+                key: 'b',
+                x: 0,
+                y: 1,
+                width: 1,
+                height: 1,
+                isResizable: false,
+                isDraggable: false,
+                body: new TestObject({}),
+              }),
+            ],
+          }),
+          new SceneGridItem({
+            key: 'c',
+            x: 0,
+            y: 2,
+            width: 1,
+            height: 1,
+            isResizable: false,
+            isDraggable: false,
+            body: new TestObject({}),
+          }),
+          new SceneGridRow({
+            title: 'Row A',
+            key: 'row-a',
+            isCollapsed: true,
+            y: 3,
+          }),
+        ],
+        isLazy: false,
+      });
 
-    // move row-a to be between an uncollapsed row with a panel and a panel that is not part of that row:
-    // row-b
-    //  - b
-    // row-a
-    // c
-    const gridLayout = [
-      {
+      // we save the initial layout here, if a state is invalid we will revert to this layout
+      layout.onDragStart(
+        [
+          {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 0,
+            i: 'row-b',
+          },
+          {
+            w: 12,
+            h: 8,
+            x: 0,
+            y: 1,
+            i: 'b',
+          },
+          {
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 2,
+            i: 'c',
+          },
+          {
+            w: 24,
+            h: 1,
+            x: 0,
+            y: 3,
+            i: 'row-a',
+          },
+          // @ts-expect-error
+        ],
+        {},
+        {},
+        {},
+        {},
+        {}
+      );
+
+      // move row-a to be between an uncollapsed row with a panel and a panel that is not part of that row:
+      // row-b
+      //  - b
+      // row-a
+      // c
+      const gridLayout = [
+        {
           w: 12,
           h: 8,
           x: 0,
           y: 0,
           i: 'row-b',
-      },
-      {
+        },
+        {
           w: 12,
           h: 8,
           x: 0,
           y: 8,
           i: 'b',
-      },
-      {
+        },
+        {
           w: 24,
           h: 1,
           x: 0,
           y: 9,
           i: 'row-a',
-      },
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 10,
-        i: 'c',
-    },
-    ]
+        },
+        {
+          w: 24,
+          h: 1,
+          x: 0,
+          y: 10,
+          i: 'c',
+        },
+      ];
 
-    layout.onDragStop(
-      gridLayout,
-      // @ts-expect-error
-      {},
-      {
-        w: 24,
-        h: 1,
-        x: 0,
-        y: 10,
-        i: 'c',
-      },
-      {},
-      {},
-      {}
-    );
+      layout.onDragStop(
+        gridLayout,
+        // @ts-expect-error
+        {},
+        {
+          w: 24,
+          h: 1,
+          x: 0,
+          y: 10,
+          i: 'c',
+        },
+        {},
+        {},
+        {}
+      );
 
-    //first call is skipped because onDragStop sets _skipOnLayoutChange
-    layout.onLayoutChange([])
-    layout.onLayoutChange(gridLayout)
+      //first call is skipped because onDragStop sets _skipOnLayoutChange
+      layout.onLayoutChange([]);
+      layout.onLayoutChange(gridLayout);
 
-    console.log(layout.state.children);
-
-    expect(layout.state.children[0].state.key).toEqual('row-b');
-    expect(layout.state.children[1].state.key).toEqual('row-a');
-    expect(layout.state.children[2].state.key).toEqual('c');
-  })
-});
+      expect(layout.state.children[0].state.key).toEqual('row-b');
+      expect(layout.state.children[1].state.key).toEqual('row-a');
+      expect(layout.state.children[2].state.key).toEqual('c');
+    });
+  });
 
   describe('when using rows', () => {
     it('should update objects relations when moving object out of a row', () => {

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -427,8 +427,8 @@ describe('SceneGridLayout', () => {
             y: 2,
             i: 'b',
           },
-          // @ts-expect-error
         ],
+        // @ts-expect-error
         {},
         {},
         {},
@@ -563,8 +563,8 @@ describe('SceneGridLayout', () => {
             y: 3,
             i: 'row-c',
           },
-          // @ts-expect-error
         ],
+        // @ts-expect-error
         {},
         {},
         {},
@@ -688,8 +688,8 @@ describe('SceneGridLayout', () => {
             y: 2,
             i: 'b',
           },
-          // @ts-expect-error
         ],
+        // @ts-expect-error
         {},
         {},
         {},
@@ -821,8 +821,8 @@ describe('SceneGridLayout', () => {
             y: 3,
             i: 'row-a',
           },
-          // @ts-expect-error
         ],
+        // @ts-expect-error
         {},
         {},
         {},

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -150,7 +150,7 @@ describe('SceneTimeRange', () => {
 
       timeRange.onTimeRangeChange({
         from: toUtc('2020-01-01'),
-        to: toUtc('now'),
+        to: toUtc(),
         raw: { from: toUtc('2020-01-01'), to: 'now' },
       });
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -112,7 +112,7 @@ describe('SceneVariableList', () => {
       expect(C.state.loading).toBe(true);
     });
 
-    it('Should start update process of chained dependency', async () => {
+    it.only('Should start update process of chained dependency', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
       const B = new TestVariable({ name: 'B', query: 'A.$A.*', value: '', text: '', options: [] });
       // Important here that variable C only depends on B

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -112,7 +112,7 @@ describe('SceneVariableList', () => {
       expect(C.state.loading).toBe(true);
     });
 
-    it.only('Should start update process of chained dependency', async () => {
+    it('Should start update process of chained dependency', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
       const B = new TestVariable({ name: 'B', query: 'A.$A.*', value: '', text: '', options: [] });
       // Important here that variable C only depends on B

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -46,7 +46,7 @@ describe('MultiValueVariable', () => {
       expect(variable.state.value).toBe(ALL_VARIABLE_VALUE);
     });
 
-    it('Should pick first option is current value is All value but all value is not enabled', async () => {
+    it('Should pick first option whebn current value is All value but all value is not enabled', async () => {
       const variable = new TestVariable({
         name: 'test',
         options: [],

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -46,6 +46,24 @@ describe('MultiValueVariable', () => {
       expect(variable.state.value).toBe(ALL_VARIABLE_VALUE);
     });
 
+    it('Should pick first option is current value is All value but all value is not enabled', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        value: ALL_VARIABLE_VALUE,
+        text: ALL_VARIABLE_TEXT,
+        optionsToReturn: [
+          { label: 'B', value: 'B' },
+          { label: 'C', value: 'C' },
+        ],
+        delayMs: 0,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toBe('B');
+    });
+
     it('Should keep current value if current value is valid', async () => {
       const variable = new TestVariable({
         name: 'test',
@@ -220,6 +238,7 @@ describe('MultiValueVariable', () => {
           { label: 'A', value: '1' },
           { label: 'B', value: '2' },
         ],
+        includeAll: true,
         value: ALL_VARIABLE_VALUE,
         text: ALL_VARIABLE_TEXT,
         delayMs: 0,

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -80,7 +80,10 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
    * Check if current value is valid given new options. If not update the value.
    */
   private updateValueGivenNewOptions(options: VariableValueOption[]) {
-    const stateUpdate = this.getStateUpdateGivenNewOptions(options);
+    // Remember current value and text
+    const { value: currentValue, text: currentText } = this.state;
+
+    const stateUpdate = this.getStateUpdateGivenNewOptions(options, currentValue, currentText);
 
     this.interceptStateUpdateAfterValidation(stateUpdate);
 
@@ -88,15 +91,16 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     this.setStateHelper(stateUpdate);
 
     // Publish value changed event only if value changed
-    if (stateUpdate.value !== this.state.value || stateUpdate.text !== this.state.text || this.hasAllValue()) {
+    if (stateUpdate.value !== currentValue || stateUpdate.text !== currentText || this.hasAllValue()) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }
 
-  private getStateUpdateGivenNewOptions(options: VariableValueOption[]): Partial<MultiValueVariableState> {
-    // Remember current value and text
-    const { value: currentValue, text: currentText } = this.state;
-
+  private getStateUpdateGivenNewOptions(
+    options: VariableValueOption[],
+    currentValue: VariableValue,
+    currentText: VariableValue
+  ): Partial<MultiValueVariableState> {
     const stateUpdate: Partial<MultiValueVariableState> = {
       options,
       loading: false,
@@ -125,8 +129,8 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
         stateUpdate.text = options[0].label;
         // If multi switch to arrays
         if (this.state.isMulti) {
-          stateUpdate.value = [options[0].value];
-          stateUpdate.text = [options[0].label];
+          stateUpdate.value = [stateUpdate.value];
+          stateUpdate.text = [stateUpdate.text];
         }
       }
       return stateUpdate;


### PR DESCRIPTION
Adds logic for a special case when current value is the ALL_VALUE but the variable has not enabled all value, in this case we should just pick the first option. 

Refactored the validation function a bit so we can simplify the long nested if/else statements and leverage early return pattern instead. 

Fixes https://github.com/grafana/grafana/issues/88391
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.24.2--canary.757.9283024412.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.24.2--canary.757.9283024412.0
  # or 
  yarn add @grafana/scenes@4.24.2--canary.757.9283024412.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
