### PR TITLE
AdHoc filters: Add support for adhoc filter value groups

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -114,6 +114,56 @@ describe('AdHocFiltersVariable', () => {
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
   });
 
+  it('shows groups', async () => {
+    const { runRequest } = setup({
+      getTagValuesProvider: async () => ({
+        replace: true,
+        values: [{
+          text: 'Alice',
+          value: 'alice',
+          group: 'People',
+        }, {
+          text: 'Bob',
+          value: 'bob',
+          group: 'People',
+        }, {
+          text: 'Cat',
+          value: 'cat',
+          group: 'Animals',
+        }, {
+          text: 'Dog',
+          value: 'dog',
+          group: 'Animals',
+        }, {
+          text: 'Foo',
+          value: 'foo',
+        }]
+      })
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    await userEvent.click(selects[2]);
+
+    // Check the group headers are visible
+    expect(screen.getByText('People')).toBeInTheDocument();
+    expect(screen.getByText('Animals')).toBeInTheDocument();
+
+    // Check the correct options exist
+    expect(screen.getAllByRole('option').length).toBe(5);
+    expect(screen.getByRole('option', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Bob' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Cat' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Dog' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Foo' })).toBeInTheDocument();
+  });
+
   it('can set the same custom value again', async () => {
     const { filtersVar, runRequest } = setup();
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -114,7 +114,8 @@ describe('AdHocFiltersVariable', () => {
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
   });
 
-  it('shows groups', async () => {
+  // TODO enable once this repo is using @grafana/ui@11.1.0
+  it.skip('shows groups', async () => {
     const { runRequest } = setup({
       getTagValuesProvider: async () => ({
         replace: true,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -115,7 +115,7 @@ describe('AdHocFiltersVariable', () => {
   });
 
   // TODO enable once this repo is using @grafana/ui@11.1.0
-  it.skip('shows groups', async () => {
+  it.skip('shows groups and orders according to first occurence of a group item', async () => {
     const { runRequest } = setup({
       getTagValuesProvider: async () => ({
         replace: true,
@@ -124,13 +124,16 @@ describe('AdHocFiltersVariable', () => {
           value: 'alice',
           group: 'People',
         }, {
-          text: 'Bob',
-          value: 'bob',
-          group: 'People',
+          text: 'Bar',
+          value: 'bar'
         }, {
           text: 'Cat',
           value: 'cat',
           group: 'Animals',
+        }, {
+          text: 'Bob',
+          value: 'bob',
+          group: 'People',
         }, {
           text: 'Dog',
           value: 'dog',
@@ -157,12 +160,14 @@ describe('AdHocFiltersVariable', () => {
     expect(screen.getByText('Animals')).toBeInTheDocument();
 
     // Check the correct options exist
-    expect(screen.getAllByRole('option').length).toBe(5);
-    expect(screen.getByRole('option', { name: 'Alice' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Bob' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Cat' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Dog' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Foo' })).toBeInTheDocument();
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBe(6);
+    expect(options[0]).toHaveTextContent('Alice');
+    expect(options[1]).toHaveTextContent('Bob');
+    expect(options[2]).toHaveTextContent('Bar');
+    expect(options[3]).toHaveTextContent('Cat');
+    expect(options[4]).toHaveTextContent('Dog');
+    expect(options[5]).toHaveTextContent('Foo');
   });
 
   it('can set the same custom value again', async () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -262,30 +262,6 @@ export class AdHocFiltersVariable
       values = values.concat(override.values);
     }
 
-    values = [{
-      text: 'Cat',
-      value: 'cat',
-      group: 'Animals'
-    }, {
-      text: 'Bar',
-      value: 'bar'
-    }, {
-      text: 'Dog',
-      value: 'dog',
-      group: 'Animals'
-    }, {
-      text: 'Alice',
-      value: 'alice',
-      group: 'People'
-    }, {
-      text: 'Bob',
-      value: 'bob',
-      group: 'People'
-    }, {
-      text: 'Foo',
-      value: 'foo'
-    }];
-
     return handleOptionGroups(values);
   }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -262,6 +262,30 @@ export class AdHocFiltersVariable
       values = values.concat(override.values);
     }
 
+    values = [{
+      text: 'Cat',
+      value: 'cat',
+      group: 'Animals'
+    }, {
+      text: 'Bar',
+      value: 'bar'
+    }, {
+      text: 'Dog',
+      value: 'dog',
+      group: 'Animals'
+    }, {
+      text: 'Alice',
+      value: 'alice',
+      group: 'People'
+    }, {
+      text: 'Bob',
+      value: 'bob',
+      group: 'People'
+    }, {
+      text: 'Foo',
+      value: 'foo'
+    }];
+
     return handleOptionGroups(values);
   }
 
@@ -342,16 +366,13 @@ function handleOptionGroups(values: MetricFindValue[]): Array<SelectableValue<st
       if (!group) {
         group = [];
         groupedResults.set(groupLabel, group);
+        result.push({ label: groupLabel, options: group })
       }
 
       group.push(toSelectableValue(value));
     } else {
       result.push(toSelectableValue(value));
     }
-  }
-
-  for (const [group, values] of groupedResults) {
-    result.unshift({ label: group, options: values });
   }
 
   return result;


### PR DESCRIPTION
- adds support for `group` in `MetricFindValue` interface by collecting options by group before passing to `<Select>`
- adds unit test to check behaviour is working

For https://github.com/grafana/hyperion-planning/issues/33
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.25.0--canary.758.9305474511.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.25.0--canary.758.9305474511.0
  # or 
  yarn add @grafana/scenes@4.25.0--canary.758.9305474511.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
