### PR TITLE
Macros: Resolve browser timezone for `$__timezone`

### DIFF
--- a/packages/scenes/src/variables/macros/timeMacros.test.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.test.ts
@@ -58,7 +58,7 @@ describe('timeMacros', () => {
       }),
     });
 
-    expect(sceneInterpolator(scene1, '$__timezone')).toBe('browser');
+    expect(sceneInterpolator(scene1, '$__timezone')).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
     expect(sceneInterpolator(scene2, '$__timezone')).toBe('America/New_York');
     expect(sceneInterpolator(nestedScene, '$__timezone')).toBe('Africa/Abidjan');
   });

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -73,7 +73,13 @@ export class TimezoneMacro implements FormatVariable {
 
   public getValue() {
     const timeRange = getTimeRange(this._sceneObject);
-    return timeRange.getTimeZone();
+    const timeZone = timeRange.getTimeZone();
+
+    if (timeZone === 'browser') {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
+
+    return timeZone;
   }
 
   public getValueText?(): string {
@@ -85,7 +91,7 @@ export class TimezoneMacro implements FormatVariable {
  * Handles $__interval and $__intervalMs expression.
  */
 export class IntervalMacro implements FormatVariable {
-  public state: { name: string; type: string, match: string };
+  public state: { name: string; type: string; match: string };
   private _sceneObject: SceneObject;
 
   public constructor(name: string, sceneObject: SceneObject, match: string) {


### PR DESCRIPTION
A bug was reported when resolving `$__timezone` in scenes compared with the behavior in Grafana Dashboards.

[In Grafana Dashboards, when the browser timezone is selected, the value of the timezone is resolved](https://github.com/grafana/grafana/blob/main/public/app/features/templating/macroRegistry.ts#L32). For scenes, the value returned is `browser`. This breaks some data sources queries when they use `$__timezone`.

|Before|After|
|-|-|
![Captura de pantalla 2024-05-30 a las 10 18 22](https://github.com/grafana/scenes/assets/5699976/11bd1ee7-1d4e-4a41-8b3c-bf2ba46d5565)|![Captura de pantalla 2024-05-30 a las 10 18 36](https://github.com/grafana/scenes/assets/5699976/8df8773f-f7f1-4a08-b272-bb020e1f0e29)


In Grafana, to get the browser timezone is done through `moment`. `moment` is not a dependency of Scenes and is not needed, so we're using `Intl`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.24.3--canary.759.9299159504.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@4.24.3--canary.759.9299159504.0
  # or 
  yarn add @grafana/scenes@4.24.3--canary.759.9299159504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
