### PR TITLE
Variables: Search / typing performance improvements

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -196,7 +196,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
             $variables: new SceneVariableSet({
               variables: [
                 new TestVariable({
-                  name: 'server',
+                  name: 'manyOptions',
                   query: '',
                   optionsToReturn: getRandomOptions(100000),
                   delayMs: 0,

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -211,7 +211,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                     .setTitle('Description')
                     .setOption(
                       'content',
-                      'This tab is mainly to test a variable with 100 000 options, to test search / typing performance'
+                      'This tab is mainly to test a variable with 100 000 options, to test search / typing performance. manyOptions=$manyOptions'
                     )
                     .build(),
                 }),

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -187,6 +187,39 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
           });
         },
       }),
+      new SceneAppPage({
+        title: 'Many variable options',
+        url: `${defaults.url}/many-values`,
+        getScene: () => {
+          return new EmbeddedScene({
+            controls: [new VariableValueSelectors({})],
+            $variables: new SceneVariableSet({
+              variables: [
+                new TestVariable({
+                  name: 'server',
+                  query: '',
+                  optionsToReturn: getRandomOptions(100000),
+                  delayMs: 0,
+                }),
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  body: PanelBuilders.text()
+                    .setTitle('Description')
+                    .setOption(
+                      'content',
+                      'This tab is mainly to test a variable with 100 000 options, to test search / typing performance'
+                    )
+                    .build(),
+                }),
+              ],
+            }),
+          });
+        },
+      }),
     ],
   });
 }
@@ -243,4 +276,25 @@ function getVariableChangeBehavior(variableName: string) {
       };
     },
   });
+}
+
+function getRandomOptions(count: number) {
+  return new Array(count).fill(null).map((_, index) => ({
+    value: makeString(50),
+    label: makeString(50),
+  }));
+}
+
+function makeString(length: number) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let counter = 0;
+
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+
+  return result;
 }

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@grafana/e2e-selectors": "^10.4.1",
+    "@leeoniya/ufuzzy": "^1.0.14",
     "react-grid-layout": "1.3.4",
     "react-use": "17.4.0",
     "react-virtualized-auto-sizer": "1.0.7",

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -16,6 +16,8 @@ const filterNoOp = () => true;
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, text, key, options, includeAll } = model.useState();
   const [inputValue, setInputValue] = useState('');
+  const [hasCustomValue, setHasCustomValue] = useState(false);
+
   const optionSearcher = useMemo(
     () => getOptionSearcher(options, includeAll, value, text),
     [options, includeAll, value, text]
@@ -35,21 +37,38 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
 
   const filteredOptions = optionSearcher(inputValue);
 
+  const onOpenMenu = () => {
+    if (hasCustomValue) {
+      setInputValue(String(text));
+    }
+  };
+
+  const onCloseMenu = () => {
+    setInputValue('');
+  };
+
   return (
     <Select<VariableValue>
       id={key}
       placeholder="Select value"
       width="auto"
       value={value}
+      inputValue={inputValue}
       allowCustomValue
       virtualized
       filterOption={filterNoOp}
       tabSelectsValue={false}
       onInputChange={onInputChange}
+      onOpenMenu={onOpenMenu}
+      onCloseMenu={onCloseMenu}
       options={filteredOptions}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${value}`)}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);
+
+        if (hasCustomValue !== newValue.__isNew__) {
+          setHasCustomValue(newValue.__isNew__);
+        }
       }}
     />
   );

--- a/packages/scenes/src/variables/components/getOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.test.ts
@@ -1,0 +1,36 @@
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
+import { getOptionSearcher } from './getOptionSearcher';
+
+describe('getOptionSearcher', () => {
+  it('Should return options', async () => {
+    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], false, '1', 'A');
+    expect(optionSearcher('')).toEqual([{ label: 'A', value: '1' }]);
+  });
+
+  it('Should return include All option when includeAll is true', async () => {
+    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], true, '1', 'A');
+    expect(optionSearcher('')).toEqual([
+      { label: ALL_VARIABLE_TEXT, value: ALL_VARIABLE_VALUE },
+      { label: 'A', value: '1' },
+    ]);
+  });
+
+  it('Should add current value if not found', async () => {
+    const optionSearcher = getOptionSearcher([], false, 'customValue', 'customText');
+    expect(optionSearcher('')).toEqual([{ label: 'customText', value: 'customValue' }]);
+  });
+
+  it('Can filter options by search query', async () => {
+    const options = [
+      { label: 'Test', value: '1' },
+      { label: 'Google', value: '2' },
+      { label: 'estimate', value: '2' },
+    ];
+    const optionSearcher = getOptionSearcher(options, false, '', '');
+
+    expect(optionSearcher('est')).toEqual([
+      { label: 'Test', value: '1' },
+      { label: 'estimate', value: '2' },
+    ]);
+  });
+});

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -57,5 +57,7 @@ export function getOptionSearcher(
     if (allOptions.length > limit) {
       return allOptions.slice(0, limit);
     }
+
+    return allOptions;
   };
 }

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -1,0 +1,61 @@
+import { VariableValue, VariableValueOption } from '../types';
+import uFuzzy from '@leeoniya/ufuzzy';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
+
+export function getOptionSearcher(
+  options: VariableValueOption[],
+  includeAll: boolean | undefined,
+  value: VariableValue,
+  text: VariableValue
+) {
+  const ufuzzy = new uFuzzy();
+  let allOptions = options;
+  const haystack: string[] = [];
+  const limit = 10000;
+
+  if (includeAll) {
+    allOptions = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...allOptions];
+  }
+
+  if (!Array.isArray(value)) {
+    const current = options.find((x) => x.value === value);
+    if (!current) {
+      allOptions = [{ value: value, label: String(text) }, ...allOptions];
+    }
+  }
+
+  return (search: string) => {
+    if (search === '') {
+      if (allOptions.length > limit) {
+        return allOptions.slice(0, limit);
+      } else {
+        return allOptions;
+      }
+    }
+
+    if (haystack.length === 0) {
+      for (let i = 0; i < allOptions.length; i++) {
+        haystack.push(allOptions[i].label);
+      }
+    }
+
+    const idxs = ufuzzy.filter(haystack, search);
+    const filteredOptions: VariableValueOption[] = [];
+
+    if (idxs) {
+      for (let i = 0; i < idxs.length; i++) {
+        filteredOptions.push(allOptions[idxs[i]]);
+
+        if (filteredOptions.length > limit) {
+          return filteredOptions;
+        }
+      }
+
+      return filteredOptions;
+    }
+
+    if (allOptions.length > limit) {
+      return allOptions.slice(0, limit);
+    }
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3445,6 +3445,7 @@ __metadata:
     "@grafana/e2e-selectors": "npm:^10.4.1"
     "@grafana/eslint-config": "npm:5.1.0"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
+    "@leeoniya/ufuzzy": "npm:^1.0.14"
     "@rollup/plugin-eslint": "npm:^9.0.3"
     "@rollup/plugin-node-resolve": "npm:15.0.1"
     "@swc/core": "npm:^1.2.162"
@@ -4122,7 +4123,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@leeoniya/ufuzzy@npm:1.0.14":
+"@leeoniya/ufuzzy@npm:1.0.14, @leeoniya/ufuzzy@npm:^1.0.14":
   version: 1.0.14
   resolution: "@leeoniya/ufuzzy@npm:1.0.14"
   checksum: 10/852b580a8eaaf92e2d448f5b720e3c53e4bea22187bf5e8459256677c47183321b47b8384982e15751f42da7e77a216fd86c80e6185677d8270adeab4a4fb771


### PR DESCRIPTION
The search / typing performance is terrible for the core Select component when we get over 10K items (with 100K options we are talking 1-3 seconds per keystroke).  

In this PR 

* I am moving the option filtering to be outside the Select component, and limiting the options we pass to the Select component to 10K.  
* Using uFuzzy for the actual filtering. 
* Adding a new demo to test a variable with many options 
* in order to properly memoize the uFuzzy instance, allOptions, haystack etc I created a new function called getOptionSearcher which replaces some of the logic we had in getOptionsForSelect. Added the same tests we have for getOptionsForSelect to the getOptionSearcher (plus a search test). The GroupBy variable is still using getOptionsForSelect (and I think it might be used by scene app plugins also), so not sure we can remove it. I can refactor a bit so that getOptionsForSelect i using getOptionSearch under the hood.  

Anyway this PR radically improves search / typing performance (and menu open perf) going from 1-3 seconds per keystroke to ~50-100ms 


