### PR TITLE
Now works with custom value preserved

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -211,7 +211,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                     .setTitle('Description')
                     .setOption(
                       'content',
-                      'This tab is mainly to test a variable with 100 000 options, to test search / typing performance'
+                      'This tab is mainly to test a variable with 100 000 options, to test search / typing performance. manyOptions=$manyOptions'
                     )
                     .build(),
                 }),

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -16,6 +16,8 @@ const filterNoOp = () => true;
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, text, key, options, includeAll } = model.useState();
   const [inputValue, setInputValue] = useState('');
+  const [hasCustomValue, setHasCustomValue] = useState(false);
+
   const optionSearcher = useMemo(
     () => getOptionSearcher(options, includeAll, value, text),
     [options, includeAll, value, text]
@@ -35,21 +37,38 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
 
   const filteredOptions = optionSearcher(inputValue);
 
+  const onOpenMenu = () => {
+    if (hasCustomValue) {
+      setInputValue(String(text));
+    }
+  };
+
+  const onCloseMenu = () => {
+    setInputValue('');
+  };
+
   return (
     <Select<VariableValue>
       id={key}
       placeholder="Select value"
       width="auto"
       value={value}
+      inputValue={inputValue}
       allowCustomValue
       virtualized
       filterOption={filterNoOp}
       tabSelectsValue={false}
       onInputChange={onInputChange}
+      onOpenMenu={onOpenMenu}
+      onCloseMenu={onCloseMenu}
       options={filteredOptions}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${value}`)}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!);
+
+        if (hasCustomValue !== newValue.__isNew__) {
+          setHasCustomValue(newValue.__isNew__);
+        }
       }}
     />
   );


### PR DESCRIPTION
Merges into https://github.com/grafana/scenes/pull/763

Adds the behavior to preserve custom value input value when opening the Select after adding a custom value. 

With this change we can completely revert https://github.com/grafana/grafana/pull/87843   (and do not need https://github.com/grafana/grafana/pull/88601) 