### PR TITLE
AdHocFiltersVariable: Performance improvements

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -20,6 +20,7 @@ import {
   TextBoxVariable,
   QueryVariable,
   CustomVariable,
+  AdHocFiltersVariable,
 } from '@grafana/scenes';
 import { getQueryRunnerWithRandomWalkQuery } from './utils';
 
@@ -212,6 +213,58 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                     .setOption(
                       'content',
                       'This tab is mainly to test a variable with 100 000 options, to test search / typing performance. manyOptions=$manyOptions'
+                    )
+                    .build(),
+                }),
+              ],
+            }),
+          });
+        },
+      }),
+      new SceneAppPage({
+        title: 'Many adhoc variable values',
+        url: `${defaults.url}/many-adhoc-values`,
+        getScene: () => {
+          return new EmbeddedScene({
+            controls: [new VariableValueSelectors({})],
+            $variables: new SceneVariableSet({
+              variables: [
+                new AdHocFiltersVariable({
+                  name: 'manyAdhocOptions',
+                  getTagKeysProvider: async () => ({
+                    replace: true,
+                    values: [{
+                      value: 'a',
+                      text: 'A'
+                    }, {
+                      value: 'b',
+                      text: 'B'
+                    }, {
+                      value: 'c',
+                      text: 'C'
+                    }]
+                  }),
+                  getTagValuesProvider: async () => {
+                    return {
+                      replace: true,
+                      values: getRandomOptions(100000).map(({ value, label }) => ({
+                        value,
+                        text: label,
+                      }))
+                    };
+                  },
+                }),
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  body: PanelBuilders.text()
+                    .setTitle('Description')
+                    .setOption(
+                      'content',
+                      'This tab is mainly to test an adhoc variable with 100 000 options, to test search / typing performance. manyAdhocOptions=$manyAdhocOptions'
                     )
                     .build(),
                 }),

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -45,8 +45,8 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueValue = keyLabelToOption(filter.value, filter.valueLabel);
 
   const optionSearcher = useMemo(
-    () => getOptionSearcher(values.map(selectableValueToVariableValueOption), undefined, valueValue?.value ?? '', valueValue?.label ?? ''),
-    [values, valueValue?.value, valueValue?.label]
+    () => getOptionSearcher(values.map(selectableValueToVariableValueOption), undefined, 1000),
+    [values]
   );
 
   const onValueInputChange = (value: string, { action }: InputActionMeta) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -1,14 +1,23 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { AdHocFiltersVariable, AdHocFilterWithLabels } from './AdHocFiltersVariable';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Button, Field, InputActionMeta, Select, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import { ControlsLabel } from '../../utils/ControlsLabel';
+import { getOptionSearcher } from '../components/getOptionSearcher';
+import { VariableValueOption } from '../types';
 
 interface Props {
   filter: AdHocFilterWithLabels;
   model: AdHocFiltersVariable;
+}
+
+function selectableValueToVariableValueOption(value: SelectableValue): VariableValueOption {
+  return {
+    label: value.label ?? String(value.value),
+    value: value.value,
+  }
 }
 
 function keyLabelToOption(key: string, label?: string): SelectableValue | null {
@@ -35,6 +44,11 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const keyValue = keyLabelToOption(filter.key, filter.keyLabel);
   const valueValue = keyLabelToOption(filter.value, filter.valueLabel);
 
+  const optionSearcher = useMemo(
+    () => getOptionSearcher(values.map(selectableValueToVariableValueOption), undefined, valueValue?.value ?? '', valueValue?.label ?? ''),
+    [values, valueValue?.value, valueValue?.label]
+  );
+
   const onValueInputChange = (value: string, { action }: InputActionMeta) => {
     if (action === 'input-change') {
       setValueInputValue(value);
@@ -42,8 +56,11 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     return value;
   };
 
+  const filteredValueOptions: SelectableValue[] = optionSearcher(valueInputValue);
+
   const valueSelect = (
     <Select
+      virtualized
       allowCustomValue
       isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       allowCreateWhileLoading
@@ -53,7 +70,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       width="auto"
       value={valueValue}
       placeholder={'Select value'}
-      options={values}
+      options={filteredValueOptions}
       inputValue={valueInputValue}
       onInputChange={onValueInputChange}
       onChange={(v) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -29,6 +29,8 @@ function keyLabelToOption(key: string, label?: string): SelectableValue | null {
     : null;
 }
 
+const filterNoOp = () => true;
+
 export function AdHocFilterRenderer({ filter, model }: Props) {
   const styles = useStyles2(getStyles);
 
@@ -45,7 +47,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueValue = keyLabelToOption(filter.value, filter.valueLabel);
 
   const optionSearcher = useMemo(
-    () => getOptionSearcher(values.map(selectableValueToVariableValueOption), undefined, 1000),
+    () => getOptionSearcher(values.map(selectableValueToVariableValueOption), undefined),
     [values]
   );
 
@@ -69,6 +71,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       className={cx(styles.value, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
       value={valueValue}
+      filterOption={filterNoOp}
       placeholder={'Select value'}
       options={filteredValueOptions}
       inputValue={valueInputValue}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -187,6 +187,8 @@ describe('AdHocFiltersVariable', () => {
     expect(runRequest.mock.calls.length).toBe(2);
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
 
+    await userEvent.click(selects[2]);
+    await userEvent.clear(selects[2]);
     await userEvent.type(selects[2], 'myVeryCustomValue');
 
     expect(screen.getByText('Use custom value: myVeryCustomValue')).toBeInTheDocument();

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -19,8 +19,8 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
   const [hasCustomValue, setHasCustomValue] = useState(false);
 
   const optionSearcher = useMemo(
-    () => getOptionSearcher(options, includeAll, value, text),
-    [options, includeAll, value, text]
+    () => getOptionSearcher(options, includeAll),
+    [options, includeAll]
   );
 
   const onInputChange = (value: string, { action }: InputActionMeta) => {
@@ -50,6 +50,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
   return (
     <Select<VariableValue>
       id={key}
+      isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       placeholder="Select value"
       width="auto"
       value={value}
@@ -75,15 +76,15 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
 }
 
 export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, text, options, key, maxVisibleValues, noValueOnClear, includeAll } = model.useState();
+  const { value, options, key, maxVisibleValues, noValueOnClear, includeAll } = model.useState();
   const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
   // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
   const [uncommittedValue, setUncommittedValue] = useState(arrayValue);
   const [inputValue, setInputValue] = useState('');
 
   const optionSearcher = useMemo(
-    () => getOptionSearcher(options, includeAll, value, text),
-    [options, includeAll, value, text]
+    () => getOptionSearcher(options, includeAll),
+    [options, includeAll]
   );
 
   // Detect value changes outside

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -13,10 +13,18 @@ import { getOptionSearcher } from './getOptionSearcher';
 
 const filterNoOp = () => true;
 
+export function toSelectableValue<T>(value: T, label?: string): SelectableValue<T> {
+  return {
+    value,
+    label: label ?? String(value),
+  };
+}
+
 export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
   const { value, text, key, options, includeAll } = model.useState();
   const [inputValue, setInputValue] = useState('');
   const [hasCustomValue, setHasCustomValue] = useState(false);
+  const selectValue = toSelectableValue(value, String(text));
 
   const optionSearcher = useMemo(
     () => getOptionSearcher(options, includeAll),
@@ -53,7 +61,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       placeholder="Select value"
       width="auto"
-      value={value}
+      value={selectValue}
       inputValue={inputValue}
       allowCustomValue
       virtualized

--- a/packages/scenes/src/variables/components/getOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.test.ts
@@ -28,18 +28,4 @@ describe('getOptionSearcher', () => {
       { label: 'estimate', value: '2' },
     ]);
   });
-
-  it('Honours the configurable limit', async () => {
-    const options = [
-      { label: 'Test', value: '1' },
-      { label: 'Google', value: '2' },
-      { label: 'estimate', value: '2' },
-    ];
-    const optionSearcher = getOptionSearcher(options, false, 2);
-
-    expect(optionSearcher('')).toEqual([
-      { label: 'Test', value: '1' },
-      { label: 'Google', value: '2' },
-    ]);
-  });
 });

--- a/packages/scenes/src/variables/components/getOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.test.ts
@@ -3,21 +3,16 @@ import { getOptionSearcher } from './getOptionSearcher';
 
 describe('getOptionSearcher', () => {
   it('Should return options', async () => {
-    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], false, '1', 'A');
+    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], false);
     expect(optionSearcher('')).toEqual([{ label: 'A', value: '1' }]);
   });
 
   it('Should return include All option when includeAll is true', async () => {
-    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], true, '1', 'A');
+    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], true);
     expect(optionSearcher('')).toEqual([
       { label: ALL_VARIABLE_TEXT, value: ALL_VARIABLE_VALUE },
       { label: 'A', value: '1' },
     ]);
-  });
-
-  it('Should add current value if not found', async () => {
-    const optionSearcher = getOptionSearcher([], false, 'customValue', 'customText');
-    expect(optionSearcher('')).toEqual([{ label: 'customText', value: 'customValue' }]);
   });
 
   it('Can filter options by search query', async () => {
@@ -26,11 +21,25 @@ describe('getOptionSearcher', () => {
       { label: 'Google', value: '2' },
       { label: 'estimate', value: '2' },
     ];
-    const optionSearcher = getOptionSearcher(options, false, '', '');
+    const optionSearcher = getOptionSearcher(options, false);
 
     expect(optionSearcher('est')).toEqual([
       { label: 'Test', value: '1' },
       { label: 'estimate', value: '2' },
+    ]);
+  });
+
+  it('Honours the configurable limit', async () => {
+    const options = [
+      { label: 'Test', value: '1' },
+      { label: 'Google', value: '2' },
+      { label: 'estimate', value: '2' },
+    ];
+    const optionSearcher = getOptionSearcher(options, false, 2);
+
+    expect(optionSearcher('est')).toEqual([
+      { label: 'Test', value: '1' },
+      { label: 'Google', value: '2' },
     ]);
   });
 });

--- a/packages/scenes/src/variables/components/getOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.test.ts
@@ -37,7 +37,7 @@ describe('getOptionSearcher', () => {
     ];
     const optionSearcher = getOptionSearcher(options, false, 2);
 
-    expect(optionSearcher('est')).toEqual([
+    expect(optionSearcher('')).toEqual([
       { label: 'Test', value: '1' },
       { label: 'Google', value: '2' },
     ]);

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -1,27 +1,18 @@
-import { VariableValue, VariableValueOption } from '../types';
+import { VariableValueOption } from '../types';
 import uFuzzy from '@leeoniya/ufuzzy';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 
 export function getOptionSearcher(
   options: VariableValueOption[],
   includeAll: boolean | undefined,
-  value: VariableValue,
-  text: VariableValue
+  limit = 10000,
 ) {
   const ufuzzy = new uFuzzy();
   let allOptions = options;
   const haystack: string[] = [];
-  const limit = 10000;
 
   if (includeAll) {
     allOptions = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...allOptions];
-  }
-
-  if (!Array.isArray(value)) {
-    const current = options.find((x) => x.value === value);
-    if (!current) {
-      allOptions = [{ value: value, label: String(text) }, ...allOptions];
-    }
   }
 
   return (search: string) => {

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -5,11 +5,11 @@ import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 export function getOptionSearcher(
   options: VariableValueOption[],
   includeAll: boolean | undefined,
-  limit = 10000,
 ) {
   const ufuzzy = new uFuzzy();
   let allOptions = options;
   const haystack: string[] = [];
+  const limit = 10000;
 
   if (includeAll) {
     allOptions = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...allOptions];

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -6,7 +6,7 @@ export function getOptionSearcher(
   options: VariableValueOption[],
   includeAll: boolean | undefined,
   value: VariableValue,
-  text: VariableValue
+  text: VariableValue,
 ) {
   const ufuzzy = new uFuzzy();
   let allOptions = options;

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -6,7 +6,7 @@ export function getOptionSearcher(
   options: VariableValueOption[],
   includeAll: boolean | undefined,
   value: VariableValue,
-  text: VariableValue,
+  text: VariableValue
 ) {
   const ufuzzy = new uFuzzy();
   let allOptions = options;

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -206,8 +206,8 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
   const [uncommittedValue, setUncommittedValue] = useState(values);
 
   const optionSearcher = useMemo(
-    () => getOptionSearcher(options, includeAll, value, text),
-    [options, includeAll, value, text]
+    () => getOptionSearcher(options, includeAll),
+    [options, includeAll]
   );
 
   // Detect value changes outside


### PR DESCRIPTION
- marks variable value select `virtualized`
- makes the options and input state controlled outside of select for better performance
  - extension of https://github.com/grafana/scenes/pull/763 for adhoc filters
  - also means we can revert https://github.com/grafana/grafana/pull/87843 as this is cleaner 
- adds a demo page

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.27.0--canary.766.9398430196.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@4.27.0--canary.766.9398430196.0
  npm install @grafana/scenes@4.27.0--canary.766.9398430196.0
  # or 
  yarn add @grafana/scenes-react@4.27.0--canary.766.9398430196.0
  yarn add @grafana/scenes@4.27.0--canary.766.9398430196.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
