### PR TITLE
SceneQueryRunner: Act as if we're loading when waiting for variables to load.

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -607,7 +607,8 @@ describe('SceneQueryRunner', () => {
       await new Promise((r) => setTimeout(r, 1));
 
       expect(variable.state.loading).toBe(true);
-      expect(queryRunner.state.data?.state).toBe(undefined);
+      expect(queryRunner.state.data?.state).toBe('Loading');
+      expect(runRequestMock.mock.calls.length).toBe(0);
     });
 
     it('Should not executed query on activate even when maxDataPointsFromWidth is true', async () => {
@@ -630,7 +631,9 @@ describe('SceneQueryRunner', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(queryRunner.state.data?.state).toBe(undefined);
+      expect(variable.state.loading).toBe(true);
+      expect(queryRunner.state.data?.state).toBe('Loading');
+      expect(runRequestMock.mock.calls.length).toBe(0);
     });
 
     it('Should not executed query when time range change', async () => {
@@ -656,7 +659,9 @@ describe('SceneQueryRunner', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
-      expect(queryRunner.state.data?.state).toBe(undefined);
+      expect(variable.state.loading).toBe(true);
+      expect(queryRunner.state.data?.state).toBe('Loading');
+      expect(runRequestMock.mock.calls.length).toBe(0);
     });
 
     it('Should execute query when variable updates', async () => {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -390,6 +390,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     // Skip executing queries if variable dependency is in loading state
     if (this._variableDependency.hasDependencyInLoadingState()) {
       writeSceneLog('SceneQueryRunner', 'Variable dependency is in loading state, skipping query execution');
+      this.setState({ data: { ...this.state.data!, state: LoadingState.Loading } });
       return;
     }
 


### PR DESCRIPTION
When a scene loads and VizPanels with variable dependencies are waiting to load, there's no indication that the panel will eventually load.

This PR sets the state of the PanelData to loading when we're waiting for the variable dependencies.

Fixes: https://github.com/grafana/grafana/issues/84574

One could argue that setting the LoadingState to "NotStarted" or introducing a new state called "WaitingForDependency" would make more sense. But it would also introduce a lot more changes to grafana as a whole.

Before (notice the loading indicator on the panel chrome is not running before the variable is loaded):
![loading-before](https://github.com/grafana/scenes/assets/468940/a5bb069e-d455-4e80-85c4-3ff55b79ba87)

After:
![loading-after](https://github.com/grafana/scenes/assets/468940/1ebca98a-6d2b-41c1-95b1-ab7ca69fdf09)
