### PR TITLE
provide an option to hide the label from the variable value controller

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueControl.tsx
+++ b/packages/scenes/src/variables/components/VariableValueControl.tsx
@@ -10,7 +10,7 @@ export interface VariableValueControlState extends SceneObjectState {
   /** Render the specific select control for a variable */
   variableName: string;
   /** Hide the label in the variable value controller */
-  hideControllerLabel?: boolean;
+  hideLabel?: boolean;
 }
 
 export class VariableValueControl extends SceneObjectBase<VariableValueControlState> {

--- a/packages/scenes/src/variables/components/VariableValueControl.tsx
+++ b/packages/scenes/src/variables/components/VariableValueControl.tsx
@@ -9,6 +9,8 @@ export interface VariableValueControlState extends SceneObjectState {
   layout?: ControlsLayout;
   /** Render the specific select control for a variable */
   variableName: string;
+  /** Hide the label in the variable value controller */
+  hideControllerLabel?: boolean;
 }
 
 export class VariableValueControl extends SceneObjectBase<VariableValueControlState> {

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -36,10 +36,10 @@ interface VariableSelectProps {
   /** To override hide from VariableValueSelectByName  */
   showAlways?: boolean;
   /** To provide an option to hide the label in the variable value selector */
-  hideControllerLabel?: boolean;
+  hideLabel?: boolean;
 }
 
-export function VariableValueSelectWrapper({ variable, layout, showAlways, hideControllerLabel }: VariableSelectProps) {
+export function VariableValueSelectWrapper({ variable, layout, showAlways, hideLabel }: VariableSelectProps) {
   const state = useSceneObjectState<SceneVariableState>(variable, { shouldActivateOrKeepAlive: true });
 
   if (state.hide === VariableHide.hideVariable && !showAlways) {
@@ -49,7 +49,7 @@ export function VariableValueSelectWrapper({ variable, layout, showAlways, hideC
   if (layout === 'vertical') {
     return (
       <div className={verticalContainer} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
-        <VariableLabel variable={variable} layout={layout} hideControllerLabel={hideControllerLabel} />
+        <VariableLabel variable={variable} layout={layout} hideLabel={hideLabel} />
         <variable.Component model={variable} />
       </div>
     );
@@ -57,16 +57,16 @@ export function VariableValueSelectWrapper({ variable, layout, showAlways, hideC
 
   return (
     <div className={containerStyle} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
-      <VariableLabel variable={variable} hideControllerLabel={hideControllerLabel} />
+      <VariableLabel variable={variable} hideLabel={hideLabel} />
       <variable.Component model={variable} />
     </div>
   );
 }
 
-function VariableLabel({ variable, layout, hideControllerLabel }: VariableSelectProps) {
+function VariableLabel({ variable, layout, hideLabel }: VariableSelectProps) {
   const { state } = variable;
 
-  if (variable.state.hide === VariableHide.hideLabel || hideControllerLabel) {
+  if (variable.state.hide === VariableHide.hideLabel || hideLabel) {
     return null;
   }
 

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -35,9 +35,11 @@ interface VariableSelectProps {
   variable: SceneVariable;
   /** To override hide from VariableValueSelectByName  */
   showAlways?: boolean;
+  /** To provide an option to hide the label in the variable value selector */
+  hideControllerLabel?: boolean;
 }
 
-export function VariableValueSelectWrapper({ variable, layout, showAlways }: VariableSelectProps) {
+export function VariableValueSelectWrapper({ variable, layout, showAlways, hideControllerLabel }: VariableSelectProps) {
   const state = useSceneObjectState<SceneVariableState>(variable, { shouldActivateOrKeepAlive: true });
 
   if (state.hide === VariableHide.hideVariable && !showAlways) {
@@ -47,7 +49,7 @@ export function VariableValueSelectWrapper({ variable, layout, showAlways }: Var
   if (layout === 'vertical') {
     return (
       <div className={verticalContainer} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
-        <VariableLabel variable={variable} layout={layout} />
+        <VariableLabel variable={variable} layout={layout} hideControllerLabel={hideControllerLabel} />
         <variable.Component model={variable} />
       </div>
     );
@@ -55,16 +57,16 @@ export function VariableValueSelectWrapper({ variable, layout, showAlways }: Var
 
   return (
     <div className={containerStyle} data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}>
-      <VariableLabel variable={variable} />
+      <VariableLabel variable={variable} hideControllerLabel={hideControllerLabel} />
       <variable.Component model={variable} />
     </div>
   );
 }
 
-function VariableLabel({ variable, layout }: VariableSelectProps) {
+function VariableLabel({ variable, layout, hideControllerLabel }: VariableSelectProps) {
   const { state } = variable;
 
-  if (variable.state.hide === VariableHide.hideLabel) {
+  if (variable.state.hide === VariableHide.hideLabel || hideControllerLabel) {
     return null;
   }
 


### PR DESCRIPTION
when using the `VariableValueControl` there is not an option to hide the label in the variable value controller, this change provides an option to work alongside the variable-level hide config so users can hide the filters in the main control bar, and also hide the label in the places where the variable value controller is used. 

![image](https://github.com/grafana/scenes/assets/7052378/e6485050-2b4c-4a16-b855-b97e59ef36e6)

