### PR TITLE
fix: downgrade workspace prettier to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^8.57.0",
     "lerna": "^6.5.1",
     "lint-staged": "^13.2.0",
-    "prettier": "^3.2.5",
+    "prettier": "2.5.1",
     "turbo": "latest"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14560,7 +14560,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     lerna: "npm:^6.5.1"
     lint-staged: "npm:^13.2.0"
-    prettier: "npm:^3.2.5"
+    prettier: "npm:2.5.1"
     turbo: "npm:latest"
   languageName: unknown
   linkType: soft
@@ -20790,15 +20790,6 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.2.5":
-  version: 3.2.5
-  resolution: "prettier@npm:3.2.5"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10/d509f9da0b70e8cacc561a1911c0d99ec75117faed27b95cc8534cb2349667dee6351b0ca83fa9d5703f14127faa52b798de40f5705f02d843da133fc3aa416a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To match the version we have in all the packages, and to work
with lerna v6.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.26.1--canary.771.9386870862.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@4.26.1--canary.771.9386870862.0
  npm install @grafana/scenes@4.26.1--canary.771.9386870862.0
  # or 
  yarn add @grafana/scenes-react@4.26.1--canary.771.9386870862.0
  yarn add @grafana/scenes@4.26.1--canary.771.9386870862.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
