### PR TITLE
Variables: Support variable expressions inside custom values

### DIFF
--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -59,6 +59,28 @@ describe('sceneInterpolator', () => {
 
       expect(sceneInterpolator(scene, '${test:regex}')).toBe('.*');
     });
+
+    it('It can contain a variable expression', () => {
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({
+          variables: [
+            new TestVariable({
+              name: 'test',
+              value: ALL_VARIABLE_VALUE,
+              text: ALL_VARIABLE_TEXT,
+              allValue: '$other',
+            }),
+            new TestVariable({
+              name: 'other',
+              value: 'hello',
+              text: 'hello',
+            }),
+          ],
+        }),
+      });
+
+      expect(sceneInterpolator(scene, '${test}')).toBe('hello');
+    });
   });
 
   describe('Given an expression with fieldPath', () => {

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -23,7 +23,7 @@ export function sceneInterpolator(
   target: string | undefined | null,
   scopedVars?: ScopedVars,
   format?: InterpolationFormatParameter,
-  interpolations?: VariableInterpolation[],
+  interpolations?: VariableInterpolation[]
 ): string {
   if (!target) {
     return target ?? '';
@@ -43,10 +43,13 @@ export function sceneInterpolator(
       }
       return match;
     }
-    const value = formatValue(variable, variable.getValue(fieldPath), fmt);
+
+    const value = formatValue(sceneObject, variable, variable.getValue(fieldPath), fmt);
+
     if (interpolations) {
       interpolations.push({ match, variableName, fieldPath, format: fmt, value, found: value !== match });
     }
+
     return value;
   });
 }
@@ -76,6 +79,7 @@ function lookupFormatVariable(
 }
 
 function formatValue(
+  context: SceneObject,
   variable: FormatVariable,
   value: VariableValue | undefined | null,
   formatNameOrFn?: InterpolationFormatParameter
@@ -87,7 +91,7 @@ function formatValue(
   // Variable can return a custom value that handles formatting
   // This is useful for customAllValue and macros that return values that are already formatted or need special formatting
   if (isCustomVariableValue(value)) {
-    return value.formatter(formatNameOrFn);
+    return sceneInterpolator(context, value.formatter(formatNameOrFn));
   }
 
   // if it's an object transform value to string


### PR DESCRIPTION
Fixes #773
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.26.2--canary.774.9388258294.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@4.26.2--canary.774.9388258294.0
  npm install @grafana/scenes@4.26.2--canary.774.9388258294.0
  # or 
  yarn add @grafana/scenes-react@4.26.2--canary.774.9388258294.0
  yarn add @grafana/scenes@4.26.2--canary.774.9388258294.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
