### PR TITLE
SceneQueryRunner: Do not set panelId by default

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -180,7 +180,6 @@ describe('SceneQueryRunner', () => {
           "intervalMs": 30000,
           "liveStreaming": undefined,
           "maxDataPoints": 500,
-          "panelId": 1,
           "queryCachingTTL": 300000,
           "range": {
             "from": "2023-07-11T02:18:08.000Z",
@@ -2306,21 +2305,23 @@ interface TestExtraQueryProviderState extends SceneObjectState {
 class TestExtraQueryProvider extends SceneObjectBase<TestExtraQueryProviderState> implements ExtraQueryProvider<{}> {
   private _shouldRerun: boolean;
 
-  public constructor(state: { foo: number; }, shouldRerun: boolean) {
+  public constructor(state: { foo: number }, shouldRerun: boolean) {
     super(state);
     this._shouldRerun = shouldRerun;
   }
 
   public getExtraQueries(): ExtraQueryDescriptor[] {
-    return [{
-      req: {
-        targets: [
-          // @ts-expect-error
-          { refId: 'Extra', foo: this.state.foo },
-        ],
+    return [
+      {
+        req: {
+          targets: [
+            // @ts-expect-error
+            { refId: 'Extra', foo: this.state.foo },
+          ],
+        },
+        processor: (primary, secondary) => of({ ...primary, ...secondary }),
       },
-      processor: (primary, secondary) => of({ ...primary, ...secondary }),
-    }];
+    ];
   }
   public shouldRerun(prev: {}, next: {}): boolean {
     return this._shouldRerun;

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -497,7 +497,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       app: 'scenes',
       requestId: getNextRequestId(),
       timezone: timeRange.getTimeZone(),
-      panelId: 1,
       range: timeRange.state.value,
       interval: '1s',
       intervalMs: 1000,


### PR DESCRIPTION
Fixes https://github.com/grafana/scenes/issues/739 

[Graphite has this old condition](https://github.com/grafana/grafana/blob/c6720f1c063d89da53751fd636e16264142d7d49/public/app/plugins/datasource/graphite/datasource.ts#L242C3-L244C6)
```ts
  if (options.panelId) {
      httpOptions.requestId = this.name + '.panelId.' + options.panelId;
   }
```

which is causing duplicate requestId (and hence cancelled requests).

Think it should be fine to leave this undefined (it's optional in the type at least) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.27.0--canary.776.9400928706.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@4.27.0--canary.776.9400928706.0
  npm install @grafana/scenes@4.27.0--canary.776.9400928706.0
  # or 
  yarn add @grafana/scenes-react@4.27.0--canary.776.9400928706.0
  yarn add @grafana/scenes@4.27.0--canary.776.9400928706.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
