### PR TITLE
ScenesReact: Use new react components and hooks from inside existing EmbeddedScenes 

### DIFF
--- a/packages/scenes-app/src/demos/interopDemo.tsx
+++ b/packages/scenes-app/src/demos/interopDemo.tsx
@@ -1,5 +1,4 @@
 import {
-  EmbeddedScene,
   SceneAppPage,
   SceneAppPageState,
   SceneComponentProps,
@@ -11,16 +10,18 @@ import {
 } from '@grafana/scenes';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 import React from 'react';
-import { useTimeRange } from '@grafana/scenes-react';
+import { EmbeddedSceneWithContext, useTimeRange } from '@grafana/scenes-react';
+import { Stack } from '@grafana/ui';
+import { DemoVizLayout } from '../react-demo/utils';
+import { PlainGraphWithRandomWalk } from '../react-demo/PlainGraphWithRandomWalk';
 
 export function getInteropDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
     ...defaults,
     subTitle: 'Testing using the hooks and plain react components from normal scene',
     getScene: () => {
-      return new EmbeddedScene({
+      return new EmbeddedSceneWithContext({
         ...getEmbeddedSceneDefaults(),
-        //        context: new SceneContextObject({}),
         key: 'Flex layout embedded scene',
         body: new SceneFlexLayout({
           direction: 'column',
@@ -46,6 +47,13 @@ class CustomSceneObject extends SceneObjectBase<SceneObjectState> {
   static Component = ({ model }: SceneComponentProps<CustomSceneObject>) => {
     const [timeRange, _] = useTimeRange();
 
-    return <div>Time hook: {timeRange.from.toString()}</div>;
+    return (
+      <Stack direction="column">
+        <div>Time hook: {timeRange.from.toString()}</div>
+        <DemoVizLayout>
+          <PlainGraphWithRandomWalk title="Visualization using React VizPanel with data from useQueryRunner" />
+        </DemoVizLayout>
+      </Stack>
+    );
   };
 }

--- a/packages/scenes-react/src/index.ts
+++ b/packages/scenes-react/src/index.ts
@@ -7,4 +7,5 @@ export { RefreshPicker } from './components/RefreshPicker';
 export { CustomVariable } from './variables/CustomVariable';
 export { Breadcrumb, BreadcrumbContext, BreadcrumbProvider } from './contexts/BreadcrumbContext';
 export { useVariableValues } from './hooks/useVariableValues';
+export { EmbeddedSceneWithContext } from './interoperability/EmbeddedSceneWithContext';
 export * from './hooks/hooks';

--- a/packages/scenes-react/src/interoperability/EmbeddedSceneWithContext.tsx
+++ b/packages/scenes-react/src/interoperability/EmbeddedSceneWithContext.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { EmbeddedScene, EmbeddedSceneState, SceneComponentProps } from '@grafana/scenes';
+import { SceneContext } from '../contexts/SceneContextProvider';
+import { SceneContextObject } from '../contexts/SceneContextObject';
+
+export class EmbeddedSceneWithContext extends EmbeddedScene {
+  public constructor(state: EmbeddedSceneState) {
+    super({ ...state, context: new SceneContextObject() });
+  }
+
+  public static Component = ({ model }: SceneComponentProps<EmbeddedSceneWithContext>) => {
+    return (
+      <SceneContext.Provider value={model.state.context as SceneContextObject}>
+        <EmbeddedScene.Component model={model} />
+      </SceneContext.Provider>
+    );
+  };
+}

--- a/packages/scenes/src/components/EmbeddedScene.tsx
+++ b/packages/scenes/src/components/EmbeddedScene.tsx
@@ -17,6 +17,10 @@ export interface EmbeddedSceneState extends SceneObjectState {
    * Top row of variable selectors, filters, time pickers and custom actions.
    */
   controls?: SceneObject[];
+  /**
+   * For interoperability
+   */
+  context?: SceneObject;
 }
 
 export class EmbeddedScene extends SceneObjectBase<EmbeddedSceneState> {

--- a/packages/scenes/src/components/EmbeddedScene.tsx
+++ b/packages/scenes/src/components/EmbeddedScene.tsx
@@ -18,7 +18,7 @@ export interface EmbeddedSceneState extends SceneObjectState {
    */
   controls?: SceneObject[];
   /**
-   * For interoperability
+   * For interoperability (used from EmbeddedSceneWithContext)
    */
   context?: SceneObject;
 }


### PR DESCRIPTION
Use case 
* To help migration 
* To support mixing both forms 

Example: 

```tsx
export function getInteropDemo(defaults: SceneAppPageState) {
  return new SceneAppPage({
    ...defaults,
    subTitle: 'Testing using the hooks and plain react components from normal scene',
    getScene: () => {
      return new EmbeddedSceneWithContext({
        ...getEmbeddedSceneDefaults(),
        key: 'Flex layout embedded scene',
        body: new SceneFlexLayout({
          direction: 'column',
          children: [
            new SceneFlexItem({
              body: new VizPanel({
                title: 'Graph',
                pluginId: 'timeseries',
                $data: getQueryRunnerWithRandomWalkQuery({}),
              }),
            }),
            new SceneFlexItem({
              body: new CustomSceneObject({}),
            }),
          ],
        }),
      });
    },
  });
}

class CustomSceneObject extends SceneObjectBase<SceneObjectState> {
  static Component = ({ model }: SceneComponentProps<CustomSceneObject>) => {
    const [timeRange, _] = useTimeRange();

    return (
      <Stack direction="column">
        <div>Time hook: {timeRange.from.toString()}</div>
        <DemoVizLayout>
          <PlainGraphWithRandomWalk title="Visualization using React VizPanel with data from useQueryRunner" />
        </DemoVizLayout>
      </Stack>
    );
  };
}
```