### PR TITLE
AdHocFiltersVariable: Show operator in vertical mode

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -17,7 +17,7 @@ function selectableValueToVariableValueOption(value: SelectableValue): VariableV
   return {
     label: value.label ?? String(value.value),
     value: value.value,
-  }
+  };
 }
 
 function keyLabelToOption(key: string, label?: string): SelectableValue | null {
@@ -68,7 +68,11 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
       disabled={model.state.readOnly}
-      className={cx(styles.value, isKeysOpen ? styles.widthWhenOpen : undefined)}
+      className={cx(
+        styles.value,
+        isKeysOpen ? styles.widthWhenOpen : undefined,
+        model.state.layout === 'vertical' ? styles.valueVertical : undefined
+      )}
       width="auto"
       value={valueValue}
       filterOption={filterNoOp}
@@ -77,7 +81,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       inputValue={valueInputValue}
       onInputChange={onValueInputChange}
       onChange={(v) => {
-        model._updateFilter(filter, 'value', v)
+        model._updateFilter(filter, 'value', v);
 
         if (valueHasCustomValue !== v.__isNew__) {
           setValueHasCustomValue(v.__isNew__);
@@ -152,7 +156,17 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
 
       return (
         <Field label={label} data-testid={`AdHocFilter-${filter.key}`} className={styles.field}>
-          {valueSelect}
+          <>
+            <Select
+              className={styles.operatorVertical}
+              value={filter.operator}
+              disabled={model.state.readOnly}
+              options={model._getOperators()}
+              width="auto"
+              onChange={(v) => model._updateFilter(filter, 'operator', v)}
+            />
+            {valueSelect}
+          </>
         </Field>
       );
     } else {
@@ -242,6 +256,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   operator: css({
     flexShrink: 0,
+  }),
+  operatorVertical: css({
+    borderRight: 'none',
+    borderTopRightRadius: 0,
+    borderBottomRightRadius: 0,
+  }),
+  valueVertical: css({
+    borderTopLeftRadius: 0,
+    borderBottomLeftRadius: 0,
   }),
   removeButton: css({
     paddingLeft: theme.spacing(3 / 2),

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -68,11 +68,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
       disabled={model.state.readOnly}
-      className={cx(
-        styles.value,
-        isKeysOpen ? styles.widthWhenOpen : undefined,
-        model.state.layout === 'vertical' ? styles.valueVertical : undefined
-      )}
+      className={cx(styles.value, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
       value={valueValue}
       filterOption={filterNoOp}
@@ -156,9 +152,9 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
 
       return (
         <Field label={label} data-testid={`AdHocFilter-${filter.key}`} className={styles.field}>
-          <>
+          <div className={styles.wrapper}>
             <Select
-              className={styles.operatorVertical}
+              className={styles.operator}
               value={filter.operator}
               disabled={model.state.readOnly}
               options={model._getOperators()}
@@ -166,7 +162,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
               onChange={(v) => model._updateFilter(filter, 'operator', v)}
             />
             {valueSelect}
-          </>
+          </div>
         </Field>
       );
     } else {
@@ -256,15 +252,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   operator: css({
     flexShrink: 0,
-  }),
-  operatorVertical: css({
-    borderRight: 'none',
-    borderTopRightRadius: 0,
-    borderBottomRightRadius: 0,
-  }),
-  valueVertical: css({
-    borderTopLeftRadius: 0,
-    borderBottomLeftRadius: 0,
   }),
   removeButton: css({
     paddingLeft: theme.spacing(3 / 2),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -902,14 +902,16 @@ describe('AdHocFiltersVariable', () => {
 
       expect(variable.isActive).toBe(true);
     });
-    it('should render operator in vertical adhoc layout', () => {
+    it('should render key, value and operator in vertical adhoc layout', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
-        filters: [{ key: 'key,1', operator: '!=', value: 'val1' }],
+        filters: [{ key: 'key1', operator: '!=', value: 'val1' }],
       });
 
       render(<variable.Component model={variable} />);
       expect(screen.getByText('!=')).toBeInTheDocument();
+      expect(screen.getByText('key1')).toBeInTheDocument();
+      expect(screen.getByText('val1')).toBeInTheDocument();
     });
   });
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -906,6 +906,7 @@ describe('AdHocFiltersVariable', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
         filters: [{ key: 'key1', operator: '!=', value: 'val1' }],
+        layout: 'vertical',
       });
 
       render(<variable.Component model={variable} />);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -902,6 +902,15 @@ describe('AdHocFiltersVariable', () => {
 
       expect(variable.isActive).toBe(true);
     });
+    it('should render operator in vertical adhoc layout', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        filters: [{ key: 'key,1', operator: '!=', value: 'val1' }],
+      });
+
+      render(<variable.Component model={variable} />);
+      expect(screen.getByText('!=')).toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -34,7 +34,6 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   /**
    * @experimental
    * Controls the layout and design of the label.
-   * Vertical layout does not yet support operator selector.
    */
   layout?: ControlsLayout;
   /**


### PR DESCRIPTION
This PR adds operator in vertical mode for ad hoc filters. 

<img width="391" alt="image" src="https://github.com/grafana/scenes/assets/30407135/d33c366e-26c8-4e34-b4f6-d67dc8ebf6e6">
<img width="169" alt="image" src="https://github.com/grafana/scenes/assets/30407135/d167afc0-1129-4554-9215-695dcb042539">
