### PR TITLE
SceneRefreshPicker: Fixes url state issue

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -13,7 +13,7 @@ export const DEFAULT_INTERVALS = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', 
 
 export interface SceneRefreshPickerState extends SceneObjectState {
   // Refresh interval, e.g. 5s, 1m, 2h
-  refresh: string;
+  refresh?: string;
   autoEnabled?: boolean;
   autoMinInterval?: string;
   autoValue?: string;

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -84,10 +84,10 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   public updateFromUrl(values: SceneObjectUrlValues) {
     const refresh = values.refresh;
 
-    if (refresh && typeof refresh === 'string') {
-      this.setState({
-        refresh,
-      });
+    if (typeof refresh === 'string') {
+      this.setState({ refresh });
+    } else if (refresh == null) {
+      this.setState({ refresh: '' });
     }
   }
 

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -77,7 +77,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
 
   public getUrlState() {
     return {
-      refresh: this.state.refresh,
+      refresh: this.state.refresh !== '' ? this.state.refresh : undefined,
     };
   }
 

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -13,7 +13,7 @@ export const DEFAULT_INTERVALS = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', 
 
 export interface SceneRefreshPickerState extends SceneObjectState {
   // Refresh interval, e.g. 5s, 1m, 2h
-  refresh?: string;
+  refresh: string;
   autoEnabled?: boolean;
   autoMinInterval?: string;
   autoValue?: string;


### PR DESCRIPTION
Fixes a minor issue with `refresh=` url state appearing in `scenes-react` demos, there is was a mismatch URL state and updateFromUrl


It's a bit messy, the "off state" for auto refresh is represented by an empty string (both in internal design system RefreshPicker and in state), so leaving it like that as changing that could be messy 