### PR TITLE
Variables: Fixes sceneInterpolator when string contains variables with object prototype function names

### DIFF
--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -294,4 +294,19 @@ describe('sceneInterpolator', () => {
       expect(interpolations[0].value).toEqual('${namespace}');
     });
   });
+
+  describe('Variable expression with variable name that exists on object prototype', () => {
+    it('Should return original expression', () => {
+      const str = '$toString = 1';
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({
+          variables: [],
+        }),
+      });
+
+      expect(sceneInterpolator(scene, str, {})).toBe(str);
+      expect(sceneInterpolator(scene, str)).toBe(str);
+    });
+  });
 });

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -60,10 +60,12 @@ function lookupFormatVariable(
   scopedVars: ScopedVars | undefined,
   sceneObject: SceneObject
 ): FormatVariable | null {
-  const scopedVar = scopedVars?.[name];
+  if (scopedVars && scopedVars.hasOwnProperty(name)) {
+    const scopedVar = scopedVars[name];
 
-  if (scopedVar) {
-    return getSceneVariableForScopedVar(name, scopedVar);
+    if (scopedVar) {
+      return getSceneVariableForScopedVar(name, scopedVar);
+    }
   }
 
   const variable = lookupVariable(name, sceneObject);
@@ -71,8 +73,9 @@ function lookupFormatVariable(
     return variable;
   }
 
-  if (macrosIndex[name]) {
-    return new macrosIndex[name](name, sceneObject, match, scopedVars);
+  const Macro = macrosIndex.get(name);
+  if (Macro) {
+    return new Macro(name, sceneObject, match, scopedVars);
   }
 
   return null;

--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -6,22 +6,22 @@ import { DataMacro, FieldMacro, SeriesMacro, ValueMacro } from './dataMacros';
 import { UrlMacro } from './urlMacros';
 import { OrgMacro, UserMacro } from './contextMacros';
 
-export const macrosIndex: Record<string, MacroVariableConstructor> = {
-  [DataLinkBuiltInVars.includeVars]: AllVariablesMacro,
-  [DataLinkBuiltInVars.keepTime]: UrlTimeRangeMacro,
-  ['__value']: ValueMacro,
-  ['__data']: DataMacro,
-  ['__series']: SeriesMacro,
-  ['__field']: FieldMacro,
-  ['__url']: UrlMacro,
-  ['__from']: TimeFromAndToMacro,
-  ['__to']: TimeFromAndToMacro,
-  ['__timezone']: TimezoneMacro,
-  ['__user']: UserMacro,
-  ['__org']: OrgMacro,
-  ['__interval']: IntervalMacro,
-  ['__interval_ms']: IntervalMacro,
-};
+export const macrosIndex = new Map<string, MacroVariableConstructor>([
+  [DataLinkBuiltInVars.includeVars, AllVariablesMacro],
+  [DataLinkBuiltInVars.keepTime, UrlTimeRangeMacro],
+  ['__value', ValueMacro],
+  ['__data', DataMacro],
+  ['__series', SeriesMacro],
+  ['__field', FieldMacro],
+  ['__url', UrlMacro],
+  ['__from', TimeFromAndToMacro],
+  ['__to', TimeFromAndToMacro],
+  ['__timezone', TimezoneMacro],
+  ['__user', UserMacro],
+  ['__org', OrgMacro],
+  ['__interval', IntervalMacro],
+  ['__interval_ms', IntervalMacro],
+]);
 
 /**
  * Allows you to register a variable expression macro that can then be used in strings with syntax ${<macro_name>.<fieldPath>}
@@ -29,13 +29,13 @@ export const macrosIndex: Record<string, MacroVariableConstructor> = {
  * @returns a function that unregisters the macro
  */
 export function registerVariableMacro(name: string, macro: MacroVariableConstructor): () => void {
-  if (macrosIndex[name]) {
+  if (macrosIndex.get(name)) {
     throw new Error(`Macro already registered ${name}`);
   }
 
-  macrosIndex[name] = macro;
+  macrosIndex.set(name, macro);
 
   return () => {
-    delete macrosIndex[name];
+    macrosIndex.delete(name);
   };
 }


### PR DESCRIPTION
Fixes issues interpolating a string like `"$toString"` , if there is no variable named `toString` this should leave the original string unchanged but due to using object property lookup we matched object prototype functions (Both on scopedVars and macros) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.30.0--canary.785.9463381206.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@4.30.0--canary.785.9463381206.0
  npm install @grafana/scenes@4.30.0--canary.785.9463381206.0
  # or 
  yarn add @grafana/scenes-react@4.30.0--canary.785.9463381206.0
  yarn add @grafana/scenes@4.30.0--canary.785.9463381206.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
