### PR TITLE
Add support for new getTagKeys/getTagValues interface

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -275,7 +275,7 @@ export class AdHocFiltersVariable
 
     if (responseHasError(response)) {
       // @ts-expect-error Remove when 11.1.x is released
-      this.setState({ error: response.error });
+      this.setState({ error: response.error.message });
     }
 
     let values = dataFromResponse(response);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { AdHocVariableFilter, GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
+// @ts-expect-error Remove when 11.1.x is released
+import { AdHocVariableFilter, GetTagResponse, GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneVariable, SceneVariableState, SceneVariableValueChangedEvent, VariableValue } from '../types';
 import { ControlsLayout, SceneComponentProps } from '../../core/types';
 import { DataSourceRef } from '@grafana/schema';
-import { getQueriesForVariables, renderPrometheusLabelFilters } from '../utils';
+import { dataFromResponse, getQueriesForVariables, renderPrometheusLabelFilters, responseHasError } from '../utils';
 import { patchGetAdhocFilters } from './patchGetAdhocFilters';
 import { useStyles2 } from '@grafana/ui';
 import { sceneGraph } from '../../core/sceneGraph';
@@ -95,12 +96,12 @@ export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[]
 export type getTagKeysProvider = (
   variable: AdHocFiltersVariable,
   currentKey: string | null
-) => Promise<{ replace?: boolean; values: MetricFindValue[] }>;
+) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] }>;
 
 export type getTagValuesProvider = (
   variable: AdHocFiltersVariable,
   filter: AdHocFilterWithLabels
-) => Promise<{ replace?: boolean; values: MetricFindValue[] }>;
+) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] }>;
 
 export type AdHocFiltersVariableCreateHelperArgs = AdHocFiltersVariableState;
 
@@ -206,7 +207,7 @@ export class AdHocFiltersVariable
     const override = await this.state.getTagKeysProvider?.(this, currentKey);
 
     if (override && override.replace) {
-      return override.values.map(toSelectableValue);
+      return dataFromResponse(override.values).map(toSelectableValue);
     }
 
     if (this.state.defaultKeys) {
@@ -221,14 +222,21 @@ export class AdHocFiltersVariable
     const otherFilters = this.state.filters.filter((f) => f.key !== currentKey).concat(this.state.baseFilters ?? []);
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const queries = this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined;
-    let keys = await ds.getTagKeys({ filters: otherFilters, queries, timeRange, ...getEnrichedFiltersRequest(this) });
+    const response = await ds.getTagKeys({ filters: otherFilters, queries, timeRange, ...getEnrichedFiltersRequest(this) });
 
+    if (responseHasError(response)) {
+      // @ts-expect-error Remove when 11.1.x is released
+      this.setState({ error: response.error.message })
+    }
+
+    let keys = dataFromResponse(response);
     if (override) {
-      keys = keys.concat(override.values);
+      keys = keys.concat(dataFromResponse(override.values));
     }
 
     const tagKeyRegexFilter = this.state.tagKeyRegexFilter;
     if (tagKeyRegexFilter) {
+      // @ts-expect-error Remove when 11.1.x is released
       keys = keys.filter((f) => f.text.match(tagKeyRegexFilter));
     }
 
@@ -242,7 +250,7 @@ export class AdHocFiltersVariable
     const override = await this.state.getTagValuesProvider?.(this, filter);
 
     if (override && override.replace) {
-      return handleOptionGroups(override.values);
+      return handleOptionGroups(dataFromResponse(override.values));
     }
 
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);
@@ -257,7 +265,7 @@ export class AdHocFiltersVariable
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const queries = this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined;
 
-    let values = await ds.getTagValues({
+    const response = await ds.getTagValues({
       key: filter.key,
       filters: otherFilters,
       timeRange, // @ts-expect-error TODO: remove this once 11.1.x is released
@@ -265,8 +273,14 @@ export class AdHocFiltersVariable
       ...getEnrichedFiltersRequest(this),
     });
 
+    if (responseHasError(response)) {
+      // @ts-expect-error Remove when 11.1.x is released
+      this.setState({ error: response.error });
+    }
+
+    let values = dataFromResponse(response);
     if (override) {
-      values = values.concat(override.values);
+      values = values.concat(dataFromResponse(override.values));
     }
 
     return handleOptionGroups(values);

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -178,7 +178,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
     const response = await ds.getTagKeys({ filters: otherFilters, queries, timeRange, ...getEnrichedFiltersRequest(this) });
     if (responseHasError(response)) {
       // @ts-expect-error Remove when 11.1.x is released
-      this.setState({ error: response.error });
+      this.setState({ error: response.error.message });
     }
   
     let keys = dataFromResponse(response);

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -1,6 +1,7 @@
 import { isEqual } from 'lodash';
 import { VariableValue } from './types';
-import { AdHocVariableFilter } from '@grafana/data';
+// @ts-expect-error Remove when 11.1.x is released
+import { AdHocVariableFilter, DataQueryError, GetTagResponse, MetricFindValue } from '@grafana/data';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneDataQuery, SceneObject, SceneObjectState } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
@@ -172,4 +173,12 @@ export function toUrlCommaDelimitedString(key: string, label?: string): string {
   }
 
   return [key, label].map(escapeUrlCommaDelimiters).join(',');
+}
+
+export function dataFromResponse(response: GetTagResponse | MetricFindValue[]) {
+  return Array.isArray(response) ? response : response.data;
+}
+
+export function responseHasError(response: GetTagResponse | MetricFindValue[]): response is GetTagResponse & { error: DataQueryError } {
+  return !Array.isArray(response) && Boolean(response.error);
 }


### PR DESCRIPTION
Sets variable error state if getTagKeys/getTagValues returns an error.
Lots of `@ts-expect-error` since `11.1.x` isn't out yet 😬 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.1.0--canary.790.9497828604.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.1.0--canary.790.9497828604.0
  npm install @grafana/scenes@5.1.0--canary.790.9497828604.0
  # or 
  yarn add @grafana/scenes-react@5.1.0--canary.790.9497828604.0
  yarn add @grafana/scenes@5.1.0--canary.790.9497828604.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
