### PR TITLE
SceneQueryRunner: When waiting for a variable to load, and PanelData is undefined, we should create a valid PanelData object.

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -636,6 +636,28 @@ describe('SceneQueryRunner', () => {
       expect(runRequestMock.mock.calls.length).toBe(0);
     });
 
+    it('Should produce valid PanelData when a variable is loading', async () => {
+      const variable = new TestVariable({ name: 'A', value: '1' });
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A', query: '$A' }],
+      });
+
+      const scene = new SceneFlexLayout({
+        $variables: new SceneVariableSet({ variables: [variable] }),
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        children: [],
+      });
+
+      scene.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(queryRunner.state.data?.state).toBe('Loading');
+      expect(queryRunner.state.data?.timeRange).toBeDefined();
+      expect(queryRunner.state.data?.series).toBeDefined();
+    });
+
     it('Should not executed query on activate even when maxDataPointsFromWidth is true', async () => {
       const variable = new TestVariable({ name: 'A', value: '1' });
       const queryRunner = new SceneQueryRunner({

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -415,7 +415,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     // Skip executing queries if variable dependency is in loading state
     if (this._variableDependency.hasDependencyInLoadingState()) {
       writeSceneLog('SceneQueryRunner', 'Variable dependency is in loading state, skipping query execution');
-      this.setState({ data: { ...this.state.data!, state: LoadingState.Loading } });
+      this.setState({ data: { ...(this.state.data ?? emptyPanelData), state: LoadingState.Loading } });
       return;
     }
 


### PR DESCRIPTION
If `this.state.data` is undefined. We're going to create the object  `{ state: LoadingState.Loading }` because we're spreading undefined.

We can instead spread `emptyPanelData` and set data to a valid object.