### PR TITLE
UrlSync: Fixes issue with recent url sync change

### DIFF
--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -40,8 +40,8 @@
     "@grafana/e2e-selectors": "^11.0.0",
     "@leeoniya/ufuzzy": "^1.0.14",
     "react-grid-layout": "1.3.4",
-    "react-use": "17.4.0",
-    "react-virtualized-auto-sizer": "1.0.7",
+    "react-use": "17.5.0",
+    "react-virtualized-auto-sizer": "1.0.24",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -45,10 +45,8 @@ class TestObj extends SceneObjectBase<TestObjectState> {
       this.setState({ optional: typeof values.optional === 'string' ? values.optional : undefined });
     }
 
-    if (values.hasOwnProperty('nested')) {
+    if (values.hasOwnProperty('nested') && !this.state.nested) {
       this.setState({ nested: new TestObj({ name: 'default name' }) });
-    } else if (this.state.nested) {
-      this.setState({ nested: undefined });
     }
   }
 }
@@ -484,6 +482,30 @@ describe('UrlSyncManager', () => {
       obj1.setState({ name: 'A' });
 
       expect(locationService.getLocation().search).toEqual('?name=A&name-2=A');
+    });
+  });
+
+  describe('When init sync root is not scene root', () => {
+    it('Should sync init root', async () => {
+      const scene = new TestObj({ 
+        name: 'scene-root',
+        nested: new TestObj({ 
+          name: 'url-sync-root',
+         })
+       });
+
+      urlManager = new UrlSyncManager();
+     
+      locationService.push(`/?name=test1`);
+      urlManager.initSync(scene.state.nested!);
+
+      deactivate = activateFullSceneTree(scene);      
+
+      // Only updated the nested scene (as it's the only part of scene tree that is synced)
+      expect(scene.state.nested?.state.name).toEqual('test1');
+      
+      // Unchanged
+      expect(scene.state.name).toEqual('scene-root');
     });
   });
 });

--- a/packages/scenes/src/services/utils.ts
+++ b/packages/scenes/src/services/utils.ts
@@ -39,9 +39,13 @@ export function syncStateFromSearchParams(root: SceneObject, urlParams: URLSearc
   syncStateFromUrl(root, urlParams, urlKeyMapper);
 }
 
-export function syncStateFromUrl(root: SceneObject, urlParams: URLSearchParams, urlKeyMapper: UniqueUrlKeyMapper) {
-  if (!root.parent) {
-    // If top level object we need to sync here
+export function syncStateFromUrl(
+  root: SceneObject,
+  urlParams: URLSearchParams,
+  urlKeyMapper: UniqueUrlKeyMapper,
+  onlyChildren?: boolean
+) {
+  if (!onlyChildren) {
     syncUrlStateToObject(root, urlParams, urlKeyMapper);
   }
 
@@ -50,7 +54,7 @@ export function syncStateFromUrl(root: SceneObject, urlParams: URLSearchParams, 
     syncUrlStateToObject(child, urlParams, urlKeyMapper);
   });
 
-  root.forEachChild((child) => syncStateFromUrl(child, urlParams, urlKeyMapper));
+  root.forEachChild((child) => syncStateFromUrl(child, urlParams, urlKeyMapper, true));
 }
 
 function syncUrlStateToObject(sceneObject: SceneObject, urlParams: URLSearchParams, urlKeyMapper: UniqueUrlKeyMapper) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,8 +3603,8 @@ __metadata:
     react-grid-layout: "npm:1.3.4"
     react-router-dom: "npm:^5.2.0"
     react-select-event: "npm:^5.5.1"
-    react-use: "npm:17.4.0"
-    react-virtualized-auto-sizer: "npm:1.0.7"
+    react-use: "npm:17.5.0"
+    react-virtualized-auto-sizer: "npm:1.0.24"
     rimraf: "npm:^3.0.2"
     rollup: "npm:2.79.1"
     rollup-plugin-dts: "npm:^5.0.0"
@@ -22148,13 +22148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-virtualized-auto-sizer@npm:1.0.7":
-  version: 1.0.7
-  resolution: "react-virtualized-auto-sizer@npm:1.0.7"
+"react-virtualized-auto-sizer@npm:1.0.24":
+  version: 1.0.24
+  resolution: "react-virtualized-auto-sizer@npm:1.0.24"
   peerDependencies:
-    react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
-    react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc
-  checksum: 10/a16d8ac11a0efa20d44f36a5cf3854027895b806363a409f2ddc07ff92bfc92aaf5b8eee21f3e1b153cee2273db5e5383b6334d4b530d934ed08808ecfb45b9f
+    react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
+    react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
+  checksum: 10/02101a340bdbe3e40c49dbc52e524eb7ca18832690e91f045a25675600d7adc0a63e800a4ace6a014132adcdcce0e12a8137971de408427a5a3112d7c87c9f3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes issue with recent url change. 

When URL sync root was not the scene root (which is the case for data trails for now, might change it later). 

This fixes the state update from URL logic so that the URL sync root is also synced even when it has a parent. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.1--canary.793.9496367270.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.0.1--canary.793.9496367270.0
  npm install @grafana/scenes@5.0.1--canary.793.9496367270.0
  # or 
  yarn add @grafana/scenes-react@5.0.1--canary.793.9496367270.0
  yarn add @grafana/scenes@5.0.1--canary.793.9496367270.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
