### PR TITLE
UrlSync: Remove console.log left in prev PR

### DIFF
--- a/packages/scenes/src/services/UrlSyncManager.ts
+++ b/packages/scenes/src/services/UrlSyncManager.ts
@@ -40,7 +40,6 @@ export class UrlSyncManager implements UrlSyncManagerLike {
 
     this._urlKeyMapper.clear();
     this._lastLocation = locationService.getLocation();
-    console.log('initSync', this._lastLocation.search);
 
     this.handleNewObject(this._sceneRoot);
   }
@@ -136,7 +135,6 @@ class UrlParamsCache {
     this.#location = location;
     this.#cache = new URLSearchParams(location.search);
 
-    console.log('UrlParamsCache.getParams', this.#cache.toString());
     return this.#cache;
   }
 }


### PR DESCRIPTION
Missed to remove these log lines in prev merged PR 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.2--canary.794.9497058323.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.0.2--canary.794.9497058323.0
  npm install @grafana/scenes@5.0.2--canary.794.9497058323.0
  # or 
  yarn add @grafana/scenes-react@5.0.2--canary.794.9497058323.0
  yarn add @grafana/scenes@5.0.2--canary.794.9497058323.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
