### PR TITLE
Data layers: Don't run layer on activation if disabled

### DIFF
--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.test.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.test.ts
@@ -15,6 +15,18 @@ describe('SceneDataLayerBase', () => {
   });
 
   describe('when activated', () => {
+    it('should not run layer if disabled', () => {
+      const layer = new TestAnnotationsDataLayer({
+        name: 'Test layer',
+        isEnabled: false,
+        runLayerSpy: runLayerSpy,
+      });
+
+      layer.activate();
+
+      expect(runLayerSpy).toBeCalledTimes(0);
+    });
+
     it('should run query when there is no data', () => {
       const layer = new TestAnnotationsDataLayer({
         name: 'Layer 1',

--- a/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
+++ b/packages/scenes/src/querying/layers/SceneDataLayerBase.ts
@@ -142,6 +142,10 @@ export abstract class SceneDataLayerBase<T extends SceneDataLayerProviderState>
   }
 
   private shouldRunLayerOnActivate() {
+    if (!this.state.isEnabled) {
+      return false;
+    }
+
     if (this._variableValueRecorder.hasDependenciesChanged(this)) {
       writeSceneLog(
         'SceneDataLayerBase',


### PR DESCRIPTION
Currently in core Grafana annotations queries will be issued when entering the dashboard no matterif the layer is enabled or not.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.0.3--canary.795.9498844134.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.0.3--canary.795.9498844134.0
  npm install @grafana/scenes@5.0.3--canary.795.9498844134.0
  # or 
  yarn add @grafana/scenes-react@5.0.3--canary.795.9498844134.0
  yarn add @grafana/scenes@5.0.3--canary.795.9498844134.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
