### PR TITLE
Scenes: Return value if not string in interpolator

### DIFF
--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -309,4 +309,10 @@ describe('sceneInterpolator', () => {
       expect(sceneInterpolator(scene, str)).toBe(str);
     });
   });
+
+  it('should not try to interpolate and return value if it is not a string', () => {
+    const scene = new TestScene({});
+
+    expect(sceneInterpolator(scene, 123 as any)).toBe(123);
+  });
 });

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -25,7 +25,7 @@ export function sceneInterpolator(
   format?: InterpolationFormatParameter,
   interpolations?: VariableInterpolation[]
 ): string {
-  if (!target) {
+  if (!target || typeof target !== 'string') {
     return target ?? '';
   }
 


### PR DESCRIPTION
If a transformation passes a number down to the `sceneInterpolator` this will throw an error in the panel.
This fixes the crash by assuring only strings gets interpolated.