### PR TITLE
TimeRangeCompare: Do not re-run queries if all have opted out of comparison

### DIFF
--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -124,7 +124,7 @@ export class SceneTimeRangeCompare
     queries: SceneDataQuery[]
   ): boolean {
     return (
-      prev.compareWith !== next.compareWith && queries.filter((query) => query.timeRangeCompare !== false).length > 0
+      prev.compareWith !== next.compareWith && queries.find((query) => query.timeRangeCompare !== false) !== undefined
     );
   }
 

--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -4,7 +4,7 @@ import { ButtonGroup, ButtonSelect, Checkbox, ToolbarButton, useStyles2 } from '
 import React from 'react';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectState, SceneObjectUrlValues } from '../core/types';
+import { SceneComponentProps, SceneDataQuery, SceneObjectState, SceneObjectUrlValues } from '../core/types';
 import { DataQueryExtended } from '../querying/SceneQueryRunner';
 import { ExtraQueryDescriptor, ExtraQueryDataProcessor, ExtraQueryProvider } from '../querying/ExtraQueryProvider';
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
@@ -39,8 +39,8 @@ export const DEFAULT_COMPARE_OPTIONS = [
 
 export class SceneTimeRangeCompare
   extends SceneObjectBase<SceneTimeRangeCompareState>
-  implements ExtraQueryProvider<SceneTimeRangeCompareState> {
-
+  implements ExtraQueryProvider<SceneTimeRangeCompareState>
+{
   static Component = SceneTimeRangeCompareRenderer;
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['compareWith'] });
 
@@ -117,9 +117,15 @@ export class SceneTimeRangeCompare
     return extraQueries;
   }
 
-  // The query runner should rerun the comparison query if the compareWith value has changed.
-  public shouldRerun(prev: SceneTimeRangeCompareState, next: SceneTimeRangeCompareState): boolean {
-    return prev.compareWith !== next.compareWith;
+  // The query runner should rerun the comparison query if the compareWith value has changed and there are queries that haven't opted out of TWC
+  public shouldRerun(
+    prev: SceneTimeRangeCompareState,
+    next: SceneTimeRangeCompareState,
+    queries: SceneDataQuery[]
+  ): boolean {
+    return (
+      prev.compareWith !== next.compareWith && queries.filter((query) => query.timeRangeCompare !== false).length > 0
+    );
   }
 
   public getCompareTimeRange(timeRange: TimeRange): TimeRange | undefined {
@@ -212,7 +218,7 @@ const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary
     });
   });
   return of(secondary);
-}
+};
 
 function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeRangeCompare>) {
   const styles = useStyles2(getStyles);

--- a/packages/scenes/src/querying/ExtraQueryProvider.ts
+++ b/packages/scenes/src/querying/ExtraQueryProvider.ts
@@ -1,8 +1,8 @@
-import { DataQueryRequest, PanelData } from "@grafana/data";
-import { Observable } from "rxjs";
+import { DataQueryRequest, PanelData } from '@grafana/data';
+import { Observable } from 'rxjs';
 
-import { SceneObjectBase } from "../core/SceneObjectBase";
-import { SceneObjectState } from "../core/types";
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneDataQuery, SceneObjectState } from '../core/types';
 
 // A processor function called by the query runner with responses
 // to any extra requests.
@@ -39,7 +39,7 @@ export interface ExtraQueryProvider<T extends SceneObjectState> extends SceneObj
   // When the provider's state changes this function will be passed both the previous and the
   // next state. The implementation can use this to determine whether the change should trigger
   // a rerun of the query or not.
-  shouldRerun(prev: T, next: T): boolean;
+  shouldRerun(prev: T, next: T, queries: SceneDataQuery[]): boolean;
 }
 
 export function isExtraQueryProvider(obj: any): obj is ExtraQueryProvider<any> {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -139,7 +139,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     for (const provider of providers) {
       this._subs.add(
         provider.subscribeToState((n, p) => {
-          if (provider.shouldRerun(p, n)) {
+          if (provider.shouldRerun(p, n, this.state.queries)) {
             this.runQueries();
           }
         })


### PR DESCRIPTION
:wave: 

We found an issue in app o11y where changing time window comparison value causes query runner to re-run queries even if all queries have opted out of TWC. This causes unnecessary querying and side effects for us.

This PR fixes makes twc not trigger re-run if all queries are opted-out

Thanks!