### PR TITLE
Add `toAbsolute` method to SceneTimePicker

### DIFF
--- a/packages/scenes/src/components/SceneTimePicker.test.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.test.tsx
@@ -76,6 +76,20 @@ describe('SceneTimePicker', () => {
     expect(dateTime(t2.from).diff(t1.from, 'h')).toBe(-6);
     expect(dateTime(t2.from).diff(t1.from, 'h')).toBe(-6);
   });
+
+
+  it('correctly calculates absolute time range', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(1704071943000); //  Monday, January 1, 2024 1:19:03 AM
+    const { timePicker, timeRange } = setupScene({
+      from: 'now-6h',
+      to: 'now',
+    });
+
+    timePicker.toAbsolute();
+    expect(timeRange.state.from).toBe('2023-12-31T19:19:03.000Z');
+    expect(timeRange.state.to).toBe('2024-01-01T01:19:03.000Z');
+  });
 });
 
 it('calculates zoomed time range correctly', () => {

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -26,6 +26,14 @@ export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
     timeRange.setState({ fiscalYearStartMonth: month });
   };
 
+  public toAbsolute = () => {
+    const timeRange = sceneGraph.getTimeRange(this);
+    const timeRangeVal = timeRange.state.value;
+    const from = toUtc(timeRangeVal.from);
+    const to = toUtc(timeRangeVal.to);
+    timeRange.onTimeRangeChange({ from, to, raw: { from, to } });
+  };
+
   public onMoveBackward = () => {
     const timeRange = sceneGraph.getTimeRange(this);
     const {


### PR DESCRIPTION
Adds a new method, `toAbsolute` to the SceneTimePicker.
This is to help fix an issue where the `t a` shortcut to change the time range to an absolute time range does not work in the scenes architecture. A follow-up PR in the main Grafana repo will be made when this one is merged.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.0--canary.800.9594766304.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.2.0--canary.800.9594766304.0
  npm install @grafana/scenes@5.2.0--canary.800.9594766304.0
  # or 
  yarn add @grafana/scenes-react@5.2.0--canary.800.9594766304.0
  yarn add @grafana/scenes@5.2.0--canary.800.9594766304.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
