### PR TITLE
VizPanel: Clear options value when the option is undefined

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -254,6 +254,18 @@ describe('VizPanel', () => {
       expect(panel.state.options.option2).toBe('updated option');
     });
 
+    test('should update partial options values to undefined value', () => {
+      panel.onOptionsChange({
+        option2: 'updated option',
+      });
+      panel.onOptionsChange({
+        option2: undefined,
+      });
+
+      expect(panel.state.options.showThresholds).toBe(true);
+      expect(panel.state.options.option2).toBe(undefined);
+    });
+
     test('should always allow overriding array values', () => {
       panel.onOptionsChange({ sortBy: ['asc'] });
       expect(panel.state.options.sortBy).toEqual(['asc']);

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -263,9 +263,15 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     // When replace is true, we want to replace the entire options object. Default will be applied.
     const nextOptions = replace
       ? optionsUpdate
-      : mergeWith(cloneDeep(options), optionsUpdate, (_, srcValue) => {
+      : mergeWith(cloneDeep(options), optionsUpdate, (objValue, srcValue, key, obj) => {
           if (isArray(srcValue)) {
             return srcValue;
+          }
+          // If customizer returns undefined, merging is handled by the method instead
+          // so we need to override the value in the object instead
+          if (objValue !== srcValue && typeof srcValue === 'undefined') {
+            obj[key] = srcValue;
+            return;
           }
           return;
         });

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -54,7 +54,7 @@ export function interpolate(
   value: string | undefined | null,
   scopedVars?: ScopedVars,
   format?: string | VariableCustomFormatterFn,
-  interpolations?: VariableInterpolation[],
+  interpolations?: VariableInterpolation[]
 ): string {
   if (value === '' || value == null) {
     return '';
@@ -125,7 +125,7 @@ function findObjectInternal(
 
 /**
  * Returns a scene object from the scene graph with the requested key.
- * 
+ *
  * Throws error if no key-matching scene object found.
  */
 export function findByKey(sceneObject: SceneObject, key: string) {
@@ -140,11 +140,15 @@ export function findByKey(sceneObject: SceneObject, key: string) {
 
 /**
  * Returns a scene object from the scene graph with the requested key and type.
- * 
+ *
  * Throws error if no key-matching scene object found.
  * Throws error if the given type does not match.
  */
-export function findByKeyAndType<TargetType extends SceneObject>(sceneObject: SceneObject, key: string, targetType: { new(...args: never[]): TargetType }) {
+export function findByKeyAndType<TargetType extends SceneObject>(
+  sceneObject: SceneObject,
+  key: string,
+  targetType: { new (...args: never[]): TargetType }
+) {
   const found = findObject(sceneObject, (sceneToCheck) => {
     return sceneToCheck.state.key === key;
   });
@@ -152,11 +156,10 @@ export function findByKeyAndType<TargetType extends SceneObject>(sceneObject: Sc
     throw new Error('Unable to find scene with key ' + key);
   }
   if (!(found instanceof targetType)) {
-    throw new Error(`Found scene object with key ${key} does not match type ${targetType.name}`) 
+    throw new Error(`Found scene object with key ${key} does not match type ${targetType.name}`);
   }
   return found;
 }
-
 
 /**
  * This will search the full scene graph, starting with the scene node passed in, then walking up the parent chain. *
@@ -222,7 +225,7 @@ export function getDataLayers(sceneObject: SceneObject, localOnly = false): Scen
  */
 export function getAncestor<ParentType>(
   sceneObject: SceneObject,
-  ancestorType: { new(...args: never[]): ParentType }
+  ancestorType: { new (...args: never[]): ParentType }
 ): ParentType {
   let parent: SceneObject | undefined = sceneObject;
 


### PR DESCRIPTION
Fixes [#89270](https://github.com/grafana/grafana/issues/89270)

**Problem**
[_.mergeWith](https://lodash.info/doc/mergeWith) ignores `undefined` values from the source object. When clearing a `VizPanel` option, we set it to `undefined` so it was not working.

To be able to set an option as `undefined`, we have to treat that case in the customizer cb passed to `_.mergeWith`.

|Before|After|
|-|-|
<video src="https://github.com/grafana/scenes/assets/5699976/76ba9bfb-c0e7-4068-9394-bff9a3bafd14"></video>|<video src="https://github.com/grafana/scenes/assets/5699976/f5654061-c535-439c-a960-32732a3c140d"></video>








<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.2.1--canary.801.9610977729.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.2.1--canary.801.9610977729.0
  npm install @grafana/scenes@5.2.1--canary.801.9610977729.0
  # or 
  yarn add @grafana/scenes-react@5.2.1--canary.801.9610977729.0
  yarn add @grafana/scenes@5.2.1--canary.801.9610977729.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

