### PR TITLE
Add VizPanelExploreButton scene object

### DIFF
--- a/packages/scenes-app/src/demos/panelHeaderActions.tsx
+++ b/packages/scenes-app/src/demos/panelHeaderActions.tsx
@@ -5,6 +5,7 @@ import {
   SceneAppPageState,
   SceneCSSGridItem,
   SceneCSSGridLayout,
+  VizPanelExploreButton,
 } from '@grafana/scenes';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 import { Button, Select } from '@grafana/ui';
@@ -51,6 +52,13 @@ export function getPanelHeaderActions(defaults: SceneAppPageState) {
                 .setHeaderActions(
                   <Select options={[{ label: 'Option 1', value: '1' }]} onChange={() => {}} value="1" />
                 )
+                .build(),
+            }),
+            new SceneCSSGridItem({
+              body: PanelBuilders.timeseries()
+                .setTitle('Panel with explore button')
+                .setData(getQueryRunnerWithRandomWalkQuery())
+                .setHeaderActions(new VizPanelExploreButton())
                 .build(),
             }),
           ],

--- a/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from 'react';
+
+import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import { LinkButton } from '@grafana/ui';
+import { DataQuery } from '@grafana/schema';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { ScopedVars } from '@grafana/data';
+import { useAsync } from 'react-use';
+
+export interface ExploreButtonOptions {
+  // Callback to hook in tracking / analytics
+  onClick?: () => void;
+
+  // Callback to modify interpolated query before passing it to explore
+  transform?: (query: DataQuery) => DataQuery;
+}
+
+interface ExploreButtonState extends SceneObjectState {
+  options: ExploreButtonOptions;
+}
+
+export class VizPanelExploreButton extends SceneObjectBase<ExploreButtonState> {
+  static Component = VizPanelExploreButtonComponent;
+
+  public constructor(options: ExploreButtonOptions = {}) {
+    super({ options });
+  }
+}
+
+function VizPanelExploreButtonComponent({ model }: SceneComponentProps<VizPanelExploreButton>) {
+  const { options } = model.useState();
+
+  const { data } = sceneGraph.getData(model).useState();
+
+  const targets = useMemo(() => data?.request?.targets ?? [], [data]);
+
+  const { from, to } = sceneGraph.getTimeRange(model).useState();
+
+  const { value: interpolatedQueries } = useAsync(async () => {
+    const scopedVars: ScopedVars = {
+      __sceneObject: { text: '__sceneObject', value: model },
+    };
+    return (
+      await Promise.allSettled(
+        targets.map(async (q) => {
+          const queryDs = await getDataSourceSrv().get(q.datasource);
+          return queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {})[0] || q;
+        })
+      )
+    )
+      .filter((promise): promise is PromiseFulfilledResult<DataQuery> => promise.status === 'fulfilled')
+      .map((q) => q.value)
+      .map((q) => options.transform?.(q) ?? q);
+  }, [targets, model]);
+
+  const left = useMemo(() => {
+    const queries: DataQuery[] = interpolatedQueries ?? [];
+
+    const datasource = queries.find((query) => !!query.datasource?.uid)?.datasource?.uid;
+
+    if (queries?.length && datasource && from && to) {
+      return encodeURIComponent(
+        JSON.stringify({
+          datasource,
+          queries,
+          range: {
+            from,
+            to,
+          },
+        })
+      );
+    }
+    return '';
+  }, [interpolatedQueries, from, to]);
+
+  if (left) {
+    return (
+      <LinkButton
+        key="explore"
+        icon="compass"
+        size="sm"
+        variant="secondary"
+        href={`/explore?left=${left}`}
+        onClick={options.onClick}
+      >
+        Explore
+      </LinkButton>
+    );
+  }
+  return null;
+}

--- a/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
@@ -7,6 +7,7 @@ import { SceneComponentProps, SceneObjectState } from '../../core/types';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { sceneGraph } from '../../core/sceneGraph';
 import { getExploreURL } from '../../utils/explore';
+import { useReturnToPrevious } from '@grafana/runtime';
 
 export interface ExploreButtonOptions {
   // Callback to hook in tracking / analytics
@@ -14,6 +15,12 @@ export interface ExploreButtonOptions {
 
   // Callback to modify interpolated query before passing it to explore
   transform?: (query: DataQuery) => DataQuery;
+
+  // Title and href for the return to previous button
+  returnToPrevious?: {
+    title: string;
+    href?: string;
+  };
 }
 
 interface ExploreButtonState extends SceneObjectState {
@@ -40,6 +47,8 @@ function VizPanelExploreButtonComponent({ model }: SceneComponentProps<VizPanelE
     [data, model, from, to]
   );
 
+  const returnToPrevious = useReturnToPrevious();
+
   if (exploreLink) {
     return (
       <LinkButton
@@ -48,7 +57,12 @@ function VizPanelExploreButtonComponent({ model }: SceneComponentProps<VizPanelE
         size="sm"
         variant="secondary"
         href={exploreLink}
-        onClick={options.onClick}
+        onClick={() => {
+          if (options.returnToPrevious) {
+            returnToPrevious(options.returnToPrevious.title, options.returnToPrevious.href);
+          }
+          options.onClick?.();
+        }}
       >
         Explore
       </LinkButton>

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -150,3 +150,4 @@ export const sceneUtils = {
 };
 
 export { SafeSerializableSceneObject } from './utils/SafeSerializableSceneObject';
+export { getExploreURL } from './utils/explore';

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -78,6 +78,7 @@ export { SceneObjectUrlSyncConfig } from './services/SceneObjectUrlSyncConfig';
 export { EmbeddedScene, type EmbeddedSceneState } from './components/EmbeddedScene';
 export { VizPanel, type VizPanelState } from './components/VizPanel/VizPanel';
 export { VizPanelMenu } from './components/VizPanel/VizPanelMenu';
+export { VizPanelExploreButton } from './components/VizPanel/VizPanelExploreButton';
 export { NestedScene } from './components/NestedScene';
 export { SceneCanvasText } from './components/SceneCanvasText';
 export { SceneToolbarButton, SceneToolbarInput } from './components/SceneToolbarButton';

--- a/packages/scenes/src/utils/explore.test.ts
+++ b/packages/scenes/src/utils/explore.test.ts
@@ -1,0 +1,108 @@
+import { PanelData, RawTimeRange, ScopedVars } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+import { AdHocFilterItem } from '@grafana/ui';
+import { getExploreURL } from './explore';
+import { VizPanel } from '../components/VizPanel/VizPanel';
+import { wrapInSafeSerializableSceneObject } from './wrapInSafeSerializableSceneObject';
+
+const mockDataSourceSrv = {
+  get: jest.fn(),
+};
+
+const mockDataSource = {
+  interpolateVariablesInQueries: jest.fn(),
+};
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => mockDataSourceSrv,
+}));
+
+interface TestQuery extends DataQuery {
+  query: string;
+}
+
+describe('getExploreURL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDataSourceSrv.get.mockReturnValue(mockDataSource);
+    mockDataSource.interpolateVariablesInQueries.mockImplementation(
+      (queries: DataQuery[], scopedVars: ScopedVars, filters: AdHocFilterItem[]) => {
+        return queries.map((q) => ({ ...q, query: (q as TestQuery).query + ' interpolated' }));
+      }
+    );
+  });
+
+  it('should interpolate queries via data source and return well formed URL', async () => {
+    const data: PanelData = {
+      request: {
+        targets: [
+          {
+            datasource: {
+              uid: 'test-ds',
+            },
+            refId: 'A',
+            query: 'test-query',
+          },
+          {
+            datasource: {
+              uid: 'test-ds',
+            },
+            refId: 'A',
+            query: 'test-query2',
+          },
+        ],
+        filters: [],
+      },
+    } as any;
+
+    const model = new VizPanel({
+      pluginId: 'custom-plugin-id',
+    });
+    const timeRange: RawTimeRange = {
+      from: 'now - 10m',
+      to: 'now',
+    };
+
+    const url = await getExploreURL(data, model, timeRange);
+
+    const expectedLeft = {
+      datasource: 'test-ds',
+      queries: [
+        {
+          datasource: { uid: 'test-ds' },
+          refId: 'A',
+          query: 'test-query interpolated',
+        },
+        {
+          datasource: { uid: 'test-ds' },
+          refId: 'A',
+          query: 'test-query2 interpolated',
+        },
+      ],
+      range: timeRange,
+    };
+
+    expect(mockDataSourceSrv.get).toHaveBeenCalledTimes(2);
+    expect(mockDataSourceSrv.get).toHaveBeenCalledWith({ uid: 'test-ds' });
+    expect(mockDataSource.interpolateVariablesInQueries).toHaveBeenCalledTimes(2);
+    expect(mockDataSource.interpolateVariablesInQueries).toHaveBeenNthCalledWith(
+      1,
+      [data.request!.targets[0]],
+      { __sceneObject: wrapInSafeSerializableSceneObject(model) },
+      data.request!.filters
+    );
+    expect(mockDataSource.interpolateVariablesInQueries).toHaveBeenNthCalledWith(
+      2,
+      [data.request!.targets[1]],
+      { __sceneObject: wrapInSafeSerializableSceneObject(model) },
+      data.request!.filters
+    );
+
+    const parsed = new URL(url, 'http://example.com');
+    expect(parsed.pathname).toBe('/explore');
+    const left = parsed.searchParams.get('left');
+    expect(left).not.toBeNull();
+    expect(JSON.parse(decodeURIComponent(left!))).toStrictEqual(expectedLeft);
+  });
+});

--- a/packages/scenes/src/utils/explore.ts
+++ b/packages/scenes/src/utils/explore.ts
@@ -1,0 +1,60 @@
+import { PanelData, RawTimeRange, ScopedVars } from '@grafana/data';
+import { SceneObject } from '../core/types';
+import { wrapInSafeSerializableSceneObject } from './wrapInSafeSerializableSceneObject';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+
+/**
+ * Returns URL to Grafana explore for the queries in the given panel data and time range.
+ */
+export async function getExploreURL(
+  data: PanelData,
+  model: SceneObject,
+  timeRange: RawTimeRange,
+  transform?: (query: DataQuery) => DataQuery
+): Promise<string> {
+  const targets = data.request?.targets;
+  if (!targets) {
+    return '';
+  }
+
+  const { from, to } = timeRange;
+
+  const filters = data.request?.filters;
+
+  const scopedVars: ScopedVars = {
+    __sceneObject: wrapInSafeSerializableSceneObject(model),
+  };
+
+  const interpolatedQueries = (
+    await Promise.allSettled(
+      targets.map(async (q) => {
+        const queryDs = await getDataSourceSrv().get(q.datasource);
+        return queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {}, filters)[0] || q;
+      })
+    )
+  )
+    .filter((promise): promise is PromiseFulfilledResult<DataQuery> => promise.status === 'fulfilled')
+    .map((q) => q.value)
+    .map((q) => transform?.(q) ?? q);
+
+  const queries: DataQuery[] = interpolatedQueries ?? [];
+
+  const datasource = queries.find((query) => !!query.datasource?.uid)?.datasource?.uid;
+
+  if (queries?.length && datasource && from && to) {
+    const left = encodeURIComponent(
+      JSON.stringify({
+        datasource,
+        queries,
+        range: {
+          from,
+          to,
+        },
+      })
+    );
+
+    return `/explore?left=${left}`;
+  }
+  return '';
+}


### PR DESCRIPTION
Hey,

On popular request, contributing a panel explore button derived from app o11y implementation. It's been copied around to other apps, so seems to make sense to contribute it to scenes.

Does this make sense? If so, I'll add tests. Also thinking it's maybe whorthwile to make a `getExploreUrl(sceneObject)` util as it's own thing in case you want something else than a button

![panel explore button](https://github.com/grafana/scenes/assets/847684/37158277-c794-4edd-a2e0-ae6fdb69e301)


