### PR TITLE
VizPanel: Allow to adapt color palette after plugin change

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -15,6 +15,7 @@ import {
   PanelProps,
   toUtc,
 } from '@grafana/data';
+import * as grafanaData from '@grafana/data';
 import { getPanelPlugin } from '../../../utils/test/__mocks__/pluginMocks';
 
 import { VizPanel } from './VizPanel';
@@ -301,6 +302,18 @@ describe('VizPanel', () => {
 
       expect(panel.state.options.showThresholds).toBe(false);
       expect(panel.state.options.option2).not.toBeDefined();
+    });
+
+    test('should allow to call getPanelOptionsWithDefaults to compute new color options for plugin', () => {
+      const spy = jest.spyOn(grafanaData, 'getPanelOptionsWithDefaults');
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+
+      panel.onOptionsChange({}, false, true);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      // Marked as after plugin change to readjust to prefered field color setting
+      expect(spy.mock.calls[0][0].isAfterPluginChange).toBe(true);
     });
   });
 

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -257,7 +257,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     this.setState({ displayMode });
   };
 
-  public onOptionsChange = (optionsUpdate: DeepPartial<TOptions>, replace = false) => {
+  public onOptionsChange = (optionsUpdate: DeepPartial<TOptions>, replace = false, isAfterPluginChange = false) => {
     const { fieldConfig, options } = this.state;
 
     // When replace is true, we want to replace the entire options object. Default will be applied.
@@ -280,7 +280,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       plugin: this._plugin!,
       currentOptions: nextOptions,
       currentFieldConfig: fieldConfig,
-      isAfterPluginChange: false,
+      isAfterPluginChange: isAfterPluginChange,
     });
 
     this.setState({


### PR DESCRIPTION
When changing panel type (plugin), each plugin has a specific field config that must override the ones selected by the user. This is mostly the color strategy.

In Grafana Dashboards, when changing the plugin type, the new options are computed by `VizPanel` manager but it always passes the `isPluginChanged` to `false`. 

This PR enables the option to recompute the options taking into account that the plugin has changed.