### PR TITLE
VizPanel: Load plugin prefered default options when activating

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -180,7 +180,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       plugin,
       currentOptions: panel.options,
       currentFieldConfig: panel.fieldConfig,
-      isAfterPluginChange: false,
+      isAfterPluginChange: true,
     });
 
     this._plugin = plugin;
@@ -280,7 +280,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       plugin: this._plugin!,
       currentOptions: nextOptions,
       currentFieldConfig: fieldConfig,
-      isAfterPluginChange: isAfterPluginChange,
+      isAfterPluginChange,
     });
 
     this.setState({


### PR DESCRIPTION
Follow up on #805 

Fixes #89836

**Problem**
[`getPanelOptionsWithDefaults`](https://github.com/grafana/grafana/blob/0285278cfc5cf8e9780f7a0624a5f1c8c6e75590/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts#L34) generates the default options for a given plugin. The third parameter allow to override color strategy default for the given options.

In Dashboards, when creating a VizPanel, we need to get the preferred plugin color strategy. If we pass the `isAfterPluginChange` to false when creating the `VizPanel`, the new options won't include the color strategy adapted to the just loaded panel. This creates the issue of always having 'classic-palette' as the default color.

**Solution**
When loading a plugin, always mark the `isAfterPluginChange` to `true` to load the color strategy correctly

**How to reproduce the bug:**
1. Go to dashboard and create a viz. Because the default viz is timeseries, the color strategy is `classic-palette`
2. Change the panel type to Gauge. The preferred color strategy is threshold. Without the change, the color strategy remains classic.

**Side notes**
#805  aimed to solve this bug, but the issue is in `VizPanelManager` the change option props happen if the plugin is defined, and it is never defined because the loading is async.

https://github.com/grafana/grafana/blob/0285278cfc5cf8e9780f7a0624a5f1c8c6e75590/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx#L260-L276


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.2--canary.806.9696859266.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.2--canary.806.9696859266.0
  npm install @grafana/scenes@5.3.2--canary.806.9696859266.0
  # or 
  yarn add @grafana/scenes-react@5.3.2--canary.806.9696859266.0
  yarn add @grafana/scenes@5.3.2--canary.806.9696859266.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
