### PR TITLE
Fix variable interpolation in query options interval

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -1046,6 +1046,25 @@ describe('SceneQueryRunner', () => {
       const getDataSourceCall = getDataSourceMock.mock.calls[0];
       expect(getDataSourceCall[0]).toEqual({ uid: 'Muuu' });
     });
+
+    it.only('Should interpolate a variable when used in query options', async () => {
+      const variable = new TestVariable({ name: 'A', value: '1h' });
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A', query: '$A' }],
+        $variables: new SceneVariableSet({ variables: [variable] }),
+        minInterval: '${A}',
+      });
+
+      queryRunner.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(sentRequest).toBeDefined();
+      const { scopedVars } = sentRequest!;
+      
+      expect(scopedVars.__interval?.text).toBe('1h')
+      expect(scopedVars.__interval?.value).toBe('1h')
+    });
   });
 
   describe('Supporting custom runtime data source', () => {

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -1047,7 +1047,7 @@ describe('SceneQueryRunner', () => {
       expect(getDataSourceCall[0]).toEqual({ uid: 'Muuu' });
     });
 
-    it.only('Should interpolate a variable when used in query options', async () => {
+    it('Should interpolate a variable when used in query options', async () => {
       const variable = new TestVariable({ name: 'A', value: '1h' });
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A', query: '$A' }],

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -46,6 +46,7 @@ import { GroupByVariable } from '../variables/groupby/GroupByVariable';
 import { AdHocFiltersVariable, isFilterComplete } from '../variables/adhoc/AdHocFiltersVariable';
 import { SceneVariable } from '../variables/types';
 import { DataLayersMerger } from './DataLayersMerger';
+import { interpolate } from '../core/sceneGraph/sceneGraph';
 
 let counter = 100;
 
@@ -540,8 +541,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       return query;
     });
 
-    // TODO interpolate minInterval
-    const lowerIntervalLimit = minInterval ? minInterval : ds.interval;
+    const lowerIntervalLimit = minInterval ? interpolate(this, minInterval) : ds.interval;
     const norm = rangeUtil.calculateInterval(timeRange.state.value, request.maxDataPoints!, lowerIntervalLimit);
 
     // make shallow copy of scoped vars,


### PR DESCRIPTION
This PR adds interpolation to the query options interval in the SceneQueryRunner.