### PR TITLE
SceneRefreshPicker: Pass up to date state into setupIntervalTimer during constructor

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -31,19 +31,20 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   private _autoTimeRangeListener: Unsubscribable | undefined;
 
   public constructor(state: Partial<SceneRefreshPickerState>) {
-    const initialState = {
+    super({
       refresh: '',
       ...state,
       autoValue: undefined,
       autoEnabled: state.autoEnabled ?? true,
       autoMinInterval: state.autoMinInterval ?? config.minRefreshInterval,
       intervals: state.intervals ?? DEFAULT_INTERVALS,
-    };
-
-    super(initialState);
+    });
 
     this.addActivationHandler(() => {
-      this.setupIntervalTimer(initialState);
+      this.setupIntervalTimer({
+        refresh: state.refresh ?? '',
+        intervals: state.intervals ?? DEFAULT_INTERVALS,
+      });
 
       return () => {
         if (this._intervalTimer) {
@@ -108,11 +109,11 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
     return rangeUtil.calculateInterval(timeRange.state.value, resolution, this.state.autoMinInterval);
   };
 
-  private setupIntervalTimer = (state?: SceneRefreshPickerState) => {
+  private setupIntervalTimer = (partialState?: Pick<SceneRefreshPickerState, 'refresh' | 'intervals'>) => {
     const timeRange = sceneGraph.getTimeRange(this);
-    // in constructor the state we reference here is not up to date, in particular refresh,
-    //  therefore passing initial state as optional variable here
-    const { refresh, intervals } = state || this.state;
+    // when calling setupIntervalTimer inside constructor this.state is out of sync with constructor state,
+    //  therefore passing partialState from constructor manually
+    const { refresh, intervals } = partialState || this.state;
 
     if (this._intervalTimer || refresh === '') {
       clearInterval(this._intervalTimer);

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -31,17 +31,19 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   private _autoTimeRangeListener: Unsubscribable | undefined;
 
   public constructor(state: Partial<SceneRefreshPickerState>) {
-    super({
+    const initialState = {
       refresh: '',
       ...state,
       autoValue: undefined,
       autoEnabled: state.autoEnabled ?? true,
       autoMinInterval: state.autoMinInterval ?? config.minRefreshInterval,
       intervals: state.intervals ?? DEFAULT_INTERVALS,
-    });
+    };
+
+    super(initialState);
 
     this.addActivationHandler(() => {
-      this.setupIntervalTimer();
+      this.setupIntervalTimer(initialState);
 
       return () => {
         if (this._intervalTimer) {
@@ -106,9 +108,11 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
     return rangeUtil.calculateInterval(timeRange.state.value, resolution, this.state.autoMinInterval);
   };
 
-  private setupIntervalTimer = () => {
+  private setupIntervalTimer = (state?: SceneRefreshPickerState) => {
     const timeRange = sceneGraph.getTimeRange(this);
-    const { refresh, intervals } = this.state;
+    // in constructor the state we reference here is not up to date, in particular refresh,
+    //  therefore passing initial state as optional variable here
+    const { refresh, intervals } = state || this.state;
 
     if (this._intervalTimer || refresh === '') {
       clearInterval(this._intervalTimer);


### PR DESCRIPTION
setupIntervalTimer was getting `refresh: ""` and not initialising auto-refresh. Passing initial state manually. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.5--canary.811.9767690637.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.5--canary.811.9767690637.0
  npm install @grafana/scenes@5.3.5--canary.811.9767690637.0
  # or 
  yarn add @grafana/scenes-react@5.3.5--canary.811.9767690637.0
  yarn add @grafana/scenes@5.3.5--canary.811.9767690637.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
