### PR TITLE
Revert "VizPanel: Load plugin prefered default options when activating"

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -54,9 +54,6 @@ interface FieldConfigPlugin1 {
 let panelProps: PanelProps | undefined;
 let panelRenderCount = 0;
 
-// Function called to compute the default panel options including prefered plugin defaults
-const getPanelOptionsSpy = jest.spyOn(grafanaData, 'getPanelOptionsWithDefaults');
-
 function getTestPlugin1(dataSupport?: PanelPluginDataSupport) {
   const pluginToLoad = getPanelPlugin(
     {
@@ -187,8 +184,7 @@ describe('VizPanel', () => {
   describe('when activated', () => {
     let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
 
-    beforeEach(async () => {
-      getPanelOptionsSpy.mockClear();
+    beforeAll(async () => {
       panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
         pluginId: 'custom-plugin-id',
         fieldConfig: {
@@ -217,12 +213,6 @@ describe('VizPanel', () => {
     it('should apply fieldConfig defaults', () => {
       expect(panel.state.fieldConfig.defaults.unit).toBe('flop');
       expect(panel.state.fieldConfig.defaults.custom!.customProp).toBe(false);
-    });
-
-    it('should apply plugin option defaults', () => {
-      expect(getPanelOptionsSpy).toHaveBeenCalledTimes(1);
-      // Marked as after plugin change to readjust to prefered field color setting
-      expect(getPanelOptionsSpy.mock.calls[0][0].isAfterPluginChange).toBe(true);
     });
 
     it('should should remove props that are not defined for plugin', () => {
@@ -315,15 +305,15 @@ describe('VizPanel', () => {
     });
 
     test('should allow to call getPanelOptionsWithDefaults to compute new color options for plugin', () => {
-      getPanelOptionsSpy.mockClear();
+      const spy = jest.spyOn(grafanaData, 'getPanelOptionsWithDefaults');
       pluginToLoad = getTestPlugin1();
       panel.activate();
 
       panel.onOptionsChange({}, false, true);
 
-      expect(getPanelOptionsSpy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(1);
       // Marked as after plugin change to readjust to prefered field color setting
-      expect(getPanelOptionsSpy.mock.calls[0][0].isAfterPluginChange).toBe(true);
+      expect(spy.mock.calls[0][0].isAfterPluginChange).toBe(true);
     });
   });
 

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -180,7 +180,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       plugin,
       currentOptions: panel.options,
       currentFieldConfig: panel.fieldConfig,
-      isAfterPluginChange: true,
+      isAfterPluginChange: false,
     });
 
     this._plugin = plugin;
@@ -280,7 +280,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       plugin: this._plugin!,
       currentOptions: nextOptions,
       currentFieldConfig: fieldConfig,
-      isAfterPluginChange,
+      isAfterPluginChange: isAfterPluginChange,
     });
 
     this.setState({


### PR DESCRIPTION
Reverts grafana/scenes#806

This caused issues when viewing panels. It is discarding initial color mode options.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.4--canary.812.9764438508.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.4--canary.812.9764438508.0
  npm install @grafana/scenes@5.3.4--canary.812.9764438508.0
  # or 
  yarn add @grafana/scenes-react@5.3.4--canary.812.9764438508.0
  yarn add @grafana/scenes@5.3.4--canary.812.9764438508.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
