### PR TITLE
Add safeStringifyValue to exported sceneUtils

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -4,7 +4,7 @@ import { cloneSceneObjectState } from './core/sceneGraph/utils';
 import { registerRuntimeDataSource } from './querying/RuntimeDataSource';
 import { getUrlState, syncStateFromSearchParams } from './services/utils';
 import { registerVariableMacro } from './variables/macros';
-import { renderPrometheusLabelFilters } from './variables/utils';
+import { renderPrometheusLabelFilters, safeStringifyValue } from './variables/utils';
 import {
   isAdHocVariable,
   isQueryVariable,
@@ -133,6 +133,7 @@ export const sceneUtils = {
   syncStateFromSearchParams,
   getUrlState,
   renderPrometheusLabelFilters,
+  safeStringifyValue,
 
   // Variable guards
   isAdHocVariable,


### PR DESCRIPTION
Adds the `safeStringifyValue` util to sceneUtils.
Using in main should fix https://github.com/grafana/grafana/issues/88064
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.0--canary.813.9776503756.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.4.0--canary.813.9776503756.0
  npm install @grafana/scenes@5.4.0--canary.813.9776503756.0
  # or 
  yarn add @grafana/scenes-react@5.4.0--canary.813.9776503756.0
  yarn add @grafana/scenes@5.4.0--canary.813.9776503756.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
