### PR TITLE
Revert "SceneRefreshPicker: Fixes url state issue (#784)"

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -77,17 +77,17 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
 
   public getUrlState() {
     return {
-      refresh: this.state.refresh !== '' ? this.state.refresh : undefined,
+      refresh: this.state.refresh,
     };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
     const refresh = values.refresh;
 
-    if (typeof refresh === 'string') {
-      this.setState({ refresh });
-    } else if (refresh == null) {
-      this.setState({ refresh: '' });
+    if (refresh && typeof refresh === 'string') {
+      this.setState({
+        refresh,
+      });
     }
   }
 


### PR DESCRIPTION
This reverts commit 54ff3dcbd885a95a0b20dd42152861f91a7e4281.

Reverts https://github.com/grafana/scenes/pull/784 that caused the initially provided refresh picker state to be reset because the lack of refresh query param would make the state fall back to default. That PR introduced a regression in core Dashboards - basically the preserved refresh starte was not respected anymore.

I think we need to handle OFF refresh as `null` or `undefined` rather than `''` to allow easier differentiation here, but for now I decide to revert it as it only affects scenes-react (WIP).

This is a part of an escalation fix: https://github.com/grafana/support-escalations/issues/11235
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.5--canary.814.9776702793.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.5--canary.814.9776702793.0
  npm install @grafana/scenes@5.3.5--canary.814.9776702793.0
  # or 
  yarn add @grafana/scenes-react@5.3.5--canary.814.9776702793.0
  yarn add @grafana/scenes@5.3.5--canary.814.9776702793.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
