### PR TITLE
Adhoc filters: Fix regression with displaying groups

### DIFF
--- a/packages/scenes/jest.config.ts
+++ b/packages/scenes/jest.config.ts
@@ -4,6 +4,7 @@ module.exports = {
   moduleNameMapper: {
     // D3 exposes ESModules. To avoid issues with Jest, we need to point them to the CJS version.
     d3: '<rootDir>/../../node_modules/d3/dist/d3.min.js',
+    '\\.css$': '<rootDir>/utils/test/__mocks__/style.ts',
   },
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./utils/setupTests.ts'],

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.test.ts
@@ -1,0 +1,36 @@
+import { getAdhocOptionSearcher } from './getAdhocOptionSearcher';
+
+describe('getAdhocOptionSearcher', () => {
+  it('Should return options', async () => {
+    const optionSearcher = getAdhocOptionSearcher([{ label: 'A', value: '1' }]);
+    expect(optionSearcher('')).toEqual([{ label: 'A', value: '1' }]);
+  });
+
+  it('Can filter options by search query', async () => {
+    const options = [
+      { label: 'Test', value: '1' },
+      { label: 'Google', value: '2' },
+      { label: 'estimate', value: '2' },
+    ];
+    const optionSearcher = getAdhocOptionSearcher(options);
+
+    expect(optionSearcher('est')).toEqual([
+      { label: 'Test', value: '1' },
+      { label: 'estimate', value: '2' },
+    ]);
+  });
+
+  it('Preserves other parameters when filtering', async () => {
+    const options = [
+      { label: 'Test', value: '1', foo: 'foo', group: 'group1' },
+      { label: 'Google', value: '2' },
+      { label: 'estimate', value: '2' },
+    ];
+    const optionSearcher = getAdhocOptionSearcher(options);
+
+    expect(optionSearcher('est')).toEqual([
+      { label: 'Test', value: '1', foo: 'foo', group: 'group1' },
+      { label: 'estimate', value: '2' },
+    ]);
+  });
+});

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
@@ -1,0 +1,47 @@
+import uFuzzy from '@leeoniya/ufuzzy';
+import { SelectableValue } from '@grafana/data';
+
+export function getAdhocOptionSearcher(
+  options: SelectableValue[],
+) {
+  const ufuzzy = new uFuzzy();
+  const haystack: string[] = [];
+  const limit = 10000;
+
+  return (search: string) => {
+    if (search === '') {
+      if (options.length > limit) {
+        return options.slice(0, limit);
+      } else {
+        return options;
+      }
+    }
+
+    if (haystack.length === 0) {
+      for (let i = 0; i < options.length; i++) {
+        haystack.push(options[i].label ?? String(options[i].value));
+      }
+    }
+
+    const idxs = ufuzzy.filter(haystack, search);
+    const filteredOptions: SelectableValue[] = [];
+
+    if (idxs) {
+      for (let i = 0; i < idxs.length; i++) {
+        filteredOptions.push(options[idxs[i]]);
+
+        if (filteredOptions.length > limit) {
+          return filteredOptions;
+        }
+      }
+
+      return filteredOptions;
+    }
+
+    if (options.length > limit) {
+      return options.slice(0, limit);
+    }
+
+    return options;
+  };
+}

--- a/packages/scenes/utils/test/__mocks__/style.ts
+++ b/packages/scenes/utils/test/__mocks__/style.ts
@@ -1,0 +1,1 @@
+export const style = 'style';


### PR DESCRIPTION
- fixes the display of groups in adhoc filters
- we initially regressed this with https://github.com/grafana/scenes/pull/766
- this PR does a couple of things:
  - creates a separate `getAdhocOptionSearcher` instead of trying to reuse the generic `getOptionSearcher` which is typed for `VariableOptions`
    - ~will add some tests for this as well~ ✅ 
  - moves the `handleOptionGroups` logic to `AdHocFilterRenderer`
  - so the flow is something like:
    - opening the option menu calls `model._getValuesFor`
    - this in turn calls `ds.getTagValues`, which returns a `MetricFindValue[]` array containing an optional group parameter
    - `_getValuesFor` then maps this to `SelectableValue[]` but keeps the group parameter
    - this is set in state as `values` in `AdHocFilterRenderer`
    - `AdHocFilterRenderer` then uses the new option searcher to filter these options down, and calls `handleOptionGroups` to group them all together as before
- you can test this locally before/after by adjusting the adhoc filters demo and providing a custom `getTagValuesProvider`:
```
                  getTagValuesProvider: async () => ({
                    replace: true,
                    values: [{
                      text: 'Alice',
                      value: 'alice',
                      group: 'People',
                    }, {
                      text: 'Bar',
                      value: 'bar'
                    }, {
                      text: 'Cat',
                      value: 'cat',
                      group: 'Animals',
                    }, {
                      text: 'Bob',
                      value: 'bob',
                      group: 'People',
                    }, {
                      text: 'Dog',
                      value: 'dog',
                      group: 'Animals',
                    }, {
                      text: 'Foo',
                      value: 'foo',
                    }]
                  })
```
![image](https://github.com/grafana/scenes/assets/20999846/43460412-ba25-4910-986b-5c13c083cf6e)

- note: there is a minor styling issue where we're not showing boundaries between groups for virtualized `Select`s. this needs fixing separately in core.
  - you can see it in the [canary storybook](https://developers.grafana.com/ui/canary/index.html?path=/story/forms-select--multi-select-with-option-groups-virtualized) as well
- note 2: ~working on a test to prevent future regressions now 🤓~ there is already a test for this in `AdhocFiltersVariable.test.ts`, but it's currently skipped and can't be enabled until scenes moves to `@grafana/ui@11.1.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.6--canary.815.9779024969.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.6--canary.815.9779024969.0
  npm install @grafana/scenes@5.3.6--canary.815.9779024969.0
  # or 
  yarn add @grafana/scenes-react@5.3.6--canary.815.9779024969.0
  yarn add @grafana/scenes@5.3.6--canary.815.9779024969.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
