### PR TITLE
Adhoc filters/Group by: Support groups

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -6,35 +6,11 @@ import { Button, Field, InputActionMeta, Select, useStyles2 } from '@grafana/ui'
 import { css, cx } from '@emotion/css';
 import { ControlsLabel } from '../../utils/ControlsLabel';
 import { getAdhocOptionSearcher } from './getAdhocOptionSearcher';
+import { handleOptionGroups } from '../utils';
 
 interface Props {
   filter: AdHocFilterWithLabels;
   model: AdHocFiltersVariable;
-}
-
-// Collect a flat list of SelectableValues with a `group` property into a hierarchical list with groups
-function handleOptionGroups(values: SelectableValue[]): Array<SelectableValue<string>> {
-  const result: Array<SelectableValue<string>> = [];
-  const groupedResults = new Map<string, Array<SelectableValue<string>>>();
-
-  for (const value of values) {
-    const groupLabel = value.group;
-    if (groupLabel) {
-      let group = groupedResults.get(groupLabel);
-
-      if (!group) {
-        group = [];
-        groupedResults.set(groupLabel, group);
-        result.push({ label: groupLabel, options: group });
-      }
-
-      group.push(value);
-    } else {
-      result.push(value);
-    }
-  }
-
-  return result;
 }
 
 function keyLabelToOption(key: string, label?: string): SelectableValue | null {

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -137,7 +137,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       width="auto"
       value={keyValue}
       placeholder={'Select label'}
-      options={keys}
+      options={handleOptionGroups(keys)}
       onChange={(v) => model._updateFilter(filter, 'key', v)}
       autoFocus={filter.key === ''}
       // there's a bug in react-select where the menu doesn't recalculate its position when the options are loaded asynchronously

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -117,7 +117,70 @@ describe('AdHocFiltersVariable', () => {
   });
 
   // TODO enable once this repo is using @grafana/ui@11.1.0
-  it.skip('shows groups and orders according to first occurence of a group item', async () => {
+  it.skip('shows key groups and orders according to first occurence of a group item', async () => {
+    const { runRequest } = setup({
+      getTagKeysProvider: async () => ({
+        replace: true,
+        values: [
+          {
+            text: 'Alice',
+            value: 'alice',
+            group: 'People',
+          },
+          {
+            text: 'Bar',
+            value: 'bar',
+          },
+          {
+            text: 'Cat',
+            value: 'cat',
+            group: 'Animals',
+          },
+          {
+            text: 'Bob',
+            value: 'bob',
+            group: 'People',
+          },
+          {
+            text: 'Dog',
+            value: 'dog',
+            group: 'Animals',
+          },
+          {
+            text: 'Foo',
+            value: 'foo',
+          },
+        ],
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    await userEvent.click(selects[0]);
+
+    // Check the group headers are visible
+    expect(screen.getByText('People')).toBeInTheDocument();
+    expect(screen.getByText('Animals')).toBeInTheDocument();
+
+    // Check the correct options exist
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBe(6);
+    expect(options[0]).toHaveTextContent('Alice');
+    expect(options[1]).toHaveTextContent('Bob');
+    expect(options[2]).toHaveTextContent('Bar');
+    expect(options[3]).toHaveTextContent('Cat');
+    expect(options[4]).toHaveTextContent('Dog');
+    expect(options[5]).toHaveTextContent('Foo');
+  });
+
+  // TODO enable once this repo is using @grafana/ui@11.1.0
+  it.skip('shows value groups and orders according to first occurence of a group item', async () => {
     const { runRequest } = setup({
       getTagValuesProvider: async () => ({
         replace: true,

--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -252,6 +252,69 @@ describe('GroupByVariable', () => {
     });
   });
 
+  // TODO enable once this repo is using @grafana/ui@11.1.0
+  it.skip('shows groups and orders according to first occurence of a group item', async () => {
+    const { runRequest } = setupTest({
+      getTagKeysProvider: async () => ({
+        replace: true,
+        values: [
+          {
+            text: 'Alice',
+            value: 'alice',
+            group: 'People',
+          },
+          {
+            text: 'Bar',
+            value: 'bar',
+          },
+          {
+            text: 'Cat',
+            value: 'cat',
+            group: 'Animals',
+          },
+          {
+            text: 'Bob',
+            value: 'bob',
+            group: 'People',
+          },
+          {
+            text: 'Dog',
+            value: 'dog',
+            group: 'Animals',
+          },
+          {
+            text: 'Foo',
+            value: 'foo',
+          },
+        ],
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('GroupBySelect-testGroupBy');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    await userEvent.click(selects[0]);
+
+    // Check the group headers are visible
+    expect(screen.getByText('People')).toBeInTheDocument();
+    expect(screen.getByText('Animals')).toBeInTheDocument();
+
+    // Check the correct options exist
+    const options = screen.getAllByRole('option');
+    expect(options.length).toBe(6);
+    expect(options[0]).toHaveTextContent('Alice');
+    expect(options[1]).toHaveTextContent('Bob');
+    expect(options[2]).toHaveTextContent('Bar');
+    expect(options[3]).toHaveTextContent('Cat');
+    expect(options[4]).toHaveTextContent('Dog');
+    expect(options[5]).toHaveTextContent('Foo');
+  });
+
   describe('component', () => {
     it('should fetch dimensions when Select is opened', async () => {
       const { variable, getTagKeysSpy } = setupTest();
@@ -353,5 +416,5 @@ export function setupTest(
     </TestContextProvider>
   );
 
-  return { scene, variable, getTagKeysSpy, timeRange };
+  return { scene, variable, getTagKeysSpy, timeRange, runRequest: runRequestMock.fn };
 }

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -70,6 +70,7 @@ export interface ValidateAndUpdateResult {}
 export interface VariableValueOption {
   label: string;
   value: VariableValueSingle;
+  group?: string;
 }
 
 export interface SceneVariableSetState extends SceneObjectState {

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import { VariableValue } from './types';
 // @ts-expect-error Remove when 11.1.x is released
-import { AdHocVariableFilter, DataQueryError, GetTagResponse, MetricFindValue } from '@grafana/data';
+import { AdHocVariableFilter, DataQueryError, GetTagResponse, MetricFindValue, SelectableValue } from '@grafana/data';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneDataQuery, SceneObject, SceneObjectState } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
@@ -181,4 +181,29 @@ export function dataFromResponse(response: GetTagResponse | MetricFindValue[]) {
 
 export function responseHasError(response: GetTagResponse | MetricFindValue[]): response is GetTagResponse & { error: DataQueryError } {
   return !Array.isArray(response) && Boolean(response.error);
+}
+
+// Collect a flat list of SelectableValues with a `group` property into a hierarchical list with groups
+export function handleOptionGroups(values: SelectableValue[]): Array<SelectableValue<string>> {
+  const result: Array<SelectableValue<string>> = [];
+  const groupedResults = new Map<string, Array<SelectableValue<string>>>();
+
+  for (const value of values) {
+    const groupLabel = value.group;
+    if (groupLabel) {
+      let group = groupedResults.get(groupLabel);
+
+      if (!group) {
+        group = [];
+        groupedResults.set(groupLabel, group);
+        result.push({ label: groupLabel, options: group });
+      }
+
+      group.push(value);
+    } else {
+      result.push(value);
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
- supports displaying groups in adhoc filter keys 
- supports displaying groups in groupby
- adds (skipped) unit tests for both
  - can't enable the tests until the repo moves to use `@grafana/ui@11.1.0` 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.0--canary.816.9794480649.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.4.0--canary.816.9794480649.0
  npm install @grafana/scenes@5.4.0--canary.816.9794480649.0
  # or 
  yarn add @grafana/scenes-react@5.4.0--canary.816.9794480649.0
  yarn add @grafana/scenes@5.4.0--canary.816.9794480649.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
