### PR TITLE
LazyLoader: Hide wrapper if child is hidden 

### DIFF
--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -5,6 +5,7 @@ import {
   PanelBuilders,
   SceneAppPage,
   SceneAppPageState,
+  SceneCSSGridItem,
   SceneCSSGridLayout,
   SceneComponentProps,
   SceneObjectBase,
@@ -73,11 +74,16 @@ export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
 }
 
 function getLayoutChildren(count: number) {
-  return Array.from(Array(count), (v, index) =>
-    PanelBuilders.stat()
-      .setTitle(`Panel ${count}`)
-      .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
-      .build()
+  return Array.from(
+    Array(count),
+    (v, index) =>
+      new SceneCSSGridItem({
+        body: PanelBuilders.stat()
+          .setTitle(`Panel ${count}`)
+          .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
+          .build(),
+        isHidden: index % 3 === 0,
+      })
   );
 }
 

--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -24,7 +24,8 @@ const autoRowOptions = ['150px', '250px', 'auto'];
 export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({
     ...defaults,
-    subTitle: 'A CSS Grid Layout demo, isLazy is enabled to showcase lazy rendering of panels',
+    subTitle:
+      'A CSS Grid Layout demo, isLazy is enabled to showcase lazy rendering of panels. Every 3rd panel is hidden to test the layout working properly.',
     getScene: () => {
       const layout = new SceneCSSGridLayout({
         children: getLayoutChildren(10),
@@ -79,7 +80,7 @@ function getLayoutChildren(count: number) {
     (v, index) =>
       new SceneCSSGridItem({
         body: PanelBuilders.stat()
-          .setTitle(`Panel ${count}`)
+          .setTitle(`Panel ${index + 1}`)
           .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
           .build(),
         isHidden: index % 3 === 0,

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -76,11 +76,10 @@ function SceneCSSGridLayoutRenderer({ model }: SceneCSSGridItemRenderProps<Scene
     <div className={style}>
       {children.map((item) => {
         const Component = item.Component as ComponentType<SceneCSSGridItemRenderProps<SceneObject>>;
-        const itemState = item.useState() as SceneCSSGridItemState;
         
         if (isLazy) {
           return (
-            <LazyLoader isHidden={itemState.isHidden} key={item.state.key!} className={style}>
+            <LazyLoader key={item.state.key!} className={style}>
               <Component key={item.state.key} model={item} parentState={model.state} />
             </LazyLoader>
           );

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -76,9 +76,11 @@ function SceneCSSGridLayoutRenderer({ model }: SceneCSSGridItemRenderProps<Scene
     <div className={style}>
       {children.map((item) => {
         const Component = item.Component as ComponentType<SceneCSSGridItemRenderProps<SceneObject>>;
+        const itemState = item.useState() as SceneCSSGridItemState;
+        
         if (isLazy) {
           return (
-            <LazyLoader key={item.state.key!} className={style}>
+            <LazyLoader isHidden={itemState.isHidden} key={item.state.key!} className={style}>
               <Component key={item.state.key} model={item} parentState={model.state} />
             </LazyLoader>
           );

--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import React, { ForwardRefExoticComponent, useImperativeHandle, useRef, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { uniqueId } from 'lodash';

--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -12,6 +12,7 @@ export function useUniqueId(): string {
 export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'children'> {
   children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
   key: string;
+  isHidden?: boolean;
   onLoad?: () => void;
   onChange?: (isInView: boolean) => void;
 }
@@ -23,7 +24,7 @@ export interface LazyLoaderType extends ForwardRefExoticComponent<Props> {
 }
 
 export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props>(
-  ({ children, onLoad, onChange, ...rest }, ref) => {
+  ({ children, onLoad, onChange, isHidden, ...rest }, ref) => {
     const id = useUniqueId();
     const [loaded, setLoaded] = useState(false);
     const [isInView, setIsInView] = useState(false);
@@ -57,6 +58,9 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
       };
     });
 
+    if (isHidden) {
+      return null;
+    }
     return (
       <div id={id} ref={innerRef} {...rest}>
         {loaded && (typeof children === 'function' ? children({ isInView }) : children)}

--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -1,7 +1,8 @@
-import React, { ForwardRefExoticComponent, useImperativeHandle, useRef, useState } from 'react';
+import React, { ForwardRefExoticComponent, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { uniqueId } from 'lodash';
+import { css } from '@emotion/css';
 
 export function useUniqueId(): string {
   const idRefLazy = useRef<string | undefined>(undefined);
@@ -12,7 +13,6 @@ export function useUniqueId(): string {
 export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'children'> {
   children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
   key: string;
-  isHidden?: boolean;
   onLoad?: () => void;
   onChange?: (isInView: boolean) => void;
 }
@@ -24,8 +24,9 @@ export interface LazyLoaderType extends ForwardRefExoticComponent<Props> {
 }
 
 export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props>(
-  ({ children, onLoad, onChange, isHidden, ...rest }, ref) => {
+  ({ children, onLoad, onChange, className, ...rest }, ref) => {
     const id = useUniqueId();
+    const style = useStyle();
     const [loaded, setLoaded] = useState(false);
     const [isInView, setIsInView] = useState(false);
     const innerRef = useRef<HTMLDivElement>(null);
@@ -58,16 +59,21 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
       };
     });
 
-    if (isHidden) {
-      return null;
-    }
     return (
-      <div id={id} ref={innerRef} {...rest}>
+      <div id={id} ref={innerRef} className={`${loaded ? style : ''} ${className}`} {...rest}>
         {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
       </div>
     );
   }
 ) as LazyLoaderType;
+
+function useStyle() {
+  return css({
+    '&:empty': {
+      display: 'none',
+    },
+  });
+}
 
 LazyLoader.displayName = 'LazyLoader';
 LazyLoader.callbacks = {} as Record<string, (e: IntersectionObserverEntry) => void>;


### PR DESCRIPTION
When using a `SceneCSSGridLayout`, the `isLazy` property and items setting their `isHidden` property dynamically, the `LazyLoader` would still be visible.

This PR just subscribes to the item's state and also hides the `LazyLoader`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.8--canary.823.9872224365.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.8--canary.823.9872224365.0
  npm install @grafana/scenes@5.3.8--canary.823.9872224365.0
  # or 
  yarn add @grafana/scenes-react@5.3.8--canary.823.9872224365.0
  yarn add @grafana/scenes@5.3.8--canary.823.9872224365.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
