### PR TITLE
Experiment with a proxy for solving JSON.stringify issue

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -316,11 +316,15 @@ describe('SceneQueryRunner', () => {
 
       await new Promise((r) => setTimeout(r, 1));
 
+      expect(1).toBe(1);
       const getDataSourceCall = getDataSourceMock.mock.calls[0];
       const runRequestCall = runRequestMock.mock.calls[0];
 
-      expect(runRequestCall[1].scopedVars.__sceneObject).toEqual({ value: queryRunner, text: '__sceneObject' });
-      expect(getDataSourceCall[1].__sceneObject).toEqual({ value: queryRunner, text: '__sceneObject' });
+      expect(runRequestCall[1].scopedVars.__sceneObject.value.__proxiedObject).toBe(queryRunner);
+      expect(runRequestCall[1].scopedVars.__sceneObject.text).toBe('__sceneObject');
+
+      expect(getDataSourceCall[1].__sceneObject.value.__proxiedObject).toBe(queryRunner);
+      expect(getDataSourceCall[1].__sceneObject.text).toBe('__sceneObject');
     });
 
     it('should pass adhoc filters via request object', async () => {
@@ -1061,9 +1065,9 @@ describe('SceneQueryRunner', () => {
 
       expect(sentRequest).toBeDefined();
       const { scopedVars } = sentRequest!;
-      
-      expect(scopedVars.__interval?.text).toBe('1h')
-      expect(scopedVars.__interval?.value).toBe('1h')
+
+      expect(scopedVars.__interval?.text).toBe('1h');
+      expect(scopedVars.__interval?.value).toBe('1h');
     });
   });
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -47,6 +47,7 @@ import { AdHocFiltersVariable, isFilterComplete } from '../variables/adhoc/AdHoc
 import { SceneVariable } from '../variables/types';
 import { DataLayersMerger } from './DataLayersMerger';
 import { interpolate } from '../core/sceneGraph/sceneGraph';
+import { proxifyScopedVarSceneObject } from '../utils/proxifyScopedVarSceneObject';
 
 let counter = 100;
 
@@ -108,7 +109,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   private _containerWidth?: number;
   private _variableValueRecorder = new VariableValueRecorder();
   private _results = new ReplaySubject<SceneDataProviderResult>(1);
-  private _scopedVars = { __sceneObject: { value: this, text: '__sceneObject' } };
+  private _scopedVars = { __sceneObject: { value: proxifyScopedVarSceneObject(this), text: '__sceneObject' } };
   private _layerAnnotations?: DataFrame[];
   private _resultAnnotations?: DataFrame[];
 

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -9,6 +9,7 @@ import { TestVariable } from '../../../variables/variants/TestVariable';
 import { SceneDataLayerSet } from '../../SceneDataLayerSet';
 import { AnnotationsDataLayer } from './AnnotationsDataLayer';
 import { TestSceneWithRequestEnricher } from '../../../utils/test/TestSceneWithRequestEnricher';
+import { ProxiedSceneObject } from '../../../utils/proxifyScopedVarSceneObject';
 
 let mockedEvents: Array<Partial<Field>> = [];
 
@@ -221,7 +222,7 @@ describe('AnnotationsDataLayer', () => {
         const { scopedVars } = sentRequest!;
 
         expect(scopedVars['__sceneObject']).toBeDefined();
-        expect(scopedVars['__sceneObject']?.value).toBe(layer);
+        expect((scopedVars['__sceneObject']?.value as ProxiedSceneObject).__proxiedObject).toBe(layer);
         expect(Object.keys(scopedVars)).toMatchInlineSnapshot(`
           [
             "__interval",

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
@@ -18,6 +18,7 @@ import { SceneDataLayerBase } from '../SceneDataLayerBase';
 import { DataLayerControlSwitch } from '../SceneDataLayerControls';
 import { AnnotationQueryResults, executeAnnotationQuery } from './standardAnnotationQuery';
 import { dedupAnnotations, postProcessQueryResult } from './utils';
+import { proxifyScopedVarSceneObject } from '../../../utils/proxifyScopedVarSceneObject';
 
 interface AnnotationsDataLayerState extends SceneDataLayerProviderState {
   query: AnnotationQuery;
@@ -29,7 +30,9 @@ export class AnnotationsDataLayer
 {
   static Component = AnnotationsDataLayerRenderer;
 
-  private _scopedVars: ScopedVars = { __sceneObject: { value: this, text: '__sceneObject' } };
+  private _scopedVars: ScopedVars = {
+    __sceneObject: { value: proxifyScopedVarSceneObject(this), text: '__sceneObject' },
+  };
   private _timeRangeSub: Unsubscribable | undefined;
 
   public constructor(initialState: AnnotationsDataLayerState) {

--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -18,6 +18,7 @@ import { shouldUseLegacyRunner, standardAnnotationSupport } from './standardAnno
 import { Dashboard, LoadingState } from '@grafana/schema';
 import { SceneObject, SceneTimeRangeLike } from '../../../core/types';
 import { getEnrichedDataRequest } from '../../getEnrichedDataRequest';
+import { proxifyScopedVarSceneObject } from '../../../utils/proxifyScopedVarSceneObject';
 
 let counter = 100;
 function getNextRequestId() {
@@ -97,7 +98,7 @@ export function executeAnnotationQuery(
     __interval: { text: interval.interval, value: interval.interval },
     __interval_ms: { text: interval.intervalMs.toString(), value: interval.intervalMs },
     __annotation: { text: annotation.name, value: annotation },
-    __sceneObject: { text: '__sceneObject', value: layer },
+    __sceneObject: { text: '__sceneObject', value: proxifyScopedVarSceneObject(layer) },
   };
 
   const queryRequest: DataQueryRequest = {

--- a/packages/scenes/src/utils/proxifyScopedVarSceneObject.ts
+++ b/packages/scenes/src/utils/proxifyScopedVarSceneObject.ts
@@ -1,0 +1,23 @@
+import { SceneObject } from '../core/types';
+
+interface ScopedVarSceneObjectProxyHandler {
+  get(target: any, prop: PropertyKey, receiver: any): any;
+}
+
+const handler: ScopedVarSceneObjectProxyHandler = {
+  get(target, prop) {
+    if (prop === '__proxiedObject') {
+      return target;
+    }
+
+    return '_r';
+  },
+};
+
+export function proxifyScopedVarSceneObject(target: SceneObject): ProxiedSceneObject {
+  return new Proxy(target, handler);
+}
+
+export type ProxiedSceneObject = Record<PropertyKey, '_r'> & {
+  __proxiedObject: SceneObject;
+};

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -15,6 +15,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariableUrlSyncHandler } from './AdHocFiltersVariableUrlSyncHandler';
 import { css } from '@emotion/css';
 import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
+import { proxifyScopedVarSceneObject } from '../../utils/proxifyScopedVarSceneObject';
 
 export interface AdHocFilterWithLabels extends AdHocVariableFilter {
   keyLabel?: string;
@@ -110,7 +111,7 @@ export class AdHocFiltersVariable
 {
   static Component = AdHocFiltersVariableRenderer;
 
-  private _scopedVars = { __sceneObject: { value: this } };
+  private _scopedVars = { __sceneObject: { value: proxifyScopedVarSceneObject(this) } };
   private _dataSourceSrv = getDataSourceSrv();
 
   protected _urlSync = new AdHocFiltersVariableUrlSyncHandler(this);
@@ -221,11 +222,16 @@ export class AdHocFiltersVariable
     const otherFilters = this.state.filters.filter((f) => f.key !== currentKey).concat(this.state.baseFilters ?? []);
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const queries = this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined;
-    const response = await ds.getTagKeys({ filters: otherFilters, queries, timeRange, ...getEnrichedFiltersRequest(this) });
+    const response = await ds.getTagKeys({
+      filters: otherFilters,
+      queries,
+      timeRange,
+      ...getEnrichedFiltersRequest(this),
+    });
 
     if (responseHasError(response)) {
       // @ts-expect-error Remove when 11.1.x is released
-      this.setState({ error: response.error.message })
+      this.setState({ error: response.error.message });
     }
 
     let keys = dataFromResponse(response);

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -16,6 +16,7 @@ import { OptionWithCheckbox } from '../components/VariableValueSelect';
 import { GroupByVariableUrlSyncHandler } from './GroupByVariableUrlSyncHandler';
 import { getOptionSearcher } from '../components/getOptionSearcher';
 import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
+import { proxifyScopedVarSceneObject } from '../../utils/proxifyScopedVarSceneObject';
 
 export interface GroupByVariableState extends MultiValueVariableState {
   /** Defaults to "Group" */
@@ -100,14 +101,14 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
 
     return from(
       getDataSource(this.state.datasource, {
-        __sceneObject: { text: '__sceneObject', value: this },
+        __sceneObject: { text: '__sceneObject', value: proxifyScopedVarSceneObject(this) },
       })
     ).pipe(
       mergeMap((ds) => {
         return from(this._getKeys(ds)).pipe(
           tap((response) => {
             if (responseHasError(response)) {
-              this.setState({ error: response.error.message })
+              this.setState({ error: response.error.message });
             }
           }),
           map((response) => dataFromResponse(response)),
@@ -162,9 +163,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
     }
 
     if (this.state.defaultOptions) {
-      return this.state.defaultOptions.concat(
-        dataFromResponse(override?.values ?? [])
-      );
+      return this.state.defaultOptions.concat(dataFromResponse(override?.values ?? []));
     }
 
     if (!ds.getTagKeys) {
@@ -175,12 +174,17 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
 
     const otherFilters = this.state.baseFilters || [];
     const timeRange = sceneGraph.getTimeRange(this).state.value;
-    const response = await ds.getTagKeys({ filters: otherFilters, queries, timeRange, ...getEnrichedFiltersRequest(this) });
+    const response = await ds.getTagKeys({
+      filters: otherFilters,
+      queries,
+      timeRange,
+      ...getEnrichedFiltersRequest(this),
+    });
     if (responseHasError(response)) {
       // @ts-expect-error Remove when 11.1.x is released
       this.setState({ error: response.error.message });
     }
-  
+
     let keys = dataFromResponse(response);
     if (override) {
       keys = keys.concat(dataFromResponse(override.values));

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -29,6 +29,7 @@ import { SceneCanvasText } from '../../../components/SceneCanvasText';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setRunRequest } from '@grafana/runtime';
+import { ProxiedSceneObject } from '../../../utils/proxifyScopedVarSceneObject';
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
@@ -174,8 +175,10 @@ describe('QueryVariable', () => {
       const getDataSourceCall = getDataSourceMock.mock.calls[0];
       const runRequestCall = runRequestMock.mock.calls[0];
 
-      expect(runRequestCall[1].scopedVars.__sceneObject).toEqual({ value: variable, text: '__sceneObject' });
-      expect(getDataSourceCall[1].__sceneObject).toEqual({ value: variable, text: '__sceneObject' });
+      expect((runRequestCall[1].scopedVars.__sceneObject.value as ProxiedSceneObject).__proxiedObject).toEqual(
+        variable
+      );
+      expect((getDataSourceCall[1].__sceneObject.value as ProxiedSceneObject).__proxiedObject).toEqual(variable);
     });
 
     describe('when refresh on dashboard load set', () => {

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -27,6 +27,7 @@ import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { SEARCH_FILTER_VARIABLE } from '../../constants';
 import { debounce } from 'lodash';
 import { registerQueryWithController } from '../../../querying/registerQueryWithController';
+import { proxifyScopedVarSceneObject } from '../../../utils/proxifyScopedVarSceneObject';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
@@ -69,7 +70,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
     return from(
       getDataSource(this.state.datasource, {
-        __sceneObject: { text: '__sceneObject', value: this },
+        __sceneObject: { text: '__sceneObject', value: proxifyScopedVarSceneObject(this) },
       })
     ).pipe(
       mergeMap((ds) => {
@@ -112,7 +113,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
   private getRequest(target: DataQuery | string, searchFilter?: string) {
     const scopedVars: ScopedVars = {
-      __sceneObject: { text: '__sceneObject', value: this },
+      __sceneObject: { text: '__sceneObject', value: proxifyScopedVarSceneObject(this) },
     };
 
     if (searchFilter) {


### PR DESCRIPTION
Just experimenting with an approach to solve scopedVars `JSON.stringify` issue upstream. Publishing this only to get a canary release out to test in core.

fyi @kaydelaney @torkelo @joshhunt @ivanortegaalba 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.3.9--canary.824.9873640037.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.3.9--canary.824.9873640037.0
  npm install @grafana/scenes@5.3.9--canary.824.9873640037.0
  # or 
  yarn add @grafana/scenes-react@5.3.9--canary.824.9873640037.0
  yarn add @grafana/scenes@5.3.9--canary.824.9873640037.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
