### PR TITLE
Possibility to refresh variable options based on state changes

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -8,6 +8,7 @@ import { writeSceneLog } from '../../utils/writeSceneLog';
 import {
   SceneVariable,
   SceneVariableDependencyConfigLike,
+  SceneVariableOptionsRefreshEvent,
   SceneVariables,
   SceneVariableSetState,
   SceneVariableValueChangedEvent,
@@ -52,6 +53,11 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     // Subscribe to changes to child variables
     this._subs.add(
       this.subscribeToEvent(SceneVariableValueChangedEvent, (event) => this._handleVariableValueChanged(event.payload))
+    );
+
+    // Subscribe to variable options changes
+    this._subs.add(
+      this.subscribeToEvent(SceneVariableOptionsRefreshEvent, (event) => this._handleVariableOptionsUpdate(event.payload))
     );
 
     this._subs.add(
@@ -253,6 +259,12 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     console.error('SceneVariableSet updateAndValidate error', err);
 
     writeVariableTraceLog(variable, 'updateAndValidate error', err);
+  }
+
+  private _handleVariableOptionsUpdate(variable: SceneVariable) {
+    this._variablesToUpdate.add(variable);
+
+    this._updateNextBatch();
   }
 
   private _handleVariableValueChanged(variableThatChanged: SceneVariable) {

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -91,6 +91,10 @@ export class SceneVariableValueChangedEvent extends BusEventWithPayload<SceneVar
   public static type = 'scene-variable-changed-value';
 }
 
+export class SceneVariableOptionsRefreshEvent extends BusEventWithPayload<SceneVariable> {
+  public static type = 'scene-variable-options-refresh';
+}
+
 export interface SceneVariableDependencyConfigLike {
   /** Return all variable names this object depend on */
   getNames(): Set<string>;

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -15,6 +15,7 @@ import {
   VariableValueSingle,
   CustomVariableValue,
   VariableCustomFormatterFn,
+  SceneVariableOptionsRefreshEvent,
 } from '../types';
 import { formatRegistry } from '../interpolation/formatRegistry';
 import { VariableFormatID } from '@grafana/schema';
@@ -327,6 +328,10 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     }
 
     return options;
+  }
+
+  public refreshOptions() {
+    this.publishEvent(new SceneVariableOptionsRefreshEvent(this), true);
   }
 
   /**


### PR DESCRIPTION
Add possibility to manually trigger a variable options refresh after a state change. Needed for various variable components in react scenes. E.g.: https://github.com/grafana/scenes/pull/820