### PR TITLE
VizPanelRenderer: Set attention with onMouseEnter

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -164,6 +164,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             onCancelQuery={model.onCancelQuery}
             // @ts-ignore
             onFocus={setPanelAttention}
+            onMouseEnter={setPanelAttention}
             onMouseMove={debouncedMouseMove}
           >
             {(innerWidth, innerHeight) => (


### PR DESCRIPTION
Fixes inconsistencies with setting panel attention from mouse movements. Requires [#90435](https://github.com/grafana/grafana/pull/90435) to be merged. I had some troubles testing it locally, as the keybindings didn't seem to work. Maybe my Scenes setup it a bit off?