### PR TITLE
Add variable dependency config to SceneGridRow

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -12,6 +12,7 @@ import { GRID_COLUMN_COUNT } from './constants';
 import { SceneGridItemLike, SceneGridItemStateLike } from './types';
 import { sceneGraph } from '../../../core/sceneGraph';
 import { selectors } from '@grafana/e2e-selectors';
+import { VariableDependencyConfig } from '../../../variables/VariableDependencyConfig';
 
 export interface SceneGridRowState extends SceneGridItemStateLike {
   title: string;
@@ -23,6 +24,10 @@ export interface SceneGridRowState extends SceneGridItemStateLike {
 
 export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
   public static Component = SceneGridRowRenderer;
+
+  protected _variableDependency = new VariableDependencyConfig(this, {
+    statePaths: ['title'],
+  });
 
   public constructor(state: Partial<SceneGridRowState>) {
     super({


### PR DESCRIPTION
Adds variable dependency config to SceneGridRow, fixing an issue where the row title wasn't updated when the variable option was changed.