### PR TITLE
fix(lazyloader): fix trying to run inexistent callbacks

### DIFF
--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -52,18 +52,18 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
       }
 
       return () => {
-        delete LazyLoader.callbacks[id];
         wrapperEl && LazyLoader.observer.unobserve(wrapperEl);
         if (Object.keys(LazyLoader.callbacks).length === 0) {
           LazyLoader.observer.disconnect();
         }
+        delete LazyLoader.callbacks[id];
       };
     });
 
     // If the element was loaded, we add the `hideEmpty` class to potentially
     // hide the LazyLoader if it does not have any children. This is the case
-    // when children have the `isHidden` property set. 
-    // We always include the `className` class, as this is coming from the 
+    // when children have the `isHidden` property set.
+    // We always include the `className` class, as this is coming from the
     // caller of the `LazyLoader` component.
     const classes = `${loaded ? hideEmpty : ''} ${className}`;
     return (
@@ -90,7 +90,9 @@ LazyLoader.addCallback = (id: string, c: (e: IntersectionObserverEntry) => void)
 LazyLoader.observer = new IntersectionObserver(
   (entries) => {
     for (const entry of entries) {
-      LazyLoader.callbacks[entry.target.id](entry);
+      if (typeof LazyLoader.callbacks[entry.target.id] === 'function') {
+        LazyLoader.callbacks[entry.target.id](entry);
+      }
     }
   },
   { rootMargin: '100px' }

--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -53,10 +53,10 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
 
       return () => {
         wrapperEl && LazyLoader.observer.unobserve(wrapperEl);
+        delete LazyLoader.callbacks[id];
         if (Object.keys(LazyLoader.callbacks).length === 0) {
           LazyLoader.observer.disconnect();
         }
-        delete LazyLoader.callbacks[id];
       };
     });
 


### PR DESCRIPTION
Not a big sample size, but I saw this error in our app logs:
https://ops.grafana-ops.net/a/grafana-lokiexplore-app/explore/service/Hosted%20Grafana%20-%20Prod/logs?patterns=%5B%5D&var-fields=&var-ds=grafanacloud-logs&var-filters=service_name%7C%3D%7CHosted%20Grafana%20-%20Prod&var-filters=kind%7C%3D%7Cexception&var-patterns=&var-lineFilter=%7C~%20%60%28%3Fi%29kl%5C.callbacks%5C%5Bt%5C.target%5C.id%5C%5D%20is%20not%20a%20function%60&var-logsFormat=%20%7C%20logfmt&urlColumns=%5B%5D&visualizationType=%22logs%22&var-labelBy=$__all&var-fieldBy=page_url&from=now-12h&to=now&timezone=browser

Basically trying to call an inexistent callback. By assumption is that it is a race condition, where the callback is deleted before the `IntersectionObserver` stopped observing. Thus, moving the deletion of callbacks after the unobserve call of the `InteractionObserver` and making sure the callback is a function.