### PR TITLE
Scenes: Move change panel plugin logic in VizPanel

### DIFF
--- a/packages/scenes-app/src/demos/dynamicPanelOptions.tsx
+++ b/packages/scenes-app/src/demos/dynamicPanelOptions.tsx
@@ -15,7 +15,7 @@ import {
 } from '@grafana/scenes';
 import { RadioButtonGroup } from '@grafana/ui';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
-import { GraphDrawStyle, LegendDisplayMode, StackingMode, TooltipDisplayMode } from '@grafana/schema';
+import { GraphDrawStyle, LegendDisplayMode, StackingMode, TooltipDisplayMode, VizOrientation } from '@grafana/schema';
 
 export function getDynamicVizOptionsTest(defaults: SceneAppPageState) {
   return new SceneAppPage({
@@ -27,7 +27,7 @@ export function getDynamicVizOptionsTest(defaults: SceneAppPageState) {
         key: 'Dynamic options demo',
         $data: getQueryRunnerWithRandomWalkQuery({ seriesCount: 3, spread: 15 }, { maxDataPoints: 50 }),
         body: new SceneFlexLayout({
-          direction: 'row',
+          direction: 'column',
           children: [
             new SceneFlexItem({
               body: PanelBuilders.timeseries()
@@ -35,11 +35,58 @@ export function getDynamicVizOptionsTest(defaults: SceneAppPageState) {
                 .setHeaderActions([new VizOptions({ value: 'lines' })])
                 .build(),
             }),
+            new SceneFlexItem({
+              body: PanelBuilders.timeseries()
+                .setTitle('Graph')
+                .setHeaderActions([new VizChange({ value: 'timeseries' })])
+                .build(),
+            }),
           ],
         }),
       });
     },
   });
+}
+
+interface VizChangeState extends SceneObjectState {
+  value: string;
+}
+
+class VizChange extends SceneObjectBase<VizChangeState> {
+  public onChange = (value: string) => {
+    this.setState({ value });
+    const viz = this.parent as VizPanel;
+
+    if (value === 'timeseries') {
+      viz.changePluginType('timeseries');
+    } else if (value === 'stat') {
+      viz.changePluginType('stat');
+    } else if (value === 'gauge_extra') {
+      const options = PanelOptionsBuilders.gauge()
+      .setOption('orientation', VizOrientation.Vertical)
+      .build();
+
+      const fieldConfig = FieldConfigBuilders.gauge().setUnit('accMS2').build();
+      
+      viz.changePluginType('gauge', options, fieldConfig);
+    }
+  }
+
+  public static Component = ({ model }: SceneComponentProps<VizOptions>) => {
+    const { value } = model.useState();
+
+    const vizOptions = [
+      { label: 'Timeseries panel', value: 'timeseries' },
+      { label: 'Stat', value: 'stat' },
+      { label: 'Gauge with extra config', value: 'gauge_extra' },
+    ];
+
+    return (
+      <>
+        <RadioButtonGroup value={value} options={vizOptions} onChange={model.onChange} size="sm" />
+      </>
+    );
+  };
 }
 
 interface VizOptionsState extends SceneObjectState {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -255,25 +255,17 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   };
 
   public async changePluginType(pluginId: string, options?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource) {
-    //we need old state for newOptions
     const {
       options: prevOptions,
       fieldConfig: prevFieldConfig,
       pluginId: prevPluginId,
     } = this.state;
 
-    //clear field config cache
+    //clear field config cache to update it later
     this._dataWithFieldConfig = undefined;
 
-    //we need options/fieldConfig to be set in loadPlugin to handle scenario where we 
-    //need the default options. e.g.: we change plugin type to new plugin that
-    //has no cached options, so we need to get default options merged with {}, instead
-    //of old plugin options, so we do not pollute new plugin options.
-    // but we cannot just set the state to {} because things will crash on rerender(e.g.: PanelOptions)
-    // because it expects options to have properties.
     await this._loadPlugin(pluginId, options ?? {}, newFieldConfig, true);
 
-    //update options if a migration is needed
     const panel: PanelModel = {
       title: this.state.title,
       options: this.state.options,
@@ -284,7 +276,6 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     const newOptions = this._plugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
 
-    //newOptions returns empty when changing to timeseries, we need isEmpty, otherwise it loses cachedOptions
     if (newOptions && !isEmpty(newOptions)) {
       this.onOptionsChange(newOptions, true, true);
     }

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -254,7 +254,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     return sceneTimeRange.state.value;
   };
 
-  public async changePluginType(pluginId: string, options?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource) {
+  public async changePluginType(pluginId: string, newOptions?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource) {
     const {
       options: prevOptions,
       fieldConfig: prevFieldConfig,
@@ -264,7 +264,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     //clear field config cache to update it later
     this._dataWithFieldConfig = undefined;
 
-    await this._loadPlugin(pluginId, options ?? {}, newFieldConfig, true);
+    await this._loadPlugin(pluginId, newOptions ?? {}, newFieldConfig, true);
 
     const panel: PanelModel = {
       title: this.state.title,
@@ -274,10 +274,12 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       type: pluginId,
     };
 
-    const newOptions = this._plugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
+    // onPanelTypeChanged is mainly used by plugins to migrate from Angular to React. 
+    // For example, this will migrate options from 'graph' to 'timeseries' if the previous and new plugin ID matches. 
+    const updatedOptions = this._plugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
 
-    if (newOptions && !isEmpty(newOptions)) {
-      this.onOptionsChange(newOptions, true, true);
+    if (updatedOptions && !isEmpty(updatedOptions)) {
+      this.onOptionsChange(updatedOptions, true, true);
     }
   }
 


### PR DESCRIPTION
This PR moves panel plugin logic from grafana, from `VizPanelManager` (related [PR](https://github.com/grafana/grafana/pull/90535) ) into the `VizPanel`. This is needed because the `VizPanel` is aware of when the plugin is updated and we need the new plugin to fetch default configs, to be able to merge existing options/fieldConfigs, if they exist, with default ones.

This also changes things a bit in the sense that we no longed create a new `VizPanel` but reuse the existing one by updating it's state with the updated options/fieldConfigs. In the `changePluginType` function we receive overwrite options and fieldConfigs which represent, in the context of core Grafana, configs that are cached when switching panels in panel edit. These configurations, if present, are passed to the VizPanel to properly set both existing configs and default panel plugin configs after loading the new plugin. If we do not have any cached configs then we will load the new panel with default values.

TODO:
- [x] Add a demo [here](http://localhost:3000/a/grafana-scenes-app/demos/dynamic-panel-options-and-field-config) for dynamically changing a plugin panel.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.5.0--canary.836.9987320115.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.5.0--canary.836.9987320115.0
  npm install @grafana/scenes@5.5.0--canary.836.9987320115.0
  # or 
  yarn add @grafana/scenes-react@5.5.0--canary.836.9987320115.0
  yarn add @grafana/scenes@5.5.0--canary.836.9987320115.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
