### PR TITLE
QueryVariable: Query is empty string by default

### DIFF
--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -109,6 +109,17 @@ class FakeQueryRunner implements QueryRunner {
 
 describe('QueryVariable', () => {
   describe('When empty query is provided', () => {
+    it('Should default to empty query', async () => {
+      const variable = new QueryVariable({ name: 'test' });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.query).toEqual('');
+      expect(variable.state.value).toEqual('');
+      expect(variable.state.text).toEqual('');
+      expect(variable.state.options).toEqual([]);
+    });
+
     it('Should default to empty options and empty value', async () => {
       const variable = new QueryVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -53,7 +53,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
       options: [],
       datasource: null,
       regex: '',
-      query: { refId: 'A' },
+      query: '',
       refresh: VariableRefresh.onDashboardLoad,
       sort: VariableSort.disabled,
       ...initialState,


### PR DESCRIPTION
**Problem**
The default it was an empty object. In Grafana this was defaulted to an empty string and this is creating compatibility issues.

**Solution**
Setting empty string to the state should solve the problem
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.4.1--canary.837.9977135077.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.4.1--canary.837.9977135077.0
  npm install @grafana/scenes@5.4.1--canary.837.9977135077.0
  # or 
  yarn add @grafana/scenes-react@5.4.1--canary.837.9977135077.0
  yarn add @grafana/scenes@5.4.1--canary.837.9977135077.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
