### PR TITLE
Update timerange in templateSrv for queryVars

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -130,6 +130,7 @@ jest.mock('@grafana/runtime', () => ({
   },
   getTemplateSrv: () => ({
     getAdhocFilters: jest.fn(),
+    updateTimeRange: jest.fn(),
   }),
   config: {
     theme: {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -27,6 +27,7 @@ import { FiltersRequestEnricher } from '../../core/types';
 
 const templateSrv = {
   getAdhocFilters: jest.fn().mockReturnValue([{ key: 'origKey', operator: '=', value: '' }]),
+  updateTimeRange: jest.fn()
 } as any;
 
 describe('AdHocFiltersVariable', () => {

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -27,6 +27,7 @@ import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { SEARCH_FILTER_VARIABLE } from '../../constants';
 import { debounce } from 'lodash';
 import { registerQueryWithController } from '../../../querying/registerQueryWithController';
+import { getTemplateSrv } from '@grafana/runtime';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
@@ -76,6 +77,8 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
         const runner = createQueryVariableRunner(ds);
         const target = runner.getTarget(this);
         const request = this.getRequest(target, args.searchFilter);
+
+        getTemplateSrv().updateTimeRange(request.range);
 
         return runner.runRequest({ variable: this, searchFilter: args.searchFilter }, request).pipe(
           registerQueryWithController({

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -27,7 +27,6 @@ import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { SEARCH_FILTER_VARIABLE } from '../../constants';
 import { debounce } from 'lodash';
 import { registerQueryWithController } from '../../../querying/registerQueryWithController';
-import { getTemplateSrv } from '@grafana/runtime';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
@@ -77,8 +76,6 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
         const runner = createQueryVariableRunner(ds);
         const target = runner.getTarget(this);
         const request = this.getRequest(target, args.searchFilter);
-
-        getTemplateSrv().updateTimeRange(request.range);
 
         return runner.runRequest({ variable: this, searchFilter: args.searchFilter }, request).pipe(
           registerQueryWithController({


### PR DESCRIPTION
We have an [escalation](https://github.com/grafana/support-escalations/issues/11540) around the ADS DS, where the timerange is not being picked on query. The time range is being pulled from templateSrv [here](https://github.com/grafana/azure-data-explorer-datasource/blob/4e52da60758a51f898040bb9fd4829e1aab6d6a7/src/datasource.ts#L501), but with the new scenes architecture this range is null/never updated in templateSrv. This PR updates the timerange using the request range in `QueryVariable.tsx`, before querying in the plugin itself.

In the old architecture there were events dispatched on various actions to update the timerange in the templateSrv. It seems in scenes we aren't updating it at all so the templateSrv timerange is always null. Updating templateSrv in SceneTimeRange on state update should cover most cases where range in templateSrv is needed, I think.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.1--canary.840.10038144895.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.6.1--canary.840.10038144895.0
  npm install @grafana/scenes@5.6.1--canary.840.10038144895.0
  # or 
  yarn add @grafana/scenes-react@5.6.1--canary.840.10038144895.0
  yarn add @grafana/scenes@5.6.1--canary.840.10038144895.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
