### PR TITLE
Make UrlSyncManager non singleton

### DIFF
--- a/packages/scenes-react/src/contexts/SceneContextObject.tsx
+++ b/packages/scenes-react/src/contexts/SceneContextObject.tsx
@@ -4,17 +4,18 @@ import {
   SceneObjectState,
   SceneVariable,
   SceneVariableSet,
-  getUrlSyncManager,
+  UrlSyncManager,
 } from '@grafana/scenes';
 import { writeSceneLog } from '../utils';
 
 export interface SceneContextObjectState extends SceneObjectState {
   childContexts?: SceneContextObject[];
   children: SceneObject[];
+  urlSyncManager: UrlSyncManager;
 }
 
 export class SceneContextObject extends SceneObjectBase<SceneContextObjectState> {
-  public constructor(state?: Partial<SceneContextObjectState>) {
+  public constructor(state: Partial<SceneContextObjectState> & { urlSyncManager: UrlSyncManager}) {
     super({
       ...state,
       children: state?.children ?? [],
@@ -23,7 +24,7 @@ export class SceneContextObject extends SceneObjectBase<SceneContextObjectState>
   }
 
   public addToScene(obj: SceneObject) {
-    getUrlSyncManager().handleNewObject(obj);
+    this.state.urlSyncManager.handleNewObject(obj);
 
     this.setState({ children: [...this.state.children, obj] });
     writeSceneLog('SceneContext', `Adding to scene: ${obj.constructor.name} key: ${obj.state.key}`);
@@ -54,7 +55,7 @@ export class SceneContextObject extends SceneObjectBase<SceneContextObjectState>
   public addVariable(variable: SceneVariable) {
     let set = this.state.$variables as SceneVariableSet;
 
-    getUrlSyncManager().handleNewObject(variable);
+    this.state.urlSyncManager.handleNewObject(variable);
 
     if (set) {
       set.setState({ variables: [...set.state.variables, variable] });

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -1,5 +1,5 @@
 import { NavModelItem, UrlQueryMap } from '@grafana/data';
-import { PluginPage } from '@grafana/runtime';
+import { PluginPage, useLocationService } from '@grafana/runtime';
 import React, { useEffect, useLayoutEffect } from 'react';
 
 import { RouteComponentProps } from 'react-router-dom';
@@ -23,6 +23,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   const scene = page.getScene(routeProps.match);
   const isInitialized = containerState.initializedScene === scene;
   const {layout} = page.state;
+  const locationService = useLocationService();
 
   useLayoutEffect(() => {
     // Before rendering scene components, we are making sure the URL sync is enabled for.
@@ -46,7 +47,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
     text: containerState.title,
     img: containerState.titleImg,
     icon: containerState.titleIcon,
-    url: getUrlWithAppState(containerState.url, containerState.preserveUrlKeys),
+    url: getUrlWithAppState(containerState.url, locationService.getSearchObject(), containerState.preserveUrlKeys),
     hideFromBreadcrumbs: containerState.hideFromBreadcrumbs,
     parentItem: getParentBreadcrumbs(
       containerState.getParentPage ? containerState.getParentPage() : containerPage.parent,
@@ -61,7 +62,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
         icon: tab.state.titleIcon,
         tabSuffix: tab.state.tabSuffix,
         active: page === tab,
-        url: getUrlWithAppState(tab.state.url, tab.state.preserveUrlKeys),
+        url: getUrlWithAppState(tab.state.url, locationService.getSearchObject(), tab.state.preserveUrlKeys),
         parentItem: pageNav,
       };
     });
@@ -106,7 +107,7 @@ function getParentBreadcrumbs(parent: SceneObject | undefined, params: UrlQueryM
   if (parent instanceof SceneAppPage) {
     return {
       text: parent.state.title,
-      url: getUrlWithAppState(parent.state.url, parent.state.preserveUrlKeys),
+      url: getUrlWithAppState(parent.state.url, params, parent.state.preserveUrlKeys),
       hideFromBreadcrumbs: parent.state.hideFromBreadcrumbs,
       parentItem: getParentBreadcrumbs(
         parent.state.getParentPage ? parent.state.getParentPage() : parent.parent,

--- a/packages/scenes/src/components/SceneApp/utils.ts
+++ b/packages/scenes/src/components/SceneApp/utils.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RouteComponentProps, useLocation } from 'react-router-dom';
 import { UrlQueryMap, locationUtil, urlUtil } from '@grafana/data';
-import { locationSearchToObject, locationService } from '@grafana/runtime';
+import { locationSearchToObject } from '@grafana/runtime';
 import { SceneObject } from '../../core/types';
 
 export function useAppQueryParams(): UrlQueryMap {
@@ -12,12 +12,13 @@ export function useAppQueryParams(): UrlQueryMap {
 /**
  *
  * @param path Url to append query params to
+ * @param searchParams Query params to be modified
  * @param preserveParams Query params to preserve
  * @returns Url with query params
  */
-export function getUrlWithAppState(path: string, preserveParams?: string[]): string {
+export function getUrlWithAppState(path: string, searchParams: UrlQueryMap, preserveParams?: string[]): string {
   // make a copy of params as the renderUrl function mutates the object
-  const paramsCopy = { ...locationService.getSearchObject() };
+  const paramsCopy = { ...searchParams };
 
   if (preserveParams) {
     for (const key of Object.keys(paramsCopy)) {

--- a/packages/scenes/src/services/UrlSyncManager.tsx
+++ b/packages/scenes/src/services/UrlSyncManager.tsx
@@ -6,7 +6,7 @@ import { writeSceneLog } from '../utils/writeSceneLog';
 import { Unsubscribable } from 'rxjs';
 import { UniqueUrlKeyMapper } from './UniqueUrlKeyMapper';
 import { getUrlState, isUrlValueEqual, syncStateFromUrl } from './utils';
-import { LocationService, locationService } from '@grafana/runtime';
+import { LocationService } from '@grafana/runtime';
 
 export interface UrlSyncManagerLike {
   initSync(root: SceneObject): void;
@@ -21,9 +21,11 @@ export class UrlSyncManager implements UrlSyncManagerLike {
   private _sceneRoot?: SceneObject;
   private _stateSub: Unsubscribable | null = null;
   private _lastLocation: Location | undefined;
-  private _paramsCache = new UrlParamsCache();
+  private _paramsCache: UrlParamsCache;
 
-  public constructor(private locationService: LocationService = locationService) {}
+  public constructor(private locationService: LocationService = locationService) {
+    this._paramsCache = new UrlParamsCache(locationService);
+  }
 
   /**
    * Updates the current scene state to match URL state.
@@ -125,9 +127,14 @@ export class UrlSyncManager implements UrlSyncManagerLike {
 class UrlParamsCache {
   #cache: URLSearchParams | undefined;
   #location: Location | undefined;
+  #locationService: LocationService;
+
+  public constructor(locationServiceArg: LocationService) {
+    this.#locationService = locationServiceArg
+  }
 
   public getParams(): URLSearchParams {
-    const location = locationService.getLocation();
+    const location = this.#locationService.getLocation();
 
     if (this.#location === location) {
       return this.#cache!;

--- a/packages/scenes/src/services/useUrlSync.ts
+++ b/packages/scenes/src/services/useUrlSync.ts
@@ -1,11 +1,28 @@
+import { useLocationService } from '@grafana/runtime';
+
 import { SceneObject } from '../core/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getUrlSyncManager } from './UrlSyncManager';
-import { locationService } from '@grafana/runtime';
+import { UrlSyncManager } from './UrlSyncManager';
 
 export function useUrlSync(sceneRoot: SceneObject): boolean {
-  const urlSyncManager = getUrlSyncManager();
+  const locationService = useLocationService();
+  const urlSyncManager = useMemo(() => {
+    // TODO: not sure what to do with these typings
+    // @ts-ignore
+    if (sceneRoot.state.urlSyncManager) {
+      // The assumption here is that we need to pass it only in case this get initialized from the
+      // UrlSyncContextProvider. In other cases this will create a new syncManager and hopefully that is ok as this
+      // should be called once somewhere in the root of the scene.
+
+      // @ts-ignore
+      return sceneRoot.state.urlSyncManager;
+    }
+
+    return new UrlSyncManager(locationService)
+  }, [locationService, sceneRoot]);
+
+
   const location = useLocation();
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -25,7 +42,7 @@ export function useUrlSync(sceneRoot: SceneObject): boolean {
     }
 
     urlSyncManager.handleNewLocation(locationToHandle);
-  }, [sceneRoot, urlSyncManager, location]);
+  }, [sceneRoot, urlSyncManager, location, locationService]);
 
   return isInitialized;
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/93225
This changes the UrlSyncManager to be used as non singleton.

This relies on this grafana PR: https://github.com/grafana/grafana/pull/90759. Also see the whole demo branch for the Sidecar project here https://github.com/grafana/grafana/pull/88797.

This isn't much changes but need some advice on how to approach any possible backward compatibility issues and testing. As there was already some code created with the non singleton use in mind the changes to apps seem minimal. See this draft PR for the Explore Traces app: https://github.com/grafana/explore-traces/pull/102