### PR TITLE
Interpolation: Backwards compatibility for SafeSerializableSceneObject

### DIFF
--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -9,6 +9,7 @@ import { lookupVariable } from '../../variables/lookupVariable';
 import { getClosest } from './utils';
 import { SceneQueryControllerLike, isQueryController } from '../../behaviors/SceneQueryController';
 import { VariableInterpolation } from '@grafana/runtime';
+import { SafeSerializableSceneObject } from '../../utils/SafeSerializableSceneObject';
 
 /**
  * Get the closest node with variables
@@ -59,8 +60,13 @@ export function interpolate(
   if (value === '' || value == null) {
     return '';
   }
+  let targetObject = sceneObject;
 
-  return sceneInterpolator(sceneObject, value, scopedVars, format, interpolations);
+  if (sceneObject instanceof SafeSerializableSceneObject) {
+    targetObject = sceneObject.valueOf();
+  }
+
+  return sceneInterpolator(targetObject, value, scopedVars, format, interpolations);
 }
 
 /**


### PR DESCRIPTION
When using latest scenes apps against an older version of grafana (prior https://github.com/grafana/grafana/pull/90272), the `sceneGraph.interpolate` will get a `SafeSerializableSceneObject` as a target which... isn't a scene object but a wrapper for one. This is because we are passing plain scopedVars.__sceneObject.value here https://github.com/grafana/grafana/blob/v11.1.0/public/app/features/templating/template_srv.ts#L253 which used to be a plain scene object, but it isn't anymore
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.2--canary.843.10055590290.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.6.2--canary.843.10055590290.0
  npm install @grafana/scenes@5.6.2--canary.843.10055590290.0
  # or 
  yarn add @grafana/scenes-react@5.6.2--canary.843.10055590290.0
  yarn add @grafana/scenes@5.6.2--canary.843.10055590290.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
