### PR TITLE
SafeSerializableSceneObject: Make sure valueOf is bound to the instance

### DIFF
--- a/packages/scenes/src/utils/SafeSerializableSceneObject.test.ts
+++ b/packages/scenes/src/utils/SafeSerializableSceneObject.test.ts
@@ -1,0 +1,22 @@
+import { cloneDeep } from 'lodash';
+import { TestScene } from '../variables/TestScene';
+import { SafeSerializableSceneObject } from './SafeSerializableSceneObject';
+
+describe('SafeSerializableSceneObject', () => {
+  test('it should resolve the correct wrapped scene object when cloned deep', () => {
+    const sceneObject = new TestScene({});
+
+    const source = new SafeSerializableSceneObject(sceneObject);
+
+    const cloned = cloneDeep(source);
+
+    expect(cloned).not.toBe(source);
+    // SafeSerializableSceneObject.value always returns itself
+    expect(cloned.value).not.toBe(source.value);
+    expect(cloned.value.valueOf()).toBe(sceneObject);
+
+    // SafeSerializableSceneObject.valueOf always returns the originally wrapped scene object
+    expect(cloned.value.valueOf()).toBe(source.value.valueOf());
+    expect(cloned.valueOf()).toBe(sceneObject);
+  });
+});

--- a/packages/scenes/src/utils/SafeSerializableSceneObject.ts
+++ b/packages/scenes/src/utils/SafeSerializableSceneObject.ts
@@ -14,9 +14,9 @@ export class SafeSerializableSceneObject implements ScopedVar {
     return undefined;
   }
 
-  public valueOf() {
+  public valueOf = () => {
     return this.#value;
-  }
+  };
 
   public get value() {
     return this;


### PR DESCRIPTION
This PR fixes an issue that may occur when the data source that interpolates queries uses `cloneDeep` to clone the provided query request. For example:

https://github.com/grafana/athena-datasource/blob/v2.17.1/src/datasource.ts#L104
https://github.com/grafana/grafana/blob/v11.1.2/public/app/plugins/datasource/cloudwatch/datasource.ts#L88

When such an object is cloned the previously unbound `SafeSerializableSceneObject.valueOf` would change `this` context that would point to the newly (cloned) created instance. This creates an issue with the code generated by typescript when using private properties (#). The diff of the compiled code can be observed here:
https://www.diffchecker.com/WLJEvKvj/

The `cloneDeep` _will not call_ the cloned object constructor - this means that the originally bound `valueOf` function _must_ preserve the `this` context of the source object.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.2--canary.844.10073760230.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.6.2--canary.844.10073760230.0
  npm install @grafana/scenes@5.6.2--canary.844.10073760230.0
  # or 
  yarn add @grafana/scenes-react@5.6.2--canary.844.10073760230.0
  yarn add @grafana/scenes@5.6.2--canary.844.10073760230.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
