### PR TITLE
Demo: Demonstrate event traversal through scene graph

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -38,6 +38,7 @@ import { getDynamicDataLayersDemo } from './dynamicDataLayers';
 import { getInteropDemo } from './interopDemo';
 import { getUrlSyncTest } from './urlSyncTest';
 import { getMlDemo } from './ml';
+import { getSceneGraphEventsDemo } from './sceneGraphEvents';
 
 export interface DemoDescriptor {
   title: string;
@@ -85,5 +86,6 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Interop with hooks and context', getPage: getInteropDemo },
     { title: 'Url sync test', getPage: getUrlSyncTest },
     { title: 'Machine Learning', getPage: getMlDemo },
+    { title: 'Events on the Scene Graph', getPage: getSceneGraphEventsDemo},
   ].sort((a, b) => a.title.localeCompare(b.title));
 }

--- a/packages/scenes-app/src/demos/sceneGraphEvents.tsx
+++ b/packages/scenes-app/src/demos/sceneGraphEvents.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect } from 'react'
+
+import {
+  EmbeddedScene,
+  SceneAppPageState,
+  SceneAppPage,
+  SceneObjectBase,
+  SceneObjectState,
+  sceneGraph,
+} from '@grafana/scenes';
+import { BusEventWithPayload } from '@grafana/data';
+import { Button, Stack, useStyles2, useTheme2 } from '@grafana/ui';
+
+export function getSceneGraphEventsDemo(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Illustrating how events traverse the scene graph',
+    getScene: () => {
+
+      const childrenKeys = Array.from("ABC");
+
+
+      const parentScene = new ExampleSceneObject({
+        key: "parentScene",
+        children:
+          [
+            ...childrenKeys.map(key => new ExampleSceneObject(
+              { key }
+            )),
+            new ExampleSceneObject(
+              {
+                key: "SUB",
+                children: childrenKeys.map(
+                  (key) => new ExampleSceneObject(
+                    { key: `SUB-${key}` }
+                  )
+                )
+              }
+            )
+          ]
+      });
+
+      return new EmbeddedScene({
+        key: "The Embedded Scene",
+        body: parentScene
+      })
+
+    },
+  });
+}
+
+interface ExampleState extends SceneObjectState {
+  children: ExampleSceneObject[];
+  recentEvent?: string;
+}
+
+class ExampleSceneObject extends SceneObjectBase<ExampleState> {
+
+  constructor(state: Partial<ExampleState>) {
+    const behaviors = state.$behaviors || [];
+    const children = state.children || [];
+    super({
+      ...state,
+      children,
+      $behaviors: [...behaviors, listen],
+    })
+  }
+
+  static Component = ExampleSceneComponent;
+}
+
+const listen = (sceneObject: ExampleSceneObject) => {
+  sceneObject.subscribeToEvent(ExampleEvent, (event) => {
+    sceneObject.setState({ recentEvent: event.payload });
+  })
+}
+
+class ExampleEvent extends BusEventWithPayload<string | undefined> {
+  public static type = 'example-event';
+}
+
+function ExampleSceneComponent({ model }: { model: ExampleSceneObject }) {
+
+  const { key, children, recentEvent } = model.useState();
+
+  const [eventFlash, setEventFlash] = React.useState(false);
+
+  useEffect(() => {
+    const subscription = model.subscribeToEvent(ExampleEvent, (event) => {
+      setEventFlash(true);
+      setTimeout(() => setEventFlash(false), 500);
+    });
+    return subscription.unsubscribe;
+  }, [model, setEventFlash])
+
+  const theme = useTheme2();
+
+  const parentState = model.parent?.useState();
+
+  const triggerNonBubbleEvent = () => model.publishEvent(new ExampleEvent(`Non-bubble by ${key}`), false)
+  const triggerBubbleEvent = () => model.publishEvent(new ExampleEvent(`Bubble by ${key}`), true)
+  const clearDescendentEvents = () => sceneGraph.findDescendents(model, ExampleSceneObject).forEach(scene => scene.setState({ recentEvent: '' }))
+
+  return <div style={{ border: `${theme.colors.border.strong} 4px solid`, borderRadius: 8, padding: 4, margin: 8 }}>
+    <h2>I am: <em>{key}</em></h2>
+    <h4>My parent is: <em>{parentState?.key}</em></h4>
+    <Stack direction={'column'} alignItems={'flex-start'} >
+      <Button fullWidth={false} onClick={triggerBubbleEvent}>Bubble</Button>
+      <Button onClick={triggerNonBubbleEvent}>Non-Bubble</Button>
+      <Button onClick={()=>model.setState({recentEvent: ''})}>Clear</Button>
+      <Button onClick={clearDescendentEvents}>Clear Descendents</Button>
+    </Stack>
+    {
+      <div style={{ margin: 4, border: `${theme.colors.border.weak} solid 2px`, transitionDuration: '200ms', background: eventFlash ? theme.colors.action.selected : theme.colors.background.primary, transform: eventFlash ? 'scale(1.0, 1.5)' : '' }}>
+        {recentEvent && <>
+          <h3>Event:</h3>
+          <h5>{recentEvent}</h5>
+        </>
+        }
+      </div>
+    }
+    {children.length > 0 &&
+      <div style={{ border: `${theme.colors.border.medium} 3px solid`, borderRadius: 4, padding: 4, margin: 4, display: 'inline-block' }}>
+        Children of {key}:
+        <Stack>
+          {
+            children.map(child => <child.Component key={child.state.key} model={child} />)
+          }
+        </Stack>
+      </div>
+    }
+  </div>
+}

--- a/packages/scenes-app/src/demos/sceneGraphEvents.tsx
+++ b/packages/scenes-app/src/demos/sceneGraphEvents.tsx
@@ -9,7 +9,7 @@ import {
   sceneGraph,
 } from '@grafana/scenes';
 import { BusEventWithPayload } from '@grafana/data';
-import { Button, Stack, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, Stack, useTheme2 } from '@grafana/ui';
 
 export function getSceneGraphEventsDemo(defaults: SceneAppPageState) {
   return new SceneAppPage({

--- a/packages/scenes/src/core/sceneGraph/index.ts
+++ b/packages/scenes/src/core/sceneGraph/index.ts
@@ -12,6 +12,7 @@ import {
   hasVariableDependencyInLoadingState,
   interpolate,
   getAncestor,
+  findDescendents,
   getQueryController,
   getUrlSyncManager,
 } from './sceneGraph';
@@ -30,6 +31,7 @@ export const sceneGraph = {
   findObject,
   findAllObjects,
   getAncestor,
+  findDescendents,
   getQueryController,
   getUrlSyncManager,
 };

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -16,7 +16,8 @@ import { SceneVariable } from '../../variables/types';
 import { QueryVariable } from '../../variables/variants/query/QueryVariable';
 import { TestVariable } from '../../variables/variants/TestVariable';
 import { SceneDataNode } from '../SceneDataNode';
-import { SceneObject } from '../types';
+import { SceneObject, SceneObjectState } from '../types';
+import { SceneObjectBase } from '../SceneObjectBase';
 
 describe('sceneGraph', () => {
   it('Can find object', () => {
@@ -216,6 +217,75 @@ describe('sceneGraph', () => {
       }).toThrow();
     });
   });
+
+  describe('findDescendents', () => {
+    
+    class TestSceneObj extends SceneObjectBase<SceneObjectState & {children?: SceneObject[]}> {   
+    }
+    class TargetSceneObj extends TestSceneObj {   
+    }
+
+    const root = new TestSceneObj({
+      children: [
+        new TargetSceneObj({key: '1-target'}),
+        new TargetSceneObj({key: '2-target', children: [
+          new TargetSceneObj({key: '2-1-target'}),
+          new TestSceneObj({key: '2-2'}),
+        ]}),
+        new TestSceneObj({key: '3', children: [
+          new TargetSceneObj({key: '3-1-target'}),
+          new TestSceneObj({key: '3-2'}),
+          new TargetSceneObj({key: '3-3-target'}),
+        ]}),
+      ]
+    })
+    
+    it('Can find all descendents', ()=>{
+      const descendents = sceneGraph.findDescendents(root, TargetSceneObj);
+
+      // Only the descendents of the starting point with the target type should be present
+      expect(descendents.length).toBe(5);
+      expect(descendents.find((s => s.state.key === '1-target'))).toBeDefined();
+      expect(descendents.find((s => s.state.key === '2-target'))).toBeDefined();
+      expect(descendents.find((s => s.state.key === '2-1-target'))).toBeDefined();
+      expect(descendents.find((s => s.state.key === '3-1-target'))).toBeDefined();
+      expect(descendents.find((s => s.state.key === '3-3-target'))).toBeDefined();
+      // Not targets should not be present
+      expect(descendents.find((s => s.state.key === '2-2'))).toBeUndefined();
+      expect(descendents.find((s => s.state.key === '3-2'))).toBeUndefined();
+      // Starting point scene object should not be present
+      expect(descendents.find((s => s === root))).toBeUndefined();
+    })
+
+    it('Will only find descendents', ()=>{
+      const target2 = root.state.children?.[1];
+
+      expect(target2).toBeDefined();
+
+      if (!target2) {
+        return;
+      }
+
+      expect(target2.state.key).toBe('2-target');
+
+      const descendents = sceneGraph.findDescendents(target2, TargetSceneObj);
+      
+      // Only the descendents of the starting point with the target type should be present
+      expect(descendents.length).toBe(1);
+      expect(descendents.find((s => s.state.key === '2-1-target'))).toBeDefined();
+      // Parents and siblings of parents should not be present
+      expect(descendents.find((s => s.state.key === '1-target'))).toBeUndefined();
+      expect(descendents.find((s => s.state.key === '2-target'))).toBeUndefined();
+      // Cousins should not be present
+      expect(descendents.find((s => s.state.key === '3-1-target'))).toBeUndefined();
+      expect(descendents.find((s => s.state.key === '3-3-target'))).toBeUndefined();
+      // Not targets should not be present
+      expect(descendents.find((s => s.state.key === '2-2'))).toBeUndefined();
+      expect(descendents.find((s => s.state.key === '3-2'))).toBeUndefined();
+      // Starting point scene object should not be present
+      expect(descendents.find((s => s === target2))).toBeUndefined();
+    })
+  })
 
   describe('can find by key (and type)', () => {
     const data = new SceneDataNode();

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -227,10 +227,9 @@ export function getDataLayers(sceneObject: SceneObject, localOnly = false): Scen
   return collected;
 }
 
-interface Type<T> extends Function {
+interface SceneType<T> extends Function {
   new (...args: never[]): T;
 }
-
 
 /**
  * A utility function to find the closest ancestor of a given type. This function expects
@@ -238,7 +237,7 @@ interface Type<T> extends Function {
  */
 export function getAncestor<ParentType>(
   sceneObject: SceneObject,
-  ancestorType: Type<ParentType>
+  ancestorType: SceneType<ParentType>
 ): ParentType {
   let parent: SceneObject | undefined = sceneObject;
 
@@ -259,7 +258,7 @@ export function getAncestor<ParentType>(
 /**
  * This will search down the full scene graph, looking for objects that match the provided descendentType type.
  */
-export function findDescendents<T extends SceneObject>(scene: SceneObject, descendentType: Type<T>) {
+export function findDescendents<T extends SceneObject>(scene: SceneObject, descendentType: SceneType<T>) {
   function isDescendentType(scene: SceneObject): scene is T {
     return scene instanceof descendentType;
   }

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -227,13 +227,18 @@ export function getDataLayers(sceneObject: SceneObject, localOnly = false): Scen
   return collected;
 }
 
+interface Type<T> extends Function {
+  new (...args: never[]): T;
+}
+
+
 /**
  * A utility function to find the closest ancestor of a given type. This function expects
  * to find it and will throw an error if it does not.
  */
 export function getAncestor<ParentType>(
   sceneObject: SceneObject,
-  ancestorType: { new (...args: never[]): ParentType }
+  ancestorType: Type<ParentType>
 ): ParentType {
   let parent: SceneObject | undefined = sceneObject;
 
@@ -249,6 +254,18 @@ export function getAncestor<ParentType>(
   }
 
   return parent as ParentType;
+}
+
+/**
+ * This will search down the full scene graph, looking for objects that match the provided descendentType type.
+ */
+export function findDescendents<T extends SceneObject>(scene: SceneObject, descendentType: Type<T>) {
+  function isDescendentType(scene: SceneObject): scene is T {
+    return scene instanceof descendentType;
+  }
+
+  const targetScenes = findAllObjects(scene, isDescendentType);
+  return targetScenes.filter(isDescendentType);
 }
 
 /**


### PR DESCRIPTION
- Added a demo to show how bubble events traverse the scene graph.

- Added a sceneGraph.findDescendents (by type) utility function

[Screencast_20240725_145040.webm](https://github.com/user-attachments/assets/8c886a6c-c448-4b1a-b6ab-5c752763b844)
