### PR TITLE
Allow setting _skipOnLayoutChange in SceneGridLayout

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -122,6 +122,10 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
     this.setState({});
   }
 
+  public ignoreLayoutChange(shouldIgnore: boolean) {
+    this._skipOnLayoutChange = shouldIgnore;
+  }
+
   public onLayoutChange = (layout: ReactGridLayout.Layout[]) => {
     if (this._skipOnLayoutChange) {
       // Layout has been updated by other RTL handler already


### PR DESCRIPTION
Needed for https://github.com/grafana/grafana/pull/91139
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.7.0--canary.849.10147076284.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.7.0--canary.849.10147076284.0
  npm install @grafana/scenes@5.7.0--canary.849.10147076284.0
  # or 
  yarn add @grafana/scenes-react@5.7.0--canary.849.10147076284.0
  yarn add @grafana/scenes@5.7.0--canary.849.10147076284.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
