### PR TITLE
SceneVariableSet: Update all variables in case of error

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -631,6 +631,46 @@ describe('SceneVariableList', () => {
 
       expect(A.state.error).toBe('Danger!');
     });
+
+    it('Should complete updating chained variables in case of error', () => {
+      const A = new TestVariable({
+        name: 'A',
+        query: 'A.*',
+        value: '',
+        text: '',
+        options: [],
+        throwError: 'Error in A',
+      });
+      const B = new TestVariable({
+        name: 'B',
+        query: 'A.$A.*',
+        value: '',
+        text: '',
+        options: [],
+        throwError: 'Error in B',
+      });
+      const C = new TestVariable({
+        name: 'C',
+        query: 'value=$B',
+        value: '',
+        text: '',
+        options: [],
+        throwError: 'Error in C',
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [C, B, A] }),
+      });
+
+      scene.activate();
+
+      expect(A.state.loading).toBe(false);
+      expect(A.state.error).toBe('Error in A');
+      expect(B.state.loading).toBe(false);
+      expect(B.state.error).toBe('Error in B');
+      expect(C.state.loading).toBe(false);
+      expect(C.state.error).toBe('Error in C');
+    });
   });
 
   describe('When nesting SceneVariableSet', () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -253,6 +253,9 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     console.error('SceneVariableSet updateAndValidate error', err);
 
     writeVariableTraceLog(variable, 'updateAndValidate error', err);
+
+    this._notifyDependentSceneObjects(variable);
+    this._updateNextBatch();
   }
 
   private _handleVariableValueChanged(variableThatChanged: SceneVariable) {


### PR DESCRIPTION
when we have chained variables in a repeat panel and one of them fails we do not update remaining ones and repeated panel does not appear because remaining variables are stuck in loading state that forces early return in repeat panel logic and does not render anything. 

In order to render the panel with some sort of error message all variables should finish updating.

part of https://github.com/grafana/grafana/pull/91149

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.7.1--canary.850.10147682812.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.7.1--canary.850.10147682812.0
  npm install @grafana/scenes@5.7.1--canary.850.10147682812.0
  # or 
  yarn add @grafana/scenes-react@5.7.1--canary.850.10147682812.0
  yarn add @grafana/scenes@5.7.1--canary.850.10147682812.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
