### PR TITLE
VizPanel: React to RefreshEvent for non-data changes

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -189,7 +189,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                           onOptionsChange={model.onOptionsChange}
                           onFieldConfigChange={model.onFieldConfigChange}
                           onChangeTimeRange={model.onTimeRangeChange}
-                          eventBus={appEvents}
+                          eventBus={context.eventBus}
                         />
                       )}
                     </PanelContextProvider>

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -11,11 +11,6 @@ jest.mock('@grafana/data', () => ({
   setWeekStart: jest.fn(),
 }));
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  RefreshEvent: jest.fn(() => ({ type: 'refresh-event' })),
-}));
-
 config.bootData = { user: { weekStart: 'monday' } } as any;
 
 function simulateDelay(newDateString: string, scene: EmbeddedScene) {
@@ -24,10 +19,6 @@ function simulateDelay(newDateString: string, scene: EmbeddedScene) {
 }
 
 describe('SceneTimeRange', () => {
-  beforeEach(() => {
-    jest.mocked(RefreshEvent).mockClear();
-  });
-
   it('when created should evaluate time range', () => {
     const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
     expect(timeRange.state.value.raw.from).toBe('now-1h');
@@ -44,9 +35,15 @@ describe('SceneTimeRange', () => {
 
   it('when time range refreshed should trigger refresh event', async () => {
     const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now' });
-    expect(RefreshEvent).not.toHaveBeenCalled();
+    const spy = jest.spyOn(timeRange, 'publishEvent');
+
     timeRange.onRefresh();
-    expect(RefreshEvent).toHaveBeenCalled();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    // The first call is a set state event, the second is the refresh event
+    expect(spy.mock.calls[1][0]).toBeInstanceOf(RefreshEvent);
+    expect(spy.mock.calls[1][1]).toBe(true);
+    expect(spy).toHaveBeenCalledWith(expect.any(RefreshEvent), true);
   });
 
   it('toUrlValues with relative range', () => {
@@ -240,78 +237,83 @@ describe('SceneTimeRange', () => {
     });
 
     it('should NOT invalidate stale time range that does not meet refresh threshold', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: {}});
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: {} });
       const scene = new EmbeddedScene({
         $timeRange: timeRange,
-        body: new SceneReactObject({
-        })
-      })
+        body: new SceneReactObject({}),
+      });
 
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
       simulateDelay(mockedHourLater, scene);
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
-    })
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
+    });
 
     it('should invalidate stale time range by default', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now'});
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now' });
       const scene = new EmbeddedScene({
         $timeRange: timeRange,
-        body: new SceneReactObject({
-        })
-      })
+        body: new SceneReactObject({}),
+      });
 
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
       simulateDelay(mockedHourLater, scene);
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedHourLater)
-    })
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedHourLater);
+    });
 
     it('should NOT invalidate stale time range before refresh duration has elapsed', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: {afterMs: 101} });
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: { afterMs: 101 } });
       const scene = new EmbeddedScene({
         $timeRange: timeRange,
-        body: new SceneReactObject({})
-      })
+        body: new SceneReactObject({}),
+      });
 
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
       simulateDelay(mocked100MsLater, scene);
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
-    })
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
+    });
 
     it('should NOT invalidate stale time range with percent when refresh threshold is not met', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: {afterMs: 60000, percent: 10}});
+      const timeRange = new SceneTimeRange({
+        from: 'now-30s',
+        to: 'now',
+        refreshOnActivate: { afterMs: 60000, percent: 10 },
+      });
       const scene = new EmbeddedScene({
         $timeRange: timeRange,
-        body: new SceneReactObject({})
-      })
+        body: new SceneReactObject({}),
+      });
 
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
       simulateDelay(mocked100MsLater, scene);
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
-    })
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
+    });
 
     it('should invalidate stale time range when refresh threshold is met', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: {afterMs: 100} });
+      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: { afterMs: 100 } });
       const scene = new EmbeddedScene({
         $timeRange: timeRange,
-        body: new SceneReactObject({
-        })
-      })
+        body: new SceneReactObject({}),
+      });
 
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
       simulateDelay(mocked100MsLater, scene);
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mocked100MsLater)
-    })
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mocked100MsLater);
+    });
 
     it('should invalidate stale time range when either refresh threshold is met', () => {
-      const timeRange = new SceneTimeRange({ from: 'now-30s', to: 'now', refreshOnActivate: {afterMs: 60000, percent: 10}});
+      const timeRange = new SceneTimeRange({
+        from: 'now-30s',
+        to: 'now',
+        refreshOnActivate: { afterMs: 60000, percent: 10 },
+      });
       const scene = new EmbeddedScene({
         $timeRange: timeRange,
-        body: new SceneReactObject({})
-      })
+        body: new SceneReactObject({}),
+      });
 
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow)
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
       simulateDelay(mocked10sLater, scene);
-      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mocked10sLater)
-    })
-  })
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mocked10sLater);
+    });
+  });
 });

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -23,9 +23,8 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       timeZone || getTimeZone(),
       state.fiscalYearStartMonth,
       state.UNSAFE_nowDelay
-
     );
-    const refreshOnActivate = state.refreshOnActivate ?? {percent: 10}
+    const refreshOnActivate = state.refreshOnActivate ?? { percent: 10 };
     super({ from, to, timeZone, value, refreshOnActivate, ...state });
 
     this.addActivationHandler(this._onActivate.bind(this));
@@ -58,7 +57,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       setWeekStart(this.state.weekStart);
     }
 
-    if(rangeUtil.isRelativeTimeRange(this.state.value.raw)){
+    if (rangeUtil.isRelativeTimeRange(this.state.value.raw)) {
       this.refreshIfStale();
     }
 
@@ -120,16 +119,16 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     );
 
     const diff = value.to.diff(this.state.value.to, 'milliseconds');
-    if(diff >= refreshAfterMs){
+    if (diff >= refreshAfterMs) {
       this.setState({
-        value
-      })
+        value,
+      });
     }
   }
 
   private calculatePercentOfInterval(percent: number): number {
     const intervalMs = this.state.value.to.diff(this.state.value.from, 'milliseconds');
-    return Math.ceil(intervalMs / percent)
+    return Math.ceil(intervalMs / percent);
   }
 
   public getTimeZone(): TimeZone {
@@ -197,7 +196,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       ),
     });
 
-    this.publishEvent(new RefreshEvent());
+    this.publishEvent(new RefreshEvent(), true);
   };
 
   public getUrlState() {


### PR DESCRIPTION
This refers to #90538

**Problem**
After attempting to fix this in #838, we discovered that the panels were not receiving the intended event because they were receiving the general app event instead of the specific panel event.

**Solution**
This pull request addresses two main issues:
- Ensure that the event is propagated to the dashboard scene so that any events subscribed to the root receive it correctly
- Replace the event bus for the panel with the one created for the context.

This ensures that the event subscribed to is the same event emitted, as they are obtained through the same mechanism.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.7.1--canary.852.10167028474.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.7.1--canary.852.10167028474.0
  npm install @grafana/scenes@5.7.1--canary.852.10167028474.0
  # or 
  yarn add @grafana/scenes-react@5.7.1--canary.852.10167028474.0
  yarn add @grafana/scenes@5.7.1--canary.852.10167028474.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
