### PR TITLE
SafeSerializableSceneObject: Wrap only for supported Grafana version

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -19,7 +19,7 @@ import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLa
 import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
 import { TestVariable } from '../variables/variants/TestVariable';
 import { TestScene } from '../variables/TestScene';
-import { RuntimeDataSource, registerRuntimeDataSource } from './RuntimeDataSource';
+import { RuntimeDataSource, registerRuntimeDataSource, runtimeDataSources } from './RuntimeDataSource';
 import { DataQuery } from '@grafana/schema';
 import { EmbeddedScene } from '../components/EmbeddedScene';
 import { SceneCanvasText } from '../components/SceneCanvasText';
@@ -37,6 +37,7 @@ import { LocalValueVariable } from '../variables/variants/LocalValueVariable';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { ExtraQueryDescriptor, ExtraQueryProvider } from './ExtraQueryProvider';
 import { SafeSerializableSceneObject } from '../utils/SafeSerializableSceneObject';
+import { config } from '@grafana/runtime';
 
 const getDataSourceMock = jest.fn().mockReturnValue({
   uid: 'test-uid',
@@ -132,6 +133,9 @@ jest.mock('@grafana/runtime', () => ({
     getAdhocFilters: jest.fn(),
   }),
   config: {
+    buildInfo: {
+      version: '1.0.0',
+    },
     theme: {
       palette: {
         gray60: '#666666',
@@ -140,9 +144,13 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-describe('SceneQueryRunner', () => {
+// 11.1.2 - will use SafeSerializableSceneObject
+// 11.1.1 - will NOT use SafeSerializableSceneObject
+describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
   let deactivationHandlers: SceneDeactivationHandler[] = [];
-
+  beforeEach(() => {
+    config.buildInfo.version = v;
+  });
   afterEach(() => {
     runRequestMock.mockClear();
     getDataSourceMock.mockClear();
@@ -174,40 +182,7 @@ describe('SceneQueryRunner', () => {
           "__interval_ms",
         ]
       `);
-      expect(request).toMatchInlineSnapshot(`
-        {
-          "app": "scenes",
-          "cacheTimeout": "30",
-          "interval": "30s",
-          "intervalMs": 30000,
-          "liveStreaming": undefined,
-          "maxDataPoints": 500,
-          "queryCachingTTL": 300000,
-          "range": {
-            "from": "2023-07-11T02:18:08.000Z",
-            "raw": {
-              "from": "now-6h",
-              "to": "now",
-            },
-            "to": "2023-07-11T08:18:08.000Z",
-          },
-          "rangeRaw": {
-            "from": "now-6h",
-            "to": "now",
-          },
-          "requestId": "SQR100",
-          "startTime": 1689063488000,
-          "targets": [
-            {
-              "datasource": {
-                "uid": "test-uid",
-              },
-              "refId": "A",
-            },
-          ],
-          "timezone": "browser",
-        }
-      `);
+      expect(request).toMatchSnapshot();
     });
   });
 
@@ -490,7 +465,7 @@ describe('SceneQueryRunner', () => {
 
       expect(queryRunner.state.data).toBeUndefined();
 
-      activateFullSceneTree(scene);
+      deactivationHandlers.push(activateFullSceneTree(scene));
 
       await new Promise((r) => setTimeout(r, 1));
 
@@ -1089,6 +1064,8 @@ describe('SceneQueryRunner', () => {
       await new Promise((r) => setTimeout(r, 1));
 
       expect(queryRunner.state.data?.series[0].fields[0].values.get(0)).toBe(123);
+
+      runtimeDataSources.clear();
     });
   });
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -17,7 +17,7 @@ import {
 
 // TODO: Remove this ignore annotation when the grafana runtime dependency has been updated
 // @ts-ignore
-import { getRunRequest, toDataQueryError, isExpressionReference } from '@grafana/runtime';
+import { getRunRequest, toDataQueryError, isExpressionReference, config } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
@@ -47,7 +47,7 @@ import { AdHocFiltersVariable, isFilterComplete } from '../variables/adhoc/AdHoc
 import { SceneVariable } from '../variables/types';
 import { DataLayersMerger } from './DataLayersMerger';
 import { interpolate } from '../core/sceneGraph/sceneGraph';
-import { SafeSerializableSceneObject } from '../utils/SafeSerializableSceneObject';
+import { wrapInSafeSerializableSceneObject } from '../utils/wrapInSafeSerializableSceneObject';
 
 let counter = 100;
 
@@ -109,7 +109,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   private _containerWidth?: number;
   private _variableValueRecorder = new VariableValueRecorder();
   private _results = new ReplaySubject<SceneDataProviderResult>(1);
-  private _scopedVars = { __sceneObject: new SafeSerializableSceneObject(this) };
+  private _scopedVars = { __sceneObject: wrapInSafeSerializableSceneObject(this) };
   private _layerAnnotations?: DataFrame[];
   private _resultAnnotations?: DataFrame[];
 

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SceneQueryRunner when running query should build DataQueryRequest object 2`] = `
+{
+  "app": "scenes",
+  "cacheTimeout": "30",
+  "interval": "30s",
+  "intervalMs": 30000,
+  "liveStreaming": undefined,
+  "maxDataPoints": 500,
+  "queryCachingTTL": 300000,
+  "range": {
+    "from": "2023-07-11T02:18:08.000Z",
+    "raw": {
+      "from": "now-6h",
+      "to": "now",
+    },
+    "to": "2023-07-11T08:18:08.000Z",
+  },
+  "rangeRaw": {
+    "from": "now-6h",
+    "to": "now",
+  },
+  "requestId": "SQR100",
+  "startTime": 1689063488000,
+  "targets": [
+    {
+      "datasource": {
+        "uid": "test-uid",
+      },
+      "refId": "A",
+    },
+  ],
+  "timezone": "browser",
+}
+`;
+
+exports[`SceneQueryRunner when running query should build DataQueryRequest object 4`] = `
+{
+  "app": "scenes",
+  "cacheTimeout": "30",
+  "interval": "30s",
+  "intervalMs": 30000,
+  "liveStreaming": undefined,
+  "maxDataPoints": 500,
+  "queryCachingTTL": 300000,
+  "range": {
+    "from": "2023-07-11T02:18:08.000Z",
+    "raw": {
+      "from": "now-6h",
+      "to": "now",
+    },
+    "to": "2023-07-11T08:18:08.000Z",
+  },
+  "rangeRaw": {
+    "from": "now-6h",
+    "to": "now",
+  },
+  "requestId": "SQR172",
+  "startTime": 1689063488000,
+  "targets": [
+    {
+      "datasource": {
+        "uid": "test-uid",
+      },
+      "refId": "A",
+    },
+  ],
+  "timezone": "browser",
+}
+`;

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -56,7 +56,7 @@ exports[`SceneQueryRunner when running query should build DataQueryRequest objec
     "from": "now-6h",
     "to": "now",
   },
-  "requestId": "SQR172",
+  "requestId": "SQR176",
   "startTime": 1689063488000,
   "targets": [
     {

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -10,6 +10,7 @@ import { SceneDataLayerSet } from '../../SceneDataLayerSet';
 import { AnnotationsDataLayer } from './AnnotationsDataLayer';
 import { TestSceneWithRequestEnricher } from '../../../utils/test/TestSceneWithRequestEnricher';
 import { SafeSerializableSceneObject } from '../../../utils/SafeSerializableSceneObject';
+import { config } from '@grafana/runtime';
 
 let mockedEvents: Array<Partial<Field>> = [];
 
@@ -64,6 +65,9 @@ jest.mock('@grafana/runtime', () => ({
   },
 
   config: {
+    buildInfo: {
+      version: '1.0.0',
+    },
     theme2: {
       visualization: {
         getColorByName: jest.fn().mockReturnValue('red'),
@@ -72,8 +76,11 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-describe('AnnotationsDataLayer', () => {
+// 11.1.2 - will use SafeSerializableSceneObject
+// 11.1.1 - will NOT use SafeSerializableSceneObject
+describe.each(['11.1.2', '11.1.1'])('AnnotationsDataLayer', (v) => {
   beforeEach(() => {
+    config.buildInfo.version = v;
     runRequestMock.mockClear();
   });
 

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
@@ -18,7 +18,7 @@ import { SceneDataLayerBase } from '../SceneDataLayerBase';
 import { DataLayerControlSwitch } from '../SceneDataLayerControls';
 import { AnnotationQueryResults, executeAnnotationQuery } from './standardAnnotationQuery';
 import { dedupAnnotations, postProcessQueryResult } from './utils';
-import { SafeSerializableSceneObject } from '../../../utils/SafeSerializableSceneObject';
+import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
 
 interface AnnotationsDataLayerState extends SceneDataLayerProviderState {
   query: AnnotationQuery;
@@ -31,7 +31,7 @@ export class AnnotationsDataLayer
   static Component = AnnotationsDataLayerRenderer;
 
   private _scopedVars: ScopedVars = {
-    __sceneObject: new SafeSerializableSceneObject(this),
+    __sceneObject: wrapInSafeSerializableSceneObject(this),
   };
   private _timeRangeSub: Unsubscribable | undefined;
 

--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -18,7 +18,7 @@ import { shouldUseLegacyRunner, standardAnnotationSupport } from './standardAnno
 import { Dashboard, LoadingState } from '@grafana/schema';
 import { SceneObject, SceneTimeRangeLike } from '../../../core/types';
 import { getEnrichedDataRequest } from '../../getEnrichedDataRequest';
-import { SafeSerializableSceneObject } from '../../../utils/SafeSerializableSceneObject';
+import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
 
 let counter = 100;
 function getNextRequestId() {
@@ -98,7 +98,7 @@ export function executeAnnotationQuery(
     __interval: { text: interval.interval, value: interval.interval },
     __interval_ms: { text: interval.intervalMs.toString(), value: interval.intervalMs },
     __annotation: { text: annotation.name, value: annotation },
-    __sceneObject: new SafeSerializableSceneObject(layer),
+    __sceneObject: wrapInSafeSerializableSceneObject(layer),
   };
 
   const queryRequest: DataQueryRequest = {

--- a/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.test.ts
+++ b/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.test.ts
@@ -9,7 +9,7 @@ describe('shouldWrapInSafeSerializableSceneObject', () => {
       }
     );
     it.each(['10.4.7-123', '10.4.7', '10.4.8', '10.5.0'])(
-      'should return false for version higher than 10.4.7 version (%s)',
+      'should return true for version higher than 10.4.7 version (%s)',
       (version) => {
         expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
       }

--- a/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.test.ts
+++ b/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.test.ts
@@ -2,14 +2,14 @@ import { shouldWrapInSafeSerializableSceneObject } from './wrapInSafeSerializabl
 
 describe('shouldWrapInSafeSerializableSceneObject', () => {
   describe('Grafana 10', () => {
-    it.each(['10.4.6-123', '10.4.6', '10.3.0', '10.2.0', '10.1.0'])(
-      'should return false for version lower than 10.4.7 version (%s)',
+    it.each(['10.4.7', '10.4.6-123', '10.4.6', '10.3.0', '10.2.0', '10.1.0'])(
+      'should return false for version lower than 10.4.8 version (%s)',
       (version) => {
         expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(false);
       }
     );
-    it.each(['10.4.7-123', '10.4.7', '10.4.8', '10.5.0'])(
-      'should return true for version higher than 10.4.7 version (%s)',
+    it.each(['10.4.8-123', '10.4.8', '10.5.0'])(
+      'should return true for version higher than 10.4.8 version (%s)',
       (version) => {
         expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
       }
@@ -24,8 +24,8 @@ describe('shouldWrapInSafeSerializableSceneObject', () => {
           expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(false);
         }
       );
-      it.each(['11.0.3-123', '11.0.3', '11.0.4'])(
-        'should return true for version higher than 11.0.3 version (%s)',
+      it.each(['11.0.4-123', '11.0.4', '11.0.5'])(
+        'should return true for version higher than 11.0.4 version (%s)',
         (version) => {
           expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
         }

--- a/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.test.ts
+++ b/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.test.ts
@@ -1,0 +1,54 @@
+import { shouldWrapInSafeSerializableSceneObject } from './wrapInSafeSerializableSceneObject';
+
+describe('shouldWrapInSafeSerializableSceneObject', () => {
+  describe('Grafana 10', () => {
+    it.each(['10.4.6-123', '10.4.6', '10.3.0', '10.2.0', '10.1.0'])(
+      'should return false for version lower than 10.4.7 version (%s)',
+      (version) => {
+        expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(false);
+      }
+    );
+    it.each(['10.4.7-123', '10.4.7', '10.4.8', '10.5.0'])(
+      'should return false for version higher than 10.4.7 version (%s)',
+      (version) => {
+        expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
+      }
+    );
+  });
+
+  describe('Grafana 11+', () => {
+    describe('11.0.x', () => {
+      it.each(['11.0.2-123', '11.0.2', '11.0.1-123', '11.0.1'])(
+        'should return false for version lower than 11.0.3 version (%s)',
+        (version) => {
+          expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(false);
+        }
+      );
+      it.each(['11.0.3-123', '11.0.3', '11.0.4'])(
+        'should return true for version higher than 11.0.3 version (%s)',
+        (version) => {
+          expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
+        }
+      );
+    });
+    describe('11.1.x', () => {
+      it.each(['11.1.1-123', '11.1.1'])('should return false for version lower than 11.1.2 version (%s)', (version) => {
+        expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(false);
+      });
+      it.each(['11.1.2-123', '11.1.2', '11.1.3'])(
+        'should return true for version higher than 11.1.2 version (%s)',
+        (version) => {
+          expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
+        }
+      );
+    });
+    describe('11.2+', () => {
+      it.each(['11.2.0-123', '11.2.0', '11.2.1', '11.3.0', '12.0.0', '12.0.0-123'])(
+        'should return true for version higher than 11.2+ version (%s)',
+        (version) => {
+          expect(shouldWrapInSafeSerializableSceneObject(version)).toBe(true);
+        }
+      );
+    });
+  });
+});

--- a/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.ts
+++ b/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.ts
@@ -1,0 +1,37 @@
+import { config } from '@grafana/runtime';
+import { SceneObject } from '../core/types';
+import { SafeSerializableSceneObject } from './SafeSerializableSceneObject';
+import { ScopedVar } from '@grafana/data';
+
+export function shouldWrapInSafeSerializableSceneObject(grafanaVersion: string): boolean {
+  const pattern = /^(\d+)\.(\d+)\.(\d+)/;
+  const match = grafanaVersion.match(pattern);
+
+  if (!match) {
+    return false;
+  }
+
+  const major = parseInt(match[1], 10);
+  const minor = parseInt(match[2], 10);
+  const patch = parseInt(match[3], 10);
+
+  if (major === 11) {
+    return (minor === 0 && patch >= 3) || (minor === 1 && patch >= 2) || minor > 1;
+  }
+
+  if (major === 10) {
+    return (minor === 4 && patch >= 7) || minor >= 5;
+  }
+
+  return major > 11; // Assuming versions greater than 11 are also supported.
+}
+
+export function wrapInSafeSerializableSceneObject(sceneObject: SceneObject): ScopedVar {
+  const version = config.buildInfo.version;
+
+  if (shouldWrapInSafeSerializableSceneObject(version)) {
+    return new SafeSerializableSceneObject(sceneObject);
+  }
+
+  return { value: sceneObject, text: '__sceneObject' };
+}

--- a/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.ts
+++ b/packages/scenes/src/utils/wrapInSafeSerializableSceneObject.ts
@@ -16,11 +16,11 @@ export function shouldWrapInSafeSerializableSceneObject(grafanaVersion: string):
   const patch = parseInt(match[3], 10);
 
   if (major === 11) {
-    return (minor === 0 && patch >= 3) || (minor === 1 && patch >= 2) || minor > 1;
+    return (minor === 0 && patch >= 4) || (minor === 1 && patch >= 2) || minor > 1;
   }
 
   if (major === 10) {
-    return (minor === 4 && patch >= 7) || minor >= 5;
+    return (minor === 4 && patch >= 8) || minor >= 5;
   }
 
   return major > 11; // Assuming versions greater than 11 are also supported.

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import { act, getAllByRole, render, waitFor, screen } from '@testing-library/react';
 import { SceneVariableValueChangedEvent } from '../types';
 import { AdHocFiltersVariable, AdHocFiltersVariableState } from './AdHocFiltersVariable';
-import { DataSourceSrv, locationService, setDataSourceSrv, setRunRequest, setTemplateSrv } from '@grafana/runtime';
+import {
+  DataSourceSrv,
+  config,
+  locationService,
+  setDataSourceSrv,
+  setRunRequest,
+  setTemplateSrv,
+} from '@grafana/runtime';
 import {
   AdHocVariableFilter,
   DataQueryRequest,
@@ -29,21 +36,28 @@ const templateSrv = {
   getAdhocFilters: jest.fn().mockReturnValue([{ key: 'origKey', operator: '=', value: '' }]),
 } as any;
 
-describe('AdHocFiltersVariable', () => {
+describe('templateSrv.getAdhocFilters patch ', () => {
+  it('calls original when scene object is not active', async () => {
+    const { unmount } = setup();
+    unmount();
+
+    const result = templateSrv.getAdhocFilters('name');
+    expect(result[0].key).toBe('origKey');
+  });
+});
+
+// 11.1.2 - will use SafeSerializableSceneObject
+// 11.1.1 - will NOT use SafeSerializableSceneObject
+describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
+  beforeEach(() => {
+    config.buildInfo.version = v;
+  });
   it('renders filters', async () => {
     setup();
     expect(screen.getByText('key1')).toBeInTheDocument();
     expect(screen.getByText('val1')).toBeInTheDocument();
     expect(screen.getByText('key2')).toBeInTheDocument();
     expect(screen.getByText('val2')).toBeInTheDocument();
-  });
-
-  it('templateSrv.getAdhocFilters patch calls original when scene object is not active', async () => {
-    const { unmount } = setup();
-    unmount();
-
-    const result = templateSrv.getAdhocFilters('name');
-    expect(result[0].key).toBe('origKey');
   });
 
   it('adds filter', async () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -15,7 +15,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariableUrlSyncHandler } from './AdHocFiltersVariableUrlSyncHandler';
 import { css } from '@emotion/css';
 import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
-import { SafeSerializableSceneObject } from '../../utils/SafeSerializableSceneObject';
+import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSerializableSceneObject';
 
 export interface AdHocFilterWithLabels extends AdHocVariableFilter {
   keyLabel?: string;
@@ -111,7 +111,7 @@ export class AdHocFiltersVariable
 {
   static Component = AdHocFiltersVariableRenderer;
 
-  private _scopedVars = { __sceneObject: new SafeSerializableSceneObject(this) };
+  private _scopedVars = { __sceneObject: wrapInSafeSerializableSceneObject(this) };
   private _dataSourceSrv = getDataSourceSrv();
 
   protected _urlSync = new AdHocFiltersVariableUrlSyncHandler(this);

--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -1,5 +1,5 @@
 import { DataQueryRequest, DataSourceApi, getDefaultTimeRange, LoadingState, PanelData } from '@grafana/data';
-import { DataSourceSrv, locationService, setDataSourceSrv, setRunRequest } from '@grafana/runtime';
+import { DataSourceSrv, locationService, setDataSourceSrv, setRunRequest, config } from '@grafana/runtime';
 import { act, getAllByRole, render, screen } from '@testing-library/react';
 import { lastValueFrom, Observable, of } from 'rxjs';
 import React from 'react';
@@ -15,7 +15,14 @@ import userEvent from '@testing-library/user-event';
 import { TestContextProvider } from '../../../utils/test/TestContextProvider';
 import { FiltersRequestEnricher } from '../../core/types';
 
-describe('GroupByVariable', () => {
+// 11.1.2 - will use SafeSerializableSceneObject
+// 11.1.1 - will NOT use SafeSerializableSceneObject
+describe.each(['11.1.2', '11.1.1'])('GroupByVariable', (v) => {
+  // const cachedCongif = config;
+  beforeEach(() => {
+    config.buildInfo.version = v;
+  });
+
   it('should not resolve values from the data source if default options provided', async () => {
     const { variable, getTagKeysSpy } = setupTest({
       defaultOptions: [

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -16,7 +16,7 @@ import { OptionWithCheckbox } from '../components/VariableValueSelect';
 import { GroupByVariableUrlSyncHandler } from './GroupByVariableUrlSyncHandler';
 import { getOptionSearcher } from '../components/getOptionSearcher';
 import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
-import { SafeSerializableSceneObject } from '../../utils/SafeSerializableSceneObject';
+import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSerializableSceneObject';
 
 export interface GroupByVariableState extends MultiValueVariableState {
   /** Defaults to "Group" */
@@ -103,7 +103,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
 
     return from(
       getDataSource(this.state.datasource, {
-        __sceneObject: new SafeSerializableSceneObject(this),
+        __sceneObject: wrapInSafeSerializableSceneObject(this),
       })
     ).pipe(
       mergeMap((ds) => {

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -28,7 +28,7 @@ import { VariableValueSelectors } from '../../components/VariableValueSelectors'
 import { SceneCanvasText } from '../../../components/SceneCanvasText';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { setRunRequest } from '@grafana/runtime';
+import { config, setRunRequest } from '@grafana/runtime';
 import { SafeSerializableSceneObject } from '../../../utils/SafeSerializableSceneObject';
 
 const runRequestMock = jest.fn().mockReturnValue(
@@ -89,6 +89,16 @@ jest.mock('@grafana/runtime', () => ({
       return Promise.resolve(fakeDsMock);
     },
   }),
+  config: {
+    buildInfo: {
+      version: '1.0.0',
+    },
+    theme2: {
+      visualization: {
+        getColorByName: jest.fn().mockReturnValue('red'),
+      },
+    },
+  },
 }));
 
 class FakeQueryRunner implements QueryRunner {
@@ -108,7 +118,11 @@ class FakeQueryRunner implements QueryRunner {
   }
 }
 
-describe('QueryVariable', () => {
+describe.each(['11.1.2', '11.1.1'])('QueryVariable', (v) => {
+  beforeEach(() => {
+    config.buildInfo.version = v;
+  });
+
   describe('When empty query is provided', () => {
     it('Should default to empty query', async () => {
       const variable = new QueryVariable({ name: 'test' });

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -27,7 +27,7 @@ import { DataQuery, DataSourceRef } from '@grafana/schema';
 import { SEARCH_FILTER_VARIABLE } from '../../constants';
 import { debounce } from 'lodash';
 import { registerQueryWithController } from '../../../querying/registerQueryWithController';
-import { SafeSerializableSceneObject } from '../../../utils/SafeSerializableSceneObject';
+import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
@@ -70,7 +70,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
     return from(
       getDataSource(this.state.datasource, {
-        __sceneObject: new SafeSerializableSceneObject(this),
+        __sceneObject: wrapInSafeSerializableSceneObject(this),
       })
     ).pipe(
       mergeMap((ds) => {
@@ -113,7 +113,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
   private getRequest(target: DataQuery | string, searchFilter?: string) {
     const scopedVars: ScopedVars = {
-      __sceneObject: new SafeSerializableSceneObject(this),
+      __sceneObject: wrapInSafeSerializableSceneObject(this),
     };
 
     if (searchFilter) {


### PR DESCRIPTION
This PR brings backwards compatibility for `scopedVars.__sceneObject` and `SafeSerializableSceneObject`. (ref https://github.com/grafana/scenes/pull/828, https://github.com/grafana/scenes/issues/851)

With this change, Scenes apps using 5.8+ will be able to run smoothly in Grafana versions that do not contain https://github.com/grafana/grafana/pull/90833.

For versions that will have [this](https://github.com/grafana/grafana/pull/90833) included, that is :
- 11.2.x 
- 11.1.2+ (backport MERGED: https://github.com/grafana/grafana/pull/90837)
- 11.0.4+ (backport MERGED: https://github.com/grafana/grafana/pull/91240)
- 10.4.8+ (backport MERGED: https://github.com/grafana/grafana/pull/91242)

`scopedVars.__sceneObject` WILL use `SafeSerializableSceneObject`. For versions other than mentioned above, `scopedVars.__sceneObject` will be just an old good plan `ScopedVar`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.10.0--canary.854.10453539660.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.10.0--canary.854.10453539660.0
  npm install @grafana/scenes@5.10.0--canary.854.10453539660.0
  # or 
  yarn add @grafana/scenes-react@5.10.0--canary.854.10453539660.0
  yarn add @grafana/scenes@5.10.0--canary.854.10453539660.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


# Release notes

Brings a fix for [variables interpolation bug](https://github.com/grafana/scenes/issues/851) when apps using scenes 5.6.0+ were run in Grafana version lower than 11.2.0, 11.1.2, 11.0.4, 10.4.8.
