### PR TITLE
SceneVariableSetTest - add test cases when one of chained variables throws errors

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -632,7 +632,7 @@ describe('SceneVariableList', () => {
       expect(A.state.error).toBe('Danger!');
     });
 
-    it('Should complete updating chained variables in case of error', () => {
+    it('Should complete updating chained variables in case of error in all variables', () => {
       const A = new TestVariable({
         name: 'A',
         query: 'A.*',
@@ -670,6 +670,92 @@ describe('SceneVariableList', () => {
       expect(B.state.error).toBe('Error in B');
       expect(C.state.loading).toBe(false);
       expect(C.state.error).toBe('Error in C');
+    });
+    it('Should complete updating chained variables in case of error in the first variable', () => {
+      const A = new TestVariable({
+        name: 'A',
+        query: 'A.*',
+        value: '',
+        text: '',
+        options: [],
+        throwError: 'Error in A',
+      });
+      const B = new TestVariable({
+        name: 'B',
+        query: 'A.$A.*',
+        value: '',
+        text: '',
+        options: [],
+      });
+      const C = new TestVariable({
+        name: 'C',
+        query: 'value=$B',
+        value: '',
+        text: '',
+        options: [],
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [C, B, A] }),
+      });
+
+      scene.activate();
+
+      expect(A.state.loading).toBe(false);
+      expect(A.state.error).toBe('Error in A');
+
+      B.signalUpdateCompleted();
+      expect(B.state.loading).toBe(false);
+      expect(B.state.value).toBe('');
+      expect(B.state.error).toBeUndefined();
+
+      C.signalUpdateCompleted();
+      expect(C.state.loading).toBe(false);
+      expect(C.state.value).toBe('value=');
+      expect(C.state.error).toBeUndefined();
+    });
+    it('Should complete updating chained variables in case of error in the middle variables', () => {
+      const A = new TestVariable({
+        name: 'A',
+        query: 'A.*',
+        value: '',
+        text: '',
+        options: [],
+      });
+      const B = new TestVariable({
+        name: 'B',
+        query: 'A.$A.*',
+        value: '',
+        text: '',
+        options: [],
+        throwError: 'Error in B',
+      });
+      const C = new TestVariable({
+        name: 'C',
+        query: 'value=$B',
+        value: '',
+        text: '',
+        options: [],
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [C, B, A] }),
+      });
+
+      scene.activate();
+      A.signalUpdateCompleted();
+
+      expect(A.state.loading).toBe(false);
+      expect(A.state.error).toBeUndefined();
+
+      expect(B.state.loading).toBe(false);
+      expect(B.state.value).toBe('');
+      expect(B.state.error).toBe('Error in B');
+
+      C.signalUpdateCompleted();
+      expect(C.state.loading).toBe(false);
+      expect(C.state.value).toBe('value=');
+      expect(C.state.error).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
More test cases:

A throws, B and C do not throw
B throws, A and C do not throw