### PR TITLE
AdHocFilters: Support custom filter keys

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -39,10 +39,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const keyValue = keyLabelToOption(filter.key, filter.keyLabel);
   const valueValue = keyLabelToOption(filter.value, filter.valueLabel);
 
-  const optionSearcher = useMemo(
-    () => getAdhocOptionSearcher(values),
-    [values]
-  );
+  const optionSearcher = useMemo(() => getAdhocOptionSearcher(values), [values]);
 
   const onValueInputChange = (value: string, { action }: InputActionMeta) => {
     if (action === 'input-change') {
@@ -111,6 +108,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       disabled={model.state.readOnly}
       className={cx(styles.key, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
+      allowCustomValue={true}
       value={keyValue}
       placeholder={'Select label'}
       options={handleOptionGroups(keys)}


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11781
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.7.3--canary.857.10198637822.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.7.3--canary.857.10198637822.0
  npm install @grafana/scenes@5.7.3--canary.857.10198637822.0
  # or 
  yarn add @grafana/scenes-react@5.7.3--canary.857.10198637822.0
  yarn add @grafana/scenes@5.7.3--canary.857.10198637822.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
