### PR TITLE
SceneQueryRunner: run queries when datasource variable updates

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -48,6 +48,7 @@ import { SceneVariable } from '../variables/types';
 import { DataLayersMerger } from './DataLayersMerger';
 import { interpolate } from '../core/sceneGraph/sceneGraph';
 import { SafeSerializableSceneObject } from '../utils/SafeSerializableSceneObject';
+import { DataSourceVariable } from '../variables/variants/DataSourceVariable';
 
 let counter = 100;
 
@@ -265,6 +266,10 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     }
 
     if (variable instanceof GroupByVariable && this._isRelevantAutoVariable(variable)) {
+      this.runQueries();
+    }
+
+    if (variable instanceof DataSourceVariable) {
       this.runQueries();
     }
   }


### PR DESCRIPTION
Runtime datasources don't update the UID of the datasource string that is passed into the datasource property when the datasource variable is updated.

As such we should allow developers to pass in a datasource variable into the $variables, and any update to the datasource variable should cause any queryRunner to re-query.