### PR TITLE
Add backwards compatibility for query variables referencing themselves

### DIFF
--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -1,13 +1,21 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-import { TestAnnotationsDataLayer } from '../../querying/layers/TestDataLayer';
-import { SceneDataLayerSet } from '../../querying/SceneDataLayerSet';
+import React from 'react';
+import { of } from 'rxjs';
+
+import { sceneGraph } from '.';
+import { hasVariableDependencyInLoadingState } from './sceneGraph';
 import { EmbeddedScene } from '../../components/EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { SceneCanvasText } from '../../components/SceneCanvasText';
 import { SceneTimePicker } from '../../components/SceneTimePicker';
+import { TestAnnotationsDataLayer } from '../../querying/layers/TestDataLayer';
+import { SceneDataLayerSet } from '../../querying/SceneDataLayerSet';
+import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
+import { SceneVariableSet } from '../../variables/sets/SceneVariableSet';
+import { SceneVariable } from '../../variables/types';
+import { QueryVariable } from '../../variables/variants/query/QueryVariable';
+import { TestVariable } from '../../variables/variants/TestVariable';
 import { SceneDataNode } from '../SceneDataNode';
-import { sceneGraph } from '.';
 import { SceneObject } from '../types';
 
 describe('sceneGraph', () => {
@@ -209,7 +217,7 @@ describe('sceneGraph', () => {
     });
   });
 
-  describe('can find by key (and type)', ()=>{
+  describe('can find by key (and type)', () => {
     const data = new SceneDataNode();
     const item1 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A' }), $data: data });
     const item2 = new SceneFlexItem({ key: 'B', body: new SceneCanvasText({ text: 'B' }) });
@@ -233,9 +241,87 @@ describe('sceneGraph', () => {
     // By type
     expect(sceneGraph.findByKeyAndType(scene, 'A', SceneFlexItem)).toBe(item1);
     // By wrong type
-    expect(()=>sceneGraph.findByKeyAndType(scene, 'A', SceneDataNode)).toThrow();
+    expect(() => sceneGraph.findByKeyAndType(scene, 'A', SceneDataNode)).toThrow();
     // By wrong key
-    expect(()=>sceneGraph.findByKey(scene, 'NOT A KEY')).toThrow();
-    expect(()=>sceneGraph.findByKeyAndType(scene, 'NOT A KEY', SceneFlexItem)).toThrow();
-  })
+    expect(() => sceneGraph.findByKey(scene, 'NOT A KEY')).toThrow();
+    expect(() => sceneGraph.findByKeyAndType(scene, 'NOT A KEY', SceneFlexItem)).toThrow();
+  });
+
+  describe('hasVariableDependencyInLoadingState', () => {
+    const setupVariables = (variables: SceneVariable[]) => {
+      const data = new SceneDataNode();
+      const item1 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A' }), $data: data });
+      const item2 = new SceneFlexItem({ key: 'B', body: new SceneCanvasText({ text: 'B' }) });
+      const timePicker = new SceneTimePicker({ key: 'time-picker' });
+      const scene = new EmbeddedScene({
+        $variables: new SceneVariableSet({ variables }),
+        controls: [timePicker],
+        body: new SceneFlexLayout({
+          children: [item1, item2],
+        }),
+      });
+
+      activateFullSceneTree(scene);
+
+      return scene;
+    };
+
+    it('should return false when there are no dependencies', () => {
+      const noDependencies = new TestVariable({
+        loading: false,
+        name: 'resolvedVar',
+        query: 'foo',
+      });
+      const scene = setupVariables([noDependencies]);
+
+      expect(hasVariableDependencyInLoadingState(scene)).toBe(false);
+    });
+
+    it('should return false when no variables are in the loading state', () => {
+      const resolvedVariable = new TestVariable({
+        name: 'resolvedVar',
+        query: 'foo',
+      });
+      const notLoadingDependecies = new TestVariable({
+        name: 'notLoadingDependecies',
+        query: '$resolvedVar',
+      });
+      setupVariables([resolvedVariable, notLoadingDependecies]);
+
+      resolvedVariable.signalUpdateCompleted();
+      notLoadingDependecies.signalUpdateCompleted();
+
+      expect(hasVariableDependencyInLoadingState(notLoadingDependecies)).toBe(false);
+    });
+
+    it('should return true when at least one variable is in the loading state', () => {
+      const loadingVariable = new TestVariable({
+        name: 'loadingVar',
+        query: 'foo',
+      });
+      const loadingDependecies = new TestVariable({
+        name: 'loadingDependecies',
+        query: '$loadingVar',
+      });
+
+      setupVariables([loadingVariable, loadingDependecies]);
+
+      expect(hasVariableDependencyInLoadingState(loadingDependecies)).toBe(true);
+    });
+
+    it.only('should return false if the variable is a QueryVariable and it is loading because is refering itself', () => {
+      const logSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const loadingVariable = new QueryVariable({
+        name: 'loadingVar',
+        query: '$loadingVar',
+      });
+      // Mocking the getValueOptions to avoid the actual request
+      jest.spyOn(loadingVariable, 'getValueOptions').mockImplementation(() => of([]));
+
+      setupVariables([loadingVariable]);
+
+      expect(hasVariableDependencyInLoadingState(loadingVariable)).toBe(false);
+      expect(logSpy).toHaveBeenCalledWith('Query variable is referencing itself');
+    });
+  });
 });

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -9,6 +9,7 @@ import { lookupVariable } from '../../variables/lookupVariable';
 import { getClosest } from './utils';
 import { SceneQueryControllerLike, isQueryController } from '../../behaviors/SceneQueryController';
 import { VariableInterpolation } from '@grafana/runtime';
+import { QueryVariable } from '../../variables/variants/query/QueryVariable';
 
 /**
  * Get the closest node with variables
@@ -75,6 +76,12 @@ export function hasVariableDependencyInLoadingState(sceneObject: SceneObject) {
   }
 
   for (const name of sceneObject.variableDependency.getNames()) {
+    // This is for backwards compability. In the old architecture query variables could reference itself in a query without breaking.
+    if (sceneObject instanceof QueryVariable && sceneObject.state.name === name) {
+      console.warn('Query variable is referencing itself');
+      continue;
+    }
+
     const variable = lookupVariable(name, sceneObject);
     if (!variable) {
       continue;

--- a/packages/scenes/src/variables/variants/DataSourceVariable.test.ts
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.test.ts
@@ -1,11 +1,10 @@
 import { lastValueFrom } from 'rxjs';
 
-import { DataSourceInstanceSettings, ScopedVars, PluginType } from '@grafana/data';
+import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
 
 import { SceneObject, SceneObjectState } from '../../core/types';
 
 import { DataSourceVariable } from './DataSourceVariable';
-import { VariableCustomFormatterFn } from '../types';
 import { DataSourceSrv, GetDataSourceListFilters, setDataSourceSrv } from '@grafana/runtime';
 import { sceneGraph } from '../../core/sceneGraph';
 


### PR DESCRIPTION
There are some old dashboards that have query variables that reference themself in the query, this is preventing the query runner from executing the variable query as it is waiting for the variable to load. 

I'm not confident this is the best solution to this issue. A different approach would be to remove the reference to itself when we build the scene, however this could potentially be quite messy. We should probably also look into if this is an issue with other variable types.

https://github.com/grafana/support-escalations/issues/11766