### PR TITLE
SceneQueryRunner: make runWithTimeRange protected

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -400,7 +400,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     });
   }
 
-  private async runWithTimeRange(timeRange: SceneTimeRangeLike) {
+  protected async runWithTimeRange(timeRange: SceneTimeRangeLike) {
     // If no maxDataPoints specified we might need to wait for container width to be set from the outside
     if (!this.state.maxDataPoints && this.state.maxDataPointsFromWidth && !this._containerWidth) {
       return;


### PR DESCRIPTION
In explore logs we want more control over when queries are run, so we want to extend the `SceneQueryRunner` class and call private method `runWithTimeRange`.

This PR simply makes runWithTimeRange protected instead of private so we can override the default behavior of `runQueries` for specific datasource api calls.
