### PR TITLE
MultiValueVariable: Fix issue where url update would not take options into account

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -7,6 +7,7 @@ import { SceneVariableValueChangedEvent } from '../types';
 import { CustomAllValue } from '../variants/MultiValueVariable';
 import { TestVariable } from './TestVariable';
 import { subscribeToStateUpdates } from '../../../utils/test/utils';
+import { CustomVariable } from './CustomVariable';
 
 describe('MultiValueVariable', () => {
   describe('When validateAndUpdate is called', () => {
@@ -519,6 +520,34 @@ describe('MultiValueVariable', () => {
       });
 
       variable.urlSync?.updateFromUrl({ ['var-test']: '2' });
+      expect(variable.state.value).toEqual('2');
+      expect(variable.state.text).toEqual('B');
+    });
+
+    it('updateFromUrl should update value from label in the case of key/value custom variable', async () => {
+      const variable = new CustomVariable({
+        name: 'test',
+        options: [],
+        value: '',
+        text: '',
+        query: 'A : 1,B : 2',
+      });
+
+      await variable.urlSync?.updateFromUrl({ ['var-test']: 'B' });
+      expect(variable.state.value).toEqual('2');
+      expect(variable.state.text).toEqual('B');
+    });
+
+    it('updateFromUrl should update value from value in the case of key/value custom variable', async () => {
+      const variable = new CustomVariable({
+        name: 'test',
+        options: [],
+        value: '',
+        text: '',
+        query: 'A : 1,B : 2',
+      });
+
+      await variable.urlSync?.updateFromUrl({ ['var-test']: '2' });
       expect(variable.state.value).toEqual('2');
       expect(variable.state.text).toEqual('B');
     });


### PR DESCRIPTION
This PR fixes an issue where in a variable with key-value pairs([esc](https://github.com/grafana/support-escalations/issues/11759)), setting the key in the url param would not update to it's value but instead create a new custom option with the key as a value. 

Before:


https://github.com/user-attachments/assets/cf3aca6a-cfc6-4c7f-825d-7f1bf1fc6ff3



After:


https://github.com/user-attachments/assets/575498fe-a385-43c0-a293-bd1d180e5d17


