### PR TITLE
SceneGridLayout: Change to useMeasure and non absolute div wrapper

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -10,13 +10,10 @@ import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridRow } from './SceneGridRow';
 import * as utils from './utils';
 
-// Mocking AutoSizer to allow testing of the SceneGridLayout component rendering
-jest.mock(
-  'react-virtualized-auto-sizer',
-  () =>
-    ({ children }: { children: (args: { width: number; height: number }) => React.ReactNode }) =>
-      children({ height: 600, width: 600 })
-);
+jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
+  useMeasure: () => [() => {}, { width: 800, height: 600 }],
+}));
 
 jest.mock('./utils', () => ({
   ...jest.requireActual('./utils'),

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -74,7 +74,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
   };
 
   return (
-    <div ref={outerDivRef as RefCallback<HTMLDivElement>} style={{ flex: '1 1 auto', position: 'relative', zIndex: 1 }}>
+    <div ref={outerDivRef as RefCallback<HTMLDivElement>} style={{ flex: '1 1 auto', position: 'relative', zIndex: 1, width: '100%' }}>
       {width && height && renderGrid(width, height)}
     </div>
   );

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -25,6 +25,10 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
   validateChildrenSize(children);
 
   const renderGrid = (width: number, height: number) => {
+    if (!width || !height) {
+      return null;
+    }
+
     const layout = model.buildGridLayout(width, height);
 
     return (
@@ -78,7 +82,7 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
       ref={outerDivRef as RefCallback<HTMLDivElement>}
       style={{ flex: '1 1 auto', position: 'relative', zIndex: 1, width: '100%' }}
     >
-      {width && height && renderGrid(width, height)}
+      {renderGrid(width, height)}
     </div>
   );
 }

--- a/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayoutRenderer.tsx
@@ -74,7 +74,10 @@ export function SceneGridLayoutRenderer({ model }: SceneComponentProps<SceneGrid
   };
 
   return (
-    <div ref={outerDivRef as RefCallback<HTMLDivElement>} style={{ flex: '1 1 auto', position: 'relative', zIndex: 1, width: '100%' }}>
+    <div
+      ref={outerDivRef as RefCallback<HTMLDivElement>}
+      style={{ flex: '1 1 auto', position: 'relative', zIndex: 1, width: '100%' }}
+    >
       {width && height && renderGrid(width, height)}
     </div>
   );


### PR DESCRIPTION
In order to make the sticky controls work we cannot have an absolute wrapper around the grid (as this makes the div there the sticky lives not get the needed hight for sticky to work).

But in changing this to useMeasure and same CSS as in 
https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/dashgrid/DashboardGrid.tsx#L327 

but I am running into the same problem I have always had in that when the wrapping div is not absolute I cannot reduce the size, the resize observer is not register any change to reduced viewport as the inner grid div current width is blocking a reduction in size. 

Have no idea why it works in DashboardGrid.tsx#L327 