### PR TITLE
SafeSerializingSceneObject: Fix issue with using a private field

### DIFF
--- a/packages/scenes/src/utils/SafeSerializableSceneObject.ts
+++ b/packages/scenes/src/utils/SafeSerializableSceneObject.ts
@@ -2,12 +2,12 @@ import { ScopedVar } from '@grafana/data';
 import { SceneObject } from '../core/types';
 
 export class SafeSerializableSceneObject implements ScopedVar {
-  #value: SceneObject;
+  private _value: SceneObject;
 
   public text = '__sceneObject';
 
   public constructor(value: SceneObject) {
-    this.#value = value;
+    this._value = value;
   }
 
   public toString() {
@@ -15,7 +15,7 @@ export class SafeSerializableSceneObject implements ScopedVar {
   }
 
   public valueOf = () => {
-    return this.#value;
+    return this._value;
   };
 
   public get value() {


### PR DESCRIPTION
The use of private field here does not actually work when transpiled to a js that does not use native private fields. 

since it transforms into this:

```
var __accessCheck = (obj, member, msg) => {
  if (!member.has(obj))
    throw TypeError("Cannot " + msg);
};
var __privateGet = (obj, member, getter) => {
  __accessCheck(obj, member, "read from private field");
  return getter ? getter.call(obj) : member.get(obj);
};
var __privateAdd = (obj, member, value) => {
  if (member.has(obj))
    throw TypeError("Cannot add the same private member more than once");
  member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
};
var __privateSet = (obj, member, value, setter) => {
  __accessCheck(obj, member, "write to private field");
  setter ? setter.call(obj, value) : member.set(obj, value);
  return value;
};
var _value;
class SafeSerializableSceneObject {
  constructor(value) {
    __privateAdd(this, _value, void 0);
    this.text = "__sceneObject";
    __privateSet(this, _value, value);
  }
  toString() {
    return void 0;
  }
  valueOf() {
    return __privateGet(this, _value);
  }
  get value() {
    return this;
  }
}
_value = new WeakMap();

export { SafeSerializableSceneObject };
//# sourceMappingURL=SafeSerializableSceneObject.js.map
```

and the privateSet function call is not "preserved" when cloning / spreading leading to this error: 

<img width="676" alt="Screenshot 2024-08-17 at 09 41 30" src="https://github.com/user-attachments/assets/81703cdd-02ee-487f-9b56-1b26da1e2773">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.9.1--canary.873.10430729232.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.9.1--canary.873.10430729232.0
  npm install @grafana/scenes@5.9.1--canary.873.10430729232.0
  # or 
  yarn add @grafana/scenes-react@5.9.1--canary.873.10430729232.0
  yarn add @grafana/scenes@5.9.1--canary.873.10430729232.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
