### PR TITLE
MultiValueVariable: Fix issue where url update would not take options into account

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -7,6 +7,7 @@ import { SceneVariableValueChangedEvent } from '../types';
 import { CustomAllValue } from '../variants/MultiValueVariable';
 import { TestVariable } from './TestVariable';
 import { subscribeToStateUpdates } from '../../../utils/test/utils';
+import { CustomVariable } from './CustomVariable';
 
 describe('MultiValueVariable', () => {
   describe('When validateAndUpdate is called', () => {
@@ -643,6 +644,22 @@ describe('MultiValueVariable', () => {
       await lastValueFrom(variable.validateAndUpdate());
 
       expect(variable.getValueText()).toEqual('A + B');
+    });
+
+    it('updateFromUrl should update value from label in the case of key/value custom variable', async () => {
+      const variable = new CustomVariable({
+        name: 'test',
+        options: [],
+        value: '',
+        text: '',
+        query: 'A : 1,B : 2',
+      });
+
+      variable.urlSync?.updateFromUrl({ ['var-test']: 'B' });
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toEqual('2');
+      expect(variable.state.text).toEqual('B');
     });
 
     it('Can disable url sync', async () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -192,7 +192,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     // If the validation wants to fix the all value (All ==> $__all) then we should let that pass
     const isAllValueFix = stateUpdate.value === ALL_VARIABLE_VALUE && this.state.text === ALL_VARIABLE_TEXT;
 
-    if (this.skipNextValidation && stateUpdate.value !== this.state.value && !isAllValueFix) {
+    if (this.skipNextValidation && stateUpdate.value !== this.state.value && stateUpdate.text !== this.state.text && !isAllValueFix) {
       stateUpdate.value = this.state.value;
       stateUpdate.text = this.state.text;
     }


### PR DESCRIPTION
This PR fixes an issue where in a variable with key-value pairs([esc](https://github.com/grafana/support-escalations/issues/11759)), setting the key in the url param would not update to it's value but instead create a new custom option with the key as a value. 

Before:


https://github.com/user-attachments/assets/cf3aca6a-cfc6-4c7f-825d-7f1bf1fc6ff3



After:


https://github.com/user-attachments/assets/575498fe-a385-43c0-a293-bd1d180e5d17


