### PR TITLE
Make SceneRefreshPicker respect config.minRefreshInterval

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -11,21 +11,25 @@ import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
 
 export const DEFAULT_INTERVALS = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
 
-function filterDissalowedIntervals(i: string){
-  return config.minRefreshInterval ? rangeUtil.intervalToMs(i) >= rangeUtil.intervalToMs(config.minRefreshInterval) : true
-}
-
 export interface SceneRefreshPickerState extends SceneObjectState {
-  // Refresh interval, e.g. 5s, 1m, 2h
+  /**
+   * Refresh interval, e.g. 5s, 1m, 2h
+   */
   refresh: string;
   autoEnabled?: boolean;
   autoMinInterval?: string;
   autoValue?: string;
-  // List of allowed refresh intervals, e.g. ['5s', '1m']
+  /**
+   * List of allowed refresh intervals, e.g. ['5s', '1m']
+   */
   intervals?: string[];
   isOnCanvas?: boolean;
   primary?: boolean;
   withText?: boolean;
+  /**
+   * Overrides the default minRefreshInterval from the grafana config. Can be set to "0s" to remove the minimum refresh interval.
+   */
+  minRefreshInterval?: string;
 }
 
 export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState> {
@@ -35,6 +39,11 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   private _autoTimeRangeListener: Unsubscribable | undefined;
 
   public constructor(state: Partial<SceneRefreshPickerState>) {
+    const filterDissalowedIntervals = (i: string) => {
+      const minInterval = state.minRefreshInterval ?? config.minRefreshInterval;
+      return minInterval ? rangeUtil.intervalToMs(i) >= rangeUtil.intervalToMs(minInterval) : true;
+    };
+
     super({
       refresh: '',
       ...state,
@@ -86,7 +95,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    const { intervals } = this.state
+    const { intervals } = this.state;
     const refresh = values.refresh;
 
     if (refresh && typeof refresh === 'string') {
@@ -94,7 +103,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
         this.setState({
           refresh,
         });
-      }else{
+      } else {
         this.setState({
           // Default to the first refresh interval if the interval from the URL is not allowed, just like in the old architecture.
           refresh: intervals ? intervals[0] : undefined,


### PR DESCRIPTION
https://github.com/grafana/support-escalations/issues/12157

The refresh picker in scenes does not respect the min_refresh_interval from the config.

This PR makes sure we filter the list of intervals to only include intervals longer than the min config. Also sets the interval to the minimum interval in the list if updated from the URL with a bad interval.