### PR TITLE
UrlSync: Variable changes adds browser history steps

### DIFF
--- a/packages/scenes/src/services/UrlSyncManager.ts
+++ b/packages/scenes/src/services/UrlSyncManager.ts
@@ -148,9 +148,9 @@ export class UrlSyncManager implements UrlSyncManagerLike {
       const shouldCreateHistoryEntry = changedObject.urlSync.shouldCreateHistoryStep?.(newUrlState);
       const shouldReplace = shouldCreateHistoryEntry !== true;
 
-      writeSceneLog('UrlSyncManager', 'onStateChange updating URL');
       locationService.partial(mappedUpdated, shouldReplace);
 
+      writeSceneLog('UrlSyncManager', 'onStateChange updating URL');
       /// Mark the location already handled
       this._lastLocation = locationService.getLocation();
     }

--- a/packages/scenes/src/services/UrlSyncManager.ts
+++ b/packages/scenes/src/services/UrlSyncManager.ts
@@ -148,9 +148,9 @@ export class UrlSyncManager implements UrlSyncManagerLike {
       const shouldCreateHistoryEntry = changedObject.urlSync.shouldCreateHistoryStep?.(newUrlState);
       const shouldReplace = shouldCreateHistoryEntry !== true;
 
+      writeSceneLog('UrlSyncManager', 'onStateChange updating URL');
       locationService.partial(mappedUpdated, shouldReplace);
 
-      writeSceneLog('UrlSyncManager', 'onStateChange updating URL');
       /// Mark the location already handled
       this._lastLocation = locationService.getLocation();
     }

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -71,7 +71,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       options={filteredOptions}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${value}`)}
       onChange={(newValue) => {
-        model.changeValueTo(newValue.value!, newValue.label!);
+        model.changeValueTo(newValue.value!, newValue.label!, true);
 
         if (hasCustomValue !== newValue.__isNew__) {
           setHasCustomValue(newValue.__isNew__);
@@ -135,13 +135,13 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       hideSelectedOptions={false}
       onInputChange={onInputChange}
       onBlur={() => {
-        model.changeValueTo(uncommittedValue);
+        model.changeValueTo(uncommittedValue, undefined, true);
       }}
       filterOption={filterNoOp}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${uncommittedValue}`)}
       onChange={(newValue, action) => {
         if (action.action === 'clear' && noValueOnClear) {
-          model.changeValueTo([]);
+          model.changeValueTo([], undefined, true);
         }
         setUncommittedValue(newValue.map((x) => x.value!));
       }}

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -282,12 +282,13 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
       onBlur={() => {
         model.changeValueTo(
           uncommittedValue.map((x) => x.value!),
-          uncommittedValue.map((x) => x.label!)
+          uncommittedValue.map((x) => x.label!),
+          true
         );
       }}
       onChange={(newValue, action) => {
         if (action.action === 'clear' && noValueOnClear) {
-          model.changeValueTo([]);
+          model.changeValueTo([], undefined, true);
         }
         setUncommittedValue(newValue);
       }}


### PR DESCRIPTION
This works on top of https://github.com/grafana/scenes/pull/878 

and explores adding browser history steps for variables. 

Works surprisingly well. The challenge here is that not all variable value changes should create URL history steps.

Given a valid state of datacenter=US , cluster=US-1
* when changing datacenter=EU
* then cluster will maybe change to "EU-1" we should not record a browser history step for this change as that would create a back step for datacenter=EU cluster=US-1 (which is invalid)

To solve this we need to differentiate between variable changes that are due to user actions and those that come due to parent variable change. which is why I am adding isUserAction bool to changeValueTo 

works surprisingly well 