### PR TITLE
SceneObjectBase: Support rendering a child out of context

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -145,6 +145,23 @@ describe('SceneObject', () => {
     scene.activate();
   });
 
+  describe('Should activate parent when inactive', () => {
+    const dataChild = new SceneDataNode({});
+    const scene = new TestScene({ $data: dataChild });
+
+    const deactivate = dataChild.activate();
+    expect(scene.isActive).toBe(false);
+
+    deactivate();
+
+    dataChild._UNSAFE_PARENT_ACTIVATION = true;
+    const deactivate2 = dataChild.activate();
+    expect(scene.isActive).toBe(true);
+
+    deactivate2();
+    expect(scene.isActive).toBe(false);
+  });
+
   describe('When deactivated', () => {
     const scene = new TestScene({
       $data: new SceneDataNode({}),

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -39,6 +39,12 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   protected _variableDependency: SceneVariableDependencyConfigLike | undefined;
   protected _urlSync: SceneObjectUrlSyncHandler | undefined;
 
+  /**
+   * @experimental feature to support rendering a child scene object without it's parent being rendered.
+   * This flag will make it so that the parent is activated (if it's inactive) when this object is activated.
+   */
+  public _UNSAFE_PARENT_ACTIVATION = false;
+
   public constructor(state: TState) {
     if (!state.key) {
       state.key = uuidv4();
@@ -272,9 +278,8 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   public activate(): CancelActivationHandler {
     // If parent is not active, activate parent first
     let parentDeactivate: CancelActivationHandler | undefined;
-    if (this.parent && !this.parent.isActive) {
+    if (this.parent && !this.parent.isActive && this._UNSAFE_PARENT_ACTIVATION) {
       parentDeactivate = this.parent.activate();
-      console.log('activing parent');
     }
 
     if (!this.isActive) {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -270,6 +270,13 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
    * make sure to call the returned function when the source scene object is deactivated.
    */
   public activate(): CancelActivationHandler {
+    // If parent is not active, activate parent first
+    let parentDeactivate: CancelActivationHandler | undefined;
+    if (this.parent && !this.parent.isActive) {
+      parentDeactivate = this.parent.activate();
+      console.log('activing parent');
+    }
+
     if (!this.isActive) {
       this._internalActivate();
     }
@@ -279,6 +286,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
     let called = false;
 
     return () => {
+      if (parentDeactivate) {
+        parentDeactivate();
+      }
+
       this._refCount--;
 
       if (called) {


### PR DESCRIPTION
A problem with rendering a child in isolation is that its parents are not active.

This is one of the main reasons we clone the panel in ViewPanelScene and PanelEditor so that we render a local VizPanel copy. But this local copy has a context problem. 

The panel could be a repeated panel and have local variable context, it could be inside a repeated row (with local variable values). In the future it could be inside layout containers have have local time range and variables. 

This creates a lot of extra complexity in ViewPanelScene and PanelEdit where we have to try to copy this local variable context. 

It would be a lot easier if we could just render the real source VizPanel we want to show directly, without any local clone & trying to re-create the context. 

The main problem of rendering a child out of context is that it's parents will not be active (DashboardGridItem, SceneGridRow, etc). And right now we do not propagate variable value changes through in active objects. So we could change that and allow propagation through in-active objects but that does not solve a future problem of having full QueryVariables on local row level (for them to work SceneVariableSet would need to be activated). 

So in this PR I am trying a new way to handle activation were a SceneObject will activate it's parent if it's not active. 

Will try to add this behavior behind some kind of feature toggle / opt-in mechanism. 

OSS main PR that uses this to simplify panel edit and view panel: https://github.com/grafana/grafana/pull/92879


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.13.0--canary.887.10699625611.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.13.0--canary.887.10699625611.0
  npm install @grafana/scenes@5.13.0--canary.887.10699625611.0
  # or 
  yarn add @grafana/scenes-react@5.13.0--canary.887.10699625611.0
  yarn add @grafana/scenes@5.13.0--canary.887.10699625611.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
