### PR TITLE
AdHocFilters - multi value support in new filters UI

### DIFF
--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -214,6 +214,7 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
                   datasource: { uid: 'gdev-prometheus' },
                   filters: [{ key: 'job', operator: '=', value: 'has no text', condition: '' }],
                   layout: 'combobox',
+                  supportsMultiValueOperators: true,
                 }),
               ],
             }),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -18,7 +18,8 @@ export function AdHocFilterPill({ filter, model, readOnly }: Props) {
   const pillWrapperRef = useRef<HTMLDivElement>(null);
 
   const keyLabel = filter.keyLabel ?? filter.key;
-  const valueLabel = filter.valueLabels?.[0] ?? filter.value;
+  //@ts-expect-error
+  const valueLabel = filter.valueLabels?.join(', ') || filter.values?.join(', ') || filter.value;
 
   const handleChangeViewMode = useCallback(
     (event?: React.MouseEvent) => {
@@ -55,7 +56,7 @@ export function AdHocFilterPill({ filter, model, readOnly }: Props) {
         tabIndex={0}
         ref={pillWrapperRef}
       >
-        <span>
+        <span className={styles.pillText}>
           {keyLabel} {filter.operator} {valueLabel}
         </span>
         {!readOnly ? (
@@ -117,5 +118,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     '&:hover': {
       color: theme.colors.text.primary,
     },
+  }),
+  pillText: css({
+    whiteSpace: 'break-spaces',
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -44,6 +44,11 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Pr
   }, [shouldFocus]);
 
   if (viewMode) {
+    const pillText = (
+      <span className={styles.pillText}>
+        {keyLabel} {filter.operator} {valueLabel}
+      </span>
+    );
     return (
       <div
         className={cx(styles.combinedFilterPill, { [styles.readOnlyCombinedFilter]: readOnly })}
@@ -58,15 +63,14 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Pr
         tabIndex={0}
         ref={pillWrapperRef}
       >
-        <Tooltip
-          show={valueLabel.length < 20 ? false : undefined}
-          content={<div className={styles.tooltipText}>{valueLabel}</div>}
-          placement="top"
-        >
-          <span className={styles.pillText}>
-            {keyLabel} {filter.operator} {valueLabel}
-          </span>
-        </Tooltip>
+        {valueLabel.length < 20 ? (
+          pillText
+        ) : (
+          <Tooltip content={<div className={styles.tooltipText}>{valueLabel}</div>} placement="top">
+            {pillText}
+          </Tooltip>
+        )}
+
         {!readOnly ? (
           <IconButton
             onClick={(e) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -18,6 +18,7 @@ export function AdHocFilterPill({ filter, model, readOnly }: Props) {
   const pillWrapperRef = useRef<HTMLDivElement>(null);
 
   const keyLabel = filter.keyLabel ?? filter.key;
+  // TODO remove when we're on the latest version of @grafana/data
   //@ts-expect-error
   const valueLabel = filter.valueLabels?.join(', ') || filter.values?.join(', ') || filter.value;
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, IconButton } from '@grafana/ui';
+import { useStyles2, IconButton, Tooltip } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
 import { AdHocFilterWithLabels, AdHocFiltersVariable } from '../AdHocFiltersVariable';
@@ -58,9 +58,15 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Pr
         tabIndex={0}
         ref={pillWrapperRef}
       >
-        <span className={styles.pillText}>
-          {keyLabel} {filter.operator} {valueLabel}
-        </span>
+        <Tooltip
+          show={valueLabel.length < 20 ? false : undefined}
+          content={<div className={styles.tooltipText}>{valueLabel}</div>}
+          placement="top"
+        >
+          <span className={styles.pillText}>
+            {keyLabel} {filter.operator} {valueLabel}
+          </span>
+        </Tooltip>
         {!readOnly ? (
           <IconButton
             onClick={(e) => {
@@ -128,5 +134,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: '100%',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
+  }),
+  tooltipText: css({
+    textAlign: 'center',
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -124,6 +124,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     },
   }),
   pillText: css({
-    whiteSpace: 'break-spaces',
+    maxWidth: '200px',
+    width: '100%',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -9,9 +9,10 @@ interface Props {
   filter: AdHocFilterWithLabels;
   model: AdHocFiltersVariable;
   readOnly?: boolean;
+  focusOnInputRef?: () => void;
 }
 
-export function AdHocFilterPill({ filter, model, readOnly }: Props) {
+export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Props) {
   const styles = useStyles2(getStyles);
   const [viewMode, setViewMode] = useState(true);
   const [shouldFocus, setShouldFocus] = useState(false);
@@ -65,12 +66,14 @@ export function AdHocFilterPill({ filter, model, readOnly }: Props) {
             onClick={(e) => {
               e.stopPropagation();
               model._removeFilter(filter);
+              setTimeout(() => focusOnInputRef?.());
             }}
             onKeyDownCapture={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();
                 e.stopPropagation();
                 model._removeFilter(filter);
+                setTimeout(() => focusOnInputRef?.());
               }
             }}
             name="times"

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -123,12 +123,6 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     });
   }, []);
 
-  const handleRemoveMultiValue = useCallback(
-    (item: SelectableValue<string>) =>
-      setFilterMultiValues((selected) => selected.filter((option) => option.value !== item.value)),
-    []
-  );
-
   const onOpenChange = useCallback<NonNullable<UseFloatingOptions['onOpenChange']>>(
     (nextOpen, _, reason) => {
       setOpen(nextOpen);
@@ -182,6 +176,14 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     setInputValue(value);
     setActiveIndex(0);
   }
+
+  const handleRemoveMultiValue = useCallback(
+    (item: SelectableValue<string>) => {
+      setFilterMultiValues((selected) => selected.filter((option) => option.value !== item.value));
+      setTimeout(() => refs.domReference.current?.focus());
+    },
+    [refs.domReference]
+  );
 
   // operation order on fetched options:
   //    fuzzy search -> extract into groups -> flatten group labels and options

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -592,7 +592,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
               </div>
               {isMultiValueEdit && !optionsLoading && !optionsError && filteredDropDownItems.length ? (
                 <MultiValueApplyButton
-                  onClick={() => handleMultiValueFilterCommit(model, filter!, filterMultiValues)}
+                  onApply={() => {
+                    handleMultiValueFilterCommit(model, filter!, filterMultiValues);
+                  }}
                   floatingElement={refs.floating.current}
                   maxOptionWidth={maxOptionWidth}
                 />

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -545,6 +545,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                                 event.stopPropagation();
                               }
                               if (isMultiValueEdit) {
+                                event.preventDefault();
                                 event.stopPropagation();
                                 handleLocalMultiValueChange(item);
                                 refs.domReference.current?.focus();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -545,7 +545,6 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                             ref(node) {
                               listRef.current[index] = node;
                             },
-                            // ref: rowVirtualizer.measureElement,
                             onClick(event) {
                               if (filterInputType !== 'value') {
                                 event.stopPropagation();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -25,7 +25,13 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
       <Icon name="filter" className={styles.filterIcon} size="lg" />
 
       {filters.map((filter, index) => (
-        <AdHocFilterPill key={index} filter={filter} model={model} readOnly={readOnly} />
+        <AdHocFilterPill
+          key={index}
+          filter={filter}
+          model={model}
+          readOnly={readOnly}
+          focusOnInputRef={focusOnInputRef.current}
+        />
       ))}
 
       {!readOnly ? <AdHocFiltersAlwaysWipCombobox model={model} ref={focusOnInputRef} /> : null}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
@@ -76,18 +76,18 @@ const getStyles = (theme: GrafanaTheme2) => ({
   checkbox: css({
     paddingRight: theme.spacing(0.5),
   }),
-  multiValueApply: css({
+  multiValueApplyWrapper: css({
     position: 'absolute',
     top: 0,
     left: 0,
     display: 'flex',
-  }),
-  dropdownWrapper: css({
     backgroundColor: theme.colors.background.primary,
     color: theme.colors.text.primary,
     boxShadow: theme.shadows.z2,
     overflowY: 'auto',
     zIndex: theme.zIndex.dropdown,
+    gap: theme.spacing(1.5),
+    padding: `${theme.spacing(1.5)} ${theme.spacing(1)}`,
   }),
 });
 
@@ -106,24 +106,24 @@ export const OptionsErrorPlaceholder = ({ handleFetchOptions }: { handleFetchOpt
 };
 
 interface MultiValueApplyButtonProps {
-  onClick: () => void;
+  onApply: () => void;
   floatingElement: HTMLElement | null;
   maxOptionWidth: number;
 }
 
-export const MultiValueApplyButton = ({ onClick, floatingElement, maxOptionWidth }: MultiValueApplyButtonProps) => {
+export const MultiValueApplyButton = ({ onApply, floatingElement, maxOptionWidth }: MultiValueApplyButtonProps) => {
   const styles = useStyles2(getStyles);
 
   const floatingElementRect = floatingElement?.getBoundingClientRect();
   return (
     <div
-      className={cx(styles.dropdownWrapper, styles.multiValueApply)}
+      className={styles.multiValueApplyWrapper}
       style={{
         width: `${maxOptionWidth}px`,
         transform: `translate(${floatingElementRect?.left}px,${floatingElementRect?.bottom}px)`,
       }}
     >
-      <Button onClick={onClick} fill="text" fullWidth tabIndex={-1}>
+      <Button onClick={onApply} size="sm" tabIndex={-1}>
         Apply
       </Button>
     </div>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
@@ -1,16 +1,18 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { Button, Checkbox, useStyles2 } from '@grafana/ui';
 import React, { forwardRef, useId } from 'react';
 
 interface DropdownItemProps {
   children: React.ReactNode;
   active?: boolean;
   addGroupBottomBorder?: boolean;
+  isMultiValueEdit?: boolean;
+  checked?: boolean;
 }
 
 export const DropdownItem = forwardRef<HTMLDivElement, DropdownItemProps & React.HTMLProps<HTMLDivElement>>(
-  function DropdownItem({ children, active, addGroupBottomBorder, ...rest }, ref) {
+  function DropdownItem({ children, active, addGroupBottomBorder, isMultiValueEdit, checked, ...rest }, ref) {
     const styles = useStyles2(getStyles);
     const id = useId();
     return (
@@ -23,7 +25,10 @@ export const DropdownItem = forwardRef<HTMLDivElement, DropdownItemProps & React
         {...rest}
       >
         <div className={styles.optionBody} data-testid={`data-testid ad hoc filter option value ${children}`}>
-          <span>{children}</span>
+          <span>
+            {isMultiValueEdit ? <Checkbox tabIndex={-1} checked={checked} className={styles.checkbox} /> : null}
+            {children}
+          </span>
         </div>
       </div>
     );
@@ -68,6 +73,22 @@ const getStyles = (theme: GrafanaTheme2) => ({
   groupBottomBorder: css({
     borderBottom: `1px solid ${theme.colors.border.weak}`,
   }),
+  checkbox: css({
+    paddingRight: theme.spacing(0.5),
+  }),
+  multiValueApply: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    display: 'flex',
+  }),
+  dropdownWrapper: css({
+    backgroundColor: theme.colors.background.primary,
+    color: theme.colors.text.primary,
+    boxShadow: theme.shadows.z2,
+    overflowY: 'auto',
+    zIndex: theme.zIndex.dropdown,
+  }),
 });
 
 export const LoadingOptionsPlaceholder = () => {
@@ -81,5 +102,30 @@ export const NoOptionsPlaceholder = () => {
 export const OptionsErrorPlaceholder = ({ handleFetchOptions }: { handleFetchOptions: () => void }) => {
   return (
     <DropdownItem onClick={handleFetchOptions}>An error has occurred fetching labels. Click to retry</DropdownItem>
+  );
+};
+
+interface MultiValueApplyButtonProps {
+  onClick: () => void;
+  floatingElement: HTMLElement | null;
+  maxOptionWidth: number;
+}
+
+export const MultiValueApplyButton = ({ onClick, floatingElement, maxOptionWidth }: MultiValueApplyButtonProps) => {
+  const styles = useStyles2(getStyles);
+
+  const floatingElementRect = floatingElement?.getBoundingClientRect();
+  return (
+    <div
+      className={cx(styles.dropdownWrapper, styles.multiValueApply)}
+      style={{
+        width: `${maxOptionWidth}px`,
+        transform: `translate(${floatingElementRect?.left}px,${floatingElementRect?.bottom}px)`,
+      }}
+    >
+      <Button onClick={onClick} fill="text" fullWidth tabIndex={-1}>
+        Apply
+      </Button>
+    </div>
   );
 };

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFloatingInteractions.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFloatingInteractions.ts
@@ -17,7 +17,7 @@ type useFloatingInteractionsProps = {
   onOpenChange: UseFloatingOptions['onOpenChange'];
   activeIndex: UseListNavigationProps['activeIndex'];
   setActiveIndex: UseListNavigationProps['onNavigate'];
-  operatorIdentifier: string;
+  outsidePressIdsToIgnore: string[];
   listRef: React.MutableRefObject<Array<HTMLElement | null>>;
   disabledIndicesRef: React.MutableRefObject<number[]>;
 };
@@ -29,7 +29,7 @@ export const useFloatingInteractions = ({
   onOpenChange,
   activeIndex,
   setActiveIndex,
-  operatorIdentifier,
+  outsidePressIdsToIgnore,
   listRef,
   disabledIndicesRef,
 }: useFloatingInteractionsProps) => {
@@ -56,8 +56,13 @@ export const useFloatingInteractions = ({
   const dismiss = useDismiss(context, {
     // if outside click lands on operator pill, then ignore outside click
     outsidePress: (event) => {
-      // if outside click lands on operator pill, then ignore outside click
-      if (event.currentTarget instanceof HTMLElement && event.currentTarget.id === operatorIdentifier) {
+      const target = (event.currentTarget || event.target) as HTMLElement | null;
+      let idToCompare = target?.id || '';
+      if (target?.nodeName === 'path') {
+        idToCompare = target.parentElement?.id || '';
+      }
+
+      if (outsidePressIdsToIgnore.includes(idToCompare)) {
         return false;
       }
       return true;

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFloatingInteractions.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFloatingInteractions.ts
@@ -56,14 +56,16 @@ export const useFloatingInteractions = ({
   const dismiss = useDismiss(context, {
     // if outside click lands on operator pill, then ignore outside click
     outsidePress: (event) => {
-      const target = (event.currentTarget || event.target) as HTMLElement | null;
-      let idToCompare = target?.id || '';
-      if (target?.nodeName === 'path') {
-        idToCompare = target.parentElement?.id || '';
-      }
+      if (event.currentTarget instanceof Element) {
+        const target = event.currentTarget;
+        let idToCompare = target.id;
+        if (target.nodeName === 'path') {
+          idToCompare = target.parentElement?.id || '';
+        }
 
-      if (outsidePressIdsToIgnore.includes(idToCompare)) {
-        return false;
+        if (outsidePressIdsToIgnore.includes(idToCompare)) {
+          return false;
+        }
       }
       return true;
     },

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -228,7 +228,7 @@ export const generatePlaceholder = (
   }
   if (filterInputType === 'value') {
     if (isMultiValueEdit) {
-      return INPUT_PLACEHOLDER;
+      return 'Edit values';
     }
     return filter.valueLabels?.[0] || '';
   }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -214,3 +214,24 @@ export const generateFilterUpdatePayload = (
     [filterInputType]: item.value,
   };
 };
+
+const INPUT_PLACEHOLDER = 'Filter by label values';
+
+export const generatePlaceholder = (
+  filter: AdHocFilterWithLabels,
+  filterInputType: AdHocInputType,
+  isMultiValueEdit: boolean,
+  isAlwaysWip?: boolean
+) => {
+  if (filterInputType === 'key') {
+    return INPUT_PLACEHOLDER;
+  }
+  if (filterInputType === 'value') {
+    if (isMultiValueEdit) {
+      return INPUT_PLACEHOLDER;
+    }
+    return filter.valueLabels?.[0] || '';
+  }
+
+  return filter[filterInputType] && !isAlwaysWip ? `${filter[filterInputType]}` : INPUT_PLACEHOLDER;
+};

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -8,6 +8,7 @@ const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
 const VIRTUAL_LIST_PADDING = 8;
 export const VIRTUAL_LIST_OVERSCAN = 5;
 export const VIRTUAL_LIST_ITEM_HEIGHT = 38;
+export const VIRTUAL_LIST_ITEM_HEIGHT_WITH_DESCRIPTION = 60;
 export const ERROR_STATE_DROPDOWN_WIDTH = 366;
 
 export function fuzzySearchOptions(options: Array<SelectableValue<string>>) {
@@ -86,6 +87,9 @@ export const setupDropdownAccessibility = (
       disabledIndices.push(i);
     }
     let label = options[i].label ?? options[i].value ?? '';
+    if (label.length < (options[i].description?.length || 0)) {
+      label = options[i].description!;
+    }
 
     // rough widthEstimate
     const widthEstimate =

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -5,6 +5,7 @@ import { AdHocFiltersVariable, AdHocFilterWithLabels } from '../AdHocFiltersVari
 import { UseFloatingReturn } from '@floating-ui/react';
 
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
+const VIRTUAL_LIST_DESCRIPTION_WIDTH_ESTIMATE_MULTIPLIER = 6;
 const VIRTUAL_LIST_PADDING = 8;
 export const VIRTUAL_LIST_OVERSCAN = 5;
 export const VIRTUAL_LIST_ITEM_HEIGHT = 38;
@@ -87,14 +88,18 @@ export const setupDropdownAccessibility = (
       disabledIndices.push(i);
     }
     let label = options[i].label ?? options[i].value ?? '';
-    if (label.length < (options[i].description?.length || 0)) {
+    let multiplierToUse = VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER;
+    if (
+      label.length * VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER <
+      (options[i].description?.length || 0) * VIRTUAL_LIST_DESCRIPTION_WIDTH_ESTIMATE_MULTIPLIER
+    ) {
       label = options[i].description!;
+      multiplierToUse = VIRTUAL_LIST_DESCRIPTION_WIDTH_ESTIMATE_MULTIPLIER;
     }
 
     // rough widthEstimate
     const widthEstimate =
-      (options[i].isCustom ? label.length + 18 : label.length) * VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER +
-      VIRTUAL_LIST_PADDING * 2;
+      (options[i].isCustom ? label.length + 18 : label.length) * multiplierToUse + VIRTUAL_LIST_PADDING * 2;
     if (widthEstimate > maxOptionWidth) {
       maxOptionWidth = widthEstimate;
     }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -119,7 +119,7 @@ export type OperatorDefinition = {
   isMulti?: Boolean;
 };
 
-const OPERATORS: OperatorDefinition[] = [
+export const OPERATORS: OperatorDefinition[] = [
   {
     value: '=',
   },
@@ -355,7 +355,7 @@ export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHo
   const { filters, readOnly, addFilterButtonText } = model.useState();
   const styles = useStyles2(getStyles);
 
-  if (!model.state.supportsMultiValueOperators && model.state.layout === 'combobox') {
+  if (model.state.layout === 'combobox') {
     return <AdHocFiltersComboboxRenderer model={model} />;
   }
 


### PR DESCRIPTION
Code is rough, but creating a PR so that we can start the review while I do code clean up

Introduce the multi value ad hoc filters support in the new filters UI
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.14.2--canary.889.10771581250.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.14.2--canary.889.10771581250.0
  npm install @grafana/scenes@5.14.2--canary.889.10771581250.0
  # or 
  yarn add @grafana/scenes-react@5.14.2--canary.889.10771581250.0
  yarn add @grafana/scenes@5.14.2--canary.889.10771581250.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
