### PR TITLE
TextBoxVariable: fixes issues with TextBox variable when being updated by URL 

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueInput.tsx
+++ b/packages/scenes/src/variables/components/VariableValueInput.tsx
@@ -29,7 +29,7 @@ export function VariableValueInput({ model }: SceneComponentProps<TextBoxVariabl
       id={key}
       placeholder="Enter value"
       minWidth={15}
-      defaultValue={value}
+      value={value}
       loading={loading}
       onBlur={onBlur}
       onKeyDown={onKeyDown}

--- a/packages/scenes/src/variables/variants/TextBoxVariable.tsx
+++ b/packages/scenes/src/variables/variants/TextBoxVariable.tsx
@@ -44,13 +44,11 @@ export class TextBoxVariable
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    const update: Partial<TextBoxVariableState> = {};
     const val = values[this.getKey()];
-    if (typeof val === 'string') {
-      update.value = val;
-    }
 
-    this.setState(update);
+    if (typeof val === 'string') {
+      this.setValue(val);
+    }
   }
 
   public static Component = ({ model }: SceneComponentProps<TextBoxVariable>) => {


### PR DESCRIPTION
**Problem**
When using data links to update the variable value, the variable scene object didn't get the state from the URL because it was not setting the state properly

**Fixes**
When any dashboard interaction updates the variable values through URL.

Depends on this fix, since AutoSizeInput ignores `value` prop https://github.com/grafana/grafana/pull/92997