### PR TITLE
Revert "SceneObjectBase: Support rendering a child out of context"

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -145,23 +145,6 @@ describe('SceneObject', () => {
     scene.activate();
   });
 
-  describe('Should activate parent when inactive', () => {
-    const dataChild = new SceneDataNode({});
-    const scene = new TestScene({ $data: dataChild });
-
-    const deactivate = dataChild.activate();
-    expect(scene.isActive).toBe(false);
-
-    deactivate();
-
-    dataChild._UNSAFE_PARENT_ACTIVATION = true;
-    const deactivate2 = dataChild.activate();
-    expect(scene.isActive).toBe(true);
-
-    deactivate2();
-    expect(scene.isActive).toBe(false);
-  });
-
   describe('When deactivated', () => {
     const scene = new TestScene({
       $data: new SceneDataNode({}),

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -39,12 +39,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   protected _variableDependency: SceneVariableDependencyConfigLike | undefined;
   protected _urlSync: SceneObjectUrlSyncHandler | undefined;
 
-  /**
-   * @experimental feature to support rendering a child scene object without it's parent being rendered.
-   * This flag will make it so that the parent is activated (if it's inactive) when this object is activated.
-   */
-  public _UNSAFE_PARENT_ACTIVATION = false;
-
   public constructor(state: TState) {
     if (!state.key) {
       state.key = uuidv4();
@@ -276,12 +270,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
    * make sure to call the returned function when the source scene object is deactivated.
    */
   public activate(): CancelActivationHandler {
-    // If parent is not active, activate parent first
-    let parentDeactivate: CancelActivationHandler | undefined;
-    if (this.parent && !this.parent.isActive && this._UNSAFE_PARENT_ACTIVATION) {
-      parentDeactivate = this.parent.activate();
-    }
-
     if (!this.isActive) {
       this._internalActivate();
     }
@@ -291,10 +279,6 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
     let called = false;
 
     return () => {
-      if (parentDeactivate) {
-        parentDeactivate();
-      }
-
       this._refCount--;
 
       if (called) {


### PR DESCRIPTION
Reverts grafana/scenes#887

I did not end up needing this as a core feature, mainly because I needed the behavior to be recursive and it was pretty easy to accomplish with a external util function:
https://github.com/grafana/grafana/blob/1e884741f23cebc07097abfe5b51d09ff7568420/public/app/features/dashboard-scene/utils/utils.ts#L274


https://github.com/grafana/grafana/pull/93000/