### PR TITLE
SceneObjectBase: add clearParent

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -98,6 +98,14 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   }
 
   /**
+   * Sometimes you want to move one instance to another parent.
+   * This is a way to do that without getting the console warning.
+   */
+  public clearParent() {
+    this._parent = undefined;
+  }
+
+  /**
    * Subscribe to the scene state subject
    **/
   public subscribeToState(handler: SceneStateChangedHandler<TState>): Unsubscribable {


### PR DESCRIPTION
Sometimes it's useful to move one instance to another and in those cases we get a console.warning that the parent changes, which can be annoying in both unit tests and in production code. 

This function enabled us those uses cases without that console.warn 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.14.3--canary.892.10793378428.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.14.3--canary.892.10793378428.0
  npm install @grafana/scenes@5.14.3--canary.892.10793378428.0
  # or 
  yarn add @grafana/scenes-react@5.14.3--canary.892.10793378428.0
  yarn add @grafana/scenes@5.14.3--canary.892.10793378428.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
