### PR TITLE
MultiValueVariabe: Change when value changed event is published

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -231,7 +231,33 @@ describe('MultiValueVariable', () => {
       expect(variable.state.text).toEqual([ALL_VARIABLE_TEXT]);
     });
 
-    it('Should handle $__all value and send change event even when value is still $__all', async () => {
+    it('Should handle $__all value and send change event when value is still $__all, but options change', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        optionsToReturn: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        includeAll: true,
+        value: ALL_VARIABLE_VALUE,
+        text: ALL_VARIABLE_TEXT,
+        delayMs: 0,
+        updateOptions: false, // don't update options in TestVar, MultiVar will update it anyway
+      });
+
+      let changeEvent: SceneVariableValueChangedEvent | undefined;
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, (evt) => (changeEvent = evt));
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toBe(ALL_VARIABLE_VALUE);
+      expect(variable.state.text).toBe(ALL_VARIABLE_TEXT);
+      expect(variable.state.options).toEqual(variable.state.optionsToReturn);
+      expect(changeEvent).toBeDefined();
+    });
+
+    it('Should handle $__all value and not send change event when value is still $__all, but options are the same', async () => {
       const variable = new TestVariable({
         name: 'test',
         options: [],
@@ -253,7 +279,7 @@ describe('MultiValueVariable', () => {
       expect(variable.state.value).toBe(ALL_VARIABLE_VALUE);
       expect(variable.state.text).toBe(ALL_VARIABLE_TEXT);
       expect(variable.state.options).toEqual(variable.state.optionsToReturn);
-      expect(changeEvent).toBeDefined();
+      expect(changeEvent).not.toBeDefined();
     });
 
     it('Should default to $__all even when no options are returned', async () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -82,7 +82,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
    */
   private updateValueGivenNewOptions(options: VariableValueOption[]) {
     // Remember current value and text
-    const { value: currentValue, text: currentText } = this.state;
+    const { value: currentValue, text: currentText, options: oldOptions } = this.state;
 
     const stateUpdate = this.getStateUpdateGivenNewOptions(options, currentValue, currentText);
 
@@ -92,7 +92,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     this.setStateHelper(stateUpdate);
 
     // Publish value changed event only if value changed
-    if (stateUpdate.value !== currentValue || stateUpdate.text !== currentText || this.hasAllValue()) {
+    if (stateUpdate.value !== currentValue || stateUpdate.text !== currentText || (this.hasAllValue() && !isEqual(options, oldOptions))) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }

--- a/packages/scenes/src/variables/variants/TestVariable.tsx
+++ b/packages/scenes/src/variables/variants/TestVariable.tsx
@@ -20,6 +20,7 @@ export interface TestVariableState extends MultiValueVariableState {
   refresh?: VariableRefresh;
   throwError?: string;
   optionsToReturn?: VariableValueOption[];
+  updateOptions?: boolean;
 }
 
 /**
@@ -44,6 +45,7 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
       query: 'Query',
       options: [],
       refresh: VariableRefresh.onDashboardLoad,
+      updateOptions: true,
       ...initialState,
     });
     this.isLazy = isLazy;
@@ -78,7 +80,13 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
 
       const sub = this.completeUpdate.subscribe({
         next: () => {
-          this.setState({ issuedQuery: interpolatedQuery, options, loading: false });
+          const newState: Partial<TestVariableState> = { issuedQuery: interpolatedQuery, loading: false };
+
+          if (this.state.updateOptions) {
+            newState.options = options;
+          }
+
+          this.setState(newState);
           observer.next(options);
           observer.complete();
         },


### PR DESCRIPTION
This PR changes then the `SceneVariableValueChangedEvent` is published. It should only publish, in the case of `All` value, only when options actually change. 

This will help us in various scenarios that are currently giving us headaches like [here](https://github.com/grafana/grafana/pull/93168) where the variable potentially `hasChanged`, after a dashboard refresh, for example, but in truth there is no change in the options, and that var is set only because it sees the `All` value selected.

Another example is in the case of variables that depend on themselves, case that is supported in the new arch due to backwards compat with the old arch. If the value is `All` then the variable is constantly considered as changed and thus publishes the event which will trigger an infinite query in the variable.

In both scenarios above the issues happen only with the `All` value.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.14.4--canary.896.10848324548.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.14.4--canary.896.10848324548.0
  npm install @grafana/scenes@5.14.4--canary.896.10848324548.0
  # or 
  yarn add @grafana/scenes-react@5.14.4--canary.896.10848324548.0
  yarn add @grafana/scenes@5.14.4--canary.896.10848324548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
