### PR TITLE
AdHocVariable: Don't throw when operator is not found

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -403,7 +403,8 @@ export function isFilterComplete(filter: AdHocFilterWithLabels): boolean {
 export function isMultiValueOperator(operatorValue: string): boolean {
   const operator = OPERATORS.find((o) => o.value === operatorValue);
   if (!operator) {
-    throw new Error('Unknown operator');
+    // default to false if operator is not found
+    return false;
   }
   return Boolean(operator.isMulti);
 }


### PR DESCRIPTION
slack thread for context: https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1726085702354709
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.14.4--canary.898.10848470476.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.14.4--canary.898.10848470476.0
  npm install @grafana/scenes@5.14.4--canary.898.10848470476.0
  # or 
  yarn add @grafana/scenes-react@5.14.4--canary.898.10848470476.0
  yarn add @grafana/scenes@5.14.4--canary.898.10848470476.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
