### PR TITLE
Use locationService from context in UrlSyncManager

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -1,6 +1,6 @@
 import { NavModelItem, UrlQueryMap } from '@grafana/data';
 // @ts-ignore
-import { PluginPage, useLocationService } from '@grafana/runtime';
+import { PluginPage, useLocationService, locationService as locationServiceRuntime } from '@grafana/runtime';
 import React, { useContext, useEffect, useLayoutEffect } from 'react';
 
 import { RouteComponentProps } from 'react-router-dom';
@@ -25,7 +25,11 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   const appContext = useContext(SceneAppContext);
   const isInitialized = containerState.initializedScene === scene;
   const { layout } = page.state;
-  const locationService = useLocationService();
+
+  // As we this is basically a version/feature check for grafana/runtime this 'if' should be stable (ie for one instance
+  // of grafana this will always be true or false) so it should be safe to ignore the hook rule here
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const locationService = useLocationService ? useLocationService() : locationServiceRuntime;
 
   useLayoutEffect(() => {
     // Before rendering scene components, we are making sure the URL sync is enabled for.

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -1,6 +1,5 @@
 import { NavModelItem, UrlQueryMap } from '@grafana/data';
-// @ts-ignore
-import { PluginPage, useLocationService, locationService as locationServiceRuntime } from '@grafana/runtime';
+import { PluginPage } from '@grafana/runtime';
 import React, { useContext, useEffect, useLayoutEffect } from 'react';
 
 import { RouteComponentProps } from 'react-router-dom';
@@ -11,6 +10,7 @@ import { SceneAppDrilldownView, SceneAppPageLike } from './types';
 import { getUrlWithAppState, renderSceneComponentWithRouteProps, useAppQueryParams } from './utils';
 import { useUrlSync } from '../../services/useUrlSync';
 import { SceneAppContext } from './SceneApp';
+import { useLocationServiceSafe } from '../../utils/utils';
 
 export interface Props {
   page: SceneAppPageLike;
@@ -25,11 +25,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   const appContext = useContext(SceneAppContext);
   const isInitialized = containerState.initializedScene === scene;
   const { layout } = page.state;
-
-  // As we this is basically a version/feature check for grafana/runtime this 'if' should be stable (ie for one instance
-  // of grafana this will always be true or false) so it should be safe to ignore the hook rule here
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const locationService = useLocationService ? useLocationService() : locationServiceRuntime;
+  const locationService = useLocationServiceSafe();
 
   useLayoutEffect(() => {
     // Before rendering scene components, we are making sure the URL sync is enabled for.

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -1,4 +1,5 @@
 import { NavModelItem, UrlQueryMap } from '@grafana/data';
+// @ts-ignore
 import { PluginPage, useLocationService } from '@grafana/runtime';
 import React, { useContext, useEffect, useLayoutEffect } from 'react';
 

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -1,5 +1,5 @@
 import { NavModelItem, UrlQueryMap } from '@grafana/data';
-import { PluginPage } from '@grafana/runtime';
+import { PluginPage, useLocationService } from '@grafana/runtime';
 import React, { useContext, useEffect, useLayoutEffect } from 'react';
 
 import { RouteComponentProps } from 'react-router-dom';
@@ -24,6 +24,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
   const appContext = useContext(SceneAppContext);
   const isInitialized = containerState.initializedScene === scene;
   const { layout } = page.state;
+  const locationService = useLocationService();
 
   useLayoutEffect(() => {
     // Before rendering scene components, we are making sure the URL sync is enabled for.
@@ -47,11 +48,12 @@ export function SceneAppPageView({ page, routeProps }: Props) {
     text: containerState.title,
     img: containerState.titleImg,
     icon: containerState.titleIcon,
-    url: getUrlWithAppState(containerState.url, containerState.preserveUrlKeys),
+    url: getUrlWithAppState(containerState.url, locationService.getSearchObject(), containerState.preserveUrlKeys),
     hideFromBreadcrumbs: containerState.hideFromBreadcrumbs,
     parentItem: getParentBreadcrumbs(
       containerState.getParentPage ? containerState.getParentPage() : containerPage.parent,
-      params
+      params,
+      locationService.getSearchObject()
     ),
   };
 
@@ -62,7 +64,7 @@ export function SceneAppPageView({ page, routeProps }: Props) {
         icon: tab.state.titleIcon,
         tabSuffix: tab.state.tabSuffix,
         active: page === tab,
-        url: getUrlWithAppState(tab.state.url, tab.state.preserveUrlKeys),
+        url: getUrlWithAppState(tab.state.url, locationService.getSearchObject(), tab.state.preserveUrlKeys),
         parentItem: pageNav,
       };
     });
@@ -103,15 +105,20 @@ function getParentPageIfTab(page: SceneAppPageLike) {
   return page;
 }
 
-function getParentBreadcrumbs(parent: SceneObject | undefined, params: UrlQueryMap): NavModelItem | undefined {
+function getParentBreadcrumbs(
+  parent: SceneObject | undefined,
+  params: UrlQueryMap,
+  searchObject: UrlQueryMap
+): NavModelItem | undefined {
   if (parent instanceof SceneAppPage) {
     return {
       text: parent.state.title,
-      url: getUrlWithAppState(parent.state.url, parent.state.preserveUrlKeys),
+      url: getUrlWithAppState(parent.state.url, searchObject, parent.state.preserveUrlKeys),
       hideFromBreadcrumbs: parent.state.hideFromBreadcrumbs,
       parentItem: getParentBreadcrumbs(
         parent.state.getParentPage ? parent.state.getParentPage() : parent.parent,
-        params
+        params,
+        searchObject
       ),
     };
   }

--- a/packages/scenes/src/components/SceneApp/utils.ts
+++ b/packages/scenes/src/components/SceneApp/utils.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RouteComponentProps, useLocation } from 'react-router-dom';
 import { UrlQueryMap, locationUtil, urlUtil } from '@grafana/data';
-import { locationSearchToObject, locationService } from '@grafana/runtime';
+import { locationSearchToObject } from '@grafana/runtime';
 import { SceneObject } from '../../core/types';
 
 export function useAppQueryParams(): UrlQueryMap {
@@ -12,12 +12,13 @@ export function useAppQueryParams(): UrlQueryMap {
 /**
  *
  * @param path Url to append query params to
+ * @param searchObject Query params of the URL
  * @param preserveParams Query params to preserve
  * @returns Url with query params
  */
-export function getUrlWithAppState(path: string, preserveParams?: string[]): string {
+export function getUrlWithAppState(path: string, searchObject: UrlQueryMap, preserveParams?: string[]): string {
   // make a copy of params as the renderUrl function mutates the object
-  const paramsCopy = { ...locationService.getSearchObject() };
+  const paramsCopy = { ...searchObject };
 
   if (preserveParams) {
     for (const key of Object.keys(paramsCopy)) {

--- a/packages/scenes/src/services/useUrlSync.ts
+++ b/packages/scenes/src/services/useUrlSync.ts
@@ -1,13 +1,14 @@
 import { SceneObject, SceneUrlSyncOptions } from '../core/types';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+// @ts-ignore
 import { useLocationService } from '@grafana/runtime';
 import { writeSceneLog } from '../utils/writeSceneLog';
 import { useUrlSyncManager } from './UrlSyncManager';
 
 export function useUrlSync(sceneRoot: SceneObject, options: SceneUrlSyncOptions = {}): boolean {
   const location = useLocation();
-  const locationService = useLocationService()
+  const locationService = useLocationService();
   const [isInitialized, setIsInitialized] = useState(false);
   const urlSyncManager = useUrlSyncManager(options, locationService);
 

--- a/packages/scenes/src/services/useUrlSync.ts
+++ b/packages/scenes/src/services/useUrlSync.ts
@@ -2,13 +2,16 @@ import { SceneObject, SceneUrlSyncOptions } from '../core/types';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 // @ts-ignore
-import { useLocationService } from '@grafana/runtime';
+import { locationService as locationServiceRuntime, useLocationService } from '@grafana/runtime';
 import { writeSceneLog } from '../utils/writeSceneLog';
 import { useUrlSyncManager } from './UrlSyncManager';
 
 export function useUrlSync(sceneRoot: SceneObject, options: SceneUrlSyncOptions = {}): boolean {
   const location = useLocation();
-  const locationService = useLocationService();
+  // As we this is basically a version/feature check for grafana/runtime this 'if' should be stable (ie for one instance
+  // of grafana this will always be true or false) so it should be safe to ignore the hook rule here
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const locationService = useLocationService ? useLocationService() : locationServiceRuntime;
   const [isInitialized, setIsInitialized] = useState(false);
   const urlSyncManager = useUrlSyncManager(options, locationService);
 

--- a/packages/scenes/src/services/useUrlSync.ts
+++ b/packages/scenes/src/services/useUrlSync.ts
@@ -1,14 +1,15 @@
 import { SceneObject, SceneUrlSyncOptions } from '../core/types';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { locationService } from '@grafana/runtime';
+import { useLocationService } from '@grafana/runtime';
 import { writeSceneLog } from '../utils/writeSceneLog';
 import { useUrlSyncManager } from './UrlSyncManager';
 
 export function useUrlSync(sceneRoot: SceneObject, options: SceneUrlSyncOptions = {}): boolean {
   const location = useLocation();
+  const locationService = useLocationService()
   const [isInitialized, setIsInitialized] = useState(false);
-  const urlSyncManager = useUrlSyncManager(options);
+  const urlSyncManager = useUrlSyncManager(options, locationService);
 
   useEffect(() => {
     urlSyncManager.initSync(sceneRoot);
@@ -26,7 +27,7 @@ export function useUrlSync(sceneRoot: SceneObject, options: SceneUrlSyncOptions 
     }
 
     urlSyncManager.handleNewLocation(locationToHandle);
-  }, [sceneRoot, urlSyncManager, location]);
+  }, [sceneRoot, urlSyncManager, location, locationService]);
 
   return isInitialized;
 }

--- a/packages/scenes/src/services/useUrlSync.ts
+++ b/packages/scenes/src/services/useUrlSync.ts
@@ -1,17 +1,13 @@
 import { SceneObject, SceneUrlSyncOptions } from '../core/types';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-// @ts-ignore
-import { locationService as locationServiceRuntime, useLocationService } from '@grafana/runtime';
 import { writeSceneLog } from '../utils/writeSceneLog';
 import { useUrlSyncManager } from './UrlSyncManager';
+import { useLocationServiceSafe } from '../utils/utils';
 
 export function useUrlSync(sceneRoot: SceneObject, options: SceneUrlSyncOptions = {}): boolean {
   const location = useLocation();
-  // As we this is basically a version/feature check for grafana/runtime this 'if' should be stable (ie for one instance
-  // of grafana this will always be true or false) so it should be safe to ignore the hook rule here
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const locationService = useLocationService ? useLocationService() : locationServiceRuntime;
+  const locationService = useLocationServiceSafe();
   const [isInitialized, setIsInitialized] = useState(false);
   const urlSyncManager = useUrlSyncManager(options, locationService);
 

--- a/packages/scenes/src/utils/utils.ts
+++ b/packages/scenes/src/utils/utils.ts
@@ -1,4 +1,8 @@
 import { SceneObject, SceneObjectState } from '../core/types';
+import { locationService as locationServiceRuntime } from '@grafana/runtime';
+// @ts-ignore
+// eslint-disable-next-line no-duplicate-imports
+import { useLocationService } from '@grafana/runtime';
 
 /**
  *  This function works around the problem of Contravariance of the SceneObject.setState function
@@ -6,4 +10,15 @@ import { SceneObject, SceneObjectState } from '../core/types';
  */
 export function setBaseClassState<T extends SceneObjectState>(sceneObject: SceneObject<T>, newState: Partial<T>) {
   sceneObject.setState(newState);
+}
+
+/**
+ * Safe way to get location service that fallbacks to singleton for older runtime versions where useLocationService is
+ * not available.
+ */
+export function useLocationServiceSafe() {
+  // As we this is basically a version/feature check for grafana/runtime this 'if' should be stable (ie for one instance
+  // of grafana this will always be true or false) so it should be safe to ignore the hook rule here
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useLocationService ? useLocationService() : locationServiceRuntime;
 }

--- a/packages/scenes/src/utils/utils.ts
+++ b/packages/scenes/src/utils/utils.ts
@@ -17,7 +17,7 @@ export function setBaseClassState<T extends SceneObjectState>(sceneObject: Scene
  * not available.
  */
 export function useLocationServiceSafe() {
-  // As we this is basically a version/feature check for grafana/runtime this 'if' should be stable (ie for one instance
+  // This is basically a version/feature check for grafana/runtime so this 'if' should be stable (ie for one instance
   // of grafana this will always be true or false) so it should be safe to ignore the hook rule here
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return useLocationService ? useLocationService() : locationServiceRuntime;


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/93225
This changes the UrlSyncManager to use the `locationsService` from context making it possible to render 2 scenes app without them clashing on URL handling, which is needed for the sidecar project https://github.com/grafana/grafana/pull/91648.

See this draft PR for the Explore Traces app: https://github.com/grafana/explore-traces/pull/102 for usage.