### PR TITLE
Include isMulti and includeAll in LocalValueVariable

### DIFF
--- a/packages/scenes/src/variables/variants/LocalValueVariable.ts
+++ b/packages/scenes/src/variables/variants/LocalValueVariable.ts
@@ -20,14 +20,12 @@ export class LocalValueVariable
   extends SceneObjectBase<LocalValueVariableState>
   implements SceneVariable<LocalValueVariableState>
 {
-  public constructor(initialState: Omit<Partial<LocalValueVariableState>, 'isMulti' | 'includeAll'>) {
+  public constructor(initialState: Partial<LocalValueVariableState>) {
     super({
       type: 'system',
       value: '',
       text: '',
       name: '',
-      isMulti: true,
-      includeAll: true,
       ...initialState,
       skipUrlSync: true,
     });


### PR DESCRIPTION
isMulti and includeAll needs to be present for the interpolation of SQL queries to work. If this is not included the query would need to change if you change the repeating behavior of the panel.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.14.4--canary.900.10848367235.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.14.4--canary.900.10848367235.0
  npm install @grafana/scenes@5.14.4--canary.900.10848367235.0
  # or 
  yarn add @grafana/scenes-react@5.14.4--canary.900.10848367235.0
  yarn add @grafana/scenes@5.14.4--canary.900.10848367235.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
