### PR TITLE
Adhoc filters: Add descriptions for all operators

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -122,18 +122,20 @@ export type OperatorDefinition = {
 export const OPERATORS: OperatorDefinition[] = [
   {
     value: '=',
+    description: 'Equals',
   },
   {
     value: '!=',
+    description: 'Not equal',
   },
   {
     value: '=|',
-    description: 'Is one of. Use to filter on multiple values.',
+    description: 'One of. Use to filter on multiple values.',
     isMulti: true,
   },
   {
     value: '!=|',
-    description: 'Is not one of. Use to exclude multiple values.',
+    description: 'Not one of. Use to exclude multiple values.',
     isMulti: true,
   },
   {
@@ -146,9 +148,11 @@ export const OPERATORS: OperatorDefinition[] = [
   },
   {
     value: '<',
+    description: 'Less than',
   },
   {
     value: '>',
+    description: 'Greater than',
   },
 ];
 


### PR DESCRIPTION
Adds descriptions for all the operators, instead of just a select few

![image](https://github.com/user-attachments/assets/1f890326-45ee-4e42-b453-3c39788aac1b)
