### PR TITLE
SceneTimeRange: Fixes inconsistent representation of time range

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -1,4 +1,4 @@
-import { getTimeZone, rangeUtil, setWeekStart, TimeRange, toUtc } from '@grafana/data';
+import { getTimeZone, rangeUtil, setWeekStart, TimeRange } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
@@ -8,10 +8,10 @@ import { SceneTimeRangeLike, SceneTimeRangeState, SceneObjectUrlValues } from '.
 import { getClosest } from './sceneGraph/utils';
 import { parseUrlParam } from '../utils/parseUrlParam';
 import { evaluateTimeRange } from '../utils/evaluateTimeRange';
-import { config, locationService, RefreshEvent } from '@grafana/runtime';
+import { config, RefreshEvent } from '@grafana/runtime';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone'] });
 
   public constructor(state: Partial<SceneTimeRangeState> = {}) {
     const from = state.from ?? 'now-6h';
@@ -149,27 +149,22 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
   public onTimeRangeChange = (timeRange: TimeRange) => {
     const update: Partial<SceneTimeRangeState> = {};
-    const updateToEval: Partial<SceneTimeRangeState> = {};
 
     if (typeof timeRange.raw.from === 'string') {
       update.from = timeRange.raw.from;
-      updateToEval.from = timeRange.raw.from;
     } else {
       update.from = timeRange.raw.from.toISOString();
-      updateToEval.from = timeRange.raw.from.toISOString(true);
     }
 
     if (typeof timeRange.raw.to === 'string') {
       update.to = timeRange.raw.to;
-      updateToEval.to = timeRange.raw.to;
     } else {
       update.to = timeRange.raw.to.toISOString();
-      updateToEval.to = timeRange.raw.to.toISOString(true);
     }
 
     update.value = evaluateTimeRange(
-      updateToEval.from,
-      updateToEval.to,
+      update.from,
+      update.to,
       this.getTimeZone(),
       this.state.fiscalYearStartMonth,
       this.state.UNSAFE_nowDelay
@@ -177,16 +172,12 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
     // Only update if time range actually changed
     if (update.from !== this.state.from || update.to !== this.state.to) {
-      this._urlSync.performBrowserHistoryAction(() => {
-        this.setState(update);
-      });
+      this.setState(update);
     }
   };
 
   public onTimeZoneChange = (timeZone: TimeZone) => {
-    this._urlSync.performBrowserHistoryAction(() => {
-      this.setState({ timeZone });
-    });
+    this.setState({ timeZone });
   };
 
   public onRefresh = () => {
@@ -204,44 +195,28 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   };
 
   public getUrlState() {
-    const params = locationService.getSearchObject();
     const urlValues: SceneObjectUrlValues = { from: this.state.from, to: this.state.to };
-
     if (this.state.timeZone) {
       urlValues.timezone = this.state.timeZone;
-    }
-
-    // Clear time and time.window once they are converted to from and to
-    if (params.time && params['time.window']) {
-      urlValues.time = null;
-      urlValues['time.window'] = null;
     }
 
     return urlValues;
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    const update: Partial<SceneTimeRangeState> = {};
-
-    let from = parseUrlParam(values.from);
-    let to = parseUrlParam(values.to);
-
-    if (values.time && values['time.window']) {
-      const time = Array.isArray(values.time) ? values.time[0] : values.time;
-      const timeWindow = Array.isArray(values['time.window']) ? values['time.window'][0] : values['time.window'];
-      const timeRange = getTimeWindow(time, timeWindow);
-      from = timeRange.from;
-      to = timeRange.to;
-    }
-
-    if (!from && !to) {
+    // ignore if both are missing
+    if (!values.to && !values.from) {
       return;
     }
+
+    const update: Partial<SceneTimeRangeState> = {};
+    const from = parseUrlParam(values.from);
 
     if (from) {
       update.from = from;
     }
 
+    const to = parseUrlParam(values.to);
     if (to) {
       update.to = to;
     }
@@ -260,28 +235,4 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
     this.setState(update);
   }
-}
-
-/**
- * Calculates the duration of the time range from time-time.window/2 to time+time.window/2. Both be specified in ms. For example ?time=1500000000000&time.window=10000 results in a 10-second time range from 1499999995000 to 1500000005000`.
- * @param time - time in ms
- * @param timeWindow - time window in ms or interval string
- */
-function getTimeWindow(time: string, timeWindow: string) {
-  // Parse the time, assuming it could be an ISO string or a number in milliseconds
-  const valueTime = isNaN(Date.parse(time)) ? parseInt(time, 10) : Date.parse(time);
-
-  let timeWindowMs;
-
-  if (timeWindow.match(/^\d+$/) && parseInt(timeWindow, 10)) {
-    // when time window is specified in ms
-    timeWindowMs = parseInt(timeWindow, 10);
-  } else {
-    timeWindowMs = rangeUtil.intervalToMs(timeWindow);
-  }
-
-  return {
-    from: toUtc(valueTime - timeWindowMs / 2).toISOString(),
-    to: toUtc(valueTime + timeWindowMs / 2).toISOString(),
-  };
 }

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -1,4 +1,4 @@
-import { getTimeZone, rangeUtil, setWeekStart, TimeRange } from '@grafana/data';
+import { getTimeZone, rangeUtil, setWeekStart, TimeRange, toUtc } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
@@ -8,10 +8,10 @@ import { SceneTimeRangeLike, SceneTimeRangeState, SceneObjectUrlValues } from '.
 import { getClosest } from './sceneGraph/utils';
 import { parseUrlParam } from '../utils/parseUrlParam';
 import { evaluateTimeRange } from '../utils/evaluateTimeRange';
-import { config, RefreshEvent } from '@grafana/runtime';
+import { config, locationService, RefreshEvent } from '@grafana/runtime';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
 
   public constructor(state: Partial<SceneTimeRangeState> = {}) {
     const from = state.from ?? 'now-6h';
@@ -172,12 +172,16 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
     // Only update if time range actually changed
     if (update.from !== this.state.from || update.to !== this.state.to) {
-      this.setState(update);
+      this._urlSync.performBrowserHistoryAction(() => {
+        this.setState(update);
+      });
     }
   };
 
   public onTimeZoneChange = (timeZone: TimeZone) => {
-    this.setState({ timeZone });
+    this._urlSync.performBrowserHistoryAction(() => {
+      this.setState({ timeZone });
+    });
   };
 
   public onRefresh = () => {
@@ -195,28 +199,44 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
   };
 
   public getUrlState() {
+    const params = locationService.getSearchObject();
     const urlValues: SceneObjectUrlValues = { from: this.state.from, to: this.state.to };
+
     if (this.state.timeZone) {
       urlValues.timezone = this.state.timeZone;
+    }
+
+    // Clear time and time.window once they are converted to from and to
+    if (params.time && params['time.window']) {
+      urlValues.time = null;
+      urlValues['time.window'] = null;
     }
 
     return urlValues;
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
-    // ignore if both are missing
-    if (!values.to && !values.from) {
-      return;
+    const update: Partial<SceneTimeRangeState> = {};
+
+    let from = parseUrlParam(values.from);
+    let to = parseUrlParam(values.to);
+
+    if (values.time && values['time.window']) {
+      const time = Array.isArray(values.time) ? values.time[0] : values.time;
+      const timeWindow = Array.isArray(values['time.window']) ? values['time.window'][0] : values['time.window'];
+      const timeRange = getTimeWindow(time, timeWindow);
+      from = timeRange.from;
+      to = timeRange.to;
     }
 
-    const update: Partial<SceneTimeRangeState> = {};
-    const from = parseUrlParam(values.from);
+    if (!from && !to) {
+      return;
+    }
 
     if (from) {
       update.from = from;
     }
 
-    const to = parseUrlParam(values.to);
     if (to) {
       update.to = to;
     }
@@ -235,4 +255,28 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
     this.setState(update);
   }
+}
+
+/**
+ * Calculates the duration of the time range from time-time.window/2 to time+time.window/2. Both be specified in ms. For example ?time=1500000000000&time.window=10000 results in a 10-second time range from 1499999995000 to 1500000005000`.
+ * @param time - time in ms
+ * @param timeWindow - time window in ms or interval string
+ */
+function getTimeWindow(time: string, timeWindow: string) {
+  // Parse the time, assuming it could be an ISO string or a number in milliseconds
+  const valueTime = isNaN(Date.parse(time)) ? parseInt(time, 10) : Date.parse(time);
+
+  let timeWindowMs;
+
+  if (timeWindow.match(/^\d+$/) && parseInt(timeWindow, 10)) {
+    // when time window is specified in ms
+    timeWindowMs = parseInt(timeWindow, 10);
+  } else {
+    timeWindowMs = rangeUtil.intervalToMs(timeWindow);
+  }
+
+  return {
+    from: toUtc(valueTime - timeWindowMs / 2).toISOString(),
+    to: toUtc(valueTime + timeWindowMs / 2).toISOString(),
+  };
 }


### PR DESCRIPTION
Not sure I fully understand this change (https://github.com/grafana/scenes/pull/420/ ) so this PR is reverting it.

Opening revert PR just to remember to have a discussion on this on next scenes sync. 

The original PR was fixing 
https://github.com/grafana/scenes/issues/457 

but after investing a similar issue (https://github.com/grafana/support-escalations/issues/12532) we have right now in main I think the problem is not in scenes but in the TimePicker and how it handle string raw values (it does handle them as UTC iso strings but just as plain strings) 

In my view the bug in https://github.com/grafana/scenes/issues/457  was not that the timezone was lost but the fact that we showed an iso string in those inputs to begin with. Just try setting absolute time range using the calendar dates and the time range is formatted normally, I think the same should be true when selecting an absolute time range via graph. We should not show an iso string there (with or without timezone offset).

A problem with this fix is also how it creates inconsistency, the TimeRange raw (from/to) becomes formatted differently after a call to onTimeRangeChange vs initial value evaluated in constructor or via updateFromUrl 

We have instead two ways to fix this, update TimeRangePicker so that it handles ISO date strings in from/to, PR that tries to to do that https://github.com/grafana/grafana/pull/93479 

another possible fix is to change in scenes how we store raw from/to (go back to let raw/from to be moment instances for absolute ranges) 
