### PR TITLE
SceneTimeRange: Use new weekStart prop on TimeRangePicker

### DIFF
--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -75,6 +75,8 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
       onZoom={model.onZoom}
       onChangeTimeZone={timeRange.onTimeZoneChange}
       onChangeFiscalYearStartMonth={model.onChangeFiscalYearStartMonth}
+      // @ts-ignore TODO remove after grafana/ui update to 11.2.0
+      weekStart={timeRangeState.weekStart}
     />
   );
 }

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -1,17 +1,14 @@
-import { toUtc, setWeekStart, dateMath } from '@grafana/data';
+import { toUtc, dateMath } from '@grafana/data';
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 import { PanelBuilders } from './PanelBuilders';
 import { SceneTimeRange } from './SceneTimeRange';
-import { config, RefreshEvent } from '@grafana/runtime';
+import { RefreshEvent } from '@grafana/runtime';
 import { EmbeddedScene } from '../components/EmbeddedScene';
 import { SceneReactObject } from '../components/SceneReactObject';
 
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
-  setWeekStart: jest.fn(),
 }));
-
-config.bootData = { user: { weekStart: 'monday' } } as any;
 
 function simulateDelay(newDateString: string, scene: EmbeddedScene) {
   jest.setSystemTime(new Date(newDateString));
@@ -52,15 +49,6 @@ describe('SceneTimeRange', () => {
       from: 'now-1h',
       to: 'now',
     });
-  });
-
-  it('When weekStart i set should call on activation', () => {
-    const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', weekStart: 'saturday' });
-    const deactivate = timeRange.activate();
-    expect(setWeekStart).toHaveBeenCalledWith('saturday');
-
-    deactivate();
-    expect(setWeekStart).toHaveBeenCalledWith('monday');
   });
 
   it('updateFromUrl with ISO time', () => {

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -1,4 +1,4 @@
-import { getTimeZone, rangeUtil, setWeekStart, TimeRange, toUtc } from '@grafana/data';
+import { getTimeZone, rangeUtil, TimeRange, toUtc } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
@@ -8,7 +8,7 @@ import { SceneTimeRangeLike, SceneTimeRangeState, SceneObjectUrlValues } from '.
 import { getClosest } from './sceneGraph/utils';
 import { parseUrlParam } from '../utils/parseUrlParam';
 import { evaluateTimeRange } from '../utils/evaluateTimeRange';
-import { config, locationService, RefreshEvent } from '@grafana/runtime';
+import { locationService, RefreshEvent } from '@grafana/runtime';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
@@ -53,20 +53,9 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       }
     }
 
-    if (this.state.weekStart) {
-      setWeekStart(this.state.weekStart);
-    }
-
     if (rangeUtil.isRelativeTimeRange(this.state.value.raw)) {
       this.refreshIfStale();
     }
-
-    // Deactivation handler that restore weekStart if it was changed
-    return () => {
-      if (this.state.weekStart) {
-        setWeekStart(config.bootData.user.weekStart);
-      }
-    };
   }
 
   private refreshIfStale() {


### PR DESCRIPTION
Apparently, the setWeekStart runtime function has stopped working some time ago (maybe due a browser update), not sure. 

Frontend platform added a weekStart prop to TimeRangePicker recently (but did not notify us about this) 

This updates SceneTimePicker to pass the weekStart state prop to TimeRangePicker 

I also have a a bit related PR that fixes weekStart for all scene app plugins (so TimeRangePicker uses the system or user weekStart by default) 

https://github.com/grafana/grafana/pull/93464
