### PR TITLE
DataProviderProxy: Rename and fix imports

### DIFF
--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -5,7 +5,7 @@ import {
   VizPanelState,
   VizConfig,
   SceneQueryRunner,
-  DataProviderSharer,
+  DataProviderProxy,
 } from '@grafana/scenes';
 import { usePrevious } from 'react-use';
 import { getPanelOptionsWithDefaults } from '@grafana/data';
@@ -96,7 +96,7 @@ export function VizPanel(props: VizPanelProps) {
  */
 function getDataProviderForVizPanel(data: SceneDataProvider | undefined): SceneDataProvider | undefined {
   if (data instanceof SceneQueryRunner) {
-    return new DataProviderSharer({ source: data.getRef() });
+    return new DataProviderProxy({ source: data.getRef() });
   }
   return data;
 }

--- a/packages/scenes-react/src/hooks/useDataTransformer.ts
+++ b/packages/scenes-react/src/hooks/useDataTransformer.ts
@@ -1,6 +1,6 @@
 import {
   CustomTransformerDefinition,
-  DataProviderSharer,
+  DataProviderProxy,
   SceneDataProvider,
   SceneDataTransformer,
 } from '@grafana/scenes';
@@ -23,7 +23,7 @@ export function useDataTransformer(options: UseDataTransformerOptions) {
   if (!dataTransformer) {
     dataTransformer = new SceneDataTransformer({
       key: key,
-      $data: new DataProviderSharer({ source: options.data.getRef() }),
+      $data: new DataProviderProxy({ source: options.data.getRef() }),
       transformations: options.transformations,
     });
   }

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -29,7 +29,7 @@ export { SceneTimeRange } from './core/SceneTimeRange';
 export { SceneTimeZoneOverride } from './core/SceneTimeZoneOverride';
 
 export { SceneQueryRunner, type QueryRunnerState } from './querying/SceneQueryRunner';
-export { DataProviderSharer } from './querying/DataProviderSharer';
+export { DataProviderProxy } from './querying/DataProviderProxy';
 export {
   type ExtraQueryDescriptor,
   type ExtraQueryProvider,

--- a/packages/scenes/src/querying/DataProviderProxy.ts
+++ b/packages/scenes/src/querying/DataProviderProxy.ts
@@ -1,17 +1,13 @@
-import {
-  SceneObjectBase,
-  SceneObjectRef,
-  SceneDataProvider,
-  SceneDataProviderResult,
-  SceneDataState,
-} from '@grafana/scenes';
 import { Observable } from 'rxjs';
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneObjectRef } from '../core/SceneObjectRef';
+import { SceneDataState, SceneDataProvider, SceneDataProviderResult } from '../core/types';
 
 export interface DataProviderSharerState extends SceneDataState {
   source: SceneObjectRef<SceneDataProvider>;
 }
 
-export class DataProviderSharer extends SceneObjectBase<DataProviderSharerState> implements SceneDataProvider {
+export class DataProviderProxy extends SceneObjectBase<DataProviderSharerState> implements SceneDataProvider {
   public constructor(state: DataProviderSharerState) {
     super({
       source: state.source,


### PR DESCRIPTION
Main is broken after recent PR merged (by me), not sure why the PR was green. 

This should fix it (and forgot to rename the class before merging so doing that as well) 