### PR TITLE
Add checks for valid dates before saving calculating values

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -111,6 +111,19 @@ describe('SceneTimeRange', () => {
     expect(stateSpy).toBeCalledTimes(1);
   });
 
+  it('should not allow invalid date values', () => {
+    const invalidDate = 'now)';
+    const timeRange = new SceneTimeRange({ from: 'now-1h', to: invalidDate });
+    expect(timeRange.state.value.raw.to).toBe('now');
+  });
+
+  it('should not allow invalid date values when updating from URL', () => {
+    let invalidDate = 'now)';
+    const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+    timeRange.urlSync?.updateFromUrl({ to: invalidDate });
+    expect(timeRange.state.value.raw.to).toBe('now');
+  });
+
   describe('time zones', () => {
     describe('when time zone is not specified', () => {
       it('should return default time zone', () => {

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -9,13 +9,15 @@ import { getClosest } from './sceneGraph/utils';
 import { parseUrlParam } from '../utils/parseUrlParam';
 import { evaluateTimeRange } from '../utils/evaluateTimeRange';
 import { locationService, RefreshEvent } from '@grafana/runtime';
+import { isValid } from '../utils/date';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
 
   public constructor(state: Partial<SceneTimeRangeState> = {}) {
-    const from = state.from ?? 'now-6h';
-    const to = state.to ?? 'now';
+    const from = state.from && isValid(state.from) ? state.from : 'now-6h';
+    const to = state.to && isValid(state.to) ? state.to : 'now';
+
     const timeZone = state.timeZone;
     const value = evaluateTimeRange(
       from,
@@ -214,19 +216,24 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       const time = Array.isArray(values.time) ? values.time[0] : values.time;
       const timeWindow = Array.isArray(values['time.window']) ? values['time.window'][0] : values['time.window'];
       const timeRange = getTimeWindow(time, timeWindow);
-      from = timeRange.from;
-      to = timeRange.to;
+      if (timeRange.from && isValid(timeRange.from)) {
+        from = timeRange.from;
+      }
+
+      if (timeRange.to && isValid(timeRange.to)) {
+        to = timeRange.to;
+      }
     }
 
     if (!from && !to) {
       return;
     }
 
-    if (from) {
+    if (from && isValid(from)) {
       update.from = from;
     }
 
-    if (to) {
+    if (to && isValid(to)) {
       update.to = to;
     }
 

--- a/packages/scenes/src/utils/date.ts
+++ b/packages/scenes/src/utils/date.ts
@@ -1,0 +1,15 @@
+import { isDateTime, dateMath, dateTimeParse } from '@grafana/data';
+import { TimeZone } from '@grafana/schema';
+
+export function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): boolean {
+  if (isDateTime(value)) {
+    return value.isValid();
+  }
+
+  if (dateMath.isMathString(value)) {
+    return dateMath.isValid(value);
+  }
+
+  const parsed = dateTimeParse(value, { roundUp, timeZone });
+  return parsed.isValid();
+}

--- a/packages/scenes/src/utils/parseUrlParam.test.ts
+++ b/packages/scenes/src/utils/parseUrlParam.test.ts
@@ -30,4 +30,8 @@ describe('parseUrlParam', () => {
   it('should parse epoch', () => {
     expect(parseUrlParam('1693559700000')).toMatchInlineSnapshot(`"2023-09-01T09:15:00.000Z"`);
   });
+
+  it('should parse human readable date', () => {
+    expect(parseUrlParam('2024-09-30 00:00:00')).toMatchInlineSnapshot(`"2024-09-30T00:00:00.000Z"`);
+  });
 });

--- a/packages/scenes/src/utils/parseUrlParam.ts
+++ b/packages/scenes/src/utils/parseUrlParam.ts
@@ -26,6 +26,11 @@ export function parseUrlParam(value: SceneObjectUrlValue): string | null {
     if (utcValue.isValid()) {
       return utcValue.toISOString();
     }
+  } else if (value.length === 19) {
+    const utcValue = toUtc(value, 'YYYY-MM-DD HH:mm:ss');
+    if (utcValue.isValid()) {
+      return utcValue.toISOString();
+    }
   } else if (value.length === 24) {
     const utcValue = toUtc(value);
     return utcValue.toISOString();


### PR DESCRIPTION
- Add check for invalid date values
  - App was completely breaking when we passed in invalid values to `from` or `to` (we noticed that by accident somebody copy/pasted a url and it had `to=now)`)
  - Validate `from` and `to` values before calculating the value
- Also fix issue where `from` value would revert to `1970` if setting the time range from: absolute date -> now 
  - We were not properly parsing a human readable date style from url 

Fixes [#1295](https://github.com/grafana/app-observability-plugin/issues/1295)
Fixes [#1306](https://github.com/grafana/app-observability-plugin/issues/1306)