### PR TITLE
SceneTimePicker: Implement recently used absolute time ranges view

### DIFF
--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -141,7 +141,7 @@ export function getShiftedTimeRange(dir: TimeRangeDirection, timeRange: TimeRang
   };
 }
 
-const HISTORY_LOCAL_STORAGE_KEY = 'grafana.scenes.dashboard.timepicker.history';
+const HISTORY_LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
 
 // Simplified object to store in local storage
 interface TimePickerHistoryItem {

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useLocalStorage } from 'react-use';
+import { uniqBy } from 'lodash';
 
+import { TimeRange, isDateTime, rangeUtil, toUtc } from '@grafana/data';
 import { TimeRangePicker } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneObjectState } from '../core/types';
-import { TimeRange, toUtc } from '@grafana/data';
 
 export interface SceneTimePickerState extends SceneObjectState {
   hidePicker?: boolean;
@@ -58,6 +60,11 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
   const timeRange = sceneGraph.getTimeRange(model);
   const timeZone = timeRange.getTimeZone();
   const timeRangeState = timeRange.useState();
+  const [timeRangeHistory, setTimeRangeHistory] = useLocalStorage<TimeRange[]>(HISTORY_LOCAL_STORAGE_KEY, [], {
+    raw: false,
+    serializer: serializeHistory,
+    deserializer: deserializeHistory,
+  });
 
   if (hidePicker) {
     return null;
@@ -67,7 +74,13 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
     <TimeRangePicker
       isOnCanvas={isOnCanvas ?? true}
       value={timeRangeState.value}
-      onChange={timeRange.onTimeRangeChange}
+      onChange={(range) => {
+        if (isAbsolute(range)) {
+          setTimeRangeHistory([range, ...(timeRangeHistory ?? [])]);
+        }
+
+        timeRange.onTimeRangeChange(range);
+      }}
       timeZone={timeZone}
       fiscalYearStartMonth={timeRangeState.fiscalYearStartMonth}
       onMoveBackward={model.onMoveBackward}
@@ -77,6 +90,7 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
       onChangeFiscalYearStartMonth={model.onChangeFiscalYearStartMonth}
       // @ts-ignore TODO remove after grafana/ui update to 11.2.0
       weekStart={timeRangeState.weekStart}
+      history={timeRangeHistory}
     />
   );
 }
@@ -125,4 +139,37 @@ export function getShiftedTimeRange(dir: TimeRangeDirection, timeRange: TimeRang
     to,
     raw: { from, to },
   };
+}
+
+const HISTORY_LOCAL_STORAGE_KEY = 'grafana.scenes.dashboard.timepicker.history';
+
+// Simplified object to store in local storage
+interface TimePickerHistoryItem {
+  from: string;
+  to: string;
+}
+
+function deserializeHistory(value: string): TimeRange[] {
+  const values: TimePickerHistoryItem[] = JSON.parse(value);
+  // The history is saved in UTC and with the default date format, so we need to pass those values to the convertRawToRange
+  return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined, 'YYYY-MM-DD HH:mm:ss'));
+}
+
+function serializeHistory(values: TimeRange[]) {
+  return JSON.stringify(
+    limit(
+      values.map((v) => ({
+        from: typeof v.raw.from === 'string' ? v.raw.from : v.raw.from.toISOString(),
+        to: typeof v.raw.to === 'string' ? v.raw.to : v.raw.to.toISOString(),
+      }))
+    )
+  );
+}
+
+function limit(value: TimePickerHistoryItem[]): TimePickerHistoryItem[] {
+  return uniqBy(value, (v) => v.from + v.to).slice(0, 4);
+}
+
+function isAbsolute(value: TimeRange): boolean {
+  return isDateTime(value.raw.from) || isDateTime(value.raw.to);
 }


### PR DESCRIPTION
Also added some tests :-)

Closes #909
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.16.0--canary.915.11034968022.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.16.0--canary.915.11034968022.0
  npm install @grafana/scenes@5.16.0--canary.915.11034968022.0
  # or 
  yarn add @grafana/scenes-react@5.16.0--canary.915.11034968022.0
  yarn add @grafana/scenes@5.16.0--canary.915.11034968022.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
