### PR TITLE
Combobox: Fix "Apply" button positioning when scrolling

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
@@ -77,7 +77,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     paddingRight: theme.spacing(0.5),
   }),
   multiValueApplyWrapper: css({
-    position: 'absolute',
+    position: 'fixed',
     top: 0,
     left: 0,
     display: 'flex',

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFloatingInteractions.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFloatingInteractions.ts
@@ -50,6 +50,7 @@ export const useFloatingInteractions = ({
         padding: 10,
       }),
     ],
+    strategy: 'fixed',
   });
 
   const role = useRole(context, { role: 'listbox' });


### PR DESCRIPTION
- fix "Apply" button positioning when scrolling
- believe this was caused by the enablement of `bodyScrolling` - need to use a "fixed" positioning strategy instead now

# before 

https://github.com/user-attachments/assets/6452ea78-5601-4e5e-9a61-74bf3b9da174

# after

https://github.com/user-attachments/assets/1ee53e97-b03b-43fc-96fb-f8f3ad912caf

Fixes https://github.com/grafana/hyperion-planning/issues/124