### PR TITLE
Fix showing all value in datalinks when linking to another db and including vars

### DIFF
--- a/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
+++ b/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
@@ -48,6 +48,25 @@ describe('UrlVariables', () => {
     expect(urlVars.getValue().formatter()).toBe('var-cluster=All');
   });
 
+  it('Should handle variable with all value', () => {
+    const scene = new TestScene({
+      $variables: new SceneVariableSet({
+        variables: [
+          new TestVariable({
+            name: 'cluster',
+            value: ALL_VARIABLE_VALUE,
+            text: ALL_VARIABLE_TEXT,
+            isMulti: true,
+            includeAll: true,
+          }),
+        ],
+      }),
+    });
+
+    const urlVars = new AllVariablesMacro('__all_variables', scene);
+    expect(urlVars.getValue().formatter()).toBe('var-cluster=All');
+  });
+
   it('Should ignore variables with skipUrlSync', () => {
     const scene = new TestScene({
       $variables: new SceneVariableSet({

--- a/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
+++ b/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
@@ -64,7 +64,7 @@ describe('UrlVariables', () => {
     });
 
     const urlVars = new AllVariablesMacro('__all_variables', scene);
-    expect(urlVars.getValue().formatter()).toBe('var-cluster=All');
+    expect(urlVars.getValue().formatter()).toBe('var-cluster=%24__all');
   });
 
   it('Should ignore variables with skipUrlSync', () => {

--- a/packages/scenes/src/variables/macros/AllVariablesMacro.ts
+++ b/packages/scenes/src/variables/macros/AllVariablesMacro.ts
@@ -3,6 +3,8 @@ import { isCustomVariableValue, SceneVariable } from '../types';
 import { formatRegistry, FormatVariable } from '../interpolation/formatRegistry';
 import { SkipFormattingValue } from './types';
 import { VariableFormatID } from '@grafana/schema';
+import { MultiValueVariable } from '../variants/MultiValueVariable';
+import { ALL_VARIABLE_TEXT } from '../constants';
 
 export class AllVariablesMacro implements FormatVariable {
   public state: { name: string; type: string };
@@ -20,6 +22,12 @@ export class AllVariablesMacro implements FormatVariable {
 
     for (const name of Object.keys(allVars)) {
       const variable = allVars[name];
+
+      if (variable instanceof MultiValueVariable && variable.hasAllValue() && !variable.state.allValue) {
+        params.push(format.formatter(ALL_VARIABLE_TEXT, [], variable))
+        continue;
+      }
+
       const value = variable.getValue();
 
       if (!value) {

--- a/packages/scenes/src/variables/macros/AllVariablesMacro.ts
+++ b/packages/scenes/src/variables/macros/AllVariablesMacro.ts
@@ -4,7 +4,7 @@ import { formatRegistry, FormatVariable } from '../interpolation/formatRegistry'
 import { SkipFormattingValue } from './types';
 import { VariableFormatID } from '@grafana/schema';
 import { MultiValueVariable } from '../variants/MultiValueVariable';
-import { ALL_VARIABLE_TEXT } from '../constants';
+import { ALL_VARIABLE_VALUE } from '../constants';
 
 export class AllVariablesMacro implements FormatVariable {
   public state: { name: string; type: string };
@@ -24,7 +24,7 @@ export class AllVariablesMacro implements FormatVariable {
       const variable = allVars[name];
 
       if (variable instanceof MultiValueVariable && variable.hasAllValue() && !variable.state.allValue) {
-        params.push(format.formatter(ALL_VARIABLE_TEXT, [], variable))
+        params.push(format.formatter(ALL_VARIABLE_VALUE, [], variable))
         continue;
       }
 


### PR DESCRIPTION
Fixes an issue where setting a datalink to another dashboard that included template vars and selecting the `All` value in the initial dashboard would generate the URL for the second dashboard using all the values concatenated instead of the special `All` value.

This PR addresses that and bring back the functionality from the old arch

Before:

https://github.com/user-attachments/assets/5493db27-27f0-4e15-8ae8-782f213620f8


After:

https://github.com/user-attachments/assets/86f92cc2-cb48-48ea-a1ef-d14a22abe5f6

Closes https://github.com/grafana/grafana/issues/90180
