### PR TITLE
Fix row title styling for large titles

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -131,6 +131,7 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
       cursor: 'pointer',
       background: 'transparent',
       border: 'none',
+      minWidth: 0,
       gap: theme.spacing(1),
     }),
     rowCollapsed: css({
@@ -139,6 +140,12 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
     rowTitle: css({
       fontSize: theme.typography.h5.fontSize,
       fontWeight: theme.typography.fontWeightMedium,
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      maxWidth: '100%',
+      flexGrow: 1,
+      minWidth: 0,
     }),
     collapsedInfo: css({
       fontSize: theme.typography.bodySmall.fontSize,
@@ -149,6 +156,7 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
     }),
     rowTitleAndActionsGroup: css({
       display: 'flex',
+      minWidth: 0,
 
       '&:hover, &:focus-within': {
         '& > div': {
@@ -158,6 +166,7 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
     }),
     rowActions: css({
       display: 'flex',
+      whiteSpace: 'nowrap',
       opacity: 0,
       transition: '200ms opacity ease-in 200ms',
 
@@ -177,6 +186,7 @@ export const getSceneGridRowStyles = (theme: GrafanaTheme2) => {
       },
     }),
     panelCount: css({
+      whiteSpace: 'nowrap',
       paddingLeft: theme.spacing(2),
       color: theme.colors.text.secondary,
       fontStyle: 'italic',


### PR DESCRIPTION
Fixes row styling for rows with very large titles. This bug is also reproducible in the old arch

Before:

https://github.com/user-attachments/assets/889ec127-cceb-47a6-b0b8-2022237008ea


After:

https://github.com/user-attachments/assets/4fdd543e-1e4b-4e91-873b-821c25242c36

