### PR TITLE
Refresh: Improve / harden refresh url sync

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -193,6 +193,31 @@ describe('SceneRefreshPicker', () => {
     expect(dateTime(t4.to).diff(t3.to, 's')).toBe(12);
   });
 
+  describe('Url sync', () => {
+    it('Should not return url state when refresh is empty string', () => {
+      const { refreshPicker } = setupScene('');
+      expect(refreshPicker.getUrlState()).toEqual({ refresh: undefined });
+    });
+
+    it('Should not return url state when refresh is boolean', () => {
+      // @ts-ignore
+      const { refreshPicker } = setupScene(false);
+      expect(refreshPicker.getUrlState()).toEqual({ refresh: undefined });
+    });
+
+    it('Should not return url state when refresh is interval string', () => {
+      // @ts-ignore
+      const { refreshPicker } = setupScene('11s');
+      expect(refreshPicker.getUrlState()).toEqual({ refresh: '11s' });
+    });
+
+    it('Should not update url with invalid refresh', () => {
+      const { refreshPicker } = setupScene('');
+      refreshPicker.updateFromUrl({ refresh: 'true' });
+      expect(refreshPicker.state.refresh).toEqual('');
+    });
+  });
+
   describe('min interval config', () => {
     beforeAll(() => {
       config.minRefreshInterval = '30s';

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -62,7 +62,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
           this._autoRefreshBlocked = false;
           this.onRefresh();
         }
-      }
+      };
 
       document.addEventListener('visibilitychange', onVisibilityChange);
 
@@ -100,20 +100,22 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   };
 
   public getUrlState() {
-    return {
-      refresh: this.state.refresh,
-    };
+    let refresh: string | undefined = this.state.refresh;
+
+    if (typeof refresh !== 'string' || refresh.length === 0) {
+      refresh = undefined;
+    }
+
+    return { refresh };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
     const { intervals } = this.state;
-    const refresh = values.refresh;
+    let refresh = values.refresh;
 
-    if (refresh && typeof refresh === 'string') {
+    if (typeof refresh === 'string' && isIntervalString(refresh)) {
       if (intervals?.includes(refresh)) {
-        this.setState({
-          refresh,
-        });
+        this.setState({ refresh });
       } else {
         this.setState({
           // Default to the first refresh interval if the interval from the URL is not allowed, just like in the old architecture.
@@ -232,4 +234,13 @@ function useQueryControllerState(model: SceneObject): boolean {
   }
 
   return queryController.useState().isRunning;
+}
+
+function isIntervalString(str: string): boolean {
+  try {
+    const res = rangeUtil.describeInterval(str);
+    return res.count > 0;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/93756 where old dashboards with refresh: true would end up with refresh=true in URL which would set the auto refresh to first valid interval. 

The OSS PR fixed the issue but this PR is to make sure it can't be introduced again somehow by mistake

This PR 

* Never add refresh to URL unless it has a value (so no longer `&refresh=` added to URL)
* Never allow invalid interval values to set refresh to first valid valid value 