### PR TITLE
SceneContextObject: Export context object

### DIFF
--- a/packages/scenes-react/src/index.ts
+++ b/packages/scenes-react/src/index.ts
@@ -15,4 +15,5 @@ export { useVariableValue } from './hooks/useVariableValue';
 export { AnnotationLayer } from './components/AnnotationLayer';
 export { EmbeddedSceneWithContext } from './interoperability/EmbeddedSceneWithContext';
 export { VizGridLayout } from './components/VizGridLayout';
+export { SceneContextObject } from './contexts/SceneContextObject';
 export * from './hooks/hooks';


### PR DESCRIPTION
Needed if we want to be able to use react-context hooks in dashboard scenes 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.16.3--canary.925.11130578774.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.16.3--canary.925.11130578774.0
  npm install @grafana/scenes@5.16.3--canary.925.11130578774.0
  # or 
  yarn add @grafana/scenes-react@5.16.3--canary.925.11130578774.0
  yarn add @grafana/scenes@5.16.3--canary.925.11130578774.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
