### PR TITLE
AdHocFilters: Better match old handling of queryparam formatting for ad hoc filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -1,6 +1,6 @@
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValue, SceneObjectUrlValues } from '../../core/types';
-import { AdHocFiltersVariable, AdHocFilterWithLabels, isFilterComplete, isMultiValueOperator } from './AdHocFiltersVariable';
-import { escapeUrlPipeDelimiters, toUrlCommaDelimitedString, unescapeUrlDelimiters } from '../utils';
+import { AdHocFiltersVariable, AdHocFilterWithLabels, isMultiValueOperator } from './AdHocFiltersVariable';
+import { unescapeUrlDelimiters } from '../utils';
 
 export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _variable: AdHocFiltersVariable) {}
@@ -14,14 +14,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
   }
 
   public getUrlState(): SceneObjectUrlValues {
-    const filters = this._variable.state.filters;
-
-    if (filters.length === 0) {
-      return { [this.getKey()]: [''] };
-    }
-
-    const value = filters.filter(isFilterComplete).map((filter) => toArray(filter).map(escapeUrlPipeDelimiters).join('|'));
-    return { [this.getKey()]: value };
+    return { [this.getKey()]: this._variable.getValueForUrl()?.toString() ?? '' };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues): void {
@@ -44,23 +37,6 @@ function deserializeUrlToFilters(value: SceneObjectUrlValue): AdHocFilterWithLab
 
   const filter = toFilter(value);
   return filter === null ? [] : [filter];
-}
-
-function toArray(filter: AdHocFilterWithLabels): string[] {
-  const result = [
-    toUrlCommaDelimitedString(filter.key, filter.keyLabel),
-    filter.operator,
-  ];
-  if (isMultiValueOperator(filter.operator)) {
-    // TODO remove expect-error when we're on the latest version of @grafana/data
-    // @ts-expect-error
-    filter.values.forEach((value, index) => {
-      result.push(toUrlCommaDelimitedString(value, filter.valueLabels?.[index]));
-    });
-  } else {
-    result.push(toUrlCommaDelimitedString(filter.value, filter.valueLabels?.[0]));
-  }
-  return result;
 }
 
 function toFilter(urlValue: string | number | boolean | undefined | null): AdHocFilterWithLabels | null {

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -24,6 +24,7 @@ export interface FormatVariable {
   };
 
   getValue(fieldPath?: string): VariableValue | undefined | null;
+  getValueForUrl?(fieldPath?: string): VariableValue | undefined | null;
   getValueText?(fieldPath?: string): string;
 }
 
@@ -280,6 +281,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       description:
         'Format variables as URL parameters. Example in multi-variable scenario A + B + C => var-foo=A&var-foo=B&var-foo=C.',
       formatter: (value, _args, variable) => {
+        if (variable.getValueForUrl) {
+          value = variable.getValueForUrl() ?? '';
+        }
+
         if (Array.isArray(value)) {
           return value.map((v) => formatQueryParameter(variable.state.name, v)).join('&');
         }

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -27,6 +27,8 @@ export interface SceneVariable<TState extends SceneVariableState = SceneVariable
    */
   getValue(fieldPath?: string): VariableValue | undefined | null;
 
+  getValueForUrl?(fieldPath?: string): VariableValue | undefined | null;
+
   /**
    * Should return the value display text, used by the "text" formatter
    * Example: ${podId:text}


### PR DESCRIPTION
In the old architecture, template variable adapters had a `getValueForUrl` method that could return a processed value suited for including in a URL if necessary. This was used in templateSrv:

https://github.com/grafana/grafana/blob/fb3b13b567ca074bcf9dca552e5ee4e6feff30ce/public/app/features/templating/template_srv.ts#L330-L335

To better match this behavior under scenes, I've moved some functions around and added an optional `getValueForUrl` method to the `SceneVariable` and `FormatVariable` interfaces. This method gets called from the `queryparam` formatter, if it exists.

Fixes: https://github.com/grafana/grafana/issues/94303