### PR TITLE
VizPanel: Fixes issue with viz panel when passing it SceneDataTransformer

### DIFF
--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -6,6 +6,7 @@ import {
   VizConfig,
   SceneQueryRunner,
   DataProviderProxy,
+  SceneDataNode,
 } from '@grafana/scenes';
 import { usePrevious } from 'react-use';
 import { getPanelOptionsWithDefaults } from '@grafana/data';
@@ -95,7 +96,7 @@ export function VizPanel(props: VizPanelProps) {
  * TODO: Figure out a better way to handle this'
  */
 function getDataProviderForVizPanel(data: SceneDataProvider | undefined): SceneDataProvider | undefined {
-  if (data instanceof SceneQueryRunner) {
+  if (data && !(data instanceof SceneDataNode)) {
     return new DataProviderProxy({ source: data.getRef() });
   }
   return data;

--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -4,7 +4,6 @@ import {
   VizPanel as VizPanelObject,
   VizPanelState,
   VizConfig,
-  SceneQueryRunner,
   DataProviderProxy,
   SceneDataNode,
 } from '@grafana/scenes';


### PR DESCRIPTION
When passing a VizPanel a dataProvider of type SceneDataTransformer (returned by useDataTransformer) it would log error that we are changing it's parent 

<img width="726" alt="Screenshot 2024-10-03 at 13 58 41" src="https://github.com/user-attachments/assets/c6f3a48a-a170-49cd-b833-6ac522ccca3f">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.16.4--canary.928.11176592185.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.16.4--canary.928.11176592185.0
  npm install @grafana/scenes@5.16.4--canary.928.11176592185.0
  # or 
  yarn add @grafana/scenes-react@5.16.4--canary.928.11176592185.0
  yarn add @grafana/scenes@5.16.4--canary.928.11176592185.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
