### PR TITLE
Annotations: Include templateSrv.getVariables with dashboard object in legacy annotation queries

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -13,7 +13,7 @@ import {
   ScopedVars,
 } from '@grafana/data';
 
-import { getRunRequest } from '@grafana/runtime';
+import { getRunRequest, getTemplateSrv } from '@grafana/runtime';
 import { shouldUseLegacyRunner, standardAnnotationSupport } from './standardAnnotationsSupport';
 import { Dashboard, LoadingState } from '@grafana/schema';
 import { SceneObject, SceneTimeRangeLike } from '../../../core/types';
@@ -49,7 +49,9 @@ export function executeAnnotationQuery(
         range: timeRange.state.value,
         rangeRaw: timeRange.state.value.raw,
         annotation: query,
-        dashboard: {},
+        dashboard: {
+          getVariables: getTemplateSrv().getVariables
+        },
       })
     ).pipe(
       map((events) => ({


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/94216


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.17.0--canary.929.11178151684.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.17.0--canary.929.11178151684.0
  npm install @grafana/scenes@5.17.0--canary.929.11178151684.0
  # or 
  yarn add @grafana/scenes-react@5.17.0--canary.929.11178151684.0
  yarn add @grafana/scenes@5.17.0--canary.929.11178151684.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
