### PR TITLE
Emit RefreshEvent on annotation enable/disable

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
@@ -19,6 +19,7 @@ import { DataLayerControlSwitch } from '../SceneDataLayerControls';
 import { AnnotationQueryResults, executeAnnotationQuery } from './standardAnnotationQuery';
 import { dedupAnnotations, postProcessQueryResult } from './utils';
 import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
+import { RefreshEvent } from '@grafana/runtime';
 
 interface AnnotationsDataLayerState extends SceneDataLayerProviderState {
   query: AnnotationQuery;
@@ -46,6 +47,8 @@ export class AnnotationsDataLayer
   }
 
   public onEnable(): void {
+    this.publishEvent(new RefreshEvent(), true);
+    
     const timeRange = sceneGraph.getTimeRange(this);
 
     this._timeRangeSub = timeRange.subscribeToState(() => {
@@ -54,6 +57,8 @@ export class AnnotationsDataLayer
   }
 
   public onDisable(): void {
+    this.publishEvent(new RefreshEvent(), true);
+
     this._timeRangeSub?.unsubscribe();
   }
 


### PR DESCRIPTION
This fix moves logic from [this](https://github.com/grafana/grafana/pull/93327) into the `AnnotationDataLayer`. 

This is needed to add backwards compatibility to how the old arch worked with RefreshEvents. Plugin devs depend on this event. This need is better explained in the PR above.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.18.0--canary.930.11181993017.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.18.0--canary.930.11181993017.0
  npm install @grafana/scenes@5.18.0--canary.930.11181993017.0
  # or 
  yarn add @grafana/scenes-react@5.18.0--canary.930.11181993017.0
  yarn add @grafana/scenes@5.18.0--canary.930.11181993017.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
