### PR TITLE
Interpolation: Fixes queryparam variable format when used with adhoc filter variable

### DIFF
--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -1,3 +1,4 @@
+import { AdHocFiltersVariable } from '../adhoc/AdHocFiltersVariable';
 import { VariableValue } from '../types';
 import { TestVariable } from '../variants/TestVariable';
 
@@ -76,5 +77,26 @@ describe('formatRegistry', () => {
     expect(formatValue(VariableFormatID.UriEncode, '/any-path/any-second-path?query=foo()bar BAZ')).toBe(
       '/any-path/any-second-path?query=foo%28%29bar%20BAZ'
     );
+  });
+
+  describe('queryparam', () => {
+    it('should url encode value', () => {
+      const result = formatValue(VariableFormatID.QueryParam, 'helloAZ%=');
+      expect(result).toBe('var-server=helloAZ%25%3D');
+    });
+
+    it('should use variable url sync handler', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [
+          { key: 'key1', operator: '=', value: 'val1' },
+          { key: 'key2', operator: '=~', value: 'val2' },
+        ],
+      });
+
+      const result = formatRegistry.get(VariableFormatID.QueryParam).formatter('asd', [], variable);
+      expect(result).toBe('var-Filters=key1%7C%3D%7Cval1&var-Filters=key2%7C%3D~%7Cval2');
+    });
   });
 });

--- a/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
+++ b/packages/scenes/src/variables/macros/AllVariablesMacro.test.ts
@@ -45,7 +45,7 @@ describe('UrlVariables', () => {
     });
 
     const urlVars = new AllVariablesMacro('__all_variables', scene);
-    expect(urlVars.getValue().formatter()).toBe('var-cluster=All');
+    expect(urlVars.getValue().formatter()).toBe('var-cluster=$__all');
   });
 
   it('Should handle variable with all value', () => {
@@ -64,7 +64,7 @@ describe('UrlVariables', () => {
     });
 
     const urlVars = new AllVariablesMacro('__all_variables', scene);
-    expect(urlVars.getValue().formatter()).toBe('var-cluster=%24__all');
+    expect(urlVars.getValue().formatter()).toBe('var-cluster=$__all');
   });
 
   it('Should ignore variables with skipUrlSync', () => {


### PR DESCRIPTION
Tries to leverage the existing url sync handler interface / abstraction inside the variable interpolation value formatters. 

Alternative fix for  
https://github.com/grafana/scenes/pull/926

Fixes: https://github.com/grafana/grafana/issues/94303 