### PR TITLE
PanelBuilders: Mixin function to share config

### DIFF
--- a/docusaurus/docs/visualizations.md
+++ b/docusaurus/docs/visualizations.md
@@ -216,6 +216,17 @@ const scene = new EmbeddedScene({
 
 This built panel is now ready to be used in a scene.
 
+### Extract common visualization config to a mixin function 
+
+```ts
+function latencyGraphMixin(builder: ReturnType<typeof PanelBuilders["timeseries"]>) {
+  builder.setMin(0);
+  builder.setOption('legend', { showLegend: false: true })
+}
+
+const panel = PanelBuilders.timeseries().applyMixin(latencyGraphMixin).setData(...)
+```
+
 ## Custom visualizations
 
 If you want to determine how data is visualized in your Grafana app plugin, you can do so in two ways. You always have the option to create a custom `SceneObject`, but you won't get the `PanelChrome` with loading state and other features

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
@@ -240,6 +240,15 @@ describe('VizPanelBuilder', () => {
         }
       `);
     });
+
+    it('allows mixin function', () => {
+      const mixin = (builder: ReturnType<typeof getTestBuilder>) => {
+        builder.setOption('numeric', 2);
+      };
+
+      const p1 = getTestBuilder().applyMixin(mixin).build();
+      expect(p1.state.options.numeric).toEqual(2);
+    });
   });
 
   describe('overrides', () => {

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -216,6 +216,14 @@ export class VizPanelBuilder<TOptions extends {}, TFieldConfig extends {}>
   }
 
   /**
+   * Makes it possible to shared config between different builders
+   */
+  public applyMixin(mixin: (builder: this) => void): this {
+    mixin(this);
+    return this;
+  }
+
+  /**
    * Build the panel.
    */
   public build() {


### PR DESCRIPTION
Data trails has this super awkward way to share config between builders where they wait for activation to call onOptionsChange. '

The reason for this hack is that it's not super easy to share config between builders (esp as one of the builders is created by a different path, so extracting the shared config to a factory function that creates the builder + shared config is not possible). 

https://github.com/grafana/grafana/blob/main/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx#L323

One way to support shared config would be to move it to a function that takes in a builder, but for that pattern to feel nice I think having an function on the builder directly to enable this makes it so much more readable and clean (vs having to define a builder variable, pass it to shared config function, then apply some more options & call build). 

The other way to solve this is to try to move VizPanel & PanelBuilders to VizConfig (or be more similar to VizConfigBuilder), but a much bigger change 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.19.0--canary.932.11250344357.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.19.0--canary.932.11250344357.0
  npm install @grafana/scenes@5.19.0--canary.932.11250344357.0
  # or 
  yarn add @grafana/scenes-react@5.19.0--canary.932.11250344357.0
  yarn add @grafana/scenes@5.19.0--canary.932.11250344357.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
