### PR TITLE
Fix a crash when refresh interval set to empty string

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.test.ts
+++ b/packages/scenes/src/components/SceneRefreshPicker.test.ts
@@ -255,6 +255,11 @@ describe('SceneRefreshPicker', () => {
       const { refreshPicker } = setupScene('5s', ['5s', '30s', '1m'], undefined, undefined, '0ms');
       expect(refreshPicker.state.intervals).toContain('5s');
     });
+
+    it('does not crash if refresh interval is set to empty string', () => {
+      const { refreshPicker } = setupScene('5s', [''], undefined, undefined, '10s');
+      expect(refreshPicker.state.intervals).toEqual([]);
+    });
   });
 
   describe('auto interval', () => {

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -42,7 +42,12 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   public constructor(state: Partial<SceneRefreshPickerState>) {
     const filterDissalowedIntervals = (i: string) => {
       const minInterval = state.minRefreshInterval ?? config.minRefreshInterval;
-      return minInterval ? rangeUtil.intervalToMs(i) >= rangeUtil.intervalToMs(minInterval) : true;
+      try {
+        return minInterval ? rangeUtil.intervalToMs(i) >= rangeUtil.intervalToMs(minInterval) : true;
+      } catch (e) {
+        // Unable to parse interval
+        return false;
+      }
     };
 
     super({


### PR DESCRIPTION
If a dashboard has refresh_interval set to an array with just an empty string in it `[""]` the parsing of the interval will fail and the dashboard will fail to load.

This fix filters out any intervals we're unable to parse.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.19.1--canary.933.11257845651.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.19.1--canary.933.11257845651.0
  npm install @grafana/scenes@5.19.1--canary.933.11257845651.0
  # or 
  yarn add @grafana/scenes-react@5.19.1--canary.933.11257845651.0
  yarn add @grafana/scenes@5.19.1--canary.933.11257845651.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
