### PR TITLE
VizPanel: Fix issue where changing panel options wouldn't cause re-render

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -83,6 +83,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   _pluginLoadError?: string;
   /** Internal */
   _pluginInstanceState?: any;
+  _renderCounter?: number;
 }
 
 export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends SceneObjectBase<
@@ -107,6 +108,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       fieldConfig: { defaults: {}, overrides: [] },
       title: 'Title',
       pluginId: 'timeseries',
+      _renderCounter: 0,
       ...state,
     });
 
@@ -323,6 +325,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     this.setState({
       options: withDefaults.options as DeepPartial<TOptions>,
+      _renderCounter: (this.state._renderCounter ?? 0) + 1,
     });
   };
 

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -27,6 +27,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     headerActions,
     titleItems,
     description,
+    _renderCounter = 0,
   } = model.useState();
   const [ref, { width, height }] = useMeasure();
   const appEvents = useMemo(() => getAppEvents(), []);
@@ -186,7 +187,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                           transparent={false}
                           width={innerWidth}
                           height={innerHeight}
-                          renderCounter={0}
+                          renderCounter={_renderCounter}
                           replaceVariables={model.interpolate}
                           onOptionsChange={model.onOptionsChange}
                           onFieldConfigChange={model.onFieldConfigChange}


### PR DESCRIPTION
In scenes, changing certain panel options, for example the "Show threshold labels" option on Gauge panels, wouldn't re-render the panel. Looking at the GaugePanel component's render function, we have the following:

```typescript
  render() {
    const { height, width, data, renderCounter, options } = this.props;

    const { minVizHeight, minVizWidth } = this.calculateGaugeSize();

    return (
      <VizRepeater
        getValues={this.getValues}
        renderValue={this.renderValue}
        width={width}
        height={height}
        source={data}
        autoGrid={true}
        renderCounter={renderCounter}
        orientation={options.orientation}
        minVizHeight={minVizHeight}
        minVizWidth={minVizWidth}
      />
    );
  }
```

The options prop _does_ update, but `VizRepeater` is a pure component and since options isn't passed as a prop, the component doesn't re-render.
To fix this, I've added a `renderCounter` to `VizPanel` that gets incremented when the panel options change. Since `renderCounter` is passed to `VizRepeater`, a re-render is triggered.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.20.0--canary.934.11258648927.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.20.0--canary.934.11258648927.0
  npm install @grafana/scenes@5.20.0--canary.934.11258648927.0
  # or 
  yarn add @grafana/scenes-react@5.20.0--canary.934.11258648927.0
  yarn add @grafana/scenes@5.20.0--canary.934.11258648927.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
