### PR TITLE
TimeRange: Fix timezone not being sync with url

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -211,6 +211,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
     let from = parseUrlParam(values.from);
     let to = parseUrlParam(values.to);
+    let timeZone = values.timezone;
 
     if (values.time && values['time.window']) {
       const time = Array.isArray(values.time) ? values.time[0] : values.time;
@@ -225,7 +226,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       }
     }
 
-    if (!from && !to) {
+    if (!from && !to && !timeZone) {
       return;
     }
 


### PR DESCRIPTION
Related to #https://github.com/grafana/support-escalations/issues/12963

### Issue
Passing the timezone as a parameter in the URL is not working. 

After checking the code, I noticed we were returning early and not considering `timezone` URL parameter

### Testing change in core grafana

https://github.com/user-attachments/assets/f8ee25cd-42f9-4ea4-a75b-643ea977f847



### Todo
- [x] Allow `timezone` to be synced through rul
- [ ] Add unit test