### PR TITLE
feat: sort adhoc filter options using ufuzzy

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -44,12 +44,17 @@ export function fuzzySearchOptions(options: Array<SelectableValue<string>>) {
         haystack.push(options[i].label || options[i].value!);
       }
     }
-    const idxs = ufuzzy.filter(haystack, search);
+    const [idxs, info, order] = ufuzzy.search(haystack, search);
     const filteredOptions: Array<SelectableValue<string>> = [];
 
     if (idxs) {
       for (let i = 0; i < idxs.length; i++) {
-        filteredOptions.push(options[idxs[i]]);
+        if (info && order) {
+          const idx = order[i];
+          filteredOptions.push(options[idxs[idx]]);
+        } else {
+          filteredOptions.push(options[idxs[i]]);
+        }
 
         if (filteredOptions.length > limit) {
           return filteredOptions;

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.test.ts
@@ -15,8 +15,8 @@ describe('getAdhocOptionSearcher', () => {
     const optionSearcher = getAdhocOptionSearcher(options);
 
     expect(optionSearcher('est')).toEqual([
-      { label: 'Test', value: '1' },
       { label: 'estimate', value: '2' },
+      { label: 'Test', value: '1' },
     ]);
   });
 
@@ -29,8 +29,8 @@ describe('getAdhocOptionSearcher', () => {
     const optionSearcher = getAdhocOptionSearcher(options);
 
     expect(optionSearcher('est')).toEqual([
-      { label: 'Test', value: '1', foo: 'foo', group: 'group1' },
       { label: 'estimate', value: '2' },
+      { label: 'Test', value: '1', foo: 'foo', group: 'group1' },
     ]);
   });
 });

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
@@ -23,12 +23,17 @@ export function getAdhocOptionSearcher(
       }
     }
 
-    const idxs = ufuzzy.filter(haystack, search);
+    const [idxs, info, order] = ufuzzy.search(haystack, search);
     const filteredOptions: SelectableValue[] = [];
 
     if (idxs) {
       for (let i = 0; i < idxs.length; i++) {
-        filteredOptions.push(options[idxs[i]]);
+        if (info && order) {
+          const idx = order[i];
+          filteredOptions.push(options[idxs[idx]]);
+        } else {
+          filteredOptions.push(options[idxs[i]]);
+        }
 
         if (filteredOptions.length > limit) {
           return filteredOptions;

--- a/packages/scenes/src/variables/components/getOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.test.ts
@@ -24,8 +24,8 @@ describe('getOptionSearcher', () => {
     const optionSearcher = getOptionSearcher(options, false);
 
     expect(optionSearcher('est')).toEqual([
-      { label: 'Test', value: '1' },
       { label: 'estimate', value: '2' },
+      { label: 'Test', value: '1' },
     ]);
   });
 });

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -30,12 +30,17 @@ export function getOptionSearcher(
       }
     }
 
-    const idxs = ufuzzy.filter(haystack, search);
+    const [idxs, info, order] = ufuzzy.search(haystack, search);
     const filteredOptions: VariableValueOption[] = [];
 
     if (idxs) {
       for (let i = 0; i < idxs.length; i++) {
-        filteredOptions.push(allOptions[idxs[i]]);
+        if (info && order) {
+          const idx = order[i];
+          filteredOptions.push(allOptions[idxs[idx]]);
+        } else {
+          filteredOptions.push(allOptions[idxs[i]]);
+        }
 
         if (filteredOptions.length > limit) {
           return filteredOptions;


### PR DESCRIPTION
Prior to this change, we were leaving the order of the options in adhoc filters unchanged, which has led to some
[poor quality search results][example] across plugins using adhoc filters.

This change sorts the options in adhoc filters using ufuzzy, which should lead to better search results. This is the same approach used in Grafana core (see [1], [2], [3] for examples).

[example]: https://raintank-corp.slack.com/archives/C075BDBTX96/p1729076789303509
[1]: https://github.com/grafana/grafana/blob/ca1fd028a2a1aa0dd560d8220c9f04c243d77445/public/app/features/variables/pickers/OptionsPicker/reducer.ts#L264-L272
[2]: https://github.com/grafana/grafana/blob/ca1fd028a2a1aa0dd560d8220c9f04c243d77445/public/app/features/trails/services/search.ts#L13
[3]: https://github.com/grafana/grafana/blob/ca1fd028a2a1aa0dd560d8220c9f04c243d77445/public/app/features/explore/Logs/utils/uFuzzy.ts#L13