### PR TITLE
AdHocFilterCombobox: Improve backspace functionality to delete filter key, operator and values separately

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -15,7 +15,7 @@ interface Props {
 export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }: Props) {
   const styles = useStyles2(getStyles);
   const [viewMode, setViewMode] = useState(true);
-  const [shouldFocus, setShouldFocus] = useState(false);
+  const [shouldFocusOnPillWrapper, setShouldFocusOnPillWrapper] = useState(false);
   const pillWrapperRef = useRef<HTMLDivElement>(null);
 
   const keyLabel = filter.keyLabel ?? filter.key;
@@ -24,24 +24,24 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
   const valueLabel = filter.valueLabels?.join(', ') || filter.values?.join(', ') || filter.value;
 
   const handleChangeViewMode = useCallback(
-    (event?: React.MouseEvent) => {
+    (event?: React.MouseEvent, shouldFocusOnPillWrapperOverride?: boolean) => {
       event?.stopPropagation();
       if (readOnly) {
         return;
       }
 
-      setShouldFocus(!viewMode);
+      setShouldFocusOnPillWrapper(shouldFocusOnPillWrapperOverride ?? !viewMode);
       setViewMode(!viewMode);
     },
     [readOnly, viewMode]
   );
 
   useEffect(() => {
-    if (shouldFocus) {
+    if (shouldFocusOnPillWrapper) {
       pillWrapperRef.current?.focus();
-      setShouldFocus(false);
+      setShouldFocusOnPillWrapper(false);
     }
-  }, [shouldFocus]);
+  }, [shouldFocusOnPillWrapper]);
 
   // set viewMode to false when filter.forceEdit is defined
   useEffect(() => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -9,10 +9,10 @@ interface Props {
   filter: AdHocFilterWithLabels;
   model: AdHocFiltersVariable;
   readOnly?: boolean;
-  focusOnInputRef?: () => void;
+  focusOnWipInputRef?: () => void;
 }
 
-export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Props) {
+export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }: Props) {
   const styles = useStyles2(getStyles);
   const [viewMode, setViewMode] = useState(true);
   const [shouldFocus, setShouldFocus] = useState(false);
@@ -42,6 +42,15 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Pr
       setShouldFocus(false);
     }
   }, [shouldFocus]);
+
+  // set viewMode to false when filter.forceEdit is defined
+  useEffect(() => {
+    if (filter.forceEdit && viewMode) {
+      setViewMode(false);
+      // immediately set forceEdit back to undefined as a clean up
+      model._updateFilter(filter, { forceEdit: undefined });
+    }
+  }, [filter, model, viewMode]);
 
   if (viewMode) {
     const pillText = (
@@ -76,14 +85,14 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Pr
             onClick={(e) => {
               e.stopPropagation();
               model._removeFilter(filter);
-              setTimeout(() => focusOnInputRef?.());
+              setTimeout(() => focusOnWipInputRef?.());
             }}
             onKeyDownCapture={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();
                 e.stopPropagation();
                 model._removeFilter(filter);
-                setTimeout(() => focusOnInputRef?.());
+                setTimeout(() => focusOnWipInputRef?.());
               }
             }}
             name="times"
@@ -96,7 +105,14 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnInputRef }: Pr
     );
   }
 
-  return <AdHocCombobox filter={filter} model={model} handleChangeViewMode={handleChangeViewMode} />;
+  return (
+    <AdHocCombobox
+      filter={filter}
+      model={model}
+      handleChangeViewMode={handleChangeViewMode}
+      focusOnWipInputRef={focusOnWipInputRef}
+    />
+  );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -179,9 +179,6 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   useImperativeHandle(parentRef, () => () => refs.domReference.current?.focus(), [refs.domReference]);
 
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
-    // part of POC for seamless filter parser
-    // filterAutoParser({ event, filterInputType, options, model, filter, setInputValue, setInputType, refs });
-
     const value = event.target.value;
     setInputValue(value);
     setActiveIndex(0);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -218,6 +218,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
         setOptions(options);
         if (options[0]?.group) {
           setActiveIndex(1);
+        } else {
+          setActiveIndex(0);
         }
       } catch (e) {
         setOptionsError(true);
@@ -347,7 +349,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           );
 
           switchToNextInputType(filterInputType, setInputType, handleChangeViewMode, refs.domReference.current);
-          setActiveIndex(0);
+          setActiveIndex(null);
         }
 
         setInputValue('');

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -260,10 +260,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           return;
         }
 
-        // focus back on alway wip input when you delete first filter with backspace
-        if (model.state.filters[0] === filter) {
-          focusOnWipInputRef?.();
-        }
+        // focus back on alway wip input when you delete filter with backspace
+        focusOnWipInputRef?.();
 
         model._handleComboboxBackspace(filter!);
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -13,28 +13,31 @@ interface Props {
 export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRenderer({ model }: Props) {
   const { filters, readOnly } = model.useState();
   const styles = useStyles2(getStyles);
-  const focusOnInputRef = useRef<() => void>();
+
+  // ref that focuses on the always wip filter input
+  // defined in the combobox component via useImperativeHandle
+  const focusOnWipInputRef = useRef<() => void>();
 
   return (
     <div
       className={cx(styles.comboboxWrapper, { [styles.comboboxFocusOutline]: !readOnly })}
       onClick={() => {
-        focusOnInputRef.current?.();
+        focusOnWipInputRef.current?.();
       }}
     >
       <Icon name="filter" className={styles.filterIcon} size="lg" />
 
       {filters.map((filter, index) => (
         <AdHocFilterPill
-          key={index}
+          key={`${index}-${filter.key}`}
           filter={filter}
           model={model}
           readOnly={readOnly}
-          focusOnInputRef={focusOnInputRef.current}
+          focusOnWipInputRef={focusOnWipInputRef.current}
         />
       ))}
 
-      {!readOnly ? <AdHocFiltersAlwaysWipCombobox model={model} ref={focusOnInputRef} /> : null}
+      {!readOnly ? <AdHocFiltersAlwaysWipCombobox model={model} ref={focusOnWipInputRef} /> : null}
     </div>
   );
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -123,25 +123,28 @@ const nextInputTypeMap = {
 export const switchToNextInputType = (
   filterInputType: AdHocInputType,
   setInputType: React.Dispatch<React.SetStateAction<AdHocInputType>>,
-  handleChangeViewMode: (() => void) | undefined,
-  element: HTMLInputElement | null
+  handleChangeViewMode: ((event?: React.MouseEvent, shouldFocusOnFilterPill?: boolean) => void) | undefined,
+  element: HTMLInputElement | null,
+  shouldFocusOnPillWrapperOverride?: boolean
 ) =>
   switchInputType(
     nextInputTypeMap[filterInputType],
     setInputType,
     filterInputType === 'value' ? handleChangeViewMode : undefined,
-    element
+    element,
+    shouldFocusOnPillWrapperOverride
   );
 
 export const switchInputType = (
   filterInputType: AdHocInputType,
   setInputType: React.Dispatch<React.SetStateAction<AdHocInputType>>,
-  handleChangeViewMode?: () => void,
-  element?: HTMLInputElement | null
+  handleChangeViewMode?: (event?: React.MouseEvent, shouldFocusOnFilterPill?: boolean) => void,
+  element?: HTMLInputElement | null,
+  shouldFocusOnPillWrapperOverride?: boolean
 ) => {
   setInputType(filterInputType);
 
-  handleChangeViewMode?.();
+  handleChangeViewMode?.(undefined, shouldFocusOnPillWrapperOverride);
 
   setTimeout(() => element?.focus());
 };

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -243,13 +243,13 @@ export class AdHocFiltersVariable
 
   public _handleComboboxBackspace(filter: AdHocFilterWithLabels) {
     if (this.state.filters.length) {
-      // default filter to forceEdit to last filter (when triggering from wip filter)
+      // default forceEdit last filter (when triggering from wip filter)
       let filterToForceIndex = this.state.filters.length - 1;
 
-      // adjust index if backspace triggered from non wip filter
+      // adjust filterToForceIndex index to -1 if backspace triggered from non wip filter
+      //  to avoid triggering forceEdit logic
       if (filter !== this.state._wip) {
-        const filterIndex = this.state.filters.findIndex((f) => f === filter);
-        filterToForceIndex = filterIndex - 1;
+        filterToForceIndex = -1;
       }
 
       // const filterToForceEditExists = !!this.state.filters[filterToForceIndex];

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -252,7 +252,6 @@ export class AdHocFiltersVariable
         filterToForceIndex = -1;
       }
 
-      // const filterToForceEditExists = !!this.state.filters[filterToForceIndex];
       this.setState({
         filters: this.state.filters.reduce<AdHocFilterWithLabels[]>((acc, f, index) => {
           // adjust forceEdit of preceding filter

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -21,6 +21,8 @@ import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSeriali
 export interface AdHocFilterWithLabels extends AdHocVariableFilter {
   keyLabel?: string;
   valueLabels?: string[];
+  // this is used to externally trigger edit mode in combobox filter UI
+  forceEdit?: boolean;
 }
 
 export type AdHocControlsLayout = ControlsLayout | 'combobox';
@@ -236,6 +238,41 @@ export class AdHocFiltersVariable
 
     if (filterToRemove) {
       this._removeFilter(filterToRemove);
+    }
+  }
+
+  public _handleComboboxBackspace(filter: AdHocFilterWithLabels) {
+    if (this.state.filters.length) {
+      // default filter to forceEdit to last filter (when triggering from wip filter)
+      let filterToForceIndex = this.state.filters.length - 1;
+
+      // adjust index if backspace triggered from non wip filter
+      if (filter !== this.state._wip) {
+        const filterIndex = this.state.filters.findIndex((f) => f === filter);
+        filterToForceIndex = filterIndex - 1;
+      }
+
+      // const filterToForceEditExists = !!this.state.filters[filterToForceIndex];
+      this.setState({
+        filters: this.state.filters.reduce<AdHocFilterWithLabels[]>((acc, f, index) => {
+          // adjust forceEdit of preceding filter
+          if (index === filterToForceIndex) {
+            return [
+              ...acc,
+              {
+                ...f,
+                forceEdit: true,
+              },
+            ];
+          }
+          // remove current filter
+          if (f === filter) {
+            return acc;
+          }
+
+          return [...acc, f];
+        }, []),
+      });
     }
   }
 


### PR DESCRIPTION
Rework backspace functionality to delete filter key, operator, values individually instead of whole filter.

I am adding additional property `forceEdit` on the `AdHocFilterWithLabels` type that is purely used to trigger UI change via useEffect because that was the cleanest way I could think of to trigger edit in separate filter pills that has no reference to each other.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.21.1--canary.942.11610448397.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.21.1--canary.942.11610448397.0
  npm install @grafana/scenes@5.21.1--canary.942.11610448397.0
  # or 
  yarn add @grafana/scenes-react@5.21.1--canary.942.11610448397.0
  yarn add @grafana/scenes@5.21.1--canary.942.11610448397.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
