### PR TITLE
SceneObject: Improve cloning logic

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -6,42 +6,90 @@ import { SceneObjectStateChangedEvent } from './events';
 import { SceneObject, SceneObjectState } from './types';
 import { SceneTimeRange } from '../core/SceneTimeRange';
 import { act, renderHook } from '@testing-library/react';
+import { SceneObjectRef } from './SceneObjectRef';
 
 interface TestSceneState extends SceneObjectState {
   name?: string;
   nested?: SceneObject<TestSceneState>;
   children?: TestScene[];
   actions?: SceneObject[];
+  ref?: SceneObjectRef<TestScene>;
 }
 
-class TestScene extends SceneObjectBase<TestSceneState> {}
+class TestScene extends SceneObjectBase<TestSceneState> {
+  public static created = 0;
+
+  public constructor(state: TestSceneState) {
+    super(state);
+    TestScene.created++;
+  }
+}
 
 describe('SceneObject', () => {
-  it('Can clone', () => {
-    const scene = new TestScene({
-      nested: new TestScene({
-        name: 'nested',
-      }),
-      actions: [
-        new TestScene({
-          name: 'action child',
+  describe('Cloning', () => {
+    it('Can clone', () => {
+      const scene = new TestScene({
+        nested: new TestScene({
+          name: 'nested',
         }),
-      ],
-      children: [
-        new TestScene({
-          name: 'layout child',
-        }),
-      ],
+        actions: [
+          new TestScene({
+            name: 'action child',
+          }),
+        ],
+        children: [
+          new TestScene({
+            name: 'layout child',
+          }),
+        ],
+      });
+
+      scene.state.nested?.activate();
+
+      const clone = scene.clone();
+      expect(clone).not.toBe(scene);
+      expect(clone.state.nested).not.toBe(scene.state.nested);
+      expect(clone.state.nested?.isActive).toBe(false);
+      expect(clone.state.children![0]).not.toBe(scene.state.children![0]);
+      expect(clone.state.actions![0]).not.toBe(scene.state.actions![0]);
     });
 
-    scene.state.nested?.activate();
+    it('Can clone with ref', () => {
+      const refValue = new TestScene({ name: 'ref' });
+      const scene = new TestScene({
+        name: 'clone',
+        ref: refValue.getRef(),
+      });
 
-    const clone = scene.clone();
-    expect(clone).not.toBe(scene);
-    expect(clone.state.nested).not.toBe(scene.state.nested);
-    expect(clone.state.nested?.isActive).toBe(false);
-    expect(clone.state.children![0]).not.toBe(scene.state.children![0]);
-    expect(clone.state.actions![0]).not.toBe(scene.state.actions![0]);
+      const clone = scene.clone();
+      expect(clone.state.name).toBe('clone');
+      expect(clone.state.ref?.resolve()).toBe(refValue);
+    });
+
+    it('Should ignore cloning properties specified in overrides', () => {
+      const scene = new TestScene({ name: 'clone', nested: new TestScene({ name: 'nested' }) });
+
+      TestScene.created = 0;
+
+      scene.clone();
+
+      expect(TestScene.created).toBe(2);
+
+      scene.clone({ nested: undefined });
+
+      expect(TestScene.created).toBe(3);
+    });
+
+    it('Can clone with state change', () => {
+      const scene = new TestScene({
+        nested: new TestScene({
+          name: 'nested',
+        }),
+      });
+
+      const clone = scene.clone({ name: 'new name' });
+      expect(clone.state.name).toBe('new name');
+    });
   });
 
   it('SceneObject should have parent when added to container', () => {
@@ -65,17 +113,6 @@ describe('SceneObject', () => {
     expect(scene.state.nested?.parent).toBe(scene);
     expect(scene.state.children![0].parent).toBe(scene);
     expect(scene.state.actions![0].parent).toBe(scene);
-  });
-
-  it('Can clone with state change', () => {
-    const scene = new TestScene({
-      nested: new TestScene({
-        name: 'nested',
-      }),
-    });
-
-    const clone = scene.clone({ name: 'new name' });
-    expect(clone.state.name).toBe('new name');
   });
 
   it('Can get SceneObjectRef', () => {

--- a/packages/scenes/src/core/sceneGraph/utils.ts
+++ b/packages/scenes/src/core/sceneGraph/utils.ts
@@ -20,6 +20,8 @@ export function cloneSceneObjectState<TState extends SceneObjectState>(
 ): TState {
   const clonedState = { ...sceneState };
 
+  Object.assign(clonedState, withState);
+
   // Clone any SceneItems in state
   for (const key in clonedState) {
     const propValue = clonedState[key];
@@ -28,7 +30,8 @@ export function cloneSceneObjectState<TState extends SceneObjectState>(
     }
 
     if (propValue instanceof SceneObjectRef) {
-      throw new Error('Cannot clone a SceneObject with a SceneObjectRef in state');
+      console.warn('Cloning object with SceneObjectRef');
+      continue;
     }
 
     // Clone scene objects in arrays
@@ -44,8 +47,6 @@ export function cloneSceneObjectState<TState extends SceneObjectState>(
       clonedState[key] = newArray;
     }
   }
-
-  Object.assign(clonedState, withState);
 
   return clonedState;
 }


### PR DESCRIPTION
We currently have a bug in scenes where you cannot "apply" changes in inspect drawer because there is an error thrown when you hit "Apply" (only happens when the dashboard is NOT in edit mode). The error happens because we try go into edit mode while the inspect drawer is open the error is `'Cannot clone a SceneObject with a SceneObjectRef in state` which we throw from the cloning. 

* Remove throwing this error (replaced with a console.warning)
* Now clone callers can opt not to clone some objects by passing them in as undefined in the "withState" argument.  (makes is so we can clone the state of dashboards with overlay: undefined)

https://github.com/grafana/grafana/issues/95482