### PR TITLE
Propagate variable changes through inactive objects

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -322,11 +322,6 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
-    // Skip non active scene objects
-    if (!sceneObject.isActive) {
-      return;
-    }
-
     // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
     if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
       const localVar = sceneObject.state.$variables.getByName(variable.state.name);
@@ -335,7 +330,7 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       }
     }
 
-    if (sceneObject.variableDependency) {
+    if (sceneObject.variableDependency && sceneObject.isActive) {
       sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
     }
 


### PR DESCRIPTION
There are some use cases when a query runner is active when it's parent is inactive, but the query runner will never get notified a variable it depends on has been updated.

This happens in grafana when the dashboard datasource is used to get data from a panel that is contained in a collapsed row.

This change makes the variable change propagate to children of deactivated objects to let the sceneObject affected decide if its going to react.