### PR TITLE
SceneTimeRange: Fix passing timezone URL parameter

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -48,6 +48,7 @@ describe('SceneTimeRange', () => {
     expect(timeRange.urlSync?.getUrlState()).toEqual({
       from: 'now-1h',
       to: 'now',
+      timezone: 'browser',
     });
   });
 
@@ -56,6 +57,7 @@ describe('SceneTimeRange', () => {
     timeRange.urlSync?.updateFromUrl({
       from: '2021-01-01T10:00:00.000Z',
       to: '2021-02-03T01:20:00.000Z',
+      timezone: 'browser',
     });
 
     expect(timeRange.state.from).toEqual('2021-01-01T10:00:00.000Z');

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -191,11 +191,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
   public getUrlState() {
     const params = locationService.getSearchObject();
-    const urlValues: SceneObjectUrlValues = { from: this.state.from, to: this.state.to };
-
-    if (this.state.timeZone) {
-      urlValues.timezone = this.state.timeZone;
-    }
+    const urlValues: SceneObjectUrlValues = { from: this.state.from, to: this.state.to, timezone: this.getTimeZone() };
 
     // Clear time and time.window once they are converted to from and to
     if (params.time && params['time.window']) {

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -270,8 +270,10 @@ describe('UrlSyncManager', () => {
       expect(locationService.getSearchObject()).toEqual({
         from: 'now-6h',
         ['from-2']: 'now-10m',
+        timezone: 'browser',
         to: 'now',
         ['to-2']: 'now',
+        ['timezone-2']: 'browser',
       });
 
       outerTimeRange.setState({ from: 'now-20m' });
@@ -280,8 +282,10 @@ describe('UrlSyncManager', () => {
       expect(locationService.getSearchObject()).toEqual({
         from: 'now-20m',
         to: 'now',
+        timezone: 'browser',
         ['from-2']: 'now-10m',
         ['to-2']: 'now',
+        ['timezone-2']: 'browser',
       });
 
       // When updating via url

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -219,12 +219,22 @@ describe('sceneInterpolator', () => {
     expect(sceneInterpolator(scene, '$__all_variables', {}, VariableFormatID.PercentEncode)).toBe('var-cluster=A');
   });
 
-  it('Can use use $__url_time_range', () => {
+  it('Can use use $__url_time_range with browser timezone', () => {
     const scene = new TestScene({
       $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now' }),
     });
 
-    expect(sceneInterpolator(scene, '$__url_time_range')).toBe('from=now-5m&to=now');
+    expect(sceneInterpolator(scene, '$__url_time_range')).toBe(
+      `from=now-5m&to=now&timezone=${encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone)}`
+    );
+  });
+
+  it('Can use use $__url_time_range with custom timezone', () => {
+    const scene = new TestScene({
+      $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now', timeZone: 'utc' }),
+    });
+
+    expect(sceneInterpolator(scene, '$__url_time_range')).toBe('from=now-5m&to=now&timezone=utc');
   });
 
   describe('Interval variables', () => {

--- a/packages/scenes/src/variables/macros/timeMacros.test.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.test.ts
@@ -8,12 +8,22 @@ import { LoadingState } from '@grafana/schema';
 import { DataQueryRequest, getDefaultTimeRange } from '@grafana/data';
 
 describe('timeMacros', () => {
-  it('Can use use $__url_time_range', () => {
+  it('Can use use $__url_time_range with browser timeZone', () => {
     const scene = new TestScene({
       $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now' }),
     });
 
-    expect(sceneInterpolator(scene, '$__url_time_range')).toBe('from=now-5m&to=now');
+    expect(sceneInterpolator(scene, '$__url_time_range')).toBe(
+      `from=now-5m&to=now&timezone=${encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone)}`
+    );
+  });
+
+  it('Can use use $__url_time_range with custom timeZone', () => {
+    const scene = new TestScene({
+      $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now', timeZone: 'utc' }),
+    });
+
+    expect(sceneInterpolator(scene, '$__url_time_range')).toBe('from=now-5m&to=now&timezone=utc');
   });
 
   it('Can use use $__from and $__to', () => {

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -20,6 +20,9 @@ export class UrlTimeRangeMacro implements FormatVariable {
   public getValue(): SkipFormattingValue {
     const timeRange = getTimeRange(this._sceneObject);
     const urlState = timeRange.urlSync?.getUrlState();
+    if (urlState?.timezone === 'browser') {
+      urlState.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
     return new SkipFormattingValue(urlUtil.toUrlParams(urlState));
   }
 


### PR DESCRIPTION
This PR fixes an issue with the time range picker: moving away from `default` or `browser` to another timezone, the URL parameter changes correctly. However, going back to `default` will leave the timezone parameter set to whatever have been picked previously.

This is because the time range picker sends an empty string as the value of the timezone and `getUrlState` omits the update due to empty string.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.21.1--canary.947.11593224430.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.21.1--canary.947.11593224430.0
  npm install @grafana/scenes@5.21.1--canary.947.11593224430.0
  # or 
  yarn add @grafana/scenes-react@5.21.1--canary.947.11593224430.0
  yarn add @grafana/scenes@5.21.1--canary.947.11593224430.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
