### PR TITLE
VariableValueInput: Set max width

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueInput.tsx
+++ b/packages/scenes/src/variables/components/VariableValueInput.tsx
@@ -29,6 +29,7 @@ export function VariableValueInput({ model }: SceneComponentProps<TextBoxVariabl
       id={key}
       placeholder="Enter value"
       minWidth={15}
+      maxWidth={30}
       value={value}
       loading={loading}
       onBlur={onBlur}


### PR DESCRIPTION
Without max width, text variable expands infinitely causing strange issues like this:

https://github.com/user-attachments/assets/2a815f53-6858-47f4-942b-5d1e9cbf3cc2

Fixes: https://github.com/grafana/support-escalations/issues/13095