### PR TITLE
AdHocFiltersVariable: Pass scene reference to expressionBuilder

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -176,7 +176,6 @@ export class AdHocFiltersVariable
 
 
   public constructor(state: Partial<AdHocFiltersVariableState>) {
-
     const initialFilterExpression = !state.buildExpressionOnActivate ? renderExpression(state.expressionBuilder, state.filters) : undefined
     super({
       type: 'adhoc',

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -99,7 +99,7 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   _wip?: AdHocFilterWithLabels;
 }
 
-export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[], sceneRef?: AdHocFiltersVariable) => string;
+export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[], sceneRef: AdHocFiltersVariable) => string;
 
 export type getTagKeysProvider = (
   variable: AdHocFiltersVariable,


### PR DESCRIPTION
What:
This PR allows scene developers to use application state to modify how ad hoc variable expressions are rendered. 
In order to avoid regression, a new state property `buildExpressionOnActivate` was added which will alter the behavior of AdHocFiltersVariable to wait until activation to build the filterExpression. This allows a reference to the AdHocFiltersVariable can be included in the `expressionBuilder` callback which is not available currently when the filterExpression is created during instantiation.

Why:
Currently the expressionBuilder method is unable to reference the application context, and use-cases where application state can influence how a particular ad hoc variable is interpolated is not supported.

How:
Specifically, for Explore Logs, we need to conditionally ignore filters that match the label in the active tab so users can include multiple values by clicking on buttons in the result panels for a single label without needing to modify the ad-hoc variable state, which would introduce undesirable implications in the UI.

An example implementation in the app-plugin could look like the following:

```
  const labelVariable = new AdHocFiltersVariable({
    name: VAR_LABELS,
    datasource: EXPLORATION_DS,
    layout: 'combobox',
    buildExpressionOnActivate: true,
    expressionBuilder: renderLogQLLabelFilters,
   // [...]
  });

function expressionBuilder(filters: AdHocVariableFilter[], scene: SceneObject) {
  // Get the key of another ad hoc variable
  const primaryLabel = getServiceSelectionPrimaryLabel(scene).state.filters[0]?.key
  
  // Exclude filters matching the first key in the other variable
  filters = filters.filter(f => f.key !== primaryLabel)
  let { positiveFilters, negative } = getLogQLLabelFilters(filters);
  const negativeFilters = negative.map((filter) => renderMetadata(filter)).join(', ');

  return trim(`${positiveFilters.join(', ')}, ${negativeFilters}`, ' ,');
}

```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.21.2--canary.949.11612383247.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.21.2--canary.949.11612383247.0
  npm install @grafana/scenes@5.21.2--canary.949.11612383247.0
  # or 
  yarn add @grafana/scenes-react@5.21.2--canary.949.11612383247.0
  yarn add @grafana/scenes@5.21.2--canary.949.11612383247.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
