### PR TITLE
VizPanel: Add flag to decide whether configs should be refreshed on `changePluginType`

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -256,7 +256,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     return sceneTimeRange.state.value;
   };
 
-  public async changePluginType(pluginId: string, newOptions?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource) {
+  public async changePluginType(pluginId: string, newOptions?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource, refreshConfigs = true) {
     const {
       options: prevOptions,
       fieldConfig: prevFieldConfig,
@@ -266,7 +266,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     //clear field config cache to update it later
     this._dataWithFieldConfig = undefined;
 
-    await this._loadPlugin(pluginId, newOptions ?? {}, newFieldConfig, true);
+    await this._loadPlugin(pluginId, newOptions ?? {}, newFieldConfig, refreshConfigs);
 
     const panel: PanelModel = {
       title: this.state.title,

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -256,7 +256,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     return sceneTimeRange.state.value;
   };
 
-  public async changePluginType(pluginId: string, newOptions?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource, refreshConfigs = true) {
+  public async changePluginType(pluginId: string, newOptions?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource) {
     const {
       options: prevOptions,
       fieldConfig: prevFieldConfig,
@@ -266,7 +266,9 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     //clear field config cache to update it later
     this._dataWithFieldConfig = undefined;
 
-    await this._loadPlugin(pluginId, newOptions ?? {}, newFieldConfig, refreshConfigs);
+    // If state.pluginId is already the correct plugin we don't treat this as plain user panel type change
+    const isAfterPluginChange = this.state.pluginId !== pluginId; 
+    await this._loadPlugin(pluginId, newOptions ?? {}, newFieldConfig, isAfterPluginChange);
 
     const panel: PanelModel = {
       title: this.state.title,


### PR DESCRIPTION
In most cases we want to refresh the fieldConfig/options when changing plugin type, but in the case of Library Panels, for example, we only want to rerender the panel, without refreshing it's configs, since the existing ones are valid. Through this flag we can fix that [here](https://github.com/grafana/grafana/pull/95643) and avoid bugs where a lib panel has a set color mode, but after `changePluginType` the defaults are applied and the lib panel ones are overwritten


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.22.0--canary.950.11661930270.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.22.0--canary.950.11661930270.0
  npm install @grafana/scenes@5.22.0--canary.950.11661930270.0
  # or 
  yarn add @grafana/scenes-react@5.22.0--canary.950.11661930270.0
  yarn add @grafana/scenes@5.22.0--canary.950.11661930270.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
