### PR TITLE
Don't run migration when changing panel plugin

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -181,7 +181,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     _UNSAFE_customMigrationHandler?.(panel, plugin);
 
-    if (plugin.onPanelMigration && currentVersion !== this.state.pluginVersion && !isAfterPluginChange) {
+    if (plugin.onPanelMigration && currentVersion !== pluginVersion && !isAfterPluginChange) {
       // These migration handlers also mutate panel.fieldConfig to migrate fieldConfig
       panel.options = await plugin.onPanelMigration(panel);
     }

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -181,7 +181,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     _UNSAFE_customMigrationHandler?.(panel, plugin);
 
-    if (plugin.onPanelMigration && currentVersion !== this.state.pluginVersion) {
+    if (plugin.onPanelMigration && currentVersion !== this.state.pluginVersion && !isAfterPluginChange) {
       // These migration handlers also mutate panel.fieldConfig to migrate fieldConfig
       panel.options = await plugin.onPanelMigration(panel);
     }


### PR DESCRIPTION
When changing the panel plugin the pluginVersion will not be correct, this means the migration will always run. It shouldn't have to run when changing from one plugin type to another.