### PR TITLE
SceneObject: Cloning with state fix

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -90,6 +90,14 @@ describe('SceneObject', () => {
       const clone = scene.clone({ name: 'new name' });
       expect(clone.state.name).toBe('new name');
     });
+
+    it('Can clone with state and that state should not be cloned', () => {
+      const nested = new TestScene({ name: 'nested' });
+      const scene = new TestScene({ name: 'test', nested });
+
+      const clone = scene.clone({ nested });
+      expect(clone.state.nested).toBe(nested);
+    });
   });
 
   it('SceneObject should have parent when added to container', () => {

--- a/packages/scenes/src/core/sceneGraph/utils.ts
+++ b/packages/scenes/src/core/sceneGraph/utils.ts
@@ -24,6 +24,11 @@ export function cloneSceneObjectState<TState extends SceneObjectState>(
 
   // Clone any SceneItems in state
   for (const key in clonedState) {
+    // Do not clone if was part of withState
+    if (withState && withState[key] !== undefined) {
+      continue;
+    }
+
     const propValue = clonedState[key];
     if (propValue instanceof SceneObjectBase) {
       clonedState[key] = propValue.clone();


### PR DESCRIPTION
Was a bug in https://github.com/grafana/scenes/pull/944 where it now clones the state passed in with the `withState` function argument. This was not intended. 

I had this condition at one point in that PR but for some reason I thought I did not need it, but of course we do. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.22.1--canary.953.11666335318.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.22.1--canary.953.11666335318.0
  npm install @grafana/scenes@5.22.1--canary.953.11666335318.0
  # or 
  yarn add @grafana/scenes-react@5.22.1--canary.953.11666335318.0
  yarn add @grafana/scenes@5.22.1--canary.953.11666335318.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
