### PR TITLE
VizPanel: Adjust forceRender logic

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -127,6 +127,11 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     }
   }
 
+  public forceRender(): void {
+    // Incrementing the render counter means VizRepeater and its children will also re-render
+    this.setState({ _renderCounter: (this.state._renderCounter ?? 0) + 1});
+  }
+
   private async _loadPlugin(pluginId: string, overwriteOptions?: DeepPartial<{}>, overwriteFieldConfig?: FieldConfigSource, isAfterPluginChange?: boolean) {
     const plugin = loadPanelPluginSync(pluginId);
 


### PR DESCRIPTION
Previously when `forceRender` was called, for example when a change in the VizPanel's dependency config was detected, the VizPanelRenderer component itself would indeed re-render, but its children could potentially be pure components, like the StatPanel component, or they could be wrapped in VizRepeater, which is also pure, causing them not to re-render. These components won't re-render in cases where, for example, the panel contains data links containing template variables, as the field config object itself hasn't changed, just the value at which the variable points. By incrementing the `_renderCounter` when `forceRender` is called, panel components are also force to re-render.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.23.0--canary.954.11668840775.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.23.0--canary.954.11668840775.0
  npm install @grafana/scenes@5.23.0--canary.954.11668840775.0
  # or 
  yarn add @grafana/scenes-react@5.23.0--canary.954.11668840775.0
  yarn add @grafana/scenes@5.23.0--canary.954.11668840775.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
