### PR TITLE
AdHocFiltersCombobox - Pre-fill filter combobox value on edit

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -17,6 +17,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
   const [viewMode, setViewMode] = useState(true);
   const [shouldFocusOnPillWrapper, setShouldFocusOnPillWrapper] = useState(false);
   const pillWrapperRef = useRef<HTMLDivElement>(null);
+  const [populateInputOnEdit, setPopulateInputOnEdit] = useState(false);
 
   const keyLabel = filter.keyLabel ?? filter.key;
   // TODO remove when we're on the latest version of @grafana/data
@@ -52,6 +53,15 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
     }
   }, [filter, model, viewMode]);
 
+  // reset populateInputOnEdit when pill goes into view mode
+  useEffect(() => {
+    if (populateInputOnEdit && viewMode) {
+      setPopulateInputOnEdit(false);
+    }
+    // excluding populateInputOnEdit dependency because we only care to reset it on viewMode change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewMode]);
+
   if (viewMode) {
     const pillText = (
       <span className={styles.pillText}>
@@ -61,9 +71,14 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
     return (
       <div
         className={cx(styles.combinedFilterPill, { [styles.readOnlyCombinedFilter]: readOnly })}
-        onClick={handleChangeViewMode}
+        onClick={(e) => {
+          e.stopPropagation();
+          setPopulateInputOnEdit(true);
+          handleChangeViewMode();
+        }}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
+            setPopulateInputOnEdit(true);
             handleChangeViewMode();
           }
         }}
@@ -111,6 +126,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
       model={model}
       handleChangeViewMode={handleChangeViewMode}
       focusOnWipInputRef={focusOnWipInputRef}
+      populateInputOnEdit={populateInputOnEdit}
     />
   );
 }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -55,11 +55,9 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
 
   // reset populateInputOnEdit when pill goes into view mode
   useEffect(() => {
-    if (populateInputOnEdit && viewMode) {
-      setPopulateInputOnEdit(false);
+    if (viewMode) {
+      setPopulateInputOnEdit((prevValue) => (prevValue ? false : prevValue));
     }
-    // excluding populateInputOnEdit dependency because we only care to reset it on viewMode change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewMode]);
 
   if (viewMode) {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
 } from 'react';
 import { FloatingFocusManager, FloatingPortal, UseFloatingOptions } from '@floating-ui/react';
-import { Button, Icon, Spinner, Text, useStyles2 } from '@grafana/ui';
+import { Spinner, Text, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { AdHocFilterWithLabels, AdHocFiltersVariable, isMultiValueOperator } from '../AdHocFiltersVariable';
@@ -37,6 +37,7 @@ import {
 } from './utils';
 import { handleOptionGroups } from '../../utils';
 import { useFloatingInteractions, MAX_MENU_HEIGHT } from './useFloatingInteractions';
+import { MultiValuePill } from './MultiValuePill';
 
 interface AdHocComboboxProps {
   filter?: AdHocFilterWithLabels;
@@ -681,75 +682,6 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   );
 });
 
-interface MultiValuePillProps {
-  item: SelectableValue<string>;
-  handleRemoveMultiValue: (item: SelectableValue<string>) => void;
-  index: number;
-  handleEditMultiValuePill: (value: SelectableValue<string>) => void;
-}
-const MultiValuePill = ({ item, handleRemoveMultiValue, index, handleEditMultiValuePill }: MultiValuePillProps) => {
-  const styles = useStyles2(getStyles);
-
-  const editMultiValuePill = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.stopPropagation();
-      e.preventDefault();
-      handleEditMultiValuePill(item);
-    },
-    [handleEditMultiValuePill, item]
-  );
-
-  const editMultiValuePillWithKeyboard = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        handleEditMultiValuePill(item);
-      }
-    },
-    [handleEditMultiValuePill, item]
-  );
-
-  const removePillHandler = useCallback(
-    (e: React.SyntheticEvent) => {
-      e.stopPropagation();
-      e.preventDefault();
-      handleRemoveMultiValue(item);
-    },
-    [handleRemoveMultiValue, item]
-  );
-
-  const removePillHandlerWithKeyboard = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        removePillHandler(e);
-      }
-    },
-    [removePillHandler]
-  );
-
-  return (
-    <div
-      className={cx(styles.basePill, styles.valuePill)}
-      onClick={editMultiValuePill}
-      onKeyDownCapture={editMultiValuePillWithKeyboard}
-      tabIndex={0}
-      id={`${item.value}-${index}`}
-    >
-      {item.label ?? item.value}
-      <Button
-        onClick={removePillHandler}
-        onKeyDownCapture={removePillHandlerWithKeyboard}
-        fill="text"
-        size="sm"
-        variant="secondary"
-        className={styles.removeButton}
-        tooltip={`Remove filter value - ${item.label ?? item.value}`}
-      >
-        <Icon name="times" size="md" id={`${item.value}-${index}-close-icon`} />
-      </Button>
-    </div>
-  );
-};
-
 const getStyles = (theme: GrafanaTheme2) => ({
   comboboxWrapper: css({
     display: 'flex',
@@ -781,10 +713,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     '&:hover': {
       background: theme.colors.action.hover,
     },
-  }),
-  valuePill: css({
-    background: theme.colors.action.selected,
-    padding: theme.spacing(0.125, 0, 0.125, 1),
   }),
   dropdownWrapper: css({
     backgroundColor: theme.colors.background.primary,
@@ -818,24 +746,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
       borderTop: `1px solid ${theme.colors.border.weak}`,
     },
   }),
-  removeButton: css({
-    marginInline: theme.spacing(0.5),
-    height: '100%',
-    padding: 0,
-    cursor: 'pointer',
-    '&:hover': {
-      color: theme.colors.text.primary,
-    },
-  }),
   descriptionText: css({
     ...theme.typography.bodySmall,
     color: theme.colors.text.secondary,
     paddingTop: theme.spacing(0.5),
-  }),
-  multiValueApply: css({
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    display: 'flex',
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/MultiValuePill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/MultiValuePill.tsx
@@ -1,0 +1,107 @@
+import { cx, css } from '@emotion/css';
+import { SelectableValue, GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Button, Icon } from '@grafana/ui';
+import React, { useCallback } from 'react';
+
+interface MultiValuePillProps {
+  item: SelectableValue<string>;
+  handleRemoveMultiValue: (item: SelectableValue<string>) => void;
+  index: number;
+  handleEditMultiValuePill: (value: SelectableValue<string>) => void;
+}
+export const MultiValuePill = ({
+  item,
+  handleRemoveMultiValue,
+  index,
+  handleEditMultiValuePill,
+}: MultiValuePillProps) => {
+  const styles = useStyles2(getStyles);
+
+  const editMultiValuePill = useCallback(
+    (e: React.SyntheticEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      handleEditMultiValuePill(item);
+    },
+    [handleEditMultiValuePill, item]
+  );
+
+  const editMultiValuePillWithKeyboard = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        editMultiValuePill(e);
+      }
+    },
+    [editMultiValuePill]
+  );
+
+  const removePillHandler = useCallback(
+    (e: React.SyntheticEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      handleRemoveMultiValue(item);
+    },
+    [handleRemoveMultiValue, item]
+  );
+
+  const removePillHandlerWithKeyboard = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        removePillHandler(e);
+      }
+    },
+    [removePillHandler]
+  );
+
+  return (
+    <div
+      className={cx(styles.basePill, styles.valuePill)}
+      onClick={editMultiValuePill}
+      onKeyDown={editMultiValuePillWithKeyboard}
+      tabIndex={0}
+      id={`${item.value}-${index}`}
+    >
+      {item.label ?? item.value}
+      <Button
+        onClick={removePillHandler}
+        onKeyDownCapture={removePillHandlerWithKeyboard}
+        fill="text"
+        size="sm"
+        variant="secondary"
+        className={styles.removeButton}
+        tooltip={`Remove filter value - ${item.label ?? item.value}`}
+      >
+        <Icon name="times" size="md" id={`${item.value}-${index}-close-icon`} />
+      </Button>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  basePill: css({
+    display: 'flex',
+    alignItems: 'center',
+    background: theme.colors.action.disabledBackground,
+    border: `1px solid ${theme.colors.border.weak}`,
+    padding: theme.spacing(0.125, 1, 0.125, 1),
+    color: theme.colors.text.primary,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    minHeight: theme.spacing(2.75),
+    ...theme.typography.bodySmall,
+    cursor: 'pointer',
+  }),
+  valuePill: css({
+    background: theme.colors.action.selected,
+    padding: theme.spacing(0.125, 0, 0.125, 1),
+  }),
+  removeButton: css({
+    marginInline: theme.spacing(0.5),
+    height: '100%',
+    padding: 0,
+    cursor: 'pointer',
+    '&:hover': {
+      color: theme.colors.text.primary,
+    },
+  }),
+});

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -242,3 +242,23 @@ export const generatePlaceholder = (
 
   return filter[filterInputType] && !isAlwaysWip ? `${filter[filterInputType]}` : INPUT_PLACEHOLDER;
 };
+
+export const populateInputValueOnInputTypeSwitch = ({
+  populateInputOnEdit,
+  item,
+  filterInputType,
+  setInputValue,
+  filter,
+}: {
+  populateInputOnEdit: boolean | undefined;
+  item: SelectableValue<string>;
+  filterInputType: AdHocInputType;
+  setInputValue: (value: React.SetStateAction<string>) => void;
+  filter: AdHocFilterWithLabels | undefined;
+}) => {
+  if (populateInputOnEdit && !isMultiValueOperator(item.value || '') && nextInputTypeMap[filterInputType] === 'value') {
+    setInputValue(filter?.value || '');
+  } else {
+    setInputValue('');
+  }
+};


### PR DESCRIPTION
1. When editing value pre-fill input with the value for single value filters
2. Allow to select certain multi value to edit its content
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.23.1--canary.955.11702691002.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.23.1--canary.955.11702691002.0
  npm install @grafana/scenes@5.23.1--canary.955.11702691002.0
  # or 
  yarn add @grafana/scenes-react@5.23.1--canary.955.11702691002.0
  yarn add @grafana/scenes@5.23.1--canary.955.11702691002.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
