### PR TITLE
Variables: Add new `allowCustomValue` flag to AdHoc Variable

### DIFF
--- a/packages/scenes-react/utils/test/__mocks__/style.ts
+++ b/packages/scenes-react/utils/test/__mocks__/style.ts
@@ -1,0 +1,1 @@
+export const style = 'style';

--- a/packages/scenes-react/utils/test/__mocks__/style.ts
+++ b/packages/scenes-react/utils/test/__mocks__/style.ts
@@ -1,1 +1,0 @@
-export const style = 'style';

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -116,7 +116,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueSelect = (
     <Select
       virtualized
-      allowCustomValue
+      allowCustomValue={model.state.allowCustomValue ?? true}
       isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
@@ -171,7 +171,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       disabled={model.state.readOnly}
       className={cx(styles.key, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
-      allowCustomValue={true}
+      allowCustomValue={model.state.allowCustomValue ?? true}
       value={keyValue}
       placeholder={'Select label'}
       options={handleOptionGroups(keys)}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -66,6 +66,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   // control multi values with local state in order to commit all values at once and avoid _wip reset mid creation
   const [filterMultiValues, setFilterMultiValues] = useState<Array<SelectableValue<string>>>([]);
   const [_, setForceRefresh] = useState({});
+  const allowCustomValue = model.state.allowCustomValue ?? true;
 
   const multiValuePillWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -206,7 +207,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   const filteredDropDownItems = flattenOptionGroups(handleOptionGroups(optionsSearcher(inputValue, filterInputType)));
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
-  if (filterInputType !== 'operator' && inputValue) {
+  if (allowCustomValue && filterInputType !== 'operator' && inputValue) {
     filteredDropDownItems.push({
       value: inputValue.trim(),
       label: inputValue.trim(),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -346,6 +346,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
       if (event.key === 'Enter' && activeIndex != null) {
         // safeguard for non existing items
+        // note: custom item is added to filteredDropDownItems if allowed
         if (!filteredDropDownItems[activeIndex]) {
           return;
         }
@@ -589,7 +590,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                     <LoadingOptionsPlaceholder />
                   ) : optionsError ? (
                     <OptionsErrorPlaceholder handleFetchOptions={() => handleFetchOptions(filterInputType)} />
-                  ) : !filteredDropDownItems.length && (filterInputType === 'operator' || !inputValue) ? (
+                  ) : !filteredDropDownItems.length &&
+                    (!allowCustomValue || filterInputType === 'operator' || !inputValue) ? (
                     <NoOptionsPlaceholder />
                   ) : (
                     rowVirtualizer.getVirtualItems().map((virtualItem) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -96,6 +96,11 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   useQueriesAsFilterForOptions?: boolean;
 
   /**
+   * Flag that decides whether custom values can be added to the filter
+   */
+  allowCustomValue?: boolean;
+
+  /**
    * @internal state of the new filter being added
    */
   _wip?: AdHocFilterWithLabels;


### PR DESCRIPTION
Extends this [PR](https://github.com/grafana/scenes/pull/956) to adhoc vars as well so all related variables get this feature.

Related [PR](https://github.com/grafana/grafana/pull/96077)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.24.0--canary.960.11775742614.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.24.0--canary.960.11775742614.0
  npm install @grafana/scenes@5.24.0--canary.960.11775742614.0
  # or 
  yarn add @grafana/scenes-react@5.24.0--canary.960.11775742614.0
  yarn add @grafana/scenes@5.24.0--canary.960.11775742614.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
