### PR TITLE
VariableLabel: change variable label check to OR instead of ??

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -71,7 +71,7 @@ function VariableLabel({ variable, layout, hideLabel }: VariableSelectProps) {
   }
 
   const elementId = `var-${state.key}`;
-  const labelOrName = state.label ?? state.name;
+  const labelOrName = state.label || state.name;
 
   return (
     <ControlsLabel


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/91727

How to check:
1. create/edit variable
2. add label and save
3. remove label and save

Old: result blank variable label in UI. Disappears after refresh
New: variable label fallbacks to variable name

Don't see any risk here to change to `||` instead of `??`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.23.3--canary.963.11743338978.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.23.3--canary.963.11743338978.0
  npm install @grafana/scenes@5.23.3--canary.963.11743338978.0
  # or 
  yarn add @grafana/scenes-react@5.23.3--canary.963.11743338978.0
  yarn add @grafana/scenes@5.23.3--canary.963.11743338978.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
