### PR TITLE
Annotations: Fix issue where dashboard annotations weren't rendering

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/filterAnnotations.ts
+++ b/packages/scenes/src/querying/layers/annotations/filterAnnotations.ts
@@ -1,6 +1,8 @@
 import { DataFrame, Field } from '@grafana/data';
 import { DataLayerFilter } from '../../../core/types';
 
+const GLOBAL_ANNOTATION_ID = 0;
+
 // Provided SceneDataLayerProviderResult is an array of DataFrames.
 export function filterAnnotations(data: DataFrame[], filters: DataLayerFilter) {
   if (!Array.isArray(data) || data.length === 0) {
@@ -26,15 +28,15 @@ export function filterAnnotations(data: DataFrame[], filters: DataLayerFilter) {
       if (sourceField) {
         // Here we are filtering Grafana annotations that were added to a particular panel.
         if (panelIdField && sourceField.values[index].type === 'dashboard') {
-          matching = panelIdField.values[index] === filters.panelId;
+          matching = [filters.panelId, GLOBAL_ANNOTATION_ID].includes(panelIdField.values[index]);
         }
 
         const sourceFilter = sourceField.values[index].filter;
 
         // Here we are filtering based on annotation filter definition.
-        // Those fitlers are: Show annotation in selected panels, Exclude annotation from selected panels.
+        // Those filters are: Show annotation in selected panels, Exclude annotation from selected panels.
         if (sourceFilter) {
-          const includes = (sourceFilter.ids ?? []).includes(filters.panelId);
+          const includes = ([...(sourceFilter.ids ?? []), GLOBAL_ANNOTATION_ID]).includes(filters.panelId);
           if (sourceFilter.exclude) {
             if (includes) {
               matching = false;
@@ -82,5 +84,6 @@ export function filterAnnotations(data: DataFrame[], filters: DataLayerFilter) {
     });
     frameIdx++;
   }
+
   return processed;
 }


### PR DESCRIPTION
Fixes an issue where dashboard-wide annotations (ones created via API without a defined `panelId`, which are given the `panelId` 0 when stored in the database) would not render on existing panels. (Newly created panels rendered the annotations correctly).
Not super familiar with the code so please let me know if there's a better way to fix this that I've missed. :)

Fixes the following issue: https://github.com/grafana/support-escalations/issues/13356
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.23.4--canary.964.11745806385.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.23.4--canary.964.11745806385.0
  npm install @grafana/scenes@5.23.4--canary.964.11745806385.0
  # or 
  yarn add @grafana/scenes-react@5.23.4--canary.964.11745806385.0
  yarn add @grafana/scenes@5.23.4--canary.964.11745806385.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
