### PR TITLE
SceneVariableSet: Notify scene objects that use time macros when time changes

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -268,7 +268,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       const queryRunner = new SceneQueryRunner({
         runQueriesMode: 'manual',
         queries: [{ refId: 'A' }],
-        $timeRange
+        $timeRange,
       });
 
       queryRunner.activate();
@@ -277,13 +277,12 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
 
       expect(queryRunner.state.data).toBeUndefined();
 
-      queryRunner.runQueries()
+      queryRunner.runQueries();
 
       await new Promise((r) => setTimeout(r, 1));
 
       expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
       expect(queryRunner.state.data?.series).toHaveLength(1);
-
     });
 
     it('should not subscribe to time range when calling runQueries', async () => {
@@ -291,7 +290,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       const queryRunner = new SceneQueryRunner({
         runQueriesMode: 'manual',
         queries: [{ refId: 'A' }],
-        $timeRange
+        $timeRange,
       });
 
       queryRunner.activate();
@@ -300,29 +299,29 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(queryRunner.state.data).toBeUndefined();
 
       // Run the query manually
-      queryRunner.runQueries()
+      queryRunner.runQueries();
       await new Promise((r) => setTimeout(r, 1));
 
       expect(runRequestMock.mock.calls.length).toEqual(1);
       expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
-      expect(queryRunner.state.data?.series[0].refId).toBe('A')
+      expect(queryRunner.state.data?.series[0].refId).toBe('A');
 
       queryRunner.setState({
         queries: [{ refId: 'B' }],
-        $timeRange
-      })
+        $timeRange,
+      });
 
-      $timeRange.onRefresh()
+      $timeRange.onRefresh();
       await new Promise((r) => setTimeout(r, 1));
 
       expect(runRequestMock.mock.calls.length).toEqual(1);
-      expect(queryRunner.state.data?.series[0].refId).toBe('A')
+      expect(queryRunner.state.data?.series[0].refId).toBe('A');
 
-      queryRunner.runQueries()
+      queryRunner.runQueries();
       await new Promise((r) => setTimeout(r, 1));
 
       expect(runRequestMock.mock.calls.length).toEqual(2);
-      expect(queryRunner.state.data?.request?.targets[0].refId).toBe('B')
+      expect(queryRunner.state.data?.request?.targets[0].refId).toBe('B');
     });
 
     it('should not run queries on timerange change', async () => {
@@ -330,11 +329,11 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       const queryRunner = new SceneQueryRunner({
         runQueriesMode: 'manual',
         queries: [{ refId: 'A' }],
-        $timeRange
+        $timeRange,
       });
 
       queryRunner.activate();
-      $timeRange.onRefresh()
+      $timeRange.onRefresh();
 
       await new Promise((r) => setTimeout(r, 1));
 
@@ -345,7 +344,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       const variable = new TestVariable({ name: 'A', value: '', query: 'A.*' });
       const queryRunner = new SceneQueryRunner({
         queries: [{ refId: 'A', query: '$A' }],
-        runQueriesMode: 'manual'
+        runQueriesMode: 'manual',
       });
 
       const timeRange = new SceneTimeRange();
@@ -374,7 +373,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'test-uid' },
         queries: [{ refId: 'A' }],
-        runQueriesMode: 'manual'
+        runQueriesMode: 'manual',
       });
 
       const scene = new EmbeddedScene({ $data: queryRunner, body: new SceneCanvasText({ text: 'hello' }) });
@@ -420,7 +419,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
         queries: [{ refId: 'A' }],
         $timeRange: new SceneTimeRange(),
         runQueriesMode: 'manual',
-        maxDataPointsFromWidth: true
+        maxDataPointsFromWidth: true,
       });
 
       queryRunner.activate();
@@ -431,7 +430,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
       expect(queryRunner.state.data?.series).toHaveLength(1);
     });
-  })
+  });
 
   describe('when activated and got no data', () => {
     it('should run queries', async () => {
@@ -902,6 +901,33 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       variable.changeValueTo('AB');
 
       await new Promise((r) => setTimeout(r, 1));
+
+      expect(runRequestMock.mock.calls.length).toBe(2);
+    });
+
+    it('Should not execute query twice when time range changes and the query is using a time macro', async () => {
+      const queryRunner = new SceneQueryRunner({
+        queries: [{ refId: 'A', query: '$__from' }],
+      });
+
+      const timeRange = new SceneTimeRange();
+      const scene = new SceneFlexLayout({
+        $variables: new SceneVariableSet({ variables: [] }),
+        $timeRange: timeRange,
+        $data: queryRunner,
+        children: [],
+      });
+
+      scene.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+      expect(runRequestMock.mock.calls.length).toBe(1);
+
+      timeRange.onRefresh();
+
+      await new Promise((r) => setTimeout(r, 2));
 
       expect(runRequestMock.mock.calls.length).toBe(2);
     });

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -56,7 +56,7 @@ exports[`SceneQueryRunner when running query should build DataQueryRequest objec
     "from": "now-6h",
     "to": "now",
   },
-  "requestId": "SQR176",
+  "requestId": "SQR179",
   "startTime": 1689063488000,
   "targets": [
     {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -519,6 +519,23 @@ describe('SceneVariableList', () => {
       expect(B.state.loading).toBe(false);
       expect(C.state.loading).toBe(false);
     });
+
+    it('Should notify scene objects that use time macros', () => {
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+      const scene = new TestObjectWithVariableDependency({
+        $variables: new SceneVariableSet({ variables: [] }),
+        $timeRange: timeRange,
+        title: '${__from}',
+      });
+
+      scene.activate();
+
+      expect(scene.state.didSomethingCount).toBe(0);
+
+      timeRange.setState({ from: 'now-2h', to: 'now' });
+
+      expect(scene.state.didSomethingCount).toBe(1);
+    });
   });
 
   describe('isVariableLoadingOrWaitingToUpdate', () => {


### PR DESCRIPTION
Thought this was a clever solution (Making SceneVariableSet notify scene objects that use __from and __to macro when time range changes).

But it makes it so that SceneQueryRunner executes double queries when a query is using these macros (as SceneQueryRunner is already subscribing to time range).

Need a way to dedupe those updates.

Possible solutions
* dedupe the run queries somehow (when they are called with the same time range)
* Opt-in to being notified of time range "__from" and "__to" variables (or opt-out) in VariableDependencyConfig 


