### PR TITLE
SceneObject: Render before activation

### DIFF
--- a/packages/scenes/src/components/SceneControlsSpacer.tsx
+++ b/packages/scenes/src/components/SceneControlsSpacer.tsx
@@ -6,11 +6,8 @@ import { SceneComponentProps } from '../core/types';
 export class SceneControlsSpacer extends SceneObjectBase {
   public constructor() {
     super({});
-  }
 
-  public get Component() {
-    // Skipping wrapper component for this scene object so that it renders right away
-    return SceneControlsSpacer.Component;
+    this._renderBeforeActivation = true;
   }
 
   public static Component = (_props: SceneComponentProps<SceneControlsSpacer>) => {

--- a/packages/scenes/src/core/SceneComponentWrapper.test.tsx
+++ b/packages/scenes/src/core/SceneComponentWrapper.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SceneComponentProps, SceneObjectState } from './types';
+import { SceneObjectBase } from './SceneObjectBase';
+
+/**
+ * Used in a couple of unit tests
+ */
+export interface TestSceneState extends SceneObjectState {
+  name?: string;
+}
+
+export class TestScene extends SceneObjectBase<TestSceneState> {
+  public renderCount = 0;
+
+  public setRenderBeforeActivation(value: boolean) {
+    this._renderBeforeActivation = value;
+  }
+
+  public static Component = ({ model }: SceneComponentProps<TestScene>) => {
+    const { name } = model.useState();
+
+    model.renderCount += 1;
+
+    return (
+      <div>
+        <div>name: {name}</div>
+        <div>isActive: {model.isActive.toString()}</div>
+      </div>
+    );
+  };
+}
+
+describe('SceneComponentWrapper', () => {
+  it('Should render should activate object', () => {
+    const scene = new TestScene({ name: 'nested' });
+    render(<scene.Component model={scene} />);
+
+    expect(scene.renderCount).toBe(1);
+    expect(scene.isActive).toBe(true);
+  });
+
+  it('Unmount should deactivate', () => {
+    const scene = new TestScene({ name: 'nested' });
+    const { unmount } = render(<scene.Component model={scene} />);
+
+    expect(scene.isActive).toBe(true);
+
+    unmount();
+
+    expect(scene.isActive).toBe(false);
+  });
+
+  it('should not render component until after activation', () => {
+    const scene = new TestScene({ name: 'nested' });
+    const screen = render(<scene.Component model={scene} />);
+
+    expect(scene.renderCount).toBe(1);
+    expect(screen.getByText('isActive: true')).toBeInTheDocument();
+  });
+
+  it('should render component before activation whgen renderBeforeActivation is true', () => {
+    const scene = new TestScene({ name: 'nested' });
+    scene.setRenderBeforeActivation(true);
+
+    render(<scene.Component model={scene} />);
+
+    expect(scene.renderCount).toBe(2);
+  });
+});

--- a/packages/scenes/src/core/SceneComponentWrapper.tsx
+++ b/packages/scenes/src/core/SceneComponentWrapper.tsx
@@ -15,7 +15,7 @@ function SceneComponentWrapperWithoutMemo<T extends SceneObject>({ model, ...oth
   // By not rendering the component until the model is actiavted we make sure that parent models get activated before child models
   // Otherwise child models would be activated before parents as that is the order of React mount effects.
   // This also enables static logic to happen inside activate that can change state before the first render.
-  if (!model.isActive) {
+  if (!model.isActive && !model.renderBeforeActivation) {
     return null;
   }
 

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -372,12 +372,6 @@ describe('SceneObject', () => {
       });
     });
   });
-
-  describe('rendering', () => {
-    it('Should render should activate object', () => {
-      const scene = new TestScene({ name: 'nested' });
-    });
-  });
 });
 
 describe('useSceneObjectState', () => {

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -372,6 +372,12 @@ describe('SceneObject', () => {
       });
     });
   });
+
+  describe('rendering', () => {
+    it('Should render should activate object', () => {
+      const scene = new TestScene({ name: 'nested' });
+    });
+  });
 });
 
 describe('useSceneObjectState', () => {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -35,6 +35,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   protected _parent?: SceneObject;
   protected _subs = new Subscription();
   protected _refCount = 0;
+  protected _renderBeforeActivation = false;
 
   protected _variableDependency: SceneVariableDependencyConfigLike | undefined;
   protected _urlSync: SceneObjectUrlSyncHandler | undefined;
@@ -58,6 +59,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   /** True if currently being active (ie displayed for visual objects) */
   public get isActive(): boolean {
     return this._isActive;
+  }
+
+  public get renderBeforeActivation(): boolean {
+    return this._renderBeforeActivation;
   }
 
   /** Returns the parent, undefined for root object */

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -61,6 +61,9 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** True when there is a React component mounted for this Object */
   readonly isActive: boolean;
 
+  /** Controls if activation blocks rendering */
+  readonly renderBeforeActivation: boolean;
+
   /** SceneObject parent */
   readonly parent?: SceneObject;
 
@@ -79,7 +82,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** Publish an event and optionally bubble it up the scene */
   publishEvent(event: BusEvent, bubble?: boolean): void;
 
-  /** Utility hook that wraps useObservable. Used by React components to subscribes to state changes */
+  /** Utility hook that wraps useObservableS. Used by React components to subscribes to state changes */
   useState(): TState;
 
   /** How to modify state */

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -82,7 +82,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** Publish an event and optionally bubble it up the scene */
   publishEvent(event: BusEvent, bubble?: boolean): void;
 
-  /** Utility hook that wraps useObservableS. Used by React components to subscribes to state changes */
+  /** Utility hook that wraps useObservable. Used by React components to subscribes to state changes */
   useState(): TState;
 
   /** How to modify state */


### PR DESCRIPTION
A big decision we made early on was to force activation of the scene object before it's component get's rendered. This was mainly to make sure parent SceneVariableSets where activated before child SceneQueryRunners come asking if their variables are "ready" or not. 

To solve this and ensure that all scene objects can run state initiation logic before children get rendered/activated, we made sure the in ComponentWrapper will not render the component until after activation. In retrospect I think this was a mistake. 

But this has some really big negative effects for React and rendering without flickering / intermediate empty states. 

An example of this problem was first scene in the SceneControlsSpacer object that renders a simple empty div but because it is rendered with a null value before activation the first dom hydration is without this element then on next render the element is added and a CSS reflow happens (and the controls on the right side of it are correctly pushed to the right), but because of this intermediate empty rendering the controls flicker / move as dashboards / scene are opened. 

We have a similar problem when opening dashboard settings from a dashboard with scrollbars. we first render an empty null view which causes the scrollbars to disappear and then after dashboard general settings is rendered the scrollbars reappear causing the whole page (at last the top nav right side icons) to jump around as the scrollbar is hidden and then shown again. 

Possible solutions

* Remove this logic from ComponentWrapper (this has some big sweeping effects, as we rely on it in a few places, mainly variables but also in scenes-react). But I think there are creative solutions/workarounds. The scary bit is how much scene apps could rely on this logic in subtle ways and removing it could cause all sorts of subtle or not-so-subtle crashes.  
* Opt-in (we could opt-in to this behavior for root scene objects, but really would need to be opt-in to all nodes that can have variables which is many so becomes a bit messy) 
* Opt-out (explored in this PR). 


**PR solution**

Add a way for SceneObjects to inform ComponentWrapper that it's fine to render it before activation 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.27.0--canary.968.12050773878.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.27.0--canary.968.12050773878.0
  npm install @grafana/scenes@5.27.0--canary.968.12050773878.0
  # or 
  yarn add @grafana/scenes-react@5.27.0--canary.968.12050773878.0
  yarn add @grafana/scenes@5.27.0--canary.968.12050773878.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
