### PR TITLE
Variables: Fix search result ordering to use match quality

### DIFF
--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.16",
-    "@leeoniya/ufuzzy": "^1.0.14",
+    "@leeoniya/ufuzzy": "^1.0.16",
     "@tanstack/react-virtual": "^3.9.0",
     "react-grid-layout": "^1.3.4",
     "react-use": "^17.5.0",

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -47,18 +47,16 @@ export function fuzzySearchOptions(options: Array<SelectableValue<string>>) {
     const filteredOptions: Array<SelectableValue<string>> = [];
 
     if (idxs) {
-      for (let i = 0; i < idxs.length; i++) {
-        if (info && order) {
-          const idx = order[i];
-          filteredOptions.push(options[idxs[idx]]);
-        } else {
+      if (info && order) {
+        for (let i = 0; i < order.length && i < limit; i++) {
+          filteredOptions.push(options[info.idx[order[i]]]);
+        }
+      } else {
+        for (let i = 0; i < idxs.length && i < limit; i++) {
           filteredOptions.push(options[idxs[i]]);
         }
-
-        if (filteredOptions.length > limit) {
-          return filteredOptions;
-        }
       }
+
       return filteredOptions;
     }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -1,7 +1,7 @@
 import { SelectableValue } from '@grafana/data';
-import uFuzzy from '@leeoniya/ufuzzy';
 import { AdHocInputType } from './AdHocFiltersCombobox';
 import { AdHocFilterWithLabels, isMultiValueOperator } from '../AdHocFiltersVariable';
+import { getFuzzySearcher } from '../../utils';
 
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
 const VIRTUAL_LIST_DESCRIPTION_WIDTH_ESTIMATE_MULTIPLIER = 6;
@@ -12,59 +12,16 @@ export const VIRTUAL_LIST_ITEM_HEIGHT_WITH_DESCRIPTION = 60;
 export const ERROR_STATE_DROPDOWN_WIDTH = 366;
 
 export function fuzzySearchOptions(options: Array<SelectableValue<string>>) {
-  const ufuzzy = new uFuzzy();
-  const haystack: string[] = [];
-  const limit = 10000;
+  const haystack = options.map((o) => o.label ?? o.value!);
+  const fuzzySearch = getFuzzySearcher(haystack);
 
   return (search: string, filterInputType: AdHocInputType) => {
-    if (search === '') {
-      if (options.length > limit) {
-        return options.slice(0, limit);
-      } else {
-        return options;
-      }
+    if (filterInputType === 'operator' && search !== '') {
+      // uFuzzy can only match non-alphanum chars if quoted
+      search = `"${search}"`;
     }
 
-    if (filterInputType === 'operator') {
-      const filteredOperators = [];
-      for (let i = 0; i < options.length; i++) {
-        if ((options[i].label || options[i].value)?.includes(search)) {
-          filteredOperators.push(options[i]);
-          if (filteredOperators.length > limit) {
-            return filteredOperators;
-          }
-        }
-      }
-      return filteredOperators;
-    }
-
-    if (haystack.length === 0) {
-      for (let i = 0; i < options.length; i++) {
-        haystack.push(options[i].label || options[i].value!);
-      }
-    }
-    const [idxs, info, order] = ufuzzy.search(haystack, search);
-    const filteredOptions: Array<SelectableValue<string>> = [];
-
-    if (idxs) {
-      if (info && order) {
-        for (let i = 0; i < order.length && i < limit; i++) {
-          filteredOptions.push(options[info.idx[order[i]]]);
-        }
-      } else {
-        for (let i = 0; i < idxs.length && i < limit; i++) {
-          filteredOptions.push(options[idxs[i]]);
-        }
-      }
-
-      return filteredOptions;
-    }
-
-    if (options.length > limit) {
-      return options.slice(0, limit);
-    }
-
-    return options;
+    return fuzzySearch(search).map((i) => options[i]);
   };
 }
 export const flattenOptionGroups = (options: Array<SelectableValue<string>>) =>

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
@@ -27,16 +27,13 @@ export function getAdhocOptionSearcher(
     const filteredOptions: SelectableValue[] = [];
 
     if (idxs) {
-      for (let i = 0; i < idxs.length; i++) {
-        if (info && order) {
-          const idx = order[i];
-          filteredOptions.push(options[idxs[idx]]);
-        } else {
-          filteredOptions.push(options[idxs[i]]);
+      if (info && order) {
+        for (let i = 0; i < order.length && i < limit; i++) {
+          filteredOptions.push(options[info.idx[order[i]]]);
         }
-
-        if (filteredOptions.length > limit) {
-          return filteredOptions;
+      } else {
+        for (let i = 0; i < idxs.length && i < limit; i++) {
+          filteredOptions.push(options[idxs[i]]);
         }
       }
 

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
@@ -1,49 +1,9 @@
-import uFuzzy from '@leeoniya/ufuzzy';
 import { SelectableValue } from '@grafana/data';
+import { getFuzzySearcher } from '../utils';
 
-export function getAdhocOptionSearcher(
-  options: SelectableValue[],
-) {
-  const ufuzzy = new uFuzzy();
-  const haystack: string[] = [];
-  const limit = 10000;
+export function getAdhocOptionSearcher(options: SelectableValue[]) {
+  const haystack = options.map((o) => o.label ?? String(o.value));
+  const fuzzySearch = getFuzzySearcher(haystack);
 
-  return (search: string) => {
-    if (search === '') {
-      if (options.length > limit) {
-        return options.slice(0, limit);
-      } else {
-        return options;
-      }
-    }
-
-    if (haystack.length === 0) {
-      for (let i = 0; i < options.length; i++) {
-        haystack.push(options[i].label ?? String(options[i].value));
-      }
-    }
-
-    const [idxs, info, order] = ufuzzy.search(haystack, search);
-    const filteredOptions: SelectableValue[] = [];
-
-    if (idxs) {
-      if (info && order) {
-        for (let i = 0; i < order.length && i < limit; i++) {
-          filteredOptions.push(options[info.idx[order[i]]]);
-        }
-      } else {
-        for (let i = 0; i < idxs.length && i < limit; i++) {
-          filteredOptions.push(options[idxs[i]]);
-        }
-      }
-
-      return filteredOptions;
-    }
-
-    if (options.length > limit) {
-      return options.slice(0, limit);
-    }
-
-    return options;
-  };
+  return (search: string) => fuzzySearch(search).map((i) => options[i]);
 }

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -1,56 +1,16 @@
 import { VariableValueOption } from '../types';
-import uFuzzy from '@leeoniya/ufuzzy';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
+import { getFuzzySearcher } from '../utils';
 
-export function getOptionSearcher(
-  options: VariableValueOption[],
-  includeAll: boolean | undefined,
-) {
-  const ufuzzy = new uFuzzy();
+export function getOptionSearcher(options: VariableValueOption[], includeAll = false) {
   let allOptions = options;
-  const haystack: string[] = [];
-  const limit = 10000;
 
   if (includeAll) {
     allOptions = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...allOptions];
   }
 
-  return (search: string) => {
-    if (search === '') {
-      if (allOptions.length > limit) {
-        return allOptions.slice(0, limit);
-      } else {
-        return allOptions;
-      }
-    }
+  const haystack = allOptions.map((o) => o.label);
+  const fuzzySearch = getFuzzySearcher(haystack);
 
-    if (haystack.length === 0) {
-      for (let i = 0; i < allOptions.length; i++) {
-        haystack.push(allOptions[i].label);
-      }
-    }
-
-    const [idxs, info, order] = ufuzzy.search(haystack, search);
-    const filteredOptions: VariableValueOption[] = [];
-
-    if (idxs) {
-      if (info && order) {
-        for (let i = 0; i < order.length && i < limit; i++) {
-          filteredOptions.push(allOptions[info.idx[order[i]]]);
-        }
-      } else {
-        for (let i = 0; i < idxs.length && i < limit; i++) {
-          filteredOptions.push(allOptions[idxs[i]]);
-        }
-      }
-
-      return filteredOptions;
-    }
-
-    if (allOptions.length > limit) {
-      return allOptions.slice(0, limit);
-    }
-
-    return allOptions;
-  };
+  return (search: string) => fuzzySearch(search).map((i) => allOptions[i]);
 }

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -34,16 +34,13 @@ export function getOptionSearcher(
     const filteredOptions: VariableValueOption[] = [];
 
     if (idxs) {
-      for (let i = 0; i < idxs.length; i++) {
-        if (info && order) {
-          const idx = order[i];
-          filteredOptions.push(allOptions[idxs[idx]]);
-        } else {
-          filteredOptions.push(allOptions[idxs[i]]);
+      if (info && order) {
+        for (let i = 0; i < order.length && i < limit; i++) {
+          filteredOptions.push(allOptions[info.idx[order[i]]]);
         }
-
-        if (filteredOptions.length > limit) {
-          return filteredOptions;
+      } else {
+        for (let i = 0; i < idxs.length && i < limit; i++) {
+          filteredOptions.push(allOptions[idxs[i]]);
         }
       }
 

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -4,7 +4,7 @@ import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLa
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObjectState } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
-import { getQueriesForVariables } from './utils';
+import { getFuzzySearcher, getQueriesForVariables } from './utils';
 
 describe('getQueriesForVariables', () => {
   it('should resolve queries', () => {
@@ -173,6 +173,31 @@ describe('getQueriesForVariables', () => {
     source.activate();
 
     expect(getQueriesForVariables(source)).toEqual([{ refId: 'A' }, { refId: 'AA' }, { refId: 'B' }]);
+  });
+});
+
+describe('getFuzzySearcher orders by match quality with case-sensitivity', () => {
+  it('Can filter options by search query', async () => {
+    const haystack = [
+      'client_service_namespace',
+      'namespace',
+      'alert_namespace',
+      'container_namespace',
+      'Namespace',
+      'client_k8s_namespace_name',
+      'foobar'
+    ];
+
+    const searcher = getFuzzySearcher(haystack);
+
+    expect(searcher('Names').map((i) => haystack[i])).toEqual([
+      'Namespace',
+      'namespace',
+      'alert_namespace',
+      'container_namespace',
+      'client_k8s_namespace_name',
+      'client_service_namespace',
+    ]);
   });
 });
 

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -223,12 +223,12 @@ export function handleOptionGroups(values: SelectableValue[]): Array<SelectableV
   return result;
 }
 
-// returns matched indices by quality
 export function getFuzzySearcher(haystack: string[], limit = 10_000) {
   const ufuzzy = new uFuzzy();
 
   const FIRST = Array.from({ length: Math.min(limit, haystack.length) }, (_, i) => i);
 
+  // returns matched indices by quality
   return (search: string): number[] => {
     if (search === '') {
       return FIRST;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,7 +3533,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.26.16"
     "@grafana/eslint-config": "npm:5.1.0"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
-    "@leeoniya/ufuzzy": "npm:^1.0.14"
+    "@leeoniya/ufuzzy": "npm:^1.0.16"
     "@swc/core": "npm:^1.2.162"
     "@swc/jest": "npm:^0.2.36"
     "@tanstack/react-virtual": "npm:^3.9.0"
@@ -4146,10 +4146,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@leeoniya/ufuzzy@npm:1.0.14, @leeoniya/ufuzzy@npm:^1.0.14":
+"@leeoniya/ufuzzy@npm:1.0.14":
   version: 1.0.14
   resolution: "@leeoniya/ufuzzy@npm:1.0.14"
   checksum: 10/852b580a8eaaf92e2d448f5b720e3c53e4bea22187bf5e8459256677c47183321b47b8384982e15751f42da7e77a216fd86c80e6185677d8270adeab4a4fb771
+  languageName: node
+  linkType: hard
+
+"@leeoniya/ufuzzy@npm:^1.0.16":
+  version: 1.0.16
+  resolution: "@leeoniya/ufuzzy@npm:1.0.16"
+  checksum: 10/b6d79f59eb972615d1eedeeb7eaa444c3a56b29955b3762a46d8f099cd22457f6a6a33c1a3ab3bdcd7307cb5bac75ec3827f1c4ed7b432dc03c90fa18cc164e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
ensures that when searching `namespace`, we get exact results first ~~(although case-insensitive)~~.

Ref: https://raintank-corp.slack.com/archives/C0630AYC4SY/p1731592718073559

the code is pretty much copy-pasted in 3 places, probably should be extracted?

sample list:

```
client_service_namespace
namespace
alert_namespace
container_namespace
Namespace
client_k8s_namespace_name
```

![image](https://github.com/user-attachments/assets/6dcd55e3-366b-46cd-85d4-43ff59bbb195)