### PR TITLE
Add missing parameter to patchGetAdhocFilters.ts

### DIFF
--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
@@ -25,7 +25,7 @@ export function patchGetAdhocFilters(filterVar: AdHocFiltersVariable) {
 
   templateSrv.getAdhocFilters = function getAdhocFiltersScenePatch(dsName: string): AdHocVariableFilter[] {
     if (allActiveFilterSets.size === 0) {
-      return originalGetAdhocFilters.call(templateSrv);
+      return originalGetAdhocFilters.call(templateSrv, dsName);
     }
 
     const ds = getDataSourceSrv().getInstanceSettings(dsName);


### PR DESCRIPTION
Hello Grafana team!

During development, I encountered a bug where originalGetAdhocFilters consistently tries to locate the default data source. This occurs because the data source name is not passed correctly, resulting in it being **undefined**.

This fix addresses the issue by ensuring that the data source name is properly passed, allowing originalGetAdhocFilters to function as intended.

Please review the changes, and if everything looks good, kindly merge them. Your feedback would be greatly appreciated!