### PR TITLE
SceneVariableSet: Store the whole error object instead of the error message

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -629,7 +629,7 @@ describe('SceneVariableList', () => {
 
       scene.activate();
 
-      expect(A.state.error).toBe('Danger!');
+      expect(A.state.error).toStrictEqual(new Error('Danger!'));
     });
 
     it('Should complete updating chained variables in case of error in all variables', () => {
@@ -665,11 +665,11 @@ describe('SceneVariableList', () => {
       scene.activate();
 
       expect(A.state.loading).toBe(false);
-      expect(A.state.error).toBe('Error in A');
+      expect(A.state.error).toStrictEqual(new Error('Error in A'));
       expect(B.state.loading).toBe(false);
-      expect(B.state.error).toBe('Error in B');
+      expect(B.state.error).toStrictEqual(new Error('Error in B'));
       expect(C.state.loading).toBe(false);
-      expect(C.state.error).toBe('Error in C');
+      expect(C.state.error).toStrictEqual(new Error('Error in C'));
     });
     it('Should complete updating chained variables in case of error in the first variable', () => {
       const A = new TestVariable({
@@ -702,7 +702,7 @@ describe('SceneVariableList', () => {
       scene.activate();
 
       expect(A.state.loading).toBe(false);
-      expect(A.state.error).toBe('Error in A');
+      expect(A.state.error).toStrictEqual(new Error('Error in A'));
 
       B.signalUpdateCompleted();
       expect(B.state.loading).toBe(false);
@@ -750,7 +750,7 @@ describe('SceneVariableList', () => {
 
       expect(B.state.loading).toBe(false);
       expect(B.state.value).toBe('');
-      expect(B.state.error).toBe('Error in B');
+      expect(B.state.error).toStrictEqual(new Error('Error in B'));
 
       C.signalUpdateCompleted();
       expect(C.state.loading).toBe(false);

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -247,7 +247,7 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     this._updating.delete(variable);
     this._variablesToUpdate.delete(variable);
 
-    variable.setState({ loading: false, error: err.message });
+    variable.setState({ loading: false, error: err });
 
     console.error('SceneVariableSet updateAndValidate error', err);
 


### PR DESCRIPTION
Currently, when an error happens during the `validateAndUpdate` observable / RxJS process, we [only store the error message](https://github.com/grafana/scenes/blob/main/packages/scenes/src/variables/sets/SceneVariableSet.ts#L250). 

After this PR, the whole error object will be stored, which can then be used to to inspect its [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), stack traces or any other custom property.

This issue relates to https://github.com/grafana/scenes/pull/371