### PR TITLE
VizPanelBuilder: add setShowMenuOnHover to set PanelChrome showMenuOnHover prop

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -58,6 +58,10 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
    */
   hoverHeaderOffset?: number;
   /**
+   * Only shows vizPanelMenu on hover if true, otherwise the menu is always visible in the header
+   */
+  showMenuOnHover?: boolean
+  /**
    * Defines a menu in the top right of the panel. The menu object is only activated when the dropdown menu itself is shown.
    * So the best way to add dynamic menu actions and links is by adding them in a behavior attached to the menu.
    */

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -22,6 +22,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     _pluginLoadError,
     displayMode,
     hoverHeader,
+    showMenuOnHover,
     hoverHeaderOffset,
     menu,
     headerActions,
@@ -156,6 +157,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             width={width}
             height={height}
             displayMode={displayMode}
+            showMenuOnHover={showMenuOnHover}
             hoverHeader={hoverHeader}
             hoverHeaderOffset={hoverHeaderOffset}
             titleItems={titleItemsElement}

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -62,6 +62,15 @@ export class VizPanelBuilder<TOptions extends {}, TFieldConfig extends {}>
   }
 
   /**
+   * Set if VizPanelMenu "kebab" icon is shown on panel hover for desktop devices. Set as false to always show menu icon.
+   * @param showMenuOnHover
+   */
+  public setShowMenuOnHover(showMenuOnHover: VizPanelState['showMenuOnHover']): this {
+    this._state.showMenuOnHover = showMenuOnHover;
+    return this
+  }
+
+  /**
    * Set panel menu scene object.
    */
   public setMenu(menu: VizPanelState['menu']): this {


### PR DESCRIPTION
Requires: https://github.com/grafana/grafana/pull/96868

What is this feature?
Adds scenes support for showMenuOnHover prop which will always show the vizPanelMenu, instead of only showing on hover.

Why do we need this feature?
See issue for more https://github.com/grafana/grafana/issues/96865.

TL;DR: Explore apps make use of right aligned actions in panel headers. If the menu icon is only visible on hover, users have the expectation that every panel has a menu on hover, or they don't realize a menu is there at all. Also having empty space next to the primary CTA in the panel header just looks weird.

Who is this feature for?
Mostly for users and developers of Explore apps.

Which issue(s) does this PR fix?:

Addresses the Scenes portion of: https://github.com/grafana/grafana/issues/96865
