### PR TITLE
Add `allowCustomValue` flag to `GroupByVariable`

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -210,8 +210,16 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
   }
 }
 export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, text, key, maxVisibleValues, noValueOnClear, options, includeAll, allowCustomValue } =
-    model.useState();
+  const {
+    value,
+    text,
+    key,
+    maxVisibleValues,
+    noValueOnClear,
+    options,
+    includeAll,
+    allowCustomValue = true,
+  } = model.useState();
 
   const values = useMemo<Array<SelectableValue<VariableValueSingle>>>(() => {
     const arrayValue = isArray(value) ? value : [value];
@@ -265,7 +273,7 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
       id={key}
       placeholder={'Select value'}
       width="auto"
-      allowCustomValue={allowCustomValue ?? true}
+      allowCustomValue={allowCustomValue}
       inputValue={inputValue}
       value={uncommittedValue}
       noMultiValueWrap={true}


### PR DESCRIPTION
Continuation of https://github.com/grafana/scenes/pull/956. Recently the GroupByVariable has also been given custom values support, and this PR builds on top of that to make the setting toggleable.

Related to https://github.com/grafana/grafana/pull/96892
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.26.0--canary.974.11969434820.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.26.0--canary.974.11969434820.0
  npm install @grafana/scenes@5.26.0--canary.974.11969434820.0
  # or 
  yarn add @grafana/scenes-react@5.26.0--canary.974.11969434820.0
  yarn add @grafana/scenes@5.26.0--canary.974.11969434820.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
