### PR TITLE
VizPanel: Limit series feature

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -39,6 +39,7 @@ import { getInteropDemo } from './interopDemo';
 import { getUrlSyncTest } from './urlSyncTest';
 import { getMlDemo } from './ml';
 import { getSceneGraphEventsDemo } from './sceneGraphEvents';
+import { getSeriesLimitTest } from './seriesLimit';
 
 export interface DemoDescriptor {
   title: string;
@@ -86,6 +87,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Interop with hooks and context', getPage: getInteropDemo },
     { title: 'Url sync test', getPage: getUrlSyncTest },
     { title: 'Machine Learning', getPage: getMlDemo },
-    { title: 'Events on the Scene Graph', getPage: getSceneGraphEventsDemo},
+    { title: 'Events on the Scene Graph', getPage: getSceneGraphEventsDemo },
+    { title: 'Series limit', getPage: getSeriesLimitTest },
   ].sort((a, b) => a.title.localeCompare(b.title));
 }

--- a/packages/scenes-app/src/demos/seriesLimit.tsx
+++ b/packages/scenes-app/src/demos/seriesLimit.tsx
@@ -1,0 +1,24 @@
+import { EmbeddedScene, SceneAppPage, SceneAppPageState, SceneCSSGridLayout, VizPanel } from '@grafana/scenes';
+import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
+
+export function getSeriesLimitTest(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle: 'Test panel series limit feature',
+    getScene: () => {
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        body: new SceneCSSGridLayout({
+          children: [
+            new VizPanel({
+              title: 'Many series',
+              pluginId: 'timeseries',
+              seriesLimit: 20,
+              $data: getQueryRunnerWithRandomWalkQuery({ seriesCount: 50 }),
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -66,6 +66,8 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
    * Defines a menu that renders panel link.
    **/
   titleItems?: React.ReactNode | SceneObject | SceneObject[];
+  seriesLimit?: number;
+  seriesLimitShowAll?: boolean;
   /**
    * Add action to the top right panel header
    */
@@ -129,10 +131,15 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
   public forceRender(): void {
     // Incrementing the render counter means VizRepeater and its children will also re-render
-    this.setState({ _renderCounter: (this.state._renderCounter ?? 0) + 1});
+    this.setState({ _renderCounter: (this.state._renderCounter ?? 0) + 1 });
   }
 
-  private async _loadPlugin(pluginId: string, overwriteOptions?: DeepPartial<{}>, overwriteFieldConfig?: FieldConfigSource, isAfterPluginChange?: boolean) {
+  private async _loadPlugin(
+    pluginId: string,
+    overwriteOptions?: DeepPartial<{}>,
+    overwriteFieldConfig?: FieldConfigSource,
+    isAfterPluginChange?: boolean
+  ) {
     const plugin = loadPanelPluginSync(pluginId);
 
     if (plugin) {
@@ -162,7 +169,12 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     return panelId;
   }
 
-  private async _pluginLoaded(plugin: PanelPlugin, overwriteOptions?: DeepPartial<{}>, overwriteFieldConfig?: FieldConfigSource, isAfterPluginChange?: boolean) {
+  private async _pluginLoaded(
+    plugin: PanelPlugin,
+    overwriteOptions?: DeepPartial<{}>,
+    overwriteFieldConfig?: FieldConfigSource,
+    isAfterPluginChange?: boolean
+  ) {
     const { options, fieldConfig, title, pluginVersion, _UNSAFE_customMigrationHandler } = this.state;
 
     const panel: PanelModel = {
@@ -262,17 +274,13 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   };
 
   public async changePluginType(pluginId: string, newOptions?: DeepPartial<{}>, newFieldConfig?: FieldConfigSource) {
-    const {
-      options: prevOptions,
-      fieldConfig: prevFieldConfig,
-      pluginId: prevPluginId,
-    } = this.state;
+    const { options: prevOptions, fieldConfig: prevFieldConfig, pluginId: prevPluginId } = this.state;
 
     //clear field config cache to update it later
     this._dataWithFieldConfig = undefined;
 
     // If state.pluginId is already the correct plugin we don't treat this as plain user panel type change
-    const isAfterPluginChange = this.state.pluginId !== pluginId; 
+    const isAfterPluginChange = this.state.pluginId !== pluginId;
     await this._loadPlugin(pluginId, newOptions ?? {}, newFieldConfig, isAfterPluginChange);
 
     const panel: PanelModel = {
@@ -283,8 +291,8 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
       type: pluginId,
     };
 
-    // onPanelTypeChanged is mainly used by plugins to migrate from Angular to React. 
-    // For example, this will migrate options from 'graph' to 'timeseries' if the previous and new plugin ID matches. 
+    // onPanelTypeChanged is mainly used by plugins to migrate from Angular to React.
+    // For example, this will migrate options from 'graph' to 'timeseries' if the previous and new plugin ID matches.
     const updatedOptions = this._plugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
 
     if (updatedOptions && !isEmpty(updatedOptions)) {

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -13,6 +13,7 @@ import { isSceneObject, SceneComponentProps, SceneLayout, SceneObject } from '..
 import { VizPanel } from './VizPanel';
 import { css, cx } from '@emotion/css';
 import { debounce } from 'lodash';
+import { VizPanelSeriesLimit } from './VizPanelSeriesLimit';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -26,6 +27,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     menu,
     headerActions,
     titleItems,
+    seriesLimit,
+    seriesLimitShowAll,
     description,
     _renderCounter = 0,
   } = model.useState();
@@ -46,7 +49,8 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const dataObject = sceneGraph.getData(model);
 
   const rawData = dataObject.useState();
-  const dataWithFieldConfig = model.applyFieldConfig(rawData.data!);
+  const dataWithSeriesLimit = useDataWithSeriesLimit(rawData.data, seriesLimit, seriesLimitShowAll);
+  const dataWithFieldConfig = model.applyFieldConfig(dataWithSeriesLimit);
   const sceneTimeRange = sceneGraph.getTimeRange(model);
   const timeZone = sceneTimeRange.getTimeZone();
   const timeRange = model.getTimeRange(dataWithFieldConfig);
@@ -85,6 +89,18 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     } else {
       titleItemsElement.push(titleItems);
     }
+  }
+
+  if (seriesLimit) {
+    titleItemsElement.push(
+      <VizPanelSeriesLimit
+        key="series-limit"
+        data={rawData.data}
+        seriesLimit={seriesLimit}
+        showAll={seriesLimitShowAll}
+        onShowAllSeries={() => model.setState({ seriesLimitShowAll: !seriesLimitShowAll })}
+      />
+    );
   }
 
   // If we have local time range show that in panel header
@@ -205,6 +221,19 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
       </div>
     </div>
   );
+}
+
+function useDataWithSeriesLimit(data: PanelData | undefined, seriesLimit?: number, showAllSeries?: boolean) {
+  return useMemo(() => {
+    if (!data?.series || !seriesLimit || showAllSeries) {
+      return data;
+    }
+
+    return {
+      ...data,
+      series: data.series.slice(0, seriesLimit),
+    };
+  }, [data, seriesLimit, showAllSeries]);
 }
 
 function getDragClasses(panel: VizPanel) {

--- a/packages/scenes/src/components/VizPanel/VizPanelSeriesLimit.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelSeriesLimit.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2, PanelData } from '@grafana/data';
+import { Button, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+export interface Props {
+  showAll?: boolean;
+  seriesLimit: number;
+  data?: PanelData;
+  onShowAllSeries: () => void;
+}
+
+export function VizPanelSeriesLimit({ data, showAll, seriesLimit, onShowAllSeries }: Props) {
+  const styles = useStyles2(getStyles);
+  const seriesCount = data?.series.length;
+
+  if (seriesCount === undefined || seriesCount < seriesLimit) {
+    return null;
+  }
+
+  const buttonText = showAll ? 'Restore limit' : `Show all ${seriesCount}`;
+
+  return (
+    <div className={styles.timeSeriesDisclaimer}>
+      {!showAll && (
+        <span className={styles.warningMessage}>
+          <Icon title={`Showing only ${seriesLimit} series`} name="exclamation-triangle" aria-hidden="true" />
+        </span>
+      )}
+      <Tooltip
+        content={'Rendering too many series in a single panel may impact performance and make data harder to read.'}
+      >
+        <Button variant="secondary" size="sm" onClick={onShowAllSeries}>
+          {buttonText}
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  timeSeriesDisclaimer: css({
+    label: 'time-series-disclaimer',
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  warningMessage: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    color: theme.colors.warning.main,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+});

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.test.ts
@@ -241,6 +241,11 @@ describe('VizPanelBuilder', () => {
       `);
     });
 
+    it('allows series limit to be set', () => {
+      const p1 = getTestBuilder().setSeriesLimit(10).build();
+      expect(p1.state.seriesLimit).toEqual(10)
+    })
+
     it('allows mixin function', () => {
       const mixin = (builder: ReturnType<typeof getTestBuilder>) => {
         builder.setOption('numeric', 2);

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -216,6 +216,14 @@ export class VizPanelBuilder<TOptions extends {}, TFieldConfig extends {}>
   }
 
   /**
+   * Sets the default series limit for the panel.
+   */
+  public setSeriesLimit(seriesLimit: VizPanelState['seriesLimit']): this {
+    this._state.seriesLimit = seriesLimit
+    return this;
+  }
+
+  /**
    * Makes it possible to shared config between different builders
    */
   public applyMixin(mixin: (builder: this) => void): this {


### PR DESCRIPTION
I really like https://github.com/grafana/scenes/pull/912 as a feature but there is something about the implementation that feels a bit messy / complex, feels like there should be an simpler way to accomplish this (I blame scenes arch here for making this tricky) 

This is one approach where it's implemented more as rendering optimization feature inside VizPanel rendering instead of as a data state feature via SceneDataTransformer. A lot of the complexity in https://github.com/grafana/scenes/pull/912 is dealing with the wrapping of the already set data provider and for the title item to find and update the data transformer. 

There is benefit to that data provider approach and that is that other behaviors attached to VizPanel that are using sceneGraph.getData to get the data would also get that limited set of series, but maybe that could also be seen as a limitation of the approach. 

One downside with this approach is that it makes VizPanel itself a bit more complex where as https://github.com/grafana/scenes/pull/912 is "extending" it more via external title items & data providers 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.28.0--canary.978.12051612211.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.28.0--canary.978.12051612211.0
  npm install @grafana/scenes@5.28.0--canary.978.12051612211.0
  # or 
  yarn add @grafana/scenes-react@5.28.0--canary.978.12051612211.0
  yarn add @grafana/scenes@5.28.0--canary.978.12051612211.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
