### PR TITLE
GroupBy: Add <Select /> for single selection option

### DIFF
--- a/packages/scenes-app/src/demos/groupByStatic.tsx
+++ b/packages/scenes-app/src/demos/groupByStatic.tsx
@@ -24,7 +24,7 @@ export function getGroupByStatic(defaults: SceneAppPageState) {
           variables: [
             new GroupByVariable({
               name: 'groupBy',
-              label: 'Group By (static list)',
+              label: 'Group By MultiSelect (static list)',
               datasource: { uid: 'gdev-prometheus' },
               defaultOptions: [
                 {
@@ -36,8 +36,28 @@ export function getGroupByStatic(defaults: SceneAppPageState) {
                   value: 'job',
                 },
                 {
-                  text: 'alertname',
-                  value: 'alertname',
+                  text: 'alert_name',
+                  value: 'alert_name',
+                },
+              ],
+            }),
+            new GroupByVariable({
+              name: 'groupByOneSelection',
+              label: 'Group By OneSelection (static list)',
+              datasource: { uid: 'gdev-prometheus' },
+              isMultiSelect: false,
+              defaultOptions: [
+                {
+                  text: 'schema',
+                  value: 'schema',
+                },
+                {
+                  text: 'instance',
+                  value: 'instance',
+                },
+                {
+                  text: 'job',
+                  value: 'job',
                 },
               ],
             }),
@@ -51,7 +71,14 @@ export function getGroupByStatic(defaults: SceneAppPageState) {
             new SceneFlexItem({
               ySizing: 'content',
               body: new SceneCanvasText({
-                text: `Interpolated value (static): {$groupBy}`,
+                text: `Interpolated value MultiSelect(static): {$groupBy}`,
+                fontSize: 14,
+              }),
+            }),
+            new SceneFlexItem({
+              ySizing: 'content',
+              body: new SceneCanvasText({
+                text: `Interpolated value OneSelection (static): {$groupByOneSelection}`,
                 fontSize: 14,
               }),
             }),

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -27,6 +27,7 @@ export interface MultiValueVariableState extends SceneVariableState {
   options: VariableValueOption[];
   allowCustomValue?: boolean;
   isMulti?: boolean;
+  isMultiSelect?: boolean;
   includeAll?: boolean;
   defaultToAll?: boolean;
   allValue?: string;


### PR DESCRIPTION
What this PR does:
-  Introduced conditional rendering for <Select /> and <MultiSelect /> based on the isMultiSelect flag

**By default, isMultiSelect is true, which renders the <MultiSelect /> component (no breaking changes).**

-  When isMultiSelect is set to false, the <Select /> component is used for single selection.
-  Updated the groupByStatic Demo

**Demo**

https://github.com/user-attachments/assets/81ca7e56-bb99-46db-98f2-a333a6660995

