### PR TITLE
Fix DataSourceVariable doesn't use `options` from initial state

### DIFF
--- a/packages/scenes/src/variables/variants/DataSourceVariable.tsx
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.tsx
@@ -45,10 +45,10 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
   }
 
   public getValueOptions(args: VariableGetOptionsArgs): Observable<VariableValueOption[]> {
-    if (this.state.options) {
+    if (this.state.options?.length) {
       return of(this.state.options);
     }
-    
+
     if (!this.state.pluginId) {
       return of([]);
     }

--- a/packages/scenes/src/variables/variants/DataSourceVariable.tsx
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.tsx
@@ -45,6 +45,10 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
   }
 
   public getValueOptions(args: VariableGetOptionsArgs): Observable<VariableValueOption[]> {
+    if (this.state.options) {
+      return of(this.state.options);
+    }
+    
     if (!this.state.pluginId) {
       return of([]);
     }


### PR DESCRIPTION
Since `DataSourceVariable` is a `MultiSelectVariable` the initial state can contain `options` like this:

```ts
  const dataSourceList = getDataSourceSrv()
    .getList({
      filter: (datasource) => {
        if (
          [
            'mysql',
          ].includes(datasource.type)
        ) {
          return true;
        }
        return false;
      },
    })
    .map((ds) => {
      return { label: ds.name, value: ds.uid };
    });
  const dsVar = new DataSourceVariable({ label: 'Data Source', options: dataSourceList });
```

However, these `options` are not valued in its implementation of `getValueOptions`.