### PR TITLE
Variables: Fixes issue when variable value was null

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -7,7 +7,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import { CustomVariable } from '../variants/CustomVariable';
 import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
 import userEvent from '@testing-library/user-event';
-import { TestVariable } from '../variants/TestVariable';
 
 describe('VariableValueSelect', () => {
   let model: MultiValueVariable<MultiValueVariableState>;

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -7,6 +7,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { CustomVariable } from '../variants/CustomVariable';
 import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
 import userEvent from '@testing-library/user-event';
+import { TestVariable } from '../variants/TestVariable';
 
 describe('VariableValueSelect', () => {
   let model: MultiValueVariable<MultiValueVariableState>;
@@ -80,6 +81,7 @@ describe('VariableValueSelect', () => {
     expect(variableValueSelectElement).toBeInTheDocument();
     expect(inputElement).toBeDisabled();
   });
+
   it('should render VariableValueSelect component with disabled value', async () => {
     const model = new CustomVariable({
       name: 'test',

--- a/packages/scenes/src/variables/variants/query/toMetricFindValues.ts
+++ b/packages/scenes/src/variables/variants/query/toMetricFindValues.ts
@@ -68,8 +68,8 @@ export function toMetricFindValues(): OperatorFunction<PanelData, MetricFindValu
           for (let index = 0; index < frame.length; index++) {
             const expandable = expandableIndex !== -1 ? frame.fields[expandableIndex].values.get(index) : undefined;
             const string = frame.fields[stringIndex].values.get(index);
-            const text = textIndex !== -1 ? frame.fields[textIndex].values.get(index) : null;
-            const value = valueIndex !== -1 ? frame.fields[valueIndex].values.get(index) : null;
+            const text = textIndex !== -1 ? frame.fields[textIndex].values.get(index) : '';
+            const value = valueIndex !== -1 ? frame.fields[valueIndex].values.get(index) : '';
 
             if (valueIndex === -1 && textIndex === -1) {
               metrics.push({ text: string, value: string, expandable });

--- a/packages/scenes/src/variables/variants/query/utils.test.ts
+++ b/packages/scenes/src/variables/variants/query/utils.test.ts
@@ -1,0 +1,9 @@
+import { VariableSort } from '@grafana/data';
+import { metricNamesToVariableValues } from './utils';
+
+describe('When null values are returned', () => {
+  it('Should translated to emtpy strings', async () => {
+    const values = metricNamesToVariableValues('', VariableSort.disabled, [{ text: null, value: null }]);
+    expect(values).toEqual([{ label: '', value: '' }]);
+  });
+});

--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -4,7 +4,7 @@ import { stringToJsRegex, VariableSort } from '@grafana/data';
 
 import { VariableValueOption } from '../../types';
 
-export const metricNamesToVariableValues = (variableRegEx: string, sort: VariableSort, metricNames: any[]) => {
+export function metricNamesToVariableValues(variableRegEx: string, sort: VariableSort, metricNames: any[]) {
   let regex;
   let options: VariableValueOption[] = [];
 
@@ -14,8 +14,8 @@ export const metricNamesToVariableValues = (variableRegEx: string, sort: Variabl
 
   for (let i = 0; i < metricNames.length; i++) {
     const item = metricNames[i];
-    let text = item.text === undefined || item.text === null ? item.value : item.text;
-    let value = item.value === undefined || item.value === null ? item.text : item.value;
+    let text = item.text ?? item.value ?? '';
+    let value = item.value ?? item.text ?? '';
 
     if (isNumber(value)) {
       value = value.toString();
@@ -56,7 +56,7 @@ export const metricNamesToVariableValues = (variableRegEx: string, sort: Variabl
 
   options = uniqBy(options, 'value');
   return sortVariableValues(options, sort);
-};
+}
 
 const getAllMatches = (str: string, regex: RegExp): RegExpExecArray[] => {
   const results: RegExpExecArray[] = [];


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/96140 

A missed code in the old system was this: 
https://github.com/grafana/grafana/blob/main/public/app/features/variables/state/sharedReducer.ts#L157 

Where any non string text or value value was replaced with an empty string 