### PR TITLE
AdHocFiltersCombobox: Disable "pre-fill filter combobox value on edit" by default

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -69,12 +69,16 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         className={cx(styles.combinedFilterPill, { [styles.readOnlyCombinedFilter]: readOnly })}
         onClick={(e) => {
           e.stopPropagation();
-          setPopulateInputOnEdit(true);
+          if(model.state.populateInputOnEdit) {
+            setPopulateInputOnEdit(true);
+          }
           handleChangeViewMode();
         }}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            setPopulateInputOnEdit(true);
+            if(model.state.populateInputOnEdit) {
+              setPopulateInputOnEdit(true);
+            }
             handleChangeViewMode();
           }
         }}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1005,6 +1005,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
 
   describe('using new combobox layout - populateInputOnEdit', () => {
+    // needed for floating-ui to correctly calculate the position of the dropdown
     beforeAll(() => {
       const mockGetBoundingClientRect = jest.fn(() => ({
         width: 120,
@@ -1019,6 +1020,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         value: mockGetBoundingClientRect,
       });
     });
+
     beforeEach(() => {
       setup({
         populateInputOnEdit: true,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -95,6 +95,12 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   useQueriesAsFilterForOptions?: boolean;
 
   /**
+   * Populates the filter pill with the existing value.
+   * If true, this will hide any results from getTagValuesProvider that don't match the existing value until the user deletes the existing value.
+   */
+  populateInputOnEdit?: boolean
+
+  /**
    * Flag that decides whether custom values can be added to the filter
    */
   allowCustomValue?: boolean;


### PR DESCRIPTION
Address UX regression introduced by https://github.com/grafana/scenes/pull/955.

Since I don't understand what value https://github.com/grafana/scenes/pull/955 brings to variables without regex operators or other variables that return results from `getTagValuesProvider`, I'm proposing we disable this behavior by default, and developers can set the `populateInputOnEdit` on variables where this behavior is desired.

Fixes: https://github.com/grafana/scenes/issues/986

This PR solves the short-term problem of #955 being forced on all users of the combobox by default. 
As a follow-up it would be good to have some documentation added around what https://github.com/grafana/scenes/pull/955 is accomplishing, I assume that this is so users can more easily edit regex values, or other variables that don't return results from `getTagValuesProvider`. From there we might be able to come up with a better long-term solution (only drop into "edit" mode when there are no values returned by `getTagValuesProvider`, or only drop into edit mode when certain operators are selected, differentiate between edit and select a new value etc)