### PR TITLE
AdHocFiltersCombobox - Improve filter editing behaviour when pre-filling value on edit

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -419,8 +419,12 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     (value: SelectableValue<string>) => {
       const valueLabel = value.label || value.value!;
       setFilterMultiValues((prev) => prev.filter((item) => item.value !== value.value));
+      setPreventFiltering(true);
       setInputValue(valueLabel);
       refs.domReference.current?.focus();
+      setTimeout(() => {
+        refs.domReference.current?.select();
+      });
     },
     [refs.domReference]
   );

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -62,6 +62,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   const [inputValue, setInputValue] = useState('');
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [filterInputType, setInputType] = useState<AdHocInputType>(!isAlwaysWip ? 'value' : 'key');
+  const [preventFiltering, setPreventFiltering] = useState<boolean>(!isAlwaysWip && filterInputType === 'value');
   const styles = useStyles2(getStyles);
   // control multi values with local state in order to commit all values at once and avoid _wip reset mid creation
   const [filterMultiValues, setFilterMultiValues] = useState<Array<SelectableValue<string>>>([]);
@@ -191,6 +192,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     const value = event.target.value;
     setInputValue(value);
     setActiveIndex(0);
+    if (preventFiltering) {
+      setPreventFiltering(false);
+    }
   }
 
   const handleRemoveMultiValue = useCallback(
@@ -203,7 +207,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   // operation order on fetched options:
   //    fuzzy search -> extract into groups -> flatten group labels and options
-  const filteredDropDownItems = flattenOptionGroups(handleOptionGroups(optionsSearcher(inputValue, filterInputType)));
+  const filteredDropDownItems = flattenOptionGroups(
+    handleOptionGroups(optionsSearcher(preventFiltering ? '' : inputValue, filterInputType))
+  );
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
   if (allowCustomValue && filterInputType !== 'operator' && inputValue) {
@@ -454,6 +460,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       //   this avoids populating input during delete with backspace
       if (!hasMultiValueOperator && populateInputOnEdit) {
         setInputValue(filter?.value || '');
+        setTimeout(() => {
+          refs.domReference.current?.select();
+        });
       }
 
       refs.domReference.current?.focus();


### PR DESCRIPTION
The following should improve experience and fix regressions introduced by https://github.com/grafana/scenes/pull/955.

Fixes: https://github.com/grafana/scenes/issues/986

Adjustments:
1. highlight input value on edit (for easy deletion when typing)
2. prevent options filtering once you enter filter value edit (reenable after first onChange)
3. adjust multi-value experience to follow above

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.29.0--canary.992.12182926395.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.29.0--canary.992.12182926395.0
  npm install @grafana/scenes@5.29.0--canary.992.12182926395.0
  # or 
  yarn add @grafana/scenes-react@5.29.0--canary.992.12182926395.0
  yarn add @grafana/scenes@5.29.0--canary.992.12182926395.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
