### PR TITLE
SceneCSSGridLayout: Add support for dragging and dropping panels

### DIFF
--- a/packages/scenes-app/src/demos/cssGridToGridDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridToGridDemo.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneCSSGridItem,
+  SceneCSSGridLayout,
+  SceneComponentProps,
+  SceneObjectBase,
+  SceneObjectState,
+  SplitLayout,
+  DragManager,
+} from '@grafana/scenes';
+import { Select } from '@grafana/ui';
+import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
+import { ControlsLabel } from '@grafana/scenes/src/utils/ControlsLabel';
+import { SelectableValue } from '@grafana/data';
+
+const columnTemplateOptions = ['repeat(auto-fit, minmax(400px, 1fr))', 'repeat(3, 1fr)', '2fr 1fr 1fr', 'auto'];
+const rowTemplateOptions = ['unset', 'auto', '350px repeat(4, 150px)', 'repeat(4, 1fr)', '100%'];
+const autoRowOptions = ['150px', '250px', 'auto'];
+
+export function getCssGridToGridDemo(defaults: SceneAppPageState) {
+  return new SceneAppPage({
+    ...defaults,
+    subTitle:
+      'A CSS Grid Layout demo, isLazy is enabled to showcase lazy rendering of panels. Every 3rd panel is hidden to test the layout working properly.',
+    getScene: () => {
+      const layout = new SplitLayout({
+        primary: new SplitLayout({
+          primary: new SceneCSSGridLayout({
+            children: getLayoutChildren(2, false),
+            templateColumns: columnTemplateOptions[0],
+            templateRows: rowTemplateOptions[0],
+            autoRows: autoRowOptions[2],
+            rowGap: 1,
+            isLazy: true,
+          }) as any,
+          secondary: new SceneCSSGridLayout({
+            children: getLayoutChildren(2, false),
+            templateColumns: columnTemplateOptions[0],
+            templateRows: rowTemplateOptions[0],
+            autoRows: autoRowOptions[2],
+            rowGap: 1,
+            isLazy: true,
+          }) as any,
+          direction: 'row',
+        }),
+        secondary: new SceneCSSGridLayout({
+          children: getLayoutChildren(2, false),
+          templateColumns: columnTemplateOptions[0],
+          templateRows: rowTemplateOptions[0],
+          autoRows: autoRowOptions[2],
+          rowGap: 1,
+          isLazy: true,
+        }) as any,
+        direction: 'column',
+      });
+
+      return new EmbeddedScene({
+        ...getEmbeddedSceneDefaults(),
+        body: layout,
+        $behaviors: [new DragManager({})],
+      });
+    },
+  });
+}
+
+function getLayoutChildren(count: number, includeHidden = true) {
+  return Array.from(
+    Array(count),
+    (v, index) =>
+      new SceneCSSGridItem({
+        body: PanelBuilders.stat()
+          .setTitle(`Panel ${index + 1}`)
+          .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
+          .build(),
+        isHidden: includeHidden && index % 3 === 0,
+      })
+  );
+}
+
+export interface TemplateSelectorState extends SceneObjectState {
+  label: string;
+  value: string;
+  onChange: (template: string) => void;
+  options: string[];
+}
+
+export class TemplateSelector extends SceneObjectBase<TemplateSelectorState> {
+  public onChange = (v: SelectableValue<string>) => {
+    this.setState({ value: v.value! });
+    this.state.onChange(v.value!);
+  };
+
+  public static Component = ({ model }: SceneComponentProps<TemplateSelector>) => {
+    const { value, options, label } = model.useState();
+
+    const opts = options.map((t) => ({ label: t, value: t }));
+    const optionValue = opts.find((x) => x.value === value) ?? options[0];
+
+    return (
+      <div style={{ display: 'flex' }}>
+        <ControlsLabel label={label} />
+        <Select value={optionValue} options={opts} onChange={model.onChange} />
+      </div>
+    );
+  };
+}

--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -40,6 +40,7 @@ import { getUrlSyncTest } from './urlSyncTest';
 import { getMlDemo } from './ml';
 import { getSceneGraphEventsDemo } from './sceneGraphEvents';
 import { getSeriesLimitTest } from './seriesLimit';
+import { getCssGridToGridDemo } from './cssGridToGridDemo';
 
 export interface DemoDescriptor {
   title: string;
@@ -80,6 +81,7 @@ export function getDemos(): DemoDescriptor[] {
     { title: 'Docs examples', getPage: getDocsExamples },
     { title: 'Nested scenes and variables', getPage: getNestedScenesAndVariablesDemo },
     { title: 'CSS Grid Layout', getPage: getCssGridLayoutDemo },
+    { title: 'CSS Grid to Grid drag and drop', getPage: getCssGridToGridDemo },
     { title: 'Panel header actions', getPage: getPanelHeaderActions },
     { title: 'Vertical controls layout', getPage: getVerticalControlsLayoutDemo },
     { title: 'Interactive table with expandable rows', getPage: getInteractiveTableDemo },

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -193,7 +193,9 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             onFocus={setPanelAttention}
             onMouseEnter={setPanelAttention}
             onMouseMove={debouncedMouseMove}
-            onDragStart={dragHooks.onDragStart}
+            onDragStart={(e: React.PointerEvent) => {
+              dragHooks.onDragStart!(e, model);
+            }}
             collapsible={collapsible}
             collapsed={collapsed}
             onToggleCollapse={model.onToggleCollapse}

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -46,6 +46,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const plugin = model.getPlugin();
 
   const { dragClass, dragClassCancel } = getDragClasses(model);
+  const dragHooks = getDragHooks(model);
   const dataObject = sceneGraph.getData(model);
 
   const rawData = dataObject.useState();
@@ -174,6 +175,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             onFocus={setPanelAttention}
             onMouseEnter={setPanelAttention}
             onMouseMove={debouncedMouseMove}
+            onDragStart={dragHooks.onDragStart}
           >
             {(innerWidth, innerHeight) => (
               <>
@@ -221,6 +223,11 @@ function getDragClasses(panel: VizPanel) {
   }
 
   return { dragClass: parentLayout.getDragClass?.(), dragClassCancel: parentLayout?.getDragClassCancel?.() };
+}
+
+function getDragHooks(panel: VizPanel) {
+  const parentLayout = sceneGraph.getLayout(panel);
+  return { onDragStart: parentLayout?.onPointerDown };
 }
 
 /**

--- a/packages/scenes/src/components/layout/CSSGrid/DragManager.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/DragManager.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { SceneObjectBase } from '../../../core/SceneObjectBase';
+import { SceneObject, SceneObjectState } from '../../../core/types';
+import { Rect, SceneCSSGridLayout } from './SceneCSSGridLayout';
+import { getPortalContainer } from '@grafana/ui';
+import { SceneCSSGridItem } from './SceneCSSGridItem';
+import { sceneGraph } from '../../../core/sceneGraph';
+import { createRoot, Root } from 'react-dom/client';
+
+export type DropZone = Rect & { layoutKey: string };
+
+interface DragManagerState extends SceneObjectState {
+  activeLayout?: SceneCSSGridLayout;
+  activeItem?: SceneObject;
+  dropZone?: DropZone;
+}
+
+export class DragManager extends SceneObjectBase<DragManagerState> {
+  private layouts: Record<string, SceneCSSGridLayout> = {};
+  public dropZones: DropZone[] = [];
+
+  private portalRoot!: Root;
+  private portal = React.createRef<HTMLDivElement>();
+  private preview = React.createRef<HTMLDivElement>();
+  private originLayout: SceneCSSGridLayout | undefined;
+
+  public constructor(state: DragManagerState) {
+    super(state);
+
+    this.onDrag = this.onDrag.bind(this);
+    this.onDragStart = this.onDragStart.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
+  }
+
+  public registerLayout(layout: SceneCSSGridLayout) {
+    this.layouts[layout.state.key!] = layout;
+  }
+
+  private oldBodyStyles = '';
+  public onDragStart(e: PointerEvent, layout: SceneCSSGridLayout, item: SceneObject) {
+    // find closest layout item
+    const layoutItem = sceneGraph.getAncestor(item, SceneCSSGridItem);
+    this.originLayout = layout;
+    const root = getPortalContainer().appendChild(document.createElement('div'));
+    this.portalRoot = createRoot(root);
+
+    document.addEventListener('pointermove', this.onDrag);
+    document.addEventListener('pointerup', this.onDragEnd);
+    this.oldBodyStyles = document.body.style.cssText;
+    document.body.style.cursor = 'move';
+    document.body.style.userSelect = 'none';
+
+    // request drop zones from registered layouts
+    const dropZones = [];
+    for (const l of Object.values(this.layouts)) {
+      dropZones.push(...l.getDropZones().map((v) => ({ ...v, layoutKey: l.state.key! })));
+    }
+    this.dropZones = dropZones;
+    const { closest, offset, scrollTop } = this.closestCell(this.dropZones, { x: e.clientX, y: e.clientY });
+
+    this.portalRoot.render(
+      <>
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            pointerEvents: 'none',
+            translate: `${offset.x}px ${offset.y}px`,
+            transform: `translate(${e.clientX}px,${e.clientY}px)`,
+            width: `${closest.right - closest.left}px`,
+            height: `${closest.bottom - closest.top}px`,
+            zIndex: '999999',
+          }}
+          ref={this.portal}
+        >
+          <item.Component model={item} />
+        </div>
+        <div
+          className="react-grid-item react-grid-placeholder"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: `${closest.right - closest.left}px`,
+            height: `${closest.bottom - closest.top}px`,
+            pointerEvents: 'none',
+            zIndex: '1000',
+            translate: `${closest.left}px ${closest.top - scrollTop}px`,
+            transition: 'transform 150ms ease',
+          }}
+          ref={this.preview}
+        ></div>
+      </>
+    );
+
+    // measure and store height of all scroll zones
+    this.setState({
+      activeItem: layoutItem,
+      dropZone: closest,
+    });
+  }
+
+  public refreshDropZones() {
+    const dropZones = [];
+    for (const l of Object.values(this.layouts)) {
+      dropZones.push(...l.getDropZones().map((v) => ({ ...v, layoutKey: l.state.key! })));
+    }
+
+    this.dropZones = dropZones;
+  }
+
+  public onDrag(e: PointerEvent) {
+    const localDropZones = this.dropZones.filter((v) => v.layoutKey === this.state.activeLayout!.state.key);
+    let cell = this.closestCell(localDropZones, { x: e.clientX, y: e.clientY });
+    let state: Partial<DragManagerState> = {};
+
+    if (
+      !this.state.dropZone ||
+      this.state.dropZone.layoutKey !== cell.closest.layoutKey ||
+      this.state.dropZone.order !== cell.closest.order
+    ) {
+      // new layout item entered
+      state.dropZone = cell.closest;
+      if (this.preview.current) {
+        this.preview.current.style.width = `${state.dropZone.right - state.dropZone.left}px`;
+        this.preview.current.style.height = `${state.dropZone.bottom - state.dropZone.top}px`;
+        this.preview.current.style.translate = `${state.dropZone.left}px ${state.dropZone.top - cell.scrollTop}px`;
+        this.preview.current.style.transition = 'translate 150ms ease, width 150ms ease, height 150ms ease';
+      }
+    }
+
+    if (Object.keys(state).length > 0) {
+      this.setState(state);
+    }
+
+    // set transform on layout item we're dragging.
+    if (this.portal.current) {
+      this.portal.current.style.transform = `translate(${e.clientX}px,${e.clientY}px)`;
+    }
+  }
+
+  public onDragEnd(e: PointerEvent) {
+    document.removeEventListener('pointermove', this.onDrag);
+    document.removeEventListener('pointerup', this.onDragEnd);
+
+    document.body.releasePointerCapture(e.pointerId);
+    if (this.originLayout === this.state.activeLayout && this.originLayout) {
+      const kids = [...this.state.activeLayout!.state.children];
+      const oldIndex = kids.indexOf(this.state.activeItem!);
+      const childToMove = kids.splice(oldIndex, 1)[0];
+      kids.splice(this.state.dropZone!.order, 0, childToMove);
+      this.originLayout?.setState({
+        children: kids,
+      });
+    } else if (this.originLayout !== this.state.activeLayout && this.state.activeLayout) {
+      this.originLayout?.setState({
+        children: this.originLayout.state.children.filter((v) => v !== this.state.activeItem),
+      });
+      const kids = [...this.state.activeLayout!.state.children];
+      kids.splice(this.state.dropZone!.order, 0, this.state.activeItem!);
+      this.state.activeLayout.setState({
+        children: kids,
+      });
+    }
+
+    this.setState({ activeItem: undefined, dropZone: undefined });
+    this.portalRoot.unmount();
+    document.body.style.cssText = this.oldBodyStyles;
+  }
+
+  /** Given an array of rectangles and a point, calculate the rectangle closest to the point */
+  private closestCell(rects: DropZone[], point: Point) {
+    const scrollTopMap: Record<string, number> = {};
+    for (const rect of rects) {
+      const layout = sceneGraph.findByKeyAndType(this, rect.layoutKey, SceneCSSGridLayout);
+      scrollTopMap[rect.layoutKey] = closestScroll(layout.getContainer());
+    }
+
+    let closest = rects[0];
+    let shortestDistance = Number.MAX_SAFE_INTEGER;
+    let offset: Point = { x: 0, y: 0 };
+    let scrollTop = 0;
+    let from = 'top';
+    for (const rect of rects) {
+      const topLeft = { x: rect.left, y: rect.top };
+      const topRight = { x: rect.right, y: rect.top };
+      const bottomLeft = { x: rect.left, y: rect.bottom };
+      const bottomRight = { x: rect.right, y: rect.bottom };
+      const lines: Array<{ points: [Point, Point]; id: string }> = [
+        { points: [topLeft, topRight], id: 'top' },
+        { points: [topLeft, bottomLeft], id: 'left' },
+        { points: [bottomLeft, bottomRight], id: 'bottom' },
+        { points: [topRight, bottomRight], id: 'right' },
+      ];
+
+      for (const line of lines) {
+        const distance = shortestDistanceToLine({ x: point.x, y: point.y + scrollTopMap[rect.layoutKey] }, line.points);
+        if (distance < shortestDistance) {
+          shortestDistance = distance;
+          closest = rect;
+          scrollTop = scrollTopMap[rect.layoutKey];
+          from = line.id;
+          offset = { x: topLeft.x - point.x, y: topLeft.y - point.y - scrollTopMap[rect.layoutKey] };
+        }
+      }
+    }
+
+    return { closest, offset, scrollTop, from };
+  }
+}
+
+function closestScroll(el?: HTMLElement | null): number {
+  if (el && el.scrollTop > 0) {
+    return el.scrollTop;
+  }
+
+  return el ? closestScroll(el.parentElement) : 0;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+function shortestDistanceToLine(point: Point, line: [Point, Point]) {
+  const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = line;
+  const { x, y } = point;
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+
+  const dot = (x - x1) * dx + (y - y1) * dy;
+  const lengthSquared = dx * dx + dy * dy;
+  const param = dot / lengthSquared;
+
+  let xx = x1 + param * dx;
+  let yy = y1 + param * dy;
+
+  if (param < 0) {
+    xx = x1;
+    yy = y1;
+  } else if (param > 1) {
+    xx = x2;
+    yy = y2;
+  }
+
+  const xDistance = x - xx;
+  const yDistance = y - yy;
+  return Math.hypot(xDistance, yDistance);
+}

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridItem.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridItem.tsx
@@ -1,0 +1,58 @@
+import { css } from '@emotion/css';
+import React, { CSSProperties } from 'react';
+import { SceneObjectBase } from '../../../core/SceneObjectBase';
+import { SceneComponentProps, SceneObject, SceneObjectState } from '../../../core/types';
+import { useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+
+export interface SceneCSSGridItemPlacement {
+  /**
+   * True when the item should rendered but not visible.
+   * Useful for conditional display of layout items
+   */
+  isHidden?: boolean;
+  /**
+   * Useful for making content span across multiple rows or columns
+   */
+  gridColumn?: CSSProperties['gridColumn'];
+  gridRow?: CSSProperties['gridRow'];
+}
+
+export interface SceneCSSGridItemState extends SceneCSSGridItemPlacement, SceneObjectState {
+  body?: SceneObject;
+}
+
+export interface SceneCSSGridItemRenderProps<T> extends SceneComponentProps<T> {
+  parentState?: SceneCSSGridItemPlacement;
+}
+
+export class SceneCSSGridItem extends SceneObjectBase<SceneCSSGridItemState> {
+  public static Component = SceneCSSGridItemRenderer;
+}
+
+function SceneCSSGridItemRenderer({ model, parentState }: SceneCSSGridItemRenderProps<SceneCSSGridItem>) {
+  if (!parentState) {
+    throw new Error('SceneCSSGridItem must be a child of SceneCSSGridLayout');
+  }
+
+  const { body, isHidden } = model.useState();
+  const styles = useStyles2(getStyles, model.state);
+
+  if (!body || isHidden) {
+    return null;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <body.Component model={body} />
+    </div>
+  );
+}
+
+const getStyles = (_theme: GrafanaTheme2, state: SceneCSSGridItemState) => ({
+  wrapper: css({
+    gridColumn: state.gridColumn || 'unset',
+    gridRow: state.gridRow || 'unset',
+    position: 'relative', // Needed for VizPanel
+  }),
+});

--- a/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
+++ b/packages/scenes/src/components/layout/CSSGrid/SceneCSSGridLayout.tsx
@@ -1,10 +1,12 @@
-import { css, CSSObject } from '@emotion/css';
-import React, { ComponentType, CSSProperties, useMemo } from 'react';
+import { css } from '@emotion/css';
+import React, { ComponentType, CSSProperties, useLayoutEffect, useRef } from 'react';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
-import { SceneComponentProps, SceneLayout, SceneObjectState, SceneObject } from '../../../core/types';
-import { config } from '@grafana/runtime';
+import { SceneLayout, SceneObjectState, SceneObject } from '../../../core/types';
 import { LazyLoader } from '../LazyLoader';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import { SceneCSSGridItem, SceneCSSGridItemRenderProps } from './SceneCSSGridItem';
 
 export interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridLayoutOptions {
   children: Array<SceneCSSGridItem | SceneObject>;
@@ -19,6 +21,7 @@ export interface SceneCSSGridLayoutState extends SceneObjectState, SceneCSSGridL
   md?: SceneCSSGridLayoutOptions;
   /** True when the items should be lazy loaded */
   isLazy?: boolean;
+  _draggingIndex?: number;
 }
 
 export interface SceneCSSGridLayoutOptions {
@@ -48,6 +51,11 @@ export interface SceneCSSGridLayoutOptions {
 export class SceneCSSGridLayout extends SceneObjectBase<SceneCSSGridLayoutState> implements SceneLayout {
   public static Component = SceneCSSGridLayoutRenderer;
 
+  private gridCells: Rect[] = [];
+  private dragOffset = { x: 0, y: 0 };
+  private previewCell: Rect | undefined;
+  private oldCursor = '';
+
   public constructor(state: Partial<SceneCSSGridLayoutState>) {
     super({
       rowGap: 1,
@@ -57,126 +65,392 @@ export class SceneCSSGridLayout extends SceneObjectBase<SceneCSSGridLayoutState>
       children: state.children ?? [],
       ...state,
     });
+
+    this.onPointerDown = this.onPointerDown.bind(this);
+    this.onPointerMove = this.onPointerMove.bind(this);
+    this.onPointerUp = this.onPointerUp.bind(this);
   }
 
   public isDraggable(): boolean {
-    return false;
+    return true;
+  }
+
+  public getDragClass() {
+    return `grid-drag-handle-${this.state.key}`;
+  }
+
+  public getDragClassCancel() {
+    return 'grid-drag-cancel';
+  }
+
+  public onPointerDown(e: React.PointerEvent) {
+    if (!this.container || this.cannotDrag(e.target)) {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    this.oldCursor = document.body.style.cursor;
+    document.body.style.cursor = 'move';
+    document.body.style.userSelect = 'none';
+    document.body.setPointerCapture(e.pointerId);
+    document.addEventListener('pointermove', this.onPointerMove);
+    document.addEventListener('pointerup', this.onPointerUp);
+
+    // Find closest grid cell and make note of which cell is closest to the current mouse position (it is the cell we are dragging)
+    this.gridCells = calculateGridCells(this.container).slice(0, this.state.children.length);
+    const mousePos = { x: e.clientX, y: e.clientY };
+    const scrollTop = closestScroll(this.container);
+    this.previewCell = closestCell(this.gridCells, { x: mousePos.x, y: mousePos.y + scrollTop});
+
+    // get the layout item that occupies the previously found closest cell
+    this.draggingRef = this.container.children[this.previewCell.order + 1] as HTMLElement;
+    const elementBox = this.draggingRef.getBoundingClientRect();
+    this.dragOffset = { x: e.clientX - elementBox.left, y: e.clientY - elementBox.top };
+
+    // set the layout item's dimensions to what they were when they were in the grid
+    const computedStyles = getComputedStyle(this.draggingRef);
+    const newCoords = { x: mousePos.x - this.dragOffset.x, y: mousePos.y - this.dragOffset.y };
+    this.draggingRef.style.width = computedStyles.width;
+    this.draggingRef.style.height = computedStyles.height;
+    this.draggingRef.style.transform = `translate(${newCoords.x}px,${newCoords.y}px)`;
+    this.draggingRef.style.zIndex = '999999';
+    this.draggingRef.style.position = 'fixed';
+    this.draggingRef.style.top = '0';
+    this.draggingRef.style.left = '0';
+
+    this.movePreviewToCell(this.previewCell.rowIndex, this.previewCell.columnIndex);
+
+    // setting _draggingIndex re-renders the component and sets the various element refs referred to in the onPointerMove/Up handlers
+    this.setState({ _draggingIndex: this.previewCell.order });
+  }
+
+  private onPointerMove(e: PointerEvent) {
+    // seems to get called after onPointerDown is called and after the component re-renders, so element refs should all be set
+    // but if there's ever weird behavior it's probably a race condition related to this
+    e.preventDefault();
+    e.stopPropagation();
+
+    // we're not dragging but this handler was called, maybe left mouse was lifted on a different screen or something
+    const notDragging = !(e.buttons & 1);
+    if (notDragging) {
+      this.onPointerUp(e);
+      return;
+    }
+
+    if (this.draggingRef) {
+      const dragCurrent = { x: e.clientX, y: e.clientY };
+      const newX = dragCurrent.x - this.dragOffset.x;
+      const newY = dragCurrent.y - this.dragOffset.y;
+      this.draggingRef.style.transform = `translate(${newX}px,${newY}px)`;
+
+      const scrollTop = closestScroll(this.draggingRef);
+      const closestGridCell = closestCell(this.gridCells, { x: dragCurrent.x, y: dragCurrent.y + scrollTop });
+      const closestIndex = closestGridCell.order;
+
+      const newCellEntered =
+        this.previewCell &&
+        (closestGridCell.columnIndex !== this.previewCell.columnIndex ||
+          closestGridCell.rowIndex !== this.previewCell.rowIndex);
+
+      if (newCellEntered) {
+        this.moveChild(this.previewCell!.order, closestIndex);
+        this.previewCell = closestGridCell;
+        this.movePreviewToCell(this.previewCell.rowIndex, this.previewCell.columnIndex);
+        this.setState({ _draggingIndex: closestIndex });
+      }
+    }
+  }
+
+  private onPointerUp(e: PointerEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    document.body.style.cursor = this.oldCursor;
+    document.body.style.removeProperty('user-select');
+    document.body.releasePointerCapture(e.pointerId);
+    document.removeEventListener('pointermove', this.onPointerMove);
+    document.removeEventListener('pointerup', this.onPointerUp);
+
+    clearInlineStyles(this.draggingRef);
+    clearInlineStyles(this.dropPreview);
+
+    this.setState({ _draggingIndex: undefined });
+  }
+
+  public onKeyDown(e: React.KeyboardEvent<HTMLElement>, itemIndex: number) {
+    if (this.state._draggingIndex !== undefined) {
+      return;
+    }
+
+    if (e.key === 'ArrowLeft') {
+      if (itemIndex === 0) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+      this.moveChild(itemIndex, itemIndex - 1);
+    } else if (e.key === 'ArrowRight') {
+      if (itemIndex === this.state.children.length - 1) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+      this.moveChild(itemIndex, itemIndex + 1);
+    } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const style = getComputedStyle(this.container!);
+      const columns = style.gridTemplateColumns.split(' ');
+      const columnCount = columns.length;
+      const currentColumn = itemIndex % columnCount;
+      const rows = style.gridTemplateRows.split(' ');
+      const rowCount = rows.length;
+      const currentRow = Math.floor(itemIndex / columnCount);
+
+      let newRow = currentRow;
+      if (e.key === 'ArrowUp' && currentRow > 0) {
+        newRow = currentRow - 1;
+      } else if (e.key === 'ArrowDown' && currentRow < rowCount - 1) {
+        newRow = currentRow + 1;
+      }
+
+      const newIndex = newRow * columnCount + currentColumn;
+      this.moveChild(itemIndex, newIndex);
+    }
+  }
+
+  private cannotDrag(el: EventTarget) {
+    const dragCancelClass = this.getDragClassCancel();
+    const dragClass = this.getDragClass();
+
+    // cancel dragging if the element being interacted with has an ancestor with the drag cancel class set
+    // or if the drag class isn't set on an ancestor
+    const cannotDrag =
+      el instanceof Element &&
+      (el.classList.contains(dragCancelClass) ||
+        el.matches(`.${dragCancelClass} *`) ||
+        (!el.matches(`.${dragClass} *`) && !el.classList.contains(dragClass)));
+
+    return cannotDrag;
+  }
+
+  private moveChild(from: number, to: number) {
+    const children = [...this.state.children];
+    const childToMove = children.splice(from, 1)[0];
+    children.splice(to, 0, childToMove);
+    this.setState({ children });
+  }
+
+  private movePreviewToCell(rowIndex: number, columnIndex: number) {
+    if (this.dropPreview) {
+      this.dropPreview.style.position = 'relative';
+      this.dropPreview.style.width = '100%';
+      this.dropPreview.style.height = '100%';
+      this.dropPreview.style.gridRow = `${rowIndex} / span 1`;
+      this.dropPreview.style.gridColumn = `${columnIndex} / span 1`;
+    }
+  }
+
+  private container: HTMLElement | undefined;
+  public setContainer(el: HTMLElement) {
+    this.container = el;
+  }
+
+  private dropPreview: HTMLElement | undefined;
+  public setPreview(el: HTMLElement) {
+    this.dropPreview = el;
+  }
+
+  private draggingRef: HTMLElement | undefined;
+  public setDraggingRef(el: HTMLElement) {
+    this.draggingRef = el;
   }
 }
 
 function SceneCSSGridLayoutRenderer({ model }: SceneCSSGridItemRenderProps<SceneCSSGridLayout>) {
-  const { children, isHidden, isLazy } = model.useState();
-  const style = useLayoutStyle(model.state);
+  const { children, isHidden, isLazy, _draggingIndex } = model.useState();
+  const styles = useStyles2(getStyles, model.state);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (containerRef.current) {
+      model.setContainer(containerRef.current);
+    }
+
+    if (previewRef.current) {
+      model.setPreview(previewRef.current);
+    }
+
+    if (draggingRef.current) {
+      model.setDraggingRef(draggingRef.current);
+    }
+  });
 
   if (isHidden) {
     return null;
   }
 
   return (
-    <div className={style}>
-      {children.map((item) => {
+    <div className={styles.container} ref={containerRef}>
+      <div className={styles.dropPreview} ref={previewRef}></div>
+      {children.map((item, i) => {
         const Component = item.Component as ComponentType<SceneCSSGridItemRenderProps<SceneObject>>;
-        
-        if (isLazy) {
-          return (
-            <LazyLoader key={item.state.key!} className={style}>
-              <Component key={item.state.key} model={item} parentState={model.state} />
-            </LazyLoader>
-          );
-        }
-        return <Component key={item.state.key} model={item} parentState={model.state} />;
+        const Wrapper = isLazy ? LazyLoader : 'div';
+
+        return (
+          <Wrapper
+            key={item.state.key!}
+            ref={_draggingIndex === i ? draggingRef : undefined}
+            onKeyDown={(e) => model.onKeyDown(e, i)}
+          >
+            <Component model={item} parentState={model.state} />
+          </Wrapper>
+        );
       })}
     </div>
   );
 }
 
-export interface SceneCSSGridItemPlacement {
-  /**
-   * True when the item should rendered but not visible.
-   * Useful for conditional display of layout items
-   */
-  isHidden?: boolean;
-  /**
-   * Useful for making content span across multiple rows or columns
-   */
-  gridColumn?: CSSProperties['gridColumn'];
-  gridRow?: CSSProperties['gridRow'];
+const getStyles = (theme: GrafanaTheme2, state: SceneCSSGridLayoutState) => ({
+  dropPreview: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 0,
+    height: 0,
+    background: theme.colors.primary.transparent,
+    boxShadow: `0 0 4px ${theme.colors.primary.border}`,
+  }),
+  container: css({
+    display: 'grid',
+    position: 'relative',
+    gridTemplateColumns: state.templateColumns,
+    gridTemplateRows: state.templateRows || 'unset',
+    gridAutoRows: state.autoRows || 'unset',
+    rowGap: theme.spacing(state.rowGap ?? 1),
+    columnGap: theme.spacing(state.columnGap ?? 1),
+    justifyItems: state.justifyItems || 'unset',
+    alignItems: state.alignItems || 'unset',
+    justifyContent: state.justifyContent || 'unset',
+    flexGrow: 1,
+
+    [theme.breakpoints.down('md')]: state.md
+      ? {
+          gridTemplateRows: state.md.templateRows,
+          gridTemplateColumns: state.md.templateColumns,
+          rowGap: state.md.rowGap ? theme.spacing(state.md.rowGap ?? 1) : undefined,
+          columnGap: state.md.columnGap ? theme.spacing(state.md.rowGap ?? 1) : undefined,
+          justifyItems: state.md.justifyItems,
+          alignItems: state.md.alignItems,
+          justifyContent: state.md.justifyContent,
+        }
+      : undefined,
+  }),
+});
+
+interface Point {
+  x: number;
+  y: number;
 }
 
-export interface SceneCSSGridItemState extends SceneCSSGridItemPlacement, SceneObjectState {
-  body: SceneObject | undefined;
+interface Rect {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+  rowIndex: number;
+  columnIndex: number;
+  order: number;
 }
 
-interface SceneCSSGridItemRenderProps<T> extends SceneComponentProps<T> {
-  parentState?: SceneCSSGridItemPlacement;
-}
-
-export class SceneCSSGridItem extends SceneObjectBase<SceneCSSGridItemState> {
-  public static Component = SceneCSSGridItemRenderer;
-}
-
-function SceneCSSGridItemRenderer({ model, parentState }: SceneCSSGridItemRenderProps<SceneCSSGridItem>) {
-  if (!parentState) {
-    throw new Error('SceneCSSGridItem must be a child of SceneCSSGridLayout');
-  }
-
-  const { body, isHidden } = model.useState();
-  const style = useItemStyle(model.state);
-
-  if (!body || isHidden) {
-    return null;
-  }
-
-  return (
-    <div className={style}>
-      <body.Component model={body} />
-    </div>
-  );
-}
-
-function useLayoutStyle(state: SceneCSSGridLayoutState) {
-  return useMemo(() => {
-    const {} = state;
-    // only need breakpoints so accessing theme from config instead of context is ok
-    const style: CSSObject = {};
-    const theme = config.theme2;
-
-    style.display = 'grid';
-    style.gridTemplateColumns = state.templateColumns;
-    style.gridTemplateRows = state.templateRows || 'unset';
-    style.gridAutoRows = state.autoRows || 'unset';
-    style.rowGap = theme.spacing(state.rowGap ?? 1);
-    style.columnGap = theme.spacing(state.columnGap ?? 1);
-    style.justifyItems = state.justifyItems || 'unset';
-    style.alignItems = state.alignItems || 'unset';
-    style.justifyContent = state.justifyContent || 'unset';
-    style.flexGrow = 1;
-
-    if (state.md) {
-      style[theme.breakpoints.down('md')] = {
-        gridTemplateRows: state.md?.templateRows,
-        gridTemplateColumns: state.md?.templateColumns,
-        rowGap: state.md.rowGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
-        columnGap: state.md.columnGap ? theme.spacing(state.md?.rowGap ?? 1) : undefined,
-        justifyItems: state.md?.justifyItems,
-        alignItems: state.md?.alignItems,
-        justifyContent: state.md?.justifyContent,
-      };
+function closestCell(rects: Rect[], point: Point) {
+  let closest = rects[0];
+  let shortestDistance = Number.MAX_SAFE_INTEGER;
+  for (const rect of rects) {
+    const rectMidpoint: Point = {
+      x: rect.left + (rect.right - rect.left) / 2,
+      y: rect.top + (rect.bottom - rect.top) / 2,
+    };
+    const distance = Math.hypot(rectMidpoint.x - point.x, rectMidpoint.y - point.y);
+    if (distance < shortestDistance) {
+      shortestDistance = distance;
+      closest = rect;
     }
+  }
 
-    return css(style);
-  }, [state]);
+  return closest;
 }
 
-function useItemStyle(state: SceneCSSGridItemState) {
-  return useMemo(() => {
-    const style: CSSObject = {};
+function getGridStyles(gridElement: HTMLElement) {
+  const gridStyles = getComputedStyle(gridElement);
 
-    style.gridColumn = state.gridColumn || 'unset';
-    style.gridRow = state.gridRow || 'unset';
-    // Needed for VizPanel
-    style.position = 'relative';
+  return {
+    templateRows: gridStyles.gridTemplateRows.split(' ').map((row) => parseFloat(row)),
+    templateColumns: gridStyles.gridTemplateColumns.split(' ').map((col) => parseFloat(col)),
+    rowGap: parseFloat(gridStyles.rowGap),
+    columnGap: parseFloat(gridStyles.columnGap),
+  };
+}
 
-    return css(style);
-  }, [state]);
+function calculateGridCells(gridElement: HTMLElement) {
+  const { templateRows, templateColumns, rowGap, columnGap } = getGridStyles(gridElement);
+  const gridBoundingBox = gridElement.getBoundingClientRect();
+  const scrollTop = closestScroll(gridElement);
+  const gridOrigin = { x: gridBoundingBox.left, y: gridBoundingBox.top + scrollTop };
+
+  const rects: Rect[] = [];
+  let yTotal = gridOrigin.y;
+  for (let rowIndex = 0; rowIndex < templateRows.length; rowIndex++) {
+    const height = templateRows[rowIndex];
+    const row = {
+      top: yTotal,
+      bottom: yTotal + height,
+    };
+    yTotal = row.bottom + rowGap;
+
+    let xTotal = gridOrigin.x;
+    for (let colIndex = 0; colIndex < templateColumns.length; colIndex++) {
+      const width = templateColumns[colIndex];
+      const column = {
+        left: xTotal,
+        right: xTotal + width,
+      };
+
+      xTotal = column.right + columnGap;
+      rects.push({
+        left: column.left,
+        right: column.right,
+        top: row.top,
+        bottom: row.bottom,
+        rowIndex: rowIndex + 1,
+        columnIndex: colIndex + 1,
+        order: rowIndex * templateColumns.length + colIndex,
+      });
+    }
+  }
+
+  return rects;
+}
+
+function clearInlineStyles(el?: HTMLElement) {
+  if (!el) {
+    return;
+  }
+
+  el.style.cssText = '';
+}
+
+function closestScroll(el?: HTMLElement | null): number {
+  if (el && el.scrollTop > 0) {
+    return el.scrollTop;
+  }
+  
+  return el ? closestScroll(el.parentElement) : 0;
 }

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -143,6 +143,7 @@ export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> exte
   isDraggable(): boolean;
   getDragClass?(): string;
   getDragClassCancel?(): string;
+  onPointerDown?(e: React.PointerEvent<HTMLElement>): void;
 }
 
 export interface SceneTimeRangeState extends SceneObjectState {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -143,7 +143,7 @@ export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> exte
   isDraggable(): boolean;
   getDragClass?(): string;
   getDragClassCancel?(): string;
-  onPointerDown?(e: React.PointerEvent<HTMLElement>): void;
+  onPointerDown?(e: React.PointerEvent<Element>): void;
 }
 
 export interface SceneTimeRangeState extends SceneObjectState {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -143,7 +143,7 @@ export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> exte
   isDraggable(): boolean;
   getDragClass?(): string;
   getDragClassCancel?(): string;
-  onPointerDown?(e: React.PointerEvent<Element>): void;
+  onPointerDown?(e: React.PointerEvent<Element>, layoutItem: SceneObject): void;
 }
 
 export interface SceneTimeRangeState extends SceneObjectState {

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -96,6 +96,7 @@ export {
   type SceneFlexItemLike,
 } from './components/layout/SceneFlexLayout';
 export { SceneCSSGridLayout } from './components/layout/CSSGrid/SceneCSSGridLayout';
+export { DragManager } from './components/layout/CSSGrid/DragManager';
 export { SceneCSSGridItem } from './components/layout/CSSGrid/SceneCSSGridItem';
 export { SceneGridLayout } from './components/layout/grid/SceneGridLayout';
 export { SceneGridItem } from './components/layout/grid/SceneGridItem';

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -95,7 +95,8 @@ export {
   type SceneFlexItemState,
   type SceneFlexItemLike,
 } from './components/layout/SceneFlexLayout';
-export { SceneCSSGridLayout, SceneCSSGridItem } from './components/layout/CSSGrid/SceneCSSGridLayout';
+export { SceneCSSGridLayout } from './components/layout/CSSGrid/SceneCSSGridLayout';
+export { SceneCSSGridItem } from './components/layout/CSSGrid/SceneCSSGridItem';
 export { SceneGridLayout } from './components/layout/grid/SceneGridLayout';
 export { SceneGridItem } from './components/layout/grid/SceneGridItem';
 export { SceneGridRow } from './components/layout/grid/SceneGridRow';


### PR DESCRIPTION
There's a lot of code here but the gist of it is enables support for dragging and dropping panels in the responsive grid layout (when paired with the PR linked below)

Let me know if there are any questions or parts of the code that could use further explanation.

Related: https://github.com/grafana/grafana/pull/97495