### PR TITLE
Variables: Interpolate datasource uid when used with datasource variable

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -445,7 +445,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       const datasource = this.state.datasource ?? findFirstDatasource(queries);
       const ds = await getDataSource(datasource, this._scopedVars);
 
-      this.findAndSubscribeToAdHocFilters(datasource?.uid);
+      this.findAndSubscribeToAdHocFilters(ds.uid);
 
       const runRequest = getRunRequest();
       const { primary, secondaries, processors } = this.prepareRequests(timeRange, ds);
@@ -654,18 +654,15 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   /**
    * Walk up scene graph and find the closest filterset with matching data source
    */
-  private findAndSubscribeToAdHocFilters(uid: string | undefined) {
-    // TODO: ADD TESTS
-    const interpolatedDsUid = interpolate(this, uid);
-
-    const filtersVar = findActiveAdHocFilterVariableByUid(interpolatedDsUid);
+  private findAndSubscribeToAdHocFilters(interpolatedUid: string | undefined) {
+    const filtersVar = findActiveAdHocFilterVariableByUid(interpolatedUid);
 
     if (this._adhocFiltersVar !== filtersVar) {
       this._adhocFiltersVar = filtersVar;
       this._updateExplicitVariableDependencies();
     }
 
-    const groupByVar = findActiveGroupByVariablesByUid(interpolatedDsUid);
+    const groupByVar = findActiveGroupByVariablesByUid(interpolatedUid);
     if (this._groupByVar !== groupByVar) {
       this._groupByVar = groupByVar;
       this._updateExplicitVariableDependencies();

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -445,7 +445,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       const datasource = this.state.datasource ?? findFirstDatasource(queries);
       const ds = await getDataSource(datasource, this._scopedVars);
 
-      this.findAndSubscribeToAdHocFilters(datasource?.uid);
+      this.findAndSubscribeToAdHocFilters(ds.uid);
 
       const runRequest = getRunRequest();
       const { primary, secondaries, processors } = this.prepareRequests(timeRange, ds);

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -445,7 +445,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       const datasource = this.state.datasource ?? findFirstDatasource(queries);
       const ds = await getDataSource(datasource, this._scopedVars);
 
-      this.findAndSubscribeToAdHocFilters(ds.uid);
+      this.findAndSubscribeToAdHocFilters(datasource?.uid);
 
       const runRequest = getRunRequest();
       const { primary, secondaries, processors } = this.prepareRequests(timeRange, ds);
@@ -655,14 +655,17 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
    * Walk up scene graph and find the closest filterset with matching data source
    */
   private findAndSubscribeToAdHocFilters(uid: string | undefined) {
-    const filtersVar = findActiveAdHocFilterVariableByUid(uid);
+    // TODO: ADD TESTS
+    const interpolatedDsUid = interpolate(this, uid);
+
+    const filtersVar = findActiveAdHocFilterVariableByUid(interpolatedDsUid);
 
     if (this._adhocFiltersVar !== filtersVar) {
       this._adhocFiltersVar = filtersVar;
       this._updateExplicitVariableDependencies();
     }
 
-    const groupByVar = findActiveGroupByVariablesByUid(uid);
+    const groupByVar = findActiveGroupByVariablesByUid(interpolatedDsUid);
     if (this._groupByVar !== groupByVar) {
       this._groupByVar = groupByVar;
       this._updateExplicitVariableDependencies();

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
@@ -1,6 +1,7 @@
 import { getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 import { AdHocVariableFilter } from '@grafana/data';
 import { AdHocFiltersVariable } from './AdHocFiltersVariable';
+import { interpolate } from '../../core/sceneGraph/sceneGraph';
 
 let originalGetAdhocFilters: any = undefined;
 let allActiveFilterSets = new Set<AdHocFiltersVariable>();
@@ -45,7 +46,7 @@ export function patchGetAdhocFilters(filterVar: AdHocFiltersVariable) {
 
 export function findActiveAdHocFilterVariableByUid(dsUid: string | undefined): AdHocFiltersVariable | undefined {
   for (const filter of allActiveFilterSets.values()) {
-    if (filter.state.datasource?.uid === dsUid) {
+    if (interpolate(filter, filter.state.datasource?.uid) === dsUid) {
       return filter;
     }
   }

--- a/packages/scenes/src/variables/groupby/findActiveGroupByVariablesByUid.ts
+++ b/packages/scenes/src/variables/groupby/findActiveGroupByVariablesByUid.ts
@@ -1,10 +1,11 @@
+import { interpolate } from '../../core/sceneGraph/sceneGraph';
 import { GroupByVariable } from './GroupByVariable';
 
 export const allActiveGroupByVariables = new Set<GroupByVariable>();
 
 export function findActiveGroupByVariablesByUid(dsUid: string | undefined): GroupByVariable | undefined {
   for (const groupByVariable of allActiveGroupByVariables.values()) {
-    if (groupByVariable.state.datasource?.uid === dsUid) {
+    if (interpolate(groupByVariable, groupByVariable.state.datasource?.uid) === dsUid) {
       return groupByVariable;
     }
   }

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -106,8 +106,12 @@ export function getQueriesForVariables(
     (o) => o instanceof SceneQueryRunner
   ) as SceneQueryRunner[];
 
+  const interpolatedDsUuid = sceneGraph.interpolate(sourceObject, sourceObject.state.datasource?.uid);
+
   const applicableRunners = filterOutInactiveRunnerDuplicates(runners).filter((r) => {
-    return r.state.datasource?.uid === sourceObject.state.datasource?.uid;
+    const interpolatedQueryDsUuid = sceneGraph.interpolate(sourceObject, r.state.datasource?.uid);
+
+    return interpolatedQueryDsUuid === interpolatedDsUuid;
   });
 
   if (applicableRunners.length === 0) {


### PR DESCRIPTION
Use case - use datasource variable as a datasource for ad hoc filter and in a dashboard query. 
so we have datasource variable `dsVar` and it equals to `prom-1` as example then:

1. ds variable in filter and panel (both `${dsVar}` )
2. ds variable in filter (`${dsVar}`) and named ds in panel (`prom-1`) that are the same
3. named variable in filter (`prom-1`) and ds variable in panel (`${dsVar}`) that are the same


Issues solved:
1. `findAndSubscribeToAdHocFilters` did not get interpolated datasource name.
2. ad hoc filter options would not filter down options based on query in dashboard therefore interpolated datasource uuids in `getQueriesForVariables` 

adding dashboard JSON that replicates issue:
[dsVar as filter datasource-1733769038417.json](https://github.com/user-attachments/files/18066201/dsVar.as.filter.datasource-1733769038417.json)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.33.1--canary.996.12371059735.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.33.1--canary.996.12371059735.0
  npm install @grafana/scenes@5.33.1--canary.996.12371059735.0
  # or 
  yarn add @grafana/scenes-react@5.33.1--canary.996.12371059735.0
  yarn add @grafana/scenes@5.33.1--canary.996.12371059735.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
