### PR TITLE
feat: (scenes-react) - VizPanel add missing props and tests

### DIFF
--- a/packages/scenes-react/src/components/VizPanel.test.tsx
+++ b/packages/scenes-react/src/components/VizPanel.test.tsx
@@ -5,7 +5,6 @@ import { VizConfigBuilders, VizPanel as VizPanelObject, VizPanelMenu } from '@gr
 import { VizPanel, VizPanelProps } from './VizPanel';
 import { PanelPlugin } from '@grafana/data';
 import { TestContextProvider } from '../utils/testUtils';
-import { PanelChrome } from '@grafana/ui';
 
 let pluginToLoad: PanelPlugin | undefined;
 
@@ -62,24 +61,24 @@ describe('VizPanel', () => {
     const viz = VizConfigBuilders.timeseries().build();
     const titleItems = <div>Title Item</div>;
 
-    const {rerender, unmount} = render(
+    const { rerender, unmount } = render(
       <TestContextProvider value={scene}>
         <VizPanel titleItems={titleItems} title="Test" viz={viz} />
       </TestContextProvider>
     );
 
     const panel = scene.state.children[0] as VizPanelObject;
-    expect(panel.state.titleItems).toEqual(titleItems)
+    expect(panel.state.titleItems).toEqual(titleItems);
 
     rerender(
       <TestContextProvider value={scene}>
         <VizPanel titleItems={undefined} title="Test" viz={viz} />
       </TestContextProvider>
-    )
+    );
 
-    expect(panel.state.titleItems).toEqual(undefined)
+    expect(panel.state.titleItems).toEqual(undefined);
 
-    unmount()
+    unmount();
 
     expect(scene.state.children.length).toBe(0);
   });
@@ -96,15 +95,15 @@ describe('VizPanel', () => {
     );
 
     const panel = scene.state.children[0] as VizPanelObject;
-    expect(panel.state.headerActions).toEqual(headerActions)
+    expect(panel.state.headerActions).toEqual(headerActions);
 
     rerender(
       <TestContextProvider value={scene}>
         <VizPanel title="Test" viz={viz} />
       </TestContextProvider>
-    )
+    );
 
-    unmount()
+    unmount();
 
     expect(scene.state.children.length).toBe(0);
   });
@@ -114,12 +113,12 @@ describe('VizPanel', () => {
     const viz = VizConfigBuilders.timeseries().build();
     const headerActions = <button>Action</button>;
     const seriesLimit = 1;
-    const collapsed = true
+    const collapsed = true;
     const collapsible = true;
     const hoverHeader = true;
-    const description = 'description'
-    const menu = new VizPanelMenu({})
-    const title = 'title'
+    const description = 'description';
+    const menu = new VizPanelMenu({});
+    const title = 'title';
     const props: VizPanelProps = {
       title,
       viz,
@@ -129,8 +128,8 @@ describe('VizPanel', () => {
       collapsible,
       hoverHeader,
       description,
-      menu
-    }
+      menu,
+    };
 
     const { rerender, unmount } = render(
       <TestContextProvider value={scene}>
@@ -139,29 +138,29 @@ describe('VizPanel', () => {
     );
 
     const panel = scene.state.children[0] as VizPanelObject;
-    expect(panel.state.headerActions).toEqual(headerActions)
-    expect(panel.state.collapsed).toEqual(collapsed)
-    expect(panel.state.seriesLimit).toEqual(seriesLimit)
-    expect(panel.state.collapsible).toEqual(collapsible)
-    expect(panel.state.hoverHeader).toEqual(hoverHeader)
-    expect(panel.state.description).toEqual(description)
-    expect(panel.state.menu).toEqual(menu)
+    expect(panel.state.headerActions).toEqual(headerActions);
+    expect(panel.state.collapsed).toEqual(collapsed);
+    expect(panel.state.seriesLimit).toEqual(seriesLimit);
+    expect(panel.state.collapsible).toEqual(collapsible);
+    expect(panel.state.hoverHeader).toEqual(hoverHeader);
+    expect(panel.state.description).toEqual(description);
+    expect(panel.state.menu).toEqual(menu);
 
     rerender(
       <TestContextProvider value={scene}>
         <VizPanel title="Test" viz={viz} />
       </TestContextProvider>
-    )
+    );
 
-    expect(panel.state.headerActions).toEqual(undefined)
-    expect(panel.state.collapsed).toEqual(undefined)
-    expect(panel.state.seriesLimit).toEqual(undefined)
-    expect(panel.state.collapsible).toEqual(undefined)
-    expect(panel.state.hoverHeader).toEqual(undefined)
-    expect(panel.state.description).toEqual(undefined)
-    expect(panel.state.menu).toEqual(undefined)
+    expect(panel.state.headerActions).toEqual(undefined);
+    expect(panel.state.collapsed).toEqual(undefined);
+    expect(panel.state.seriesLimit).toEqual(undefined);
+    expect(panel.state.collapsible).toEqual(undefined);
+    expect(panel.state.hoverHeader).toEqual(undefined);
+    expect(panel.state.description).toEqual(undefined);
+    expect(panel.state.menu).toEqual(undefined);
 
-    unmount()
+    unmount();
 
     expect(scene.state.children.length).toBe(0);
   });

--- a/packages/scenes-react/src/components/VizPanel.test.tsx
+++ b/packages/scenes-react/src/components/VizPanel.test.tsx
@@ -56,59 +56,6 @@ describe('VizPanel', () => {
     expect(scene.state.children.length).toBe(0);
   });
 
-  it('Should render with displayMode', () => {
-    const scene = new SceneContextObject();
-    const viz = VizConfigBuilders.timeseries().build();
-
-    const { container } = render(
-      <TestContextProvider value={scene}>
-        <VizPanel title="Test" displayMode="transparent" viz={viz} />
-      </TestContextProvider>
-    );
-
-    expect(container.firstChild).toHaveClass('transparent');
-  });
-
-  it('Should render with hoverHeader', () => {
-    const scene = new SceneContextObject();
-    const viz = VizConfigBuilders.timeseries().build();
-
-    const { container } = render(
-      <TestContextProvider value={scene}>
-        <VizPanel title="Test" hoverHeader={true} viz={viz} />
-      </TestContextProvider>
-    );
-
-    expect(container.firstChild).toHaveClass('hover-header');
-  });
-
-  it('Should render with hoverHeaderOffset', () => {
-    const scene = new SceneContextObject();
-    const viz = VizConfigBuilders.timeseries().build();
-
-    const { container } = render(
-      <TestContextProvider value={scene}>
-        <VizPanel title="Test" hoverHeaderOffset={10} viz={viz} />
-      </TestContextProvider>
-    );
-
-    expect(container.firstChild).toHaveStyle('margin-top: 10px');
-  });
-
-  it('Should render with menu', () => {
-    const scene = new SceneContextObject();
-    const viz = VizConfigBuilders.timeseries().build();
-    const menu = new VizPanelMenu();
-
-    const { container } = render(
-      <TestContextProvider value={scene}>
-        <VizPanel title="Test" menu={menu} viz={viz} />
-      </TestContextProvider>
-    );
-
-    expect(container.querySelector('.viz-panel-menu')).toBeInTheDocument();
-  });
-
   it('Should render with titleItems', () => {
     const scene = new SceneContextObject();
     const viz = VizConfigBuilders.timeseries().build();

--- a/packages/scenes-react/src/components/VizPanel.test.tsx
+++ b/packages/scenes-react/src/components/VizPanel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { SceneContextObject } from '../contexts/SceneContextObject';
-import { VizConfigBuilders, VizPanel as VizPanelObject } from '@grafana/scenes';
+import { VizConfigBuilders, VizPanel as VizPanelObject, VizPanelMenu } from '@grafana/scenes';
 import { VizPanel } from './VizPanel';
 import { PanelPlugin } from '@grafana/data';
 import { TestContextProvider } from '../utils/testUtils';
@@ -54,5 +54,86 @@ describe('VizPanel', () => {
     unmount();
 
     expect(scene.state.children.length).toBe(0);
+  });
+
+  it('Should render with displayMode', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+
+    const { container } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" displayMode="transparent" viz={viz} />
+      </TestContextProvider>
+    );
+
+    expect(container.firstChild).toHaveClass('transparent');
+  });
+
+  it('Should render with hoverHeader', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+
+    const { container } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" hoverHeader={true} viz={viz} />
+      </TestContextProvider>
+    );
+
+    expect(container.firstChild).toHaveClass('hover-header');
+  });
+
+  it('Should render with hoverHeaderOffset', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+
+    const { container } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" hoverHeaderOffset={10} viz={viz} />
+      </TestContextProvider>
+    );
+
+    expect(container.firstChild).toHaveStyle('margin-top: 10px');
+  });
+
+  it('Should render with menu', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+    const menu = new VizPanelMenu();
+
+    const { container } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" menu={menu} viz={viz} />
+      </TestContextProvider>
+    );
+
+    expect(container.querySelector('.viz-panel-menu')).toBeInTheDocument();
+  });
+
+  it('Should render with titleItems', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+    const titleItems = <div>Title Item</div>;
+
+    const { getByText } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" titleItems={titleItems} viz={viz} />
+      </TestContextProvider>
+    );
+
+    expect(getByText('Title Item')).toBeInTheDocument();
+  });
+
+  it('Should render with headerActions', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+    const headerActions = <button>Action</button>;
+
+    const { getByText } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" headerActions={headerActions} viz={viz} />
+      </TestContextProvider>
+    );
+
+    expect(getByText('Action')).toBeInTheDocument();
   });
 });

--- a/packages/scenes-react/src/components/VizPanel.test.tsx
+++ b/packages/scenes-react/src/components/VizPanel.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { SceneContextObject } from '../contexts/SceneContextObject';
-import { VizConfigBuilders, VizPanel as VizPanelObject } from '@grafana/scenes';
-import { VizPanel } from './VizPanel';
+import { VizConfigBuilders, VizPanel as VizPanelObject, VizPanelMenu } from '@grafana/scenes';
+import { VizPanel, VizPanelProps } from './VizPanel';
 import { PanelPlugin } from '@grafana/data';
 import { TestContextProvider } from '../utils/testUtils';
+import { PanelChrome } from '@grafana/ui';
 
 let pluginToLoad: PanelPlugin | undefined;
 
@@ -61,13 +62,26 @@ describe('VizPanel', () => {
     const viz = VizConfigBuilders.timeseries().build();
     const titleItems = <div>Title Item</div>;
 
-    const { getByText } = render(
+    const {rerender, unmount} = render(
       <TestContextProvider value={scene}>
-        <VizPanel title="Test" titleItems={titleItems} viz={viz} />
+        <VizPanel titleItems={titleItems} title="Test" viz={viz} />
       </TestContextProvider>
     );
 
-    expect(getByText('Title Item')).toBeInTheDocument();
+    const panel = scene.state.children[0] as VizPanelObject;
+    expect(panel.state.titleItems).toEqual(titleItems)
+
+    rerender(
+      <TestContextProvider value={scene}>
+        <VizPanel titleItems={undefined} title="Test" viz={viz} />
+      </TestContextProvider>
+    )
+
+    expect(panel.state.titleItems).toEqual(undefined)
+
+    unmount()
+
+    expect(scene.state.children.length).toBe(0);
   });
 
   it('Should render with headerActions', () => {
@@ -75,12 +89,80 @@ describe('VizPanel', () => {
     const viz = VizConfigBuilders.timeseries().build();
     const headerActions = <button>Action</button>;
 
-    const { getByText } = render(
+    const { rerender, unmount } = render(
       <TestContextProvider value={scene}>
-        <VizPanel title="Test" headerActions={headerActions} viz={viz} />
+        <VizPanel title="Test" viz={viz} headerActions={headerActions} />
       </TestContextProvider>
     );
 
-    expect(getByText('Action')).toBeInTheDocument();
+    const panel = scene.state.children[0] as VizPanelObject;
+    expect(panel.state.headerActions).toEqual(headerActions)
+
+    rerender(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" viz={viz} />
+      </TestContextProvider>
+    )
+
+    unmount()
+
+    expect(scene.state.children.length).toBe(0);
+  });
+
+  it('Should render VizPanelProps', () => {
+    const scene = new SceneContextObject();
+    const viz = VizConfigBuilders.timeseries().build();
+    const headerActions = <button>Action</button>;
+    const seriesLimit = 1;
+    const collapsed = true
+    const collapsible = true;
+    const hoverHeader = true;
+    const description = 'description'
+    const menu = new VizPanelMenu({})
+    const title = 'title'
+    const props: VizPanelProps = {
+      title,
+      viz,
+      headerActions,
+      seriesLimit,
+      collapsed,
+      collapsible,
+      hoverHeader,
+      description,
+      menu
+    }
+
+    const { rerender, unmount } = render(
+      <TestContextProvider value={scene}>
+        <VizPanel {...props} headerActions={headerActions} />
+      </TestContextProvider>
+    );
+
+    const panel = scene.state.children[0] as VizPanelObject;
+    expect(panel.state.headerActions).toEqual(headerActions)
+    expect(panel.state.collapsed).toEqual(collapsed)
+    expect(panel.state.seriesLimit).toEqual(seriesLimit)
+    expect(panel.state.collapsible).toEqual(collapsible)
+    expect(panel.state.hoverHeader).toEqual(hoverHeader)
+    expect(panel.state.description).toEqual(description)
+    expect(panel.state.menu).toEqual(menu)
+
+    rerender(
+      <TestContextProvider value={scene}>
+        <VizPanel title="Test" viz={viz} />
+      </TestContextProvider>
+    )
+
+    expect(panel.state.headerActions).toEqual(undefined)
+    expect(panel.state.collapsed).toEqual(undefined)
+    expect(panel.state.seriesLimit).toEqual(undefined)
+    expect(panel.state.collapsible).toEqual(undefined)
+    expect(panel.state.hoverHeader).toEqual(undefined)
+    expect(panel.state.description).toEqual(undefined)
+    expect(panel.state.menu).toEqual(undefined)
+
+    unmount()
+
+    expect(scene.state.children.length).toBe(0);
   });
 });

--- a/packages/scenes-react/src/components/VizPanel.test.tsx
+++ b/packages/scenes-react/src/components/VizPanel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { SceneContextObject } from '../contexts/SceneContextObject';
-import { VizConfigBuilders, VizPanel as VizPanelObject, VizPanelMenu } from '@grafana/scenes';
+import { VizConfigBuilders, VizPanel as VizPanelObject } from '@grafana/scenes';
 import { VizPanel } from './VizPanel';
 import { PanelPlugin } from '@grafana/data';
 import { TestContextProvider } from '../utils/testUtils';

--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -25,8 +25,12 @@ export interface VizPanelProps {
   hoverHeaderOffset?: number;
   menu?: VizPanelMenu;
   titleItems?: React.ReactNode | SceneObject | SceneObject[];
+  seriesLimit?: number;
+  seriesLimitShowAll?: boolean;
   headerActions?: React.ReactNode;
   extendPanelContext?: (vizPanel: VizPanelObject, context: PanelContext) => void;
+  collapsible?: boolean;
+  collapsed?: boolean;
 }
 
 export function VizPanel(props: VizPanelProps) {
@@ -42,6 +46,10 @@ export function VizPanel(props: VizPanelProps) {
     menu,
     titleItems,
     extendPanelContext,
+    seriesLimit,
+    seriesLimitShowAll,
+    collapsible,
+    collapsed,
   } = props;
 
   const scene = useSceneContext();
@@ -67,6 +75,10 @@ export function VizPanel(props: VizPanelProps) {
       headerActions: headerActions,
       menu: menu,
       extendPanelContext: extendPanelContext,
+      collapsible: collapsible,
+      collapsed: collapsed,
+      seriesLimit: seriesLimit,
+      seriesLimitShowAll: seriesLimitShowAll,
     });
   }
 
@@ -116,6 +128,22 @@ export function VizPanel(props: VizPanelProps) {
       stateUpdate.$data = getDataProviderForVizPanel(dataProvider);
     }
 
+    if (seriesLimit !== prevProps.seriesLimit) {
+      stateUpdate.seriesLimit = seriesLimit;
+    }
+
+    if (seriesLimitShowAll !== prevProps.seriesLimitShowAll) {
+      stateUpdate.seriesLimitShowAll = seriesLimitShowAll;
+    }
+
+    if (collapsible !== prevProps.collapsible) {
+      stateUpdate.collapsible = collapsible;
+    }
+
+    if (collapsed !== prevProps.collapsed) {
+      stateUpdate.collapsed = collapsed;
+    }
+
     if (viz !== prevProps.viz) {
       if (viz.pluginId === prevProps.viz.pluginId) {
         const plugin = panel.getPlugin();
@@ -150,6 +178,10 @@ export function VizPanel(props: VizPanelProps) {
     titleItems,
     viz,
     dataProvider,
+    seriesLimit,
+    seriesLimitShowAll,
+    collapsible,
+    collapsed,
     prevProps,
   ]);
 

--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -24,7 +24,7 @@ export interface VizPanelProps {
   hoverHeader?: boolean;
   hoverHeaderOffset?: number;
   menu?: VizPanelMenu;
-  titleItems?: React.ReactNode | SceneObject | SceneObject[];
+  titleItems?: React.ReactNode;
   seriesLimit?: number;
   seriesLimitShowAll?: boolean;
   headerActions?: React.ReactNode;

--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useId } from 'react';
 import {
+  SceneObject,
+  VizPanelMenu,
   SceneDataProvider,
   VizPanel as VizPanelObject,
   VizPanelState,
@@ -9,18 +11,39 @@ import {
 } from '@grafana/scenes';
 import { usePrevious } from 'react-use';
 import { getPanelOptionsWithDefaults } from '@grafana/data';
+import { PanelContext } from '@grafana/ui';
 import { writeSceneLog } from '../utils';
 import { useSceneContext } from '../hooks/hooks';
 
 export interface VizPanelProps {
   title: string;
+  description?: string;
   dataProvider?: SceneDataProvider;
   viz: VizConfig;
+  displayMode?: 'default' | 'transparent';
+  hoverHeader?: boolean;
+  hoverHeaderOffset?: number;
+  menu?: VizPanelMenu;
+  titleItems?: React.ReactNode | SceneObject | SceneObject[];
   headerActions?: React.ReactNode;
+  extendPanelContext?: (vizPanel: VizPanelObject, context: PanelContext) => void;
 }
 
 export function VizPanel(props: VizPanelProps) {
-  const { title, viz, dataProvider, headerActions } = props;
+  const {
+    title,
+    description,
+    viz,
+    dataProvider,
+    displayMode,
+    hoverHeader,
+    hoverHeaderOffset,
+    headerActions,
+    menu,
+    titleItems,
+    extendPanelContext,
+  } = props;
+
   const scene = useSceneContext();
   const key = useId();
   const prevProps = usePrevious(props);
@@ -30,13 +53,20 @@ export function VizPanel(props: VizPanelProps) {
   if (!panel) {
     panel = new VizPanelObject({
       key: key,
-      title: title,
       pluginId: viz.pluginId,
-      pluginVersion: viz.pluginVersion,
+      title: title,
+      titleItems: titleItems,
+      description: description,
       options: viz.options,
       fieldConfig: viz.fieldConfig,
+      pluginVersion: viz.pluginVersion,
       $data: getDataProviderForVizPanel(dataProvider),
+      displayMode: displayMode,
+      hoverHeader: hoverHeader,
+      hoverHeaderOffset: hoverHeaderOffset,
       headerActions: headerActions,
+      menu: menu,
+      extendPanelContext: extendPanelContext,
     });
   }
 
@@ -52,6 +82,30 @@ export function VizPanel(props: VizPanelProps) {
 
     if (title !== prevProps.title) {
       stateUpdate.title = title;
+    }
+
+    if (description !== prevProps.description) {
+      stateUpdate.description = description;
+    }
+
+    if (displayMode !== prevProps.displayMode) {
+      stateUpdate.displayMode = displayMode;
+    }
+
+    if (hoverHeader !== prevProps.hoverHeader) {
+      stateUpdate.hoverHeader = hoverHeader;
+    }
+
+    if (hoverHeaderOffset !== prevProps.hoverHeaderOffset) {
+      stateUpdate.hoverHeaderOffset = hoverHeaderOffset;
+    }
+
+    if (menu !== prevProps.menu) {
+      stateUpdate.menu = menu;
+    }
+
+    if (titleItems !== prevProps.titleItems) {
+      stateUpdate.titleItems = titleItems;
     }
 
     if (headerActions !== prevProps.headerActions) {
@@ -84,7 +138,20 @@ export function VizPanel(props: VizPanelProps) {
       panel.setState(stateUpdate);
       writeSceneLog('VizPanel', 'Updating VizPanel state', stateUpdate);
     }
-  }, [panel, title, headerActions, viz, dataProvider, prevProps]);
+  }, [
+    panel,
+    title,
+    description,
+    displayMode,
+    hoverHeader,
+    hoverHeaderOffset,
+    headerActions,
+    menu,
+    titleItems,
+    viz,
+    dataProvider,
+    prevProps,
+  ]);
 
   return <panel.Component model={panel} />;
 }

--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useId } from 'react';
 import {
-  SceneObject,
   VizPanelMenu,
   SceneDataProvider,
   VizPanel as VizPanelObject,


### PR DESCRIPTION
# Description
- #761 
- VizPanel add missing props
- Naive attempt at adding missing VizPanel props. Perhaps more knowledgable people would know how to automatically add the VizPanelState from `scenes`. It looks like there might be some newer props in VizPanelState already
```
seriesLimit?: number;
seriesLimitShowAll?: boolean;
collapsible?: boolean;
collapsed?: boolean;
```
- The [grafana-attributions-app](https://github.com/grafana/grafana-attributions-app) was experimenting using scenes react, but almost every panel ended up needed something from the missing props 😆 .  


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.31.0--canary.998.12301751531.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.31.0--canary.998.12301751531.0
  npm install @grafana/scenes@5.31.0--canary.998.12301751531.0
  # or 
  yarn add @grafana/scenes-react@5.31.0--canary.998.12301751531.0
  yarn add @grafana/scenes@5.31.0--canary.998.12301751531.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
