### PR TITLE
sceneUtils: expose setWindowGrafanaSceneContext

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -16,6 +16,7 @@ import {
   isIntervalVariable,
   isGroupByVariable,
 } from './variables/variants/guards';
+import { setWindowGrafanaSceneContext } from './utils/compatibility/setWindowGrafanaSceneContext';
 
 export * from './core/types';
 export * from './core/events';
@@ -147,6 +148,9 @@ export const sceneUtils = {
   isQueryVariable,
   isTextBoxVariable,
   isGroupByVariable,
+
+  // Allow apps to sync with timeSrv
+  setWindowGrafanaSceneContext
 };
 
 export { SafeSerializableSceneObject } from './utils/SafeSerializableSceneObject';


### PR DESCRIPTION
So scene apps can set global timeSrv to enable copying time range

Potential usage:

```
  keybindings.addBinding({
    key: 't c',
    onTrigger: () => {
      const timeRange = sceneGraph.getTimeRange(scene)
      sceneUtils.setWindowGrafanaSceneContext(timeRange)
      appEvents.publish(new CopyTimeEvent());
    }
  })
```