### PR TITLE
fix: wrap groupBy single-select value in an array

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -345,7 +345,6 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
           model.changeValueTo([newValue.value]);
         }
       }}
-
       onOpenMenu={async () => {
         setIsFetchingOptions(true);
         await lastValueFrom(model.validateAndUpdate());

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -342,9 +342,10 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
         }
         if (newValue?.value) {
           setUncommittedValue([newValue]);
-          model.changeValueTo(newValue.value, newValue.label);
+          model.changeValueTo([newValue.value]);
         }
       }}
+
       onOpenMenu={async () => {
         setIsFetchingOptions(true);
         await lastValueFrom(model.validateAndUpdate());

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -342,10 +342,7 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
         }
         if (newValue?.value) {
           setUncommittedValue([newValue]);
-          if (newValue?.value) {
-            setUncommittedValue([newValue]);
-            model.changeValueTo([newValue.value], newValue.label ? [newValue.label] : undefined);
-          }
+          model.changeValueTo([newValue.value], newValue.label ? [newValue.label] : undefined);
         }
       }}
       onOpenMenu={async () => {

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -342,7 +342,10 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
         }
         if (newValue?.value) {
           setUncommittedValue([newValue]);
-          model.changeValueTo([newValue.value], [newValue.label!]);
+          if (newValue?.value) {
+            setUncommittedValue([newValue]);
+            model.changeValueTo([newValue.value], newValue.label ? [newValue.label] : undefined);
+          }
         }
       }}
       onOpenMenu={async () => {

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -340,9 +340,9 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
           }
           return;
         }
-        if (newValue?.value) {
+        if (newValue?.value && newValue?.label) {
           setUncommittedValue([newValue]);
-          model.changeValueTo([newValue.value]);
+          model.changeValueTo([newValue.value], [newValue.label]);
         }
       }}
       onOpenMenu={async () => {

--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -340,9 +340,9 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<MultiValu
           }
           return;
         }
-        if (newValue?.value && newValue?.label) {
+        if (newValue?.value) {
           setUncommittedValue([newValue]);
-          model.changeValueTo([newValue.value], [newValue.label]);
+          model.changeValueTo([newValue.value], [newValue.label!]);
         }
       }}
       onOpenMenu={async () => {


### PR DESCRIPTION
When trying to use the Single select in db-o11y, realized we were sending incorrect data format. 

` "error": "json: cannot unmarshal string into Go struct field internalQueryModel.groupByKeys of type []string",
`

In this PR I'm wrapping the value in an array.