### PR TITLE
SceneTimeRange: Fixes weekstart issue when evaluting data math

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -1,4 +1,4 @@
-import { getTimeZone, rangeUtil, TimeRange, toUtc } from '@grafana/data';
+import { getTimeZone, rangeUtil, setWeekStart, TimeRange, toUtc } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
 
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
@@ -8,7 +8,7 @@ import { SceneTimeRangeLike, SceneTimeRangeState, SceneObjectUrlValues } from '.
 import { getClosest } from './sceneGraph/utils';
 import { parseUrlParam } from '../utils/parseUrlParam';
 import { evaluateTimeRange } from '../utils/evaluateTimeRange';
-import { locationService, RefreshEvent } from '@grafana/runtime';
+import { config, locationService, RefreshEvent } from '@grafana/runtime';
 import { isValid } from '../utils/date';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
@@ -55,9 +55,19 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
       }
     }
 
+    if (this.state.weekStart) {
+      setWeekStart(this.state.weekStart);
+    }
+
     if (rangeUtil.isRelativeTimeRange(this.state.value.raw)) {
       this.refreshIfStale();
     }
+
+    return () => {
+      if (this.state.weekStart) {
+        setWeekStart(config.bootData.user.weekStart);
+      }
+    };
   }
 
   private refreshIfStale() {


### PR DESCRIPTION
Did a big mistake in https://github.com/grafana/scenes/pull/910 , I removed this setWeekStart as I could not see it having any impact, but did only check the weekstart shown in the calendar, now the weekstart used when evaluating datemath expressions like "This week" or "Previous week", those expression this setWeekStart (which updates moment locale setting) is needed 

Fixes https://github.com/grafana/support-escalations/issues/13898 