### PR TITLE
AdHocFiltersVariable: provide updateFilters method to allow updating filters without emitting SceneVariableValueChangedEvent

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -987,10 +987,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters( [{ key: 'key2', operator: '=', value: 'val1' }]);
+      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }]);
 
       expect(evtHandler).toHaveBeenCalled();
-      expect(variable.state.filterExpression).toEqual(`key2="val1"`)
+      expect(variable.state.filterExpression).toEqual(`key2="val1"`);
     });
 
     it('updateFilters should not publish event on when expr did change, if skipPublish is true', () => {
@@ -1008,7 +1008,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }], { skipPublish: true });
 
       expect(evtHandler).not.toHaveBeenCalled();
-      expect(variable.state.filterExpression).toEqual(`key2="val1"`)
+      expect(variable.state.filterExpression).toEqual(`key2="val1"`);
     });
 
     it('Should create variable with applyMode as manual by default and it allows to override it', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -958,7 +958,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(evtHandler).not.toHaveBeenCalled();
     });
 
-    it('Should publish event on when expr did change', () => {
+    it('updateFilters should not publish event when expr did not change', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
         applyMode: 'manual',
@@ -970,26 +970,45 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] });
-
-      expect(evtHandler).toHaveBeenCalled();
-    });
-
-    it('Should not publish event on when expr did change, if skipPublish is true', () => {
-      const variable = new AdHocFiltersVariable({
-        datasource: { uid: 'hello' },
-        applyMode: 'manual',
-        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
-      });
-
-      variable.activate();
-
-      const evtHandler = jest.fn();
-      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
-
-      variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, { skipPublish: true });
+      variable.updateFilters(variable.state.filters.slice(0));
 
       expect(evtHandler).not.toHaveBeenCalled();
+    });
+
+    it('updateFilters should publish event on when expr did change', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.updateFilters( [{ key: 'key2', operator: '=', value: 'val1' }]);
+
+      expect(evtHandler).toHaveBeenCalled();
+      expect(variable.state.filterExpression).toEqual(`key2="val1"`)
+    });
+
+    it('updateFilters should not publish event on when expr did change, if skipPublish is true', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }], { skipPublish: true });
+
+      expect(evtHandler).not.toHaveBeenCalled();
+      expect(variable.state.filterExpression).toEqual(`key2="val1"`)
     });
 
     it('Should create variable with applyMode as manual by default and it allows to override it', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -958,6 +958,40 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(evtHandler).not.toHaveBeenCalled();
     });
 
+    it('Should publish event on when expr did change', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] });
+
+      expect(evtHandler).toHaveBeenCalled();
+    })
+
+    it('Should not publish event on when expr did change, if skipPublish is true', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, {skipPublish: true});
+
+      expect(evtHandler).not.toHaveBeenCalled();
+    })
+
     it('Should create variable with applyMode as manual by default and it allows to override it', () => {
       const defaultVariable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -958,6 +958,44 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(evtHandler).not.toHaveBeenCalled();
     });
 
+    it('Should not overwrite filterExpression on setState', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+        filterExpression: '',
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.setState({ filters: variable.state.filters.slice(0), filterExpression: 'hello filter expression!' });
+
+      expect(evtHandler).not.toHaveBeenCalled();
+      expect(variable.state.filterExpression).toEqual('hello filter expression!');
+    });
+
+    it('Should overwrite filterExpression on updateFilters', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+        filterExpression: 'hello filter expression!',
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.updateFilters({ filters: variable.state.filters.slice(0) });
+
+      expect(evtHandler).toHaveBeenCalled();
+      expect(variable.state.filterExpression).toEqual('key1="val1"');
+    });
+
     it('updateFilters should not publish event when expr did not change', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
@@ -975,7 +1013,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(evtHandler).not.toHaveBeenCalled();
     });
 
-    it('updateFilters should publish event on when expr did change', () => {
+    it('updateFilters should publish event when expr did not change, but forcePublish is set', () => {
       const variable = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
         applyMode: 'manual',
@@ -987,9 +1025,47 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
+      variable.updateFilters({ filters: variable.state.filters.slice(0) }, { forcePublish: true });
+
+      expect(evtHandler).toHaveBeenCalled();
+      expect(variable.state.filterExpression).toEqual('key1="val1"');
+    });
+
+    it('updateFilters should publish event on when expr did change', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+        filterExpression: 'hello filter expression',
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
       variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] });
 
       expect(evtHandler).toHaveBeenCalled();
+      expect(variable.state.filterExpression).toEqual(`key2="val1"`);
+    });
+
+    it('updateFilters should not publish event when skip event is true', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [{ key: 'key1', operator: '=', value: 'val1' }],
+        filterExpression: 'hello filter expression',
+      });
+
+      variable.activate();
+
+      const evtHandler = jest.fn();
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
+
+      variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, { skipPublish: true });
+
+      expect(evtHandler).not.toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);
     });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -990,7 +990,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({ filters: variable.state.filters.slice(0) });
+      variable.updateFilters(variable.state.filters.slice(0));
 
       expect(evtHandler).toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual('key1="val1"');
@@ -1008,7 +1008,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({ filters: variable.state.filters.slice(0) });
+      variable.updateFilters(variable.state.filters.slice(0));
 
       expect(evtHandler).not.toHaveBeenCalled();
     });
@@ -1025,7 +1025,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({ filters: variable.state.filters.slice(0) }, { forcePublish: true });
+      variable.updateFilters(variable.state.filters.slice(0), { forcePublish: true });
 
       expect(evtHandler).toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual('key1="val1"');
@@ -1036,7 +1036,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         datasource: { uid: 'hello' },
         applyMode: 'manual',
         filters: [{ key: 'key1', operator: '=', value: 'val1' }],
-        filterExpression: 'hello filter expression',
       });
 
       variable.activate();
@@ -1044,7 +1043,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] });
+      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }]);
 
       expect(evtHandler).toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);
@@ -1063,7 +1062,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, { skipPublish: true });
+      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }], { skipPublish: true });
 
       expect(evtHandler).not.toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);
@@ -1081,7 +1080,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, { skipPublish: true });
+      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }], { skipPublish: true });
 
       expect(evtHandler).not.toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -970,7 +970,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({filters: variable.state.filters.slice(0)});
+      variable.updateFilters({ filters: variable.state.filters.slice(0) });
 
       expect(evtHandler).not.toHaveBeenCalled();
     });
@@ -987,7 +987,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({filters: [{ key: 'key2', operator: '=', value: 'val1' }]});
+      variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] });
 
       expect(evtHandler).toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);
@@ -1005,7 +1005,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters({filters: [{ key: 'key2', operator: '=', value: 'val1' }]}, { skipPublish: true });
+      variable.updateFilters({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, { skipPublish: true });
 
       expect(evtHandler).not.toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -970,7 +970,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters(variable.state.filters.slice(0));
+      variable.updateFilters({filters: variable.state.filters.slice(0)});
 
       expect(evtHandler).not.toHaveBeenCalled();
     });
@@ -987,7 +987,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }]);
+      variable.updateFilters({filters: [{ key: 'key2', operator: '=', value: 'val1' }]});
 
       expect(evtHandler).toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);
@@ -1005,7 +1005,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.updateFilters([{ key: 'key2', operator: '=', value: 'val1' }], { skipPublish: true });
+      variable.updateFilters({filters: [{ key: 'key2', operator: '=', value: 'val1' }]}, { skipPublish: true });
 
       expect(evtHandler).not.toHaveBeenCalled();
       expect(variable.state.filterExpression).toEqual(`key2="val1"`);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -973,7 +973,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] });
 
       expect(evtHandler).toHaveBeenCalled();
-    })
+    });
 
     it('Should not publish event on when expr did change, if skipPublish is true', () => {
       const variable = new AdHocFiltersVariable({
@@ -987,10 +987,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const evtHandler = jest.fn();
       variable.subscribeToEvent(SceneVariableValueChangedEvent, evtHandler);
 
-      variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, {skipPublish: true});
+      variable.setState({ filters: [{ key: 'key2', operator: '=', value: 'val1' }] }, { skipPublish: true });
 
       expect(evtHandler).not.toHaveBeenCalled();
-    })
+    });
 
     it('Should create variable with applyMode as manual by default and it allows to override it', () => {
       const defaultVariable = new AdHocFiltersVariable({

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -213,7 +213,7 @@ export class AdHocFiltersVariable
     filters: AdHocFilterWithLabels[],
     options?: {
       skipPublish?: boolean;
-      forcePublish?: boolean
+      forcePublish?: boolean;
     }
   ): void {
     let filterExpressionChanged = false;
@@ -229,7 +229,7 @@ export class AdHocFiltersVariable
       filterExpression,
     });
 
-    if (filterExpressionChanged && options?.skipPublish !== true || options?.forcePublish) {
+    if ((filterExpressionChanged && options?.skipPublish !== true) || options?.forcePublish) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -190,18 +190,7 @@ export class AdHocFiltersVariable
   }
 
   public setState(update: Partial<AdHocFiltersVariableState>): void {
-    let filterExpressionChanged = false;
-
-    if (update.filters && update.filters !== this.state.filters && !update.filterExpression) {
-      update.filterExpression = renderExpression(this.state.expressionBuilder, update.filters);
-      filterExpressionChanged = update.filterExpression !== this.state.filterExpression;
-    }
-
-    super.setState(update);
-
-    if (filterExpressionChanged) {
-      this.publishEvent(new SceneVariableValueChangedEvent(this), true);
-    }
+    this.updateFilters(update)
   }
 
   /**
@@ -210,23 +199,19 @@ export class AdHocFiltersVariable
    * allowing consumers to update the filters without triggering dependent data providers.
    */
   public updateFilters(
-    filters: AdHocFilterWithLabels[],
+    update: Partial<AdHocFiltersVariableState>,
     options?: {
       skipPublish?: boolean;
     }
   ): void {
     let filterExpressionChanged = false;
-    let filterExpression = undefined;
 
-    if (filters && filters !== this.state.filters) {
-      filterExpression = renderExpression(this.state.expressionBuilder, filters);
-      filterExpressionChanged = filterExpression !== this.state.filterExpression;
+    if (update.filters && update.filters !== this.state.filters) {
+      update.filterExpression = renderExpression(this.state.expressionBuilder, update.filters);
+      filterExpressionChanged = update.filterExpression !== this.state.filterExpression;
     }
 
-    super.setState({
-      filters,
-      filterExpression,
-    });
+    super.setState(update);
 
     if (filterExpressionChanged && options?.skipPublish !== true) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -202,18 +202,19 @@ export class AdHocFiltersVariable
     update: Partial<AdHocFiltersVariableState>,
     options?: {
       skipPublish?: boolean;
+      forcePublish?: boolean;
     }
   ): void {
     let filterExpressionChanged = false;
 
-    if (update.filters && update.filters !== this.state.filters) {
+    if (update.filters && update.filters !== this.state.filters && !update.filterExpression) {
       update.filterExpression = renderExpression(this.state.expressionBuilder, update.filters);
       filterExpressionChanged = update.filterExpression !== this.state.filterExpression;
     }
 
     super.setState(update);
 
-    if (filterExpressionChanged && options?.skipPublish !== true) {
+    if ((filterExpressionChanged && options?.skipPublish !== true) || options?.forcePublish === true) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -189,7 +189,7 @@ export class AdHocFiltersVariable
     }
   }
 
-  public setState(update: Partial<AdHocFiltersVariableState>): void {
+  public setState(update: Partial<AdHocFiltersVariableState>, options?: {skipPublish?: boolean}): void {
     let filterExpressionChanged = false;
 
     if (update.filters && update.filters !== this.state.filters && !update.filterExpression) {
@@ -199,7 +199,7 @@ export class AdHocFiltersVariable
 
     super.setState(update);
 
-    if (filterExpressionChanged) {
+    if (filterExpressionChanged && options?.skipPublish !== true) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -189,7 +189,7 @@ export class AdHocFiltersVariable
     }
   }
 
-  public setState(update: Partial<AdHocFiltersVariableState>, options?: {skipPublish?: boolean}): void {
+  public setState(update: Partial<AdHocFiltersVariableState>, options?: { skipPublish?: boolean }): void {
     let filterExpressionChanged = false;
 
     if (update.filters && update.filters !== this.state.filters && !update.filterExpression) {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -190,7 +190,7 @@ export class AdHocFiltersVariable
   }
 
   public setState(update: Partial<AdHocFiltersVariableState>): void {
-    this.updateFilters(update)
+    this.updateFilters(update);
   }
 
   /**

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -189,7 +189,7 @@ export class AdHocFiltersVariable
     }
   }
 
-  public setState(update: Partial<AdHocFiltersVariableState>, options?: { skipPublish?: boolean }): void {
+  public setState(update: Partial<AdHocFiltersVariableState>): void {
     let filterExpressionChanged = false;
 
     if (update.filters && update.filters !== this.state.filters && !update.filterExpression) {
@@ -198,6 +198,31 @@ export class AdHocFiltersVariable
     }
 
     super.setState(update);
+
+    if (filterExpressionChanged) {
+      this.publishEvent(new SceneVariableValueChangedEvent(this), true);
+    }
+  }
+
+  /**
+   * Updates the variable's `filters` and `filterExpression` state.
+   * If `skipPublish` option is true, this will not emit the `SceneVariableValueChangedEvent`,
+   * allowing consumers to update the filters without triggering dependent data providers.
+   */
+  public updateFilters(filters: AdHocFilterWithLabels[], options?: {
+    skipPublish?: boolean
+  }): void {
+    let filterExpressionChanged = false;
+    let filterExpression = undefined
+
+    if (filters && filters !== this.state.filters) {
+      filterExpression = renderExpression(this.state.expressionBuilder, filters);
+      filterExpressionChanged = filterExpression !== this.state.filterExpression;
+    }
+
+    super.setState({
+      filters, filterExpression
+    })
 
     if (filterExpressionChanged && options?.skipPublish !== true) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -209,11 +209,14 @@ export class AdHocFiltersVariable
    * If `skipPublish` option is true, this will not emit the `SceneVariableValueChangedEvent`,
    * allowing consumers to update the filters without triggering dependent data providers.
    */
-  public updateFilters(filters: AdHocFilterWithLabels[], options?: {
-    skipPublish?: boolean
-  }): void {
+  public updateFilters(
+    filters: AdHocFilterWithLabels[],
+    options?: {
+      skipPublish?: boolean;
+    }
+  ): void {
     let filterExpressionChanged = false;
-    let filterExpression = undefined
+    let filterExpression = undefined;
 
     if (filters && filters !== this.state.filters) {
       filterExpression = renderExpression(this.state.expressionBuilder, filters);
@@ -221,8 +224,9 @@ export class AdHocFiltersVariable
     }
 
     super.setState({
-      filters, filterExpression
-    })
+      filters,
+      filterExpression,
+    });
 
     if (filterExpressionChanged && options?.skipPublish !== true) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);


### PR DESCRIPTION
Use case: We have 2 ad-hoc variables at different scopes in the application, an "editing" variable at a lower scope, and a "submitted" variable at a higher scope. Both variables are interpolated by certain query providers. Our un-interpolated expression would look like this: `${AD_HOC_SUBMITTED} ${AD_HOC_EDITING}`. The submitted variable is rendered on the top scene, and on every route, but the "editing" variable only exists for a single route. Both variables are rendered in different areas of the UI.

When users are done configuring the lower scope variable, it is submitted, and moved to the higher scope variable. The value in the editing variable is deleted.

However since the `SceneVariableValueChangedEvent` is emitted whenever an individual ad-hoc variable's expression has changed, this triggers duplicate queries in our application, even though the final interpolated expression doesn't change.

Usage: 
```
// Move filter up
submittedVariable.updateFilters([ {key: 'key', operator: '=', value: 'val'} ], {skipPublish: true});

// Delete lower variable filters
editingVariable.updateFilters([], {
  skipPublish: true
});
```

Why this change:
Otherwise applications will either need to live with running duplicate queries, extend the base `AdHocFiltersVariable` class, or convert every query provider that consumes these variables to manual execution.

TL;DR:
This PR will allow the caller of updateFilters to override the default behavior and skip sending the `SceneVariableValueChangedEvent`, to allow setting the ad-hoc filters state without triggering queries.

# Release notes
New AdHocFiltersVariable method `updateFilters` to allow updating filters state. Allows skipping emit of `SceneVariableValueChangedEvent` to prevent filter changes from notifying dependent scene objects.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.36.0--canary.1004.12431956361.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.36.0--canary.1004.12431956361.0
  npm install @grafana/scenes@5.36.0--canary.1004.12431956361.0
  # or 
  yarn add @grafana/scenes-react@5.36.0--canary.1004.12431956361.0
  yarn add @grafana/scenes@5.36.0--canary.1004.12431956361.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
