### PR TITLE
Variables: current value

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -325,20 +325,14 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     setBaseClassState<MultiValueVariableState>(this, state);
   }
 
-  public getOptionsForSelectWithoutCurrentValue(): VariableValueOption[] {
+  public getOptionsForSelect(includeCurrentValue = true): VariableValueOption[] {
     let options = this.state.options;
 
     if (this.state.includeAll) {
       options = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...options];
     }
 
-    return options;
-  }
-
-  public getOptionsForSelect(): VariableValueOption[] {
-    let options = this.getOptionsForSelectWithoutCurrentValue();
-
-    if (!Array.isArray(this.state.value)) {
+    if (includeCurrentValue && !Array.isArray(this.state.value)) {
       const current = options.find((x) => x.value === this.state.value);
       if (!current) {
         options = [{ value: this.state.value, label: String(this.state.text) }, ...options];

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -325,12 +325,18 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     setBaseClassState<MultiValueVariableState>(this, state);
   }
 
-  public getOptionsForSelect(): VariableValueOption[] {
+  public getOptionsForSelectWithoutCurrentValue(): VariableValueOption[] {
     let options = this.state.options;
 
     if (this.state.includeAll) {
       options = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...options];
     }
+
+    return options;
+  }
+
+  public getOptionsForSelect(): VariableValueOption[] {
+    let options = this.getOptionsForSelectWithoutCurrentValue();
 
     if (!Array.isArray(this.state.value)) {
       const current = options.find((x) => x.value === this.state.value);


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/98005
i think the variable edit page don't need current value to show. so i add a function `getOptionsForSelectWithoutCurrentValue`.

after this pr merged. i would change this line (https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx#L116) to use  `getOptionsForSelectWithoutCurrentValue`