### PR TITLE
fix: groupBy manual applyMode

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -144,11 +144,13 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
       noValueOnClear: true,
     });
 
-    this.addActivationHandler(() => {
-      allActiveGroupByVariables.add(this);
+    if (this.state.applyMode === 'auto') {
+      this.addActivationHandler(() => {
+        allActiveGroupByVariables.add(this);
 
-      return () => allActiveGroupByVariables.delete(this);
-    });
+        return () => allActiveGroupByVariables.delete(this);
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug in **the GroupByVariable where the applyMode property was not being respected**. Specifically, the addActivationHandler logic ran regardless of the applyMode value, causing unintended behavior.

To address this, we introduced a conditional check for `this.state.applyMode === 'auto'` before invoking addActivationHandler. This ensures that activation logic only applies when the applyMode is set to auto.

Changes have been tested locally using `npm link --force ../scenes/packages/scenes`.

**Demo**

https://github.com/user-attachments/assets/7c13836a-416d-4213-83d2-df3332f46655




