### PR TITLE
AdHocFilters: add hidden option 

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -474,6 +474,16 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
+  it('does not render hidden filter in url', () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], { hidden: true });
+    });
+
+    expect(locationService.getLocation().search).toBe('?var-filters=key2%7C%3D%7Cval2');
+  });
+
   it('overrides state when url has empty key', () => {
     const { filtersVar } = setup();
 
@@ -1045,6 +1055,23 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     it('displays the existing filters', async () => {
       expect(await screen.findByText('key1 = val1')).toBeInTheDocument();
       expect(await screen.findByText('key2 = val2')).toBeInTheDocument();
+    });
+
+    it('does not display hidden filters', async () => {
+      act(() => {
+        const { filtersVar } = setup();
+
+        filtersVar.setState({
+          filters: [
+            ...filtersVar.state.filters,
+            { key: 'hidden_key', operator: '=', value: 'hidden_val', hidden: true },
+          ],
+        });
+      });
+
+      expect(await screen.findByText('key1 = val1')).toBeInTheDocument();
+      expect(await screen.findByText('key2 = val2')).toBeInTheDocument();
+      expect(await screen.queryAllByText('hidden_key = hidden_val')).toEqual([]);
     });
 
     it('focusing the input opens the key dropdown', async () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -22,6 +22,8 @@ export interface AdHocFilterWithLabels extends AdHocVariableFilter {
   valueLabels?: string[];
   // this is used to externally trigger edit mode in combobox filter UI
   forceEdit?: boolean;
+  // hide the filter from AdHocFiltersVariableRenderer and the URL
+  hidden?: boolean;
 }
 
 export type AdHocControlsLayout = ControlsLayout | 'combobox';
@@ -402,11 +404,13 @@ export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHo
 
   return (
     <div className={styles.wrapper}>
-      {filters.map((filter, index) => (
-        <React.Fragment key={index}>
-          <AdHocFilterRenderer filter={filter} model={model} />
-        </React.Fragment>
-      ))}
+      {filters
+        .filter((filter) => !filter.hidden)
+        .map((filter, index) => (
+          <React.Fragment key={index}>
+            <AdHocFilterRenderer filter={filter} model={model} />
+          </React.Fragment>
+        ))}
 
       {!readOnly && <AdHocFilterBuilder model={model} key="'builder" addFilterButtonText={addFilterButtonText} />}
     </div>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -27,6 +27,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
 
     const value = filters
       .filter(isFilterComplete)
+      .filter((filter) => !filter.hidden)
       .map((filter) => toArray(filter).map(escapeUrlPipeDelimiters).join('|'));
     return { [this.getKey()]: value };
   }


### PR DESCRIPTION
We'd like to add a search input field to a page which already has AdHocFilters with a restricted set of keywords. We have the following requirements:
  - when a search term is supplied, then all the queries on the page should be filtered as if there was a filter added for the a specific, fixed label. More precisely it should be equivalent to adding `specific_label=~.*searchTerm.*`
  - but we don't want this new filter to be shown by the AdHocFilter control (we currently use VariableValueControl for that) or the URL

This PR enables us to achieve this by introducing the `hidden` property on AdHocFilters.

Related discussion: https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1732712478401569