### PR TITLE
QueryVariable: Use correct option property for variable options sorting

### DIFF
--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -322,9 +322,9 @@ describe.each(['11.1.2', '11.1.1'])('QueryVariable', (v) => {
       await lastValueFrom(variable.validateAndUpdate());
 
       expect(variable.state.options).toEqual([
-        { label: 'val1', value: 'val1' },
-        { label: 'val2', value: 'val2' },
         { label: 'val11', value: 'val11' },
+        { label: 'val2', value: 'val2' },
+        { label: 'val1', value: 'val1' },
       ]);
     });
 
@@ -339,9 +339,9 @@ describe.each(['11.1.2', '11.1.1'])('QueryVariable', (v) => {
       await lastValueFrom(variable.validateAndUpdate());
 
       expect(variable.state.options).toEqual([
-        { label: 'val11', value: 'val11' },
-        { label: 'val2', value: 'val2' },
         { label: 'val1', value: 'val1' },
+        { label: 'val2', value: 'val2' },
+        { label: 'val11', value: 'val11' },
       ]);
     });
 

--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -130,16 +130,10 @@ function sortByNumeric(opt: VariableValueOption) {
   }
 }
 
+const collator = new Intl.Collator(undefined, { sensitivity: 'accent', numeric: true });
+
 function sortByNaturalSort(options: VariableValueOption[]) {
   return options.sort((a, b) => {
-    if (!a.label) {
-      return -1;
-    }
-
-    if (!b.label) {
-      return 1;
-    }
-
-    return a.label.localeCompare(b.label, undefined, { numeric: true });
+    return collator.compare(a.label, b.label);
   });
 }

--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -133,7 +133,7 @@ function sortByNumeric(opt: VariableValueOption) {
 const collator = new Intl.Collator(undefined, { sensitivity: 'accent', numeric: true });
 
 function sortByNaturalSort(options: VariableValueOption[]) {
-  return options.sort((a, b) => {
+  return options.slice().sort((a, b) => {
     return collator.compare(a.label, b.label);
   });
 }

--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -74,39 +74,10 @@ const getAllMatches = (str: string, regex: RegExp): RegExpExecArray[] => {
   return results;
 };
 
-export const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
+export const sortVariableValues = (options: VariableValueOption[], sortOrder: VariableSort) => {
   if (sortOrder === VariableSort.disabled) {
     return options;
   }
-
-  // @ts-ignore
-  const sortByNumeric = (opt) => {
-    if (!opt.text) {
-      return -1;
-    }
-    const matches = opt.text.match(/.*?(\d+).*/);
-    if (!matches || matches.length < 2) {
-      return -1;
-    } else {
-      return parseInt(matches[1], 10);
-    }
-  };
-
-  // @ts-ignore
-  const sortByNaturalSort = (options) => {
-    //@ts-ignore
-    return options.sort((a, b) => {
-      if (!a.text) {
-        return -1;
-      }
-
-      if (!b.text) {
-        return 1;
-      }
-
-      return a.text.localeCompare(b.text, undefined, { numeric: true });
-    });
-  };
 
   switch (sortOrder) {
     case VariableSort.alphabeticalAsc:
@@ -146,3 +117,29 @@ export const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
   }
   return options;
 };
+
+function sortByNumeric(opt: VariableValueOption) {
+  if (!opt.label) {
+    return -1;
+  }
+  const matches = opt.label.match(/.*?(\d+).*/);
+  if (!matches || matches.length < 2) {
+    return -1;
+  } else {
+    return parseInt(matches[1], 10);
+  }
+}
+
+function sortByNaturalSort(options: VariableValueOption[]) {
+  return options.sort((a, b) => {
+    if (!a.label) {
+      return -1;
+    }
+
+    if (!b.label) {
+      return 1;
+    }
+
+    return a.label.localeCompare(b.label, undefined, { numeric: true });
+  });
+}


### PR DESCRIPTION
sorting was carried out agains `option.text` instead of `option.label`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.36.2--canary.1015.12584248290.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.36.2--canary.1015.12584248290.0
  npm install @grafana/scenes@5.36.2--canary.1015.12584248290.0
  # or 
  yarn add @grafana/scenes-react@5.36.2--canary.1015.12584248290.0
  yarn add @grafana/scenes@5.36.2--canary.1015.12584248290.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
