### PR TITLE
ScenesQueryRunner: Add minInterval to variable dependencies

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -126,7 +126,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   }
 
   protected _variableDependency: VariableDependencyConfig<QueryRunnerState> = new VariableDependencyConfig(this, {
-    statePaths: ['queries', 'datasource'],
+    statePaths: ['queries', 'datasource', 'minInterval'],
     onVariableUpdateCompleted: this.onVariableUpdatesCompleted.bind(this),
     onAnyVariableChanged: this.onAnyVariableChanged.bind(this),
   });


### PR DESCRIPTION
compliments https://github.com/grafana/grafana/pull/98510. 
With both these PRs panel will redraw if you specify a variable in panel query options
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.36.3--canary.1021.12630599445.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.36.3--canary.1021.12630599445.0
  npm install @grafana/scenes@5.36.3--canary.1021.12630599445.0
  # or 
  yarn add @grafana/scenes-react@5.36.3--canary.1021.12630599445.0
  yarn add @grafana/scenes@5.36.3--canary.1021.12630599445.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
