### PR TITLE
SceneShareLinksButton: expose share links button to scene apps

### DIFF
--- a/packages/scenes/src/components/SceneShareLinksButton.tsx
+++ b/packages/scenes/src/components/SceneShareLinksButton.tsx
@@ -1,0 +1,260 @@
+import { SceneObjectBase } from '../core/SceneObjectBase';
+import { ButtonGroup, Dropdown, IconName, Menu, MenuGroup, ToolbarButton } from '@grafana/ui';
+import { SceneComponentProps, SceneObjectState, SceneTimeRangeLike } from '../core/types';
+import { config, getAppEvents, getBackendSrv, locationService, reportInteraction } from '@grafana/runtime';
+import { sceneGraph } from '../core/sceneGraph';
+import React from 'react';
+import { AppEvents, toUtc } from '@grafana/data';
+
+interface ShortLinkMenuItemData {
+  key: string;
+  label: string;
+  icon: IconName;
+  getUrl: Function;
+  shorten: boolean;
+  absTime: boolean;
+}
+
+interface ShortLinkGroupData {
+  key: string;
+  label: string;
+  items: ShortLinkMenuItemData[];
+}
+
+export interface SceneShareLinksButtonState extends SceneObjectState {
+  lastSelected: ShortLinkMenuItemData;
+  isOpen: boolean;
+  /**
+   * Reference to $timeRange
+   */
+  getSceneTimeRange?: () => SceneTimeRangeLike;
+  /**
+   * Callback on link copy
+   */
+  onCopyLink?: (shortened: boolean, absTime: boolean, url?: string) => void;
+}
+
+export class SceneShareLinksButton extends SceneObjectBase<SceneShareLinksButtonState> {
+  public constructor(state: Partial<SceneShareLinksButtonState>) {
+    super({ isOpen: false, lastSelected: defaultMode, ...state });
+  }
+
+  public setIsOpen(isOpen: boolean) {
+    this.setState({ isOpen });
+  }
+
+  public onCopyLink(shorten: boolean, absTime: boolean, url?: string) {
+    if (shorten) {
+      createAndCopyShortLink(url || global.location.href);
+      reportInteraction('grafana_explore_shortened_link_clicked', { isAbsoluteTime: absTime });
+    } else {
+      copyStringToClipboard(
+        url !== undefined
+          ? `${window.location.protocol}//${window.location.host}${config.appSubUrl}${url}`
+          : global.location.href
+      );
+
+      if (this.state.onCopyLink) {
+        this.state.onCopyLink(shorten, absTime, url);
+      }
+    }
+  }
+
+  static MenuActions = ({ model }: SceneComponentProps<SceneShareLinksButton>) => {
+    const menuOptions: ShortLinkGroupData[] = [
+      {
+        key: 'normal',
+        label: 'Normal URL links',
+        items: [
+          {
+            key: 'copy-shortened-link',
+            icon: 'link',
+            label: 'Copy shortened URL',
+            getUrl: () => undefined,
+            shorten: true,
+            absTime: false,
+          },
+          {
+            key: 'copy-link',
+            icon: 'link',
+            label: 'Copy URL',
+            getUrl: () => undefined,
+            shorten: false,
+            absTime: false,
+          },
+        ],
+      },
+      {
+        key: 'timesync',
+        label: 'Time-sync URL links (share with time range intact)',
+        items: [
+          {
+            key: 'copy-short-link-abs-time',
+            icon: 'clock-nine',
+            label: 'Copy absolute shortened URL',
+            shorten: true,
+            getUrl: () => {
+              return constructAbsoluteUrl(
+                model.state.getSceneTimeRange !== undefined
+                  ? model.state.getSceneTimeRange()
+                  : sceneGraph.getTimeRange(model)
+              );
+            },
+            absTime: true,
+          },
+          {
+            key: 'copy-link-abs-time',
+            icon: 'clock-nine',
+            label: 'Copy absolute URL',
+            shorten: false,
+            getUrl: () => {
+              return constructAbsoluteUrl(
+                model.state.getSceneTimeRange !== undefined
+                  ? model.state.getSceneTimeRange()
+                  : sceneGraph.getTimeRange(model)
+              );
+            },
+            absTime: true,
+          },
+        ],
+      },
+    ];
+
+    return (
+      <Menu>
+        {menuOptions.map((groupOption) => {
+          return (
+            <MenuGroup key={groupOption.key} label={groupOption.label}>
+              {groupOption.items.map((option) => {
+                return (
+                  <Menu.Item
+                    key={option.key}
+                    label={option.label}
+                    icon={option.icon}
+                    onClick={() => {
+                      const url = option.getUrl();
+                      model.onCopyLink(option.shorten, option.absTime, url);
+                      model.setState({
+                        lastSelected: option,
+                      });
+                    }}
+                  />
+                );
+              })}
+            </MenuGroup>
+          );
+        })}
+      </Menu>
+    );
+  };
+
+  static Component = ({ model }: SceneComponentProps<SceneShareLinksButton>) => {
+    const { lastSelected, isOpen } = model.useState();
+
+    return (
+      <ButtonGroup>
+        <ToolbarButton
+          tooltip={lastSelected.label}
+          icon={lastSelected.icon}
+          variant={'canvas'}
+          narrow={true}
+          onClick={() => {
+            const url = lastSelected.getUrl();
+            model.onCopyLink(lastSelected.shorten, lastSelected.absTime, url);
+          }}
+          aria-label={'Copy shortened URL'}
+        >
+          <span>Share</span>
+        </ToolbarButton>
+        <Dropdown
+          overlay={<SceneShareLinksButton.MenuActions model={model} />}
+          placement="bottom-end"
+          onVisibleChange={model.setIsOpen.bind(model)}
+        >
+          <ToolbarButton narrow={true} variant={'canvas'} isOpen={isOpen} aria-label={'Open copy link options'} />
+        </Dropdown>
+      </ButtonGroup>
+    );
+  };
+}
+
+const defaultMode: ShortLinkMenuItemData = {
+  key: 'copy-link',
+  label: 'Copy shortened URL',
+  icon: 'share-alt',
+  getUrl: () => undefined,
+  shorten: true,
+  absTime: false,
+};
+
+// Adapted from grafana/grafana/public/app/core/utils/shortLinks.ts shortLinks.ts
+function buildHostUrl() {
+  return `${window.location.protocol}//${window.location.host}${config.appSubUrl}`;
+}
+
+function getRelativeURLPath(url: string) {
+  let path = url.replace(buildHostUrl(), '');
+  return path.startsWith('/') ? path.substring(1, path.length) : path;
+}
+
+export const createShortLink = async function (path: string) {
+  const appEvents = getAppEvents();
+  try {
+    const shortLink = await getBackendSrv().post(`/api/short-urls`, {
+      path: getRelativeURLPath(path),
+    });
+    return shortLink.url;
+  } catch (err) {
+    console.error('Error when creating shortened link: ', err);
+
+    appEvents.publish({
+      type: AppEvents.alertError.name,
+      payload: ['Error generating shortened link'],
+    });
+  }
+};
+
+export const createAndCopyShortLink = async (path: string) => {
+  const appEvents = getAppEvents();
+  const shortLink = await createShortLink(path);
+  if (shortLink) {
+    copyStringToClipboard(shortLink);
+    appEvents.publish({
+      type: AppEvents.alertSuccess.name,
+      payload: ['Shortened link copied to clipboard'],
+    });
+  } else {
+    appEvents.publish({
+      type: AppEvents.alertError.name,
+      payload: ['Error generating shortened link'],
+    });
+  }
+};
+
+export const copyStringToClipboard = (string: string) => {
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(string);
+  } else {
+    const el = document.createElement('textarea');
+    el.value = string;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+  }
+};
+
+/**
+ * Adapted from /grafana/grafana/public/app/features/explore/utils/links.ts
+ * Returns the current URL with absolute time range
+ */
+const constructAbsoluteUrl = (timeRange: SceneTimeRangeLike): string => {
+  const from = toUtc(timeRange.state.value.from);
+  const to = toUtc(timeRange.state.value.to);
+  const location = locationService.getLocation();
+  const searchParams = new URLSearchParams(location.search);
+  searchParams.set('from', from.toISOString());
+  searchParams.set('to', to.toISOString());
+
+  return `${location.pathname}?${searchParams.toString()}`;
+};

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -124,6 +124,7 @@ export { SceneDebugger } from './components/SceneDebugger/SceneDebugger';
 export { VariableValueSelectWrapper } from './variables/components/VariableValueSelectors';
 export { ControlsLabel } from './utils/ControlsLabel';
 export { renderSelectForVariable } from './variables/components/VariableValueSelect';
+export { SceneShareLinksButton } from './components/SceneShareLinksButton';
 export { VizConfigBuilder } from './core/PanelBuilders/VizConfigBuilder';
 export { VizConfigBuilders } from './core/PanelBuilders/VizConfigBuilders';
 export { type VizConfig } from './core/PanelBuilders/types';


### PR DESCRIPTION
Exposes `SceneShareLinksButton` scene for scene apps.
SceneShareLinksButton allows consumers to define:
* optional `onCopyLink` callback (for tracking) on link copy
* optional `getSceneTimeRange` function to specify which `SceneTimeRangeLike` should be used for the link generation.

<img width="346" alt="image" src="https://github.com/user-attachments/assets/c2c79643-ed5b-4544-83b2-cd8d5e1c6eb5" />

<hr />

<img width="405" alt="image" src="https://github.com/user-attachments/assets/63b0a7cc-6ca8-4f18-a4b0-3e01056db92c" />
