### PR TITLE
sceneUtils: export methods for generating scenes URLs in external applications

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -7,7 +7,8 @@ import { getUrlState, syncStateFromSearchParams } from './services/utils';
 import { registerVariableMacro } from './variables/macros';
 import {
   escapeLabelValueInExactSelector,
-  escapeLabelValueInRegexSelector, escapeURLDelimiters,
+  escapeLabelValueInRegexSelector,
+  escapeURLDelimiters,
   renderPrometheusLabelFilters,
 } from './variables/utils';
 import {

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -5,7 +5,11 @@ import { registerRuntimeDataSource } from './querying/RuntimeDataSource';
 import { getUrlState, syncStateFromSearchParams } from './services/utils';
 
 import { registerVariableMacro } from './variables/macros';
-import { renderPrometheusLabelFilters } from './variables/utils';
+import {
+  escapeLabelValueInExactSelector,
+  escapeLabelValueInRegexSelector, escapeURLDelimiters,
+  renderPrometheusLabelFilters,
+} from './variables/utils';
 import {
   isAdHocVariable,
   isQueryVariable,
@@ -137,6 +141,9 @@ export const sceneUtils = {
   syncStateFromSearchParams,
   getUrlState,
   renderPrometheusLabelFilters,
+  escapeLabelValueInRegexSelector,
+  escapeLabelValueInExactSelector,
+  escapeURLDelimiters,
 
   // Variable guards
   isAdHocVariable,

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -311,12 +311,14 @@ describe('searchOptions falls back to substring matching for non-latin needles',
 
 describe('escapeURLVariableString', () => {
   it('Should escape pipes and commas in url parameter being passed into scenes from external application', () => {
-    expect(escapeURLDelimiters('')).toEqual('')
-    expect(escapeURLDelimiters('((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}|(KHTML, like Gecko)')).toEqual('((25[0-5]__gfp__(2[0-4]__gfp__1\\d__gfp__[1-9]__gfp__)\\d)\\.?\\b){4}__gfp__(KHTML__gfc__ like Gecko)')
-    expect(escapeURLDelimiters('|=')).toEqual('__gfp__=')
-    expect(escapeURLDelimiters('val1,val2a|val2b')).toEqual('val1__gfc__val2a__gfp__val2b')
-  })
-})
+    expect(escapeURLDelimiters('')).toEqual('');
+    expect(escapeURLDelimiters('((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}|(KHTML, like Gecko)')).toEqual(
+      '((25[0-5]__gfp__(2[0-4]__gfp__1\\d__gfp__[1-9]__gfp__)\\d)\\.?\\b){4}__gfp__(KHTML__gfc__ like Gecko)'
+    );
+    expect(escapeURLDelimiters('|=')).toEqual('__gfp__=');
+    expect(escapeURLDelimiters('val1,val2a|val2b')).toEqual('val1__gfc__val2a__gfp__val2b');
+  });
+});
 
 interface TestObjectState extends SceneObjectState {
   datasource: DataSourceRef | null;

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -4,7 +4,7 @@ import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLa
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObjectState } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
-import { getFuzzySearcher, getQueriesForVariables } from './utils';
+import { escapeURLDelimiters, getFuzzySearcher, getQueriesForVariables } from './utils';
 import { SceneVariableSet } from './sets/SceneVariableSet';
 import { DataSourceVariable } from './variants/DataSourceVariable';
 import { GetDataSourceListFilters } from '@grafana/runtime';
@@ -308,6 +308,15 @@ describe('searchOptions falls back to substring matching for non-latin needles',
     expect(searcher('南', 'key').map((o) => o.label!)).toEqual(['台南市', '南投縣']);
   });
 });
+
+describe('escapeURLVariableString', () => {
+  it('Should escape pipes and commas in url parameter being passed into scenes from external application', () => {
+    expect(escapeURLDelimiters('')).toEqual('')
+    expect(escapeURLDelimiters('((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}|(KHTML, like Gecko)')).toEqual('((25[0-5]__gfp__(2[0-4]__gfp__1\\d__gfp__[1-9]__gfp__)\\d)\\.?\\b){4}__gfp__(KHTML__gfc__ like Gecko)')
+    expect(escapeURLDelimiters('|=')).toEqual('__gfp__=')
+    expect(escapeURLDelimiters('val1,val2a|val2b')).toEqual('val1__gfc__val2a__gfp__val2b')
+  })
+})
 
 interface TestObjectState extends SceneObjectState {
   datasource: DataSourceRef | null;

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -171,6 +171,10 @@ export function escapeUrlCommaDelimiters(value: string | undefined): string {
   return /,/g[Symbol.replace](value, '__gfc__');
 }
 
+export function escapeURLDelimiters(value: string | undefined): string {
+  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(value))
+}
+
 export function unescapeUrlDelimiters(value: string | undefined): string {
   if (value === null || value === undefined) {
     return '';

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -172,7 +172,7 @@ export function escapeUrlCommaDelimiters(value: string | undefined): string {
 }
 
 export function escapeURLDelimiters(value: string | undefined): string {
-  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(value))
+  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(value));
 }
 
 export function unescapeUrlDelimiters(value: string | undefined): string {


### PR DESCRIPTION
When generating links to scenes apps in Explore or other external applications, we need to escape pipes and commas or scenes will be unable to parse the url parameters for variable values containing pipes or commas.

This PR exposes the methods scenes is using internally to build valid URLs that can be consumed by a scenes application. 

Also exposes `escapeLabelValueInRegexSelector` and `escapeLabelValueInExactSelector`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.37.0--canary.1024.12749589889.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.37.0--canary.1024.12749589889.0
  npm install @grafana/scenes@5.37.0--canary.1024.12749589889.0
  # or 
  yarn add @grafana/scenes-react@5.37.0--canary.1024.12749589889.0
  yarn add @grafana/scenes@5.37.0--canary.1024.12749589889.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
