### PR TITLE
Developer docs: fix type error in example (advanced-behaviors#actwhenvariablechanged)

### DIFF
--- a/docusaurus/docs/advanced-behaviors.md
+++ b/docusaurus/docs/advanced-behaviors.md
@@ -111,14 +111,17 @@ Performs a side effect when a variable changes.
 
 #### Usage
 
-Assuming there is a variable named `myVariable` in a scene, you can configure side effect to be performed when it's value changes:
+Assuming there is a `MultiValueVariable` variable named `myVariable` in a scene, you can configure side effect to be performed when it's value changes:
 
 ```ts
-import { behaviors } from '@grafana/scenes';
+import { behaviors, MultiValueVariable } from '@grafana/scenes';
 
 const logWhenVariableChanges = new behaviors.ActWhenVariableChanged({
   variableName: 'myVariable',
   onChange: (variable) => {
+    if (!(variable instanceof MultiValueVariable)) {
+      throw new Error('Invalid variable type for ActWhenVariableChanged behavior');
+    }
     console.log(`myVariable value changed: ${variable.state.value}`);
   },
 });


### PR DESCRIPTION
Fixes: https://github.com/grafana/scenes/issues/1016

The docs were throwing a compiler error as `value` does not exist on the generic `SceneVariable` interface.