### PR TITLE
Added class names to panel and row component to distinguish both

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -165,7 +165,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const panelId = model.getLegacyPanelId();
 
   return (
-    <div className={relativeWrapper}>
+    <div className={relativeWrapper + " oodle-panel"}>
       <div ref={ref as RefCallback<HTMLDivElement>} className={absoluteWrapper} data-viz-panel-key={model.state.key}>
         {width > 0 && height > 0 && (
           <PanelChrome

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -86,7 +86,7 @@ export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow
   const panels = count === 1 ? 'panel' : 'panels';
 
   return (
-    <div className={cx(styles.row, isCollapsed && styles.rowCollapsed)}>
+    <div className={cx(styles.row, isCollapsed && styles.rowCollapsed && "oodle-panel-row")}>
       <div className={styles.rowTitleAndActionsGroup}>
         <button
           onClick={model.onCollapseToggle}


### PR DESCRIPTION
Rows and Panels do not have any distinction in a grid. We want to add separate styles to both.
This adds distinct class names, so they can be targeted with css selectors.