### PR TITLE
Layouts: Add ability to hook into VizPanelRenderer events

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -264,7 +264,7 @@ function getDragClasses(panel: VizPanel) {
 
 function getDragHooks(panel: VizPanel) {
   const parentLayout = sceneGraph.getLayout(panel);
-  return { onDragStart: parentLayout?.onDragStart };
+  return parentLayout?.getDragHooks?.() ?? {};
 }
 
 /**

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -51,6 +51,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const plugin = model.getPlugin();
 
   const { dragClass, dragClassCancel } = getDragClasses(model);
+  const dragHooks = getDragHooks(model);
   const dataObject = sceneGraph.getData(model);
 
   const rawData = dataObject.useState();
@@ -196,6 +197,9 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             collapsible={collapsible}
             collapsed={collapsed}
             onToggleCollapse={model.onToggleCollapse}
+            onDragStart={(e: React.PointerEvent) => {
+              dragHooks.onDragStart?.(e, model);
+            }}
           >
             {(innerWidth, innerHeight) => (
               <>
@@ -256,6 +260,11 @@ function getDragClasses(panel: VizPanel) {
   }
 
   return { dragClass: parentLayout.getDragClass?.(), dragClassCancel: parentLayout?.getDragClassCancel?.() };
+}
+
+function getDragHooks(panel: VizPanel) {
+  const parentLayout = sceneGraph.getLayout(panel);
+  return { onDragStart: parentLayout?.onDragStart };
 }
 
 /**

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -144,7 +144,7 @@ export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> exte
   isDraggable(): boolean;
   getDragClass?(): string;
   getDragClassCancel?(): string;
-  onDragStart?: (e: React.PointerEvent, panel: VizPanel) => void;
+  getDragHooks?(): { onDragStart?: (e: React.PointerEvent, panel: VizPanel) => void };
 }
 
 export interface SceneTimeRangeState extends SceneObjectState {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -17,6 +17,7 @@ import { DataQuery, DataTopic, TimeZone } from '@grafana/schema';
 
 import { SceneVariableDependencyConfigLike, SceneVariables } from '../variables/types';
 import { SceneObjectRef } from './SceneObjectRef';
+import { VizPanel } from '../components/VizPanel/VizPanel';
 
 export interface SceneObjectState {
   key?: string;
@@ -143,6 +144,7 @@ export interface SceneLayout<T extends SceneLayoutState = SceneLayoutState> exte
   isDraggable(): boolean;
   getDragClass?(): string;
   getDragClassCancel?(): string;
+  onDragStart?: (e: React.PointerEvent, panel: VizPanel) => void;
 }
 
 export interface SceneTimeRangeState extends SceneObjectState {


### PR DESCRIPTION
Different layouts (row, grid, etc.) may have different requirements for handling drag/drop behavior, and so to allow for layout-specific event handling, I've added an optional method to the `SceneLayout` interface, `onDragStart`.
`VizPanelRenderer` finds the closest layout and grabs its hook(s) and then passes them through to `PanelChrome`.
We only need this one hook for now (no `onDragMove`, `onDragEnd`, etc.), but if we need to extend it later, there shouldn't be any problems.

Related: https://github.com/grafana/scenes/pull/993
Most of the code from the above PR will be moved to the main grafana repo, but this hook-handling code is still needed.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.38.0--canary.1028.12889195833.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.38.0--canary.1028.12889195833.0
  npm install @grafana/scenes@5.38.0--canary.1028.12889195833.0
  # or 
  yarn add @grafana/scenes-react@5.38.0--canary.1028.12889195833.0
  yarn add @grafana/scenes@5.38.0--canary.1028.12889195833.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
