### PR TITLE
AdHocFilterVariable: Force option label to be a string

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -460,7 +460,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
 export function toSelectableValue(input: MetricFindValue): SelectableValue<string> {
   const { text, value } = input;
   const result: SelectableValue<string> = {
-    label: text,
+    // converting text to string due to some edge cases where it can be a number
+    // TODO: remove once https://github.com/grafana/grafana/issues/99021 is closed
+    label: String(text),
     value: String(value ?? text),
   };
 


### PR DESCRIPTION
stopping the bleed from https://github.com/grafana/grafana/issues/99021 where we can get a `number` instead of `string` in `option.label` in ad hoc filters which breaks the fuzzy search
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.37.1--canary.1029.12889288329.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.37.1--canary.1029.12889288329.0
  npm install @grafana/scenes@5.37.1--canary.1029.12889288329.0
  # or 
  yarn add @grafana/scenes-react@5.37.1--canary.1029.12889288329.0
  yarn add @grafana/scenes@5.37.1--canary.1029.12889288329.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
