### PR TITLE
SceneVariableSet: Allow propagation of variable changes through local variable

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -809,7 +809,7 @@ describe('SceneVariableList', () => {
       expect(B.state.loading).toBe(true);
     });
 
-    it('When local value overrides parent variable changes on top level should propagate update but not hasChanged', () => {
+    it('When local value overrides parent variable changes on top level should propagate', () => {
       const topLevelVar = new TestVariable({
         name: 'test',
         options: [],
@@ -835,8 +835,8 @@ describe('SceneVariableList', () => {
       nestedScene.doSomethingThatRequiresVariables();
       topLevelVar.changeValueTo('E');
 
-      expect(nestedScene.state.didSomethingCount).toBe(1);
-      expect(nestedScene.state.variableValueChanged).toBe(0);
+      expect(nestedScene.state.didSomethingCount).toBe(2);
+      expect(nestedScene.state.variableValueChanged).toBe(1);
     });
   });
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -15,7 +15,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { LocalValueVariable } from '../variants/LocalValueVariable';
 import { TestObjectWithVariableDependency, TestScene } from '../TestScene';
-//import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
+import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 
 interface SceneTextItemState extends SceneObjectState {
   text: string;
@@ -809,34 +809,35 @@ describe('SceneVariableList', () => {
       expect(B.state.loading).toBe(true);
     });
 
-    // describe('When local value overrides parent variable changes on top level should not propagate', () => {
-    //   const topLevelVar = new TestVariable({
-    //     name: 'test',
-    //     options: [],
-    //     value: 'B',
-    //     optionsToReturn: [{ label: 'B', value: 'B' }],
-    //     delayMs: 0,
-    //   });
+    it('When local value overrides parent variable changes on top level should propagate update but not hasChanged', () => {
+      const topLevelVar = new TestVariable({
+        name: 'test',
+        options: [],
+        value: 'B',
+        optionsToReturn: [{ label: 'B', value: 'B' }],
+        delayMs: 0,
+      });
 
-    //   const nestedScene = new TestObjectWithVariableDependency({
-    //     title: '$test',
-    //     $variables: new SceneVariableSet({
-    //       variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
-    //     }),
-    //   });
+      const nestedScene = new TestObjectWithVariableDependency({
+        title: '$test',
+        $variables: new SceneVariableSet({
+          variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
+        }),
+      });
 
-    //   const scene = new TestScene({
-    //     $variables: new SceneVariableSet({ variables: [topLevelVar] }),
-    //     nested: nestedScene,
-    //   });
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [topLevelVar] }),
+        nested: nestedScene,
+      });
 
-    //   activateFullSceneTree(scene);
+      activateFullSceneTree(scene);
 
-    //   topLevelVar.changeValueTo('E');
+      nestedScene.doSomethingThatRequiresVariables();
+      topLevelVar.changeValueTo('E');
 
-    //   expect(nestedScene.state.didSomethingCount).toBe(0);
-    //   expect(nestedScene.state.variableValueChanged).toBe(0);
-    // });
+      expect(nestedScene.state.didSomethingCount).toBe(1);
+      expect(nestedScene.state.variableValueChanged).toBe(0);
+    });
   });
 
   describe('When changing a dependency while variable is loading', () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -809,34 +809,34 @@ describe('SceneVariableList', () => {
       expect(B.state.loading).toBe(true);
     });
 
-    describe('When local value overrides parent variable changes on top level should not propagate', () => {
-      const topLevelVar = new TestVariable({
-        name: 'test',
-        options: [],
-        value: 'B',
-        optionsToReturn: [{ label: 'B', value: 'B' }],
-        delayMs: 0,
-      });
+    // describe('When local value overrides parent variable changes on top level should not propagate', () => {
+    //   const topLevelVar = new TestVariable({
+    //     name: 'test',
+    //     options: [],
+    //     value: 'B',
+    //     optionsToReturn: [{ label: 'B', value: 'B' }],
+    //     delayMs: 0,
+    //   });
 
-      const nestedScene = new TestObjectWithVariableDependency({
-        title: '$test',
-        $variables: new SceneVariableSet({
-          variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
-        }),
-      });
+    //   const nestedScene = new TestObjectWithVariableDependency({
+    //     title: '$test',
+    //     $variables: new SceneVariableSet({
+    //       variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
+    //     }),
+    //   });
 
-      const scene = new TestScene({
-        $variables: new SceneVariableSet({ variables: [topLevelVar] }),
-        nested: nestedScene,
-      });
+    //   const scene = new TestScene({
+    //     $variables: new SceneVariableSet({ variables: [topLevelVar] }),
+    //     nested: nestedScene,
+    //   });
 
-      activateFullSceneTree(scene);
+    //   activateFullSceneTree(scene);
 
-      topLevelVar.changeValueTo('E');
+    //   topLevelVar.changeValueTo('E');
 
-      expect(nestedScene.state.didSomethingCount).toBe(0);
-      expect(nestedScene.state.variableValueChanged).toBe(0);
-    });
+    //   expect(nestedScene.state.didSomethingCount).toBe(0);
+    //   expect(nestedScene.state.variableValueChanged).toBe(0);
+    // });
   });
 
   describe('When changing a dependency while variable is loading', () => {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -15,7 +15,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { LocalValueVariable } from '../variants/LocalValueVariable';
 import { TestObjectWithVariableDependency, TestScene } from '../TestScene';
-import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
+//import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 
 interface SceneTextItemState extends SceneObjectState {
   text: string;

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -328,10 +328,11 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
 
     // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
     if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
-      // const localVar = sceneObject.state.$variables.getByName(variable.state.name);
-      // if (localVar) {
-      //   return;
-      // }
+      const localVar = sceneObject.state.$variables.getByName(variable.state.name);
+      if (localVar) {
+        hasChanged = false;
+        variable = localVar;
+      }
     }
 
     if (sceneObject.variableDependency) {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -328,10 +328,10 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
 
     // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
     if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
-      const localVar = sceneObject.state.$variables.getByName(variable.state.name);
-      if (localVar) {
-        return;
-      }
+      // const localVar = sceneObject.state.$variables.getByName(variable.state.name);
+      // if (localVar) {
+      //   return;
+      // }
     }
 
     if (sceneObject.variableDependency) {

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -332,7 +332,6 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       const localVar = sceneObject.state.$variables.getByName(variable.state.name);
       // If local variable is viewed as loading when ancestor is loading we propagate a change
       if (localVar?.isAncestorLoading) {
-        hasChanged = false;
         variable = localVar;
       } else if (localVar) {
         return;

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -13,7 +13,6 @@ import {
   SceneVariableValueChangedEvent,
 } from '../types';
 import { VariableValueRecorder } from '../VariableValueRecorder';
-import { LocalValueVariable } from '../variants/LocalValueVariable';
 
 export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
   /** Variables that have changed in since the activation or since the first manual value change */

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -13,6 +13,7 @@ import {
   SceneVariableValueChangedEvent,
 } from '../types';
 import { VariableValueRecorder } from '../VariableValueRecorder';
+import { LocalValueVariable } from '../variants/LocalValueVariable';
 
 export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
   /** Variables that have changed in since the activation or since the first manual value change */
@@ -329,9 +330,11 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
     if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
       const localVar = sceneObject.state.$variables.getByName(variable.state.name);
-      if (localVar) {
+      if (localVar?.isAncestorLoading) {
         hasChanged = false;
         variable = localVar;
+      } else {
+        return;
       }
     }
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -330,10 +330,11 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
     if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
       const localVar = sceneObject.state.$variables.getByName(variable.state.name);
+      // If local variable is viewed as loading when ancestor is loading we propagate a change
       if (localVar?.isAncestorLoading) {
         hasChanged = false;
         variable = localVar;
-      } else {
+      } else if (localVar) {
         return;
       }
     }


### PR DESCRIPTION
This is just a test, want to see if there are other ways to fix the double queries this causes in main with repeated panels 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.39.0--canary.1030.12926943216.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.39.0--canary.1030.12926943216.0
  npm install @grafana/scenes@5.39.0--canary.1030.12926943216.0
  # or 
  yarn add @grafana/scenes-react@5.39.0--canary.1030.12926943216.0
  yarn add @grafana/scenes@5.39.0--canary.1030.12926943216.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
