### PR TITLE
feat: when allowCustomValue is false, do not show the regex operators

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -130,7 +130,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(filtersVar.state.filters[0].value).toBe('myVeryCustomValue');
   });
 
-  it('shows key groups and orders according to first occurence of a group item', async () => {
+  it('shows key groups and orders according to first occurrence of a group item', async () => {
     const { runRequest } = setup({
       getTagKeysProvider: async () => ({
         replace: true,
@@ -192,7 +192,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(options[5]).toHaveTextContent('Foo');
   });
 
-  it('shows value groups and orders according to first occurence of a group item', async () => {
+  it('shows value groups and orders according to first occurrence of a group item', async () => {
     const { runRequest } = setup({
       getTagValuesProvider: async () => ({
         replace: true,
@@ -1225,6 +1225,45 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(screen.getByRole('listbox')).toBeInTheDocument();
       // check the first option just to be sure
       expect(screen.getByRole('option', { name: 'key1' })).toBeInTheDocument();
+    });
+  });
+
+  describe('operators', () => {
+    it('shows the regex operators when allowCustomValue is set true', async () => {
+      setup({
+        allowCustomValue: true,
+      });
+
+      const middleKeySelect = screen.getAllByRole('combobox')[1];
+      await userEvent.click(middleKeySelect);
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
+
+      expect(options).toEqual([
+        '=Equals',
+        '!=Not equal',
+        '=~Matches regex',
+        '!~Does not match regex',
+        '<Less than',
+        '>Greater than',
+      ]);
+    });
+
+    it('does not show the regex operators when allowCustomValue is set false', async () => {
+      setup({
+        allowCustomValue: false,
+      });
+
+      const middleKeySelect = screen.getAllByRole('combobox')[1];
+      await userEvent.click(middleKeySelect);
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
+
+      expect(options).toEqual(['=Equals', '!=Not equal', '<Less than', '>Greater than']);
     });
   });
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -123,6 +123,7 @@ export type OperatorDefinition = {
   value: string;
   description?: string;
   isMulti?: Boolean;
+  isRegex?: Boolean;
 };
 
 export const OPERATORS: OperatorDefinition[] = [
@@ -147,10 +148,12 @@ export const OPERATORS: OperatorDefinition[] = [
   {
     value: '=~',
     description: 'Matches regex',
+    isRegex: true,
   },
   {
     value: '!~',
     description: 'Does not match regex',
+    isRegex: true,
   },
   {
     value: '<',
@@ -374,10 +377,17 @@ export class AdHocFiltersVariable
   }
 
   public _getOperators() {
-    const filteredOperators = this.state.supportsMultiValueOperators
-      ? OPERATORS
-      : OPERATORS.filter((operator) => !operator.isMulti);
-    return filteredOperators.map<SelectableValue<string>>(({ value, description }) => ({
+    const { supportsMultiValueOperators, allowCustomValue } = this.state;
+
+    return OPERATORS.filter(({ isMulti, isRegex }) => {
+      if (!supportsMultiValueOperators && isMulti) {
+        return false;
+      }
+      if (!allowCustomValue && isRegex) {
+        return false;
+      }
+      return true;
+    }).map<SelectableValue<string>>(({ value, description }) => ({
       label: value,
       value,
       description,


### PR DESCRIPTION

When `allowCustomValue:false`, meaning the user cannot write other values then the ones displayed, we should not show the regex related operators (` =~`, `!~` ) in the dropdown.

Relates to [db-o11y issue](https://github.com/grafana/grafana-dbo11y-app/issues/438)



