### PR TITLE
Fix issue with custom variables losing url value when there are no options

### DIFF
--- a/packages/scenes/src/services/utils.ts
+++ b/packages/scenes/src/services/utils.ts
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash';
 
 import { SceneObject, SceneObjectUrlValue, SceneObjectUrlValues } from '../core/types';
 import { UniqueUrlKeyMapper } from './UniqueUrlKeyMapper';
+import { CustomVariable } from '../variables/variants/CustomVariable';
 
 /**
  * @param root
@@ -65,6 +66,15 @@ function syncUrlStateToObject(sceneObject: SceneObject, urlParams: URLSearchPara
     for (const key of sceneObject.urlSync.getKeys()) {
       const uniqueKey = urlKeyMapper.getUniqueKey(key, sceneObject);
       const newValue = urlParams.getAll(uniqueKey);
+
+      if (
+        sceneObject instanceof CustomVariable &&
+        uniqueKey === `var-${sceneObject.state.name}` &&
+        !sceneObject.state.options?.length
+      ) {
+        sceneObject.skipNextValidation = true;
+      }
+
       const currentValue = currentState[key];
 
       if (isUrlValueEqual(newValue, currentValue)) {

--- a/packages/scenes/src/services/utils.ts
+++ b/packages/scenes/src/services/utils.ts
@@ -2,7 +2,6 @@ import { isEqual } from 'lodash';
 
 import { SceneObject, SceneObjectUrlValue, SceneObjectUrlValues } from '../core/types';
 import { UniqueUrlKeyMapper } from './UniqueUrlKeyMapper';
-import { CustomVariable } from '../variables/variants/CustomVariable';
 
 /**
  * @param root

--- a/packages/scenes/src/services/utils.ts
+++ b/packages/scenes/src/services/utils.ts
@@ -65,7 +65,6 @@ function syncUrlStateToObject(sceneObject: SceneObject, urlParams: URLSearchPara
     for (const key of sceneObject.urlSync.getKeys()) {
       const uniqueKey = urlKeyMapper.getUniqueKey(key, sceneObject);
       const newValue = urlParams.getAll(uniqueKey);
-
       const currentValue = currentState[key];
 
       if (isUrlValueEqual(newValue, currentValue)) {

--- a/packages/scenes/src/services/utils.ts
+++ b/packages/scenes/src/services/utils.ts
@@ -67,14 +67,6 @@ function syncUrlStateToObject(sceneObject: SceneObject, urlParams: URLSearchPara
       const uniqueKey = urlKeyMapper.getUniqueKey(key, sceneObject);
       const newValue = urlParams.getAll(uniqueKey);
 
-      if (
-        sceneObject instanceof CustomVariable &&
-        uniqueKey === `var-${sceneObject.state.name}` &&
-        !sceneObject.state.options?.length
-      ) {
-        sceneObject.skipNextValidation = true;
-      }
-
       const currentValue = currentState[key];
 
       if (isUrlValueEqual(newValue, currentValue)) {

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -44,7 +44,7 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
       }
     });
 
-    if (!options.length && this.hasKeyInUrl()) {
+    if (!options.length && this.hasValueInUrl()) {
       this.skipNextValidation = true;
     }
 
@@ -55,7 +55,10 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
     return renderSelectForVariable(model);
   };
 
-  private hasKeyInUrl() {
-    return !!this.urlSync?.getKeys()?.find((key) => key === `var-${this.state.name}`);
+  private hasValueInUrl() {
+    const urlValues = this.urlSync?.getUrlState();
+    const urlKey = this.urlSync?.getKeys()?.find((key) => key === `var-${this.state.name}`);
+
+    return !!urlValues?.[urlKey ?? ''];
   }
 }

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -44,7 +44,7 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
       }
     });
 
-    if (!options.length && this.hasValueInUrl()) {
+    if (!options.length) {
       this.skipNextValidation = true;
     }
 
@@ -54,11 +54,4 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
     return renderSelectForVariable(model);
   };
-
-  private hasValueInUrl() {
-    const urlValues = this.urlSync?.getUrlState();
-    const urlKey = this.urlSync?.getKeys()?.find((key) => key === `var-${this.state.name}`);
-
-    return !!urlValues?.[urlKey ?? ''];
-  }
 }

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -44,10 +44,18 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
       }
     });
 
+    if (!options.length && this.hasKeyInUrl()) {
+      this.skipNextValidation = true;
+    }
+
     return of(options);
   }
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
     return renderSelectForVariable(model);
   };
+
+  private hasKeyInUrl() {
+    return !!this.urlSync?.getKeys()?.find((key) => key === `var-${this.state.name}`);
+  }
 }


### PR DESCRIPTION
Attempts to fix https://github.com/grafana/scenes/issues/1027, not sure if it's the way to go or if it doesn't break other stuff that I might have missed. 

It seems that it only affects CustomVariables so we could isolate it there and turn on the `skipNextValidation` flag if there are no options and we have a value in the url.