### PR TITLE
AdHocFilters: allow setting filter meta in getTagKeysProvider

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -73,6 +73,7 @@ export {
 export { LocalValueVariable } from './variables/variants/LocalValueVariable';
 export { IntervalVariable } from './variables/variants/IntervalVariable';
 export { AdHocFiltersVariable } from './variables/adhoc/AdHocFiltersVariable';
+export type { AdHocFilterWithLabels } from './variables/adhoc/AdHocFiltersVariable';
 export { GroupByVariable } from './variables/groupby/GroupByVariable';
 export { type MacroVariableConstructor } from './variables/macros/types';
 

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -47,6 +47,7 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueValue = keyLabelToOption(filter.value, filter.valueLabels?.[0]);
 
   const optionSearcher = useMemo(() => getAdhocOptionSearcher(values), [values]);
+  const onAddCustomValue = model.state.onAddCustomValue;
 
   const onValueInputChange = (value: string, { action }: InputActionMeta) => {
     if (action === 'input-change') {
@@ -127,10 +128,14 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       inputValue={valueInputValue}
       onInputChange={onValueInputChange}
       onChange={(v) => {
-        model._updateFilter(filter, {
-          value: v.value,
-          valueLabels: v.label ? [v.label] : [v.value],
-        });
+        if (onAddCustomValue && v.__isNew__) {
+          model._updateFilter(filter, onAddCustomValue(v, filter));
+        } else {
+          model._updateFilter(filter, {
+            value: v.value,
+            valueLabels: v.label ? [v.label] : [v.value],
+          });
+        }
 
         if (valueHasCustomValue !== v.__isNew__) {
           setValueHasCustomValue(v.__isNew__);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -220,6 +220,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     });
   }
 
+  // Get the optional onAddCustomValue method from the AdHocFiltersVariable if defined
+  const onAddCustomValue = model.state.onAddCustomValue;
+
   // calculate width and populate listRef and disabledIndicesRef for arrow key navigation
   const maxOptionWidth = setupDropdownAccessibility(filteredDropDownItems, listRef, disabledIndicesRef);
 
@@ -374,6 +377,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
               item: selectedItem,
               filter: filter!,
               setFilterMultiValues,
+              onAddCustomValue,
             })
           );
 
@@ -412,6 +416,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       refs.domReference,
       isLastFilter,
       focusOnWipInputRef,
+      onAddCustomValue,
     ]
   );
 
@@ -667,6 +672,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                                     item,
                                     filter: filter!,
                                     setFilterMultiValues,
+                                    onAddCustomValue,
                                   })
                                 );
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { AdHocInputType } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, isMultiValueOperator } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, isMultiValueOperator, OnAddCustomValueFn } from '../AdHocFiltersVariable';
 import { getFuzzySearcher } from '../../utils';
 
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
@@ -117,11 +117,13 @@ export const generateFilterUpdatePayload = ({
   item,
   filter,
   setFilterMultiValues,
+  onAddCustomValue,
 }: {
   filterInputType: AdHocInputType;
   item: SelectableValue<string>;
   filter: AdHocFilterWithLabels;
   setFilterMultiValues: (value: React.SetStateAction<Array<SelectableValue<string>>>) => void;
+  onAddCustomValue?: OnAddCustomValueFn;
 }): Partial<AdHocFilterWithLabels> => {
   if (filterInputType === 'key') {
     return {
@@ -131,6 +133,9 @@ export const generateFilterUpdatePayload = ({
     };
   }
   if (filterInputType === 'value') {
+    if (item.isCustom && onAddCustomValue) {
+      return onAddCustomValue(item, filter);
+    }
     return {
       value: item.value,
       valueLabels: [item.label ? item.label : item.value!],

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -127,6 +127,7 @@ export const generateFilterUpdatePayload = ({
     return {
       key: item.value,
       keyLabel: item.label ? item.label : item.value,
+      meta: item?.meta,
     };
   }
   if (filterInputType === 'value') {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -829,6 +829,47 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
+  it('Can encode a custom value', async () => {
+    const { filtersVar, runRequest } = setup({
+      allowCustomValue: true,
+      filters: [
+        {
+          key: 'key1',
+          value: 'value',
+          valueLabels: ['valueLabels'],
+          operator: '=~',
+          meta: 'metaVal',
+        },
+      ],
+      onAddCustomValue: (item, filter) => {
+        const customValue = JSON.stringify({
+          meta: filter.meta,
+          value: item.value,
+        });
+        return {
+          value: customValue,
+          valueLabels: [item.label ?? item.value ?? ''],
+        };
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    await userEvent.type(selects[2], 'myVeryCustomValue{enter}');
+
+    // should run new query when filter changed
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe(JSON.stringify({ meta: 'metaVal', value: 'myVeryCustomValue' }));
+    expect(screen.getByText('myVeryCustomValue')).toBeVisible();
+    expect(screen.queryByText('metaVal')).not.toBeInTheDocument();
+  });
+
   it('Can override and add keys and values', async () => {
     const { filtersVar } = setup({
       getTagKeysProvider: () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, getAllByRole, render, waitFor, screen } from '@testing-library/react';
 import { SceneVariableValueChangedEvent } from '../types';
-import { AdHocFiltersVariable, AdHocFiltersVariableState } from './AdHocFiltersVariable';
+import { AdHocFiltersVariable, AdHocFiltersVariableState, AdHocFilterWithLabels } from './AdHocFiltersVariable';
 import {
   DataSourceSrv,
   config,
@@ -31,6 +31,7 @@ import { VariableValueSelectors } from '../components/VariableValueSelectors';
 import { subscribeToStateUpdates } from '../../../utils/test/utils';
 import { TestContextProvider } from '../../../utils/test/TestContextProvider';
 import { FiltersRequestEnricher } from '../../core/types';
+import { generateFilterUpdatePayload } from './AdHocFiltersCombobox/utils';
 
 const templateSrv = {
   getAdhocFilters: jest.fn().mockReturnValue([{ key: 'origKey', operator: '=', value: '' }]),
@@ -759,6 +760,73 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     const values = await filtersVar._getValuesFor(filtersVar.state.filters[0]);
     expect(values).toEqual([{ label: 'v', value: '2' }]);
+  });
+
+  it('Can define custom meta in getTagKeysProvider which will be passed to getTagValuesProvider', async () => {
+    type FilterMeta = { parser: string };
+
+    const { filtersVar } = setup({
+      getTagKeysProvider: () => {
+        // getTagKeysProvider API call returns metadata needed in the value
+        return Promise.resolve({
+          replace: true,
+          values: [{ text: 'keyLabel', value: 'keyValue', meta: { parser: 'parserValue' } }],
+        });
+      },
+      getTagValuesProvider: (variable, filter: AdHocFilterWithLabels<FilterMeta>) => {
+        // getTagValuesProvider can receive this metadata, and add it to the value
+        expect(filter.meta).toEqual({ parser: 'parserValue' });
+        return Promise.resolve({
+          replace: true,
+          values: [{ text: 'valueLabel', value: JSON.stringify({ value: 'v', parser: filter.meta?.parser }) }],
+        });
+      },
+    });
+
+    const keys = await filtersVar._getKeys(null);
+    expect(keys).toEqual([{ label: 'keyLabel', value: 'keyValue', meta: { parser: 'parserValue' } }]);
+
+    // Simulate the update of the filter key after the user selects a particular key
+    act(() =>
+      filtersVar._updateFilter(
+        filtersVar.state.filters[0],
+        generateFilterUpdatePayload({
+          filterInputType: 'key',
+          item: keys[0],
+          filter: filtersVar.state.filters[0],
+          setFilterMultiValues: jest.fn(),
+        })
+      )
+    );
+
+    // Get the values for the ad-hoc variable
+    const values = await filtersVar._getValuesFor(filtersVar.state.filters[0]);
+
+    // Our value should contain the metadata from the getTagKeysProvider call made earlier
+    expect(values).toEqual([{ label: 'valueLabel', value: JSON.stringify({ value: 'v', parser: 'parserValue' }) }]);
+
+    // Simulate the update of the filter value after the user selects a particular value
+    act(() =>
+      filtersVar._updateFilter(
+        filtersVar.state.filters[0],
+        generateFilterUpdatePayload({
+          filterInputType: 'value',
+          item: values[0],
+          filter: filtersVar.state.filters[0],
+          setFilterMultiValues: jest.fn(),
+        })
+      )
+    );
+
+    // Assert that the saved filter contains the expected meta and value
+    expect(filtersVar.state.filters[0]).toEqual({
+      operator: '=',
+      keyLabel: 'keyLabel',
+      key: 'keyValue',
+      meta: { parser: 'parserValue' },
+      value: JSON.stringify({ value: 'v', parser: 'parserValue' }),
+      valueLabels: ['valueLabel'],
+    });
   });
 
   it('Can override and add keys and values', async () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -763,7 +763,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('Can define custom meta in getTagKeysProvider which will be passed to getTagValuesProvider', async () => {
-    type FilterMeta = { parser: string };
+    type FilterMeta = Record<string, string>;
 
     const { filtersVar } = setup({
       getTagKeysProvider: () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -17,7 +17,7 @@ import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
 import { AdHocFiltersComboboxRenderer } from './AdHocFiltersCombobox/AdHocFiltersComboboxRenderer';
 import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSerializableSceneObject';
 
-export interface AdHocFilterWithLabels<M = any> extends AdHocVariableFilter {
+export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> extends AdHocVariableFilter {
   keyLabel?: string;
   valueLabels?: string[];
   // this is used to externally trigger edit mode in combobox filter UI

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -17,13 +17,16 @@ import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
 import { AdHocFiltersComboboxRenderer } from './AdHocFiltersCombobox/AdHocFiltersComboboxRenderer';
 import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSerializableSceneObject';
 
-export interface AdHocFilterWithLabels extends AdHocVariableFilter {
+export interface AdHocFilterWithLabels<M = any> extends AdHocVariableFilter {
   keyLabel?: string;
   valueLabels?: string[];
   // this is used to externally trigger edit mode in combobox filter UI
   forceEdit?: boolean;
   // hide the filter from AdHocFiltersVariableRenderer and the URL
   hidden?: boolean;
+  meta?: {
+    [index: string]: M;
+  };
 }
 
 export type AdHocControlsLayout = ControlsLayout | 'combobox';
@@ -478,6 +481,10 @@ export function toSelectableValue(input: MetricFindValue): SelectableValue<strin
 
   if ('group' in input) {
     result.group = input.group;
+  }
+
+  if ('meta' in input) {
+    result.meta = input.meta;
   }
 
   return result;

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -24,9 +24,7 @@ export interface AdHocFilterWithLabels<M = any> extends AdHocVariableFilter {
   forceEdit?: boolean;
   // hide the filter from AdHocFiltersVariableRenderer and the URL
   hidden?: boolean;
-  meta?: {
-    [index: string]: M;
-  };
+  meta?: M;
 }
 
 export type AdHocControlsLayout = ControlsLayout | 'combobox';
@@ -114,7 +112,8 @@ export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[]
 
 export type getTagKeysProvider = (
   variable: AdHocFiltersVariable,
-  currentKey: string | null
+  currentKey: string | null,
+  operators?: OperatorDefinition[]
 ) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] }>;
 
 export type getTagValuesProvider = (

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -106,9 +106,18 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
    * @internal state of the new filter being added
    */
   _wip?: AdHocFilterWithLabels;
+
+  /**
+   * Allows custom formatting of a value before saving to filter state
+   */
+  onAddCustomValue?: OnAddCustomValueFn;
 }
 
 export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[]) => string;
+export type OnAddCustomValueFn = (
+  item: SelectableValue<string> & { isCustom?: boolean },
+  filter: AdHocFilterWithLabels
+) => { value: string | undefined; valueLabels: string[] };
 
 export type getTagKeysProvider = (
   variable: AdHocFiltersVariable,


### PR DESCRIPTION
### Problem:
Assume the API endpoint that is called by `getTagKeysProvider` returns metadata needed for an ad-hoc filter value, that is not the key or key label. Currently, when defining `getTagKeysProvider` in an adHocVariable, we are only able to update the `key` or `keyLabel` props of the _wip ad-hoc filter. This means that we are forced to call the same API again in the `getTagValuesProvider` that we called in `getTagKeysProvider` to re-fetch the metadata associated with the selected key, or we must save the results of the API call made in `getTagKeysProvider` outside of the ad-hoc variable state.

### Specific use case: 
In Explore Logs, we call the `detected_fields` api endpoint to get keys for Fields variables. This returns the desired parser to use when building Loki queries, but isn't part of the actual value that is queried.

For example, when adding a `caller` field, the API tells us that the field only contains values that should be parsed by the logfmt parser. The api response for this field is:
```
{
    "label": "caller",
    "type": "string",
    "cardinality": 7,
    "parsers": [
        "logfmt"
    ]
}
```

When a value is selected for this field, we build a query like this:
```
{service_name=~"nginx-json-mixed"} | logfmt | caller=`broadcast.go:48`
```

Additionally, in the future we want to differentiate fields by "type", so we can provide a different set of operators for "string" typed fields vs "duration", "float", "int", "bytes", etc. We should be able to use the meta set in this PR to overwrite the `_getOperators` after selecting a key to keep the user from seeing operators which are not valid for that field type.

### This PR:
Attempts to solve the problem by allowing custom `meta` on the SelectableValue, which is saved to the adHoc `AdHocFilterWithLabels` filter state after the user selects a key provided by `getTagKeysProvider`.

### Limitations:
Currently passing meta from the `getTagValuesProvider` to the ad-hoc filter state is not supported by this PR, however it would be trivial to pass this in the `generateFilterUpdatePayload` method.

### Related PRs:
Allowing users to set valueLabels or encode meta with custom values: https://github.com/grafana/scenes/pull/1038

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.39.0--canary.1034.12990010339.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.39.0--canary.1034.12990010339.0
  npm install @grafana/scenes@5.39.0--canary.1034.12990010339.0
  # or 
  yarn add @grafana/scenes-react@5.39.0--canary.1034.12990010339.0
  yarn add @grafana/scenes@5.39.0--canary.1034.12990010339.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
