### PR TITLE
MultiValueVariable: Add `getDefaultSingleState` method

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -47,7 +47,7 @@ describe('MultiValueVariable', () => {
       expect(variable.state.value).toBe(ALL_VARIABLE_VALUE);
     });
 
-    it('Should pick first option whebn current value is All value but all value is not enabled', async () => {
+    it('Should pick first option when current value is All value but all value is not enabled', async () => {
       const variable = new TestVariable({
         name: 'test',
         options: [],

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -247,7 +247,7 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     }
   }
 
-  public getDefaultSingleState(options: VariableValueOption[]) {
+  protected getDefaultSingleState(options: VariableValueOption[]) {
     if (this.state.defaultToAll) {
       return { value: ALL_VARIABLE_VALUE, text: ALL_VARIABLE_TEXT };
     } else if (options.length > 0) {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -179,14 +179,9 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       stateUpdate.value = matchingOption.value;
     } else {
       // Current value is found in options
-      if (this.state.defaultToAll) {
-        stateUpdate.value = ALL_VARIABLE_VALUE;
-        stateUpdate.text = ALL_VARIABLE_TEXT;
-      } else {
-        // Current value is not valid. Set to first of the available options
-        stateUpdate.value = options[0].value;
-        stateUpdate.text = options[0].label;
-      }
+      const defaultState = this.getDefaultSingleState(options);
+      stateUpdate.value = defaultState.value;
+      stateUpdate.text = defaultState.text;
     }
 
     return stateUpdate;
@@ -249,6 +244,16 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
       return { value: [options[0].value], text: [options[0].label] };
     } else {
       return { value: [], text: [] };
+    }
+  }
+
+  public getDefaultSingleState(options: VariableValueOption[]) {
+    if (this.state.defaultToAll) {
+      return { value: ALL_VARIABLE_VALUE, text: ALL_VARIABLE_TEXT };
+    } else if (options.length > 0) {
+      return { value: options[0].value, text: options[0].label };
+    } else {
+      return { value: '', text: '' };
     }
   }
 


### PR DESCRIPTION
:wave:  have a need to select default variable option that isn't necessarily the first one. Refactored a little bit to expose `getDefaultSingleState` method for picking the default option so it can be easily overridden, in the same way as `getDefaultMultiState`.