### PR TITLE
LazyLoader: Prevent empty panels from not being hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### 🐛 Bug Fix
 
-- improve demo app navigation and include  code highlighter [#1023](https://github.com/grafana/scenes/pull/1023) ([@yduartep](https://github.com/yduartep))
+- improve demo app navigation and include code highlighter [#1023](https://github.com/grafana/scenes/pull/1023) ([@yduartep](https://github.com/yduartep))
 - `@grafana/scenes`
   - feat: when allowCustomValue is false, do not show the regex operators [#1031](https://github.com/grafana/scenes/pull/1031) ([@joannaWebDev](https://github.com/joannaWebDev))
 

--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -75,14 +75,19 @@ export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
 function getLayoutChildren(count: number) {
   return Array.from(
     Array(count),
-    (v, index) =>
-      new SceneCSSGridItem({
+    (v, index) => {
+      const item = new SceneCSSGridItem({
         body: PanelBuilders.stat()
           .setTitle(`Panel ${index + 1}`)
           .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
           .build(),
-        isHidden: index % 3 === 0,
-      })
+      });
+      // hide after timeout
+      setTimeout(() => {
+        item.setState({ isHidden: index % 3 === 0 });
+      }, 1000);
+      return item;
+    }
   );
 }
 

--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -83,9 +83,11 @@ function getLayoutChildren(count: number) {
           .build(),
       });
       // hide after timeout
-      setTimeout(() => {
-        item.setState({ isHidden: index % 3 === 0 });
-      }, 1000);
+      if (index % 3 === 0) {
+        setTimeout(() => {
+          item.setState({ isHidden: true });
+        }, 1000);
+      }
       return item;
     }
   );

--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -73,24 +73,21 @@ export function getCssGridLayoutDemo(defaults: SceneAppPageState) {
 }
 
 function getLayoutChildren(count: number) {
-  return Array.from(
-    Array(count),
-    (v, index) => {
-      const item = new SceneCSSGridItem({
-        body: PanelBuilders.stat()
-          .setTitle(`Panel ${index + 1}`)
-          .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
-          .build(),
-      });
-      // hide after timeout
-      if (index % 3 === 0) {
-        setTimeout(() => {
-          item.setState({ isHidden: true });
-        }, 1000);
-      }
-      return item;
+  return Array.from(Array(count), (v, index) => {
+    const item = new SceneCSSGridItem({
+      body: PanelBuilders.stat()
+        .setTitle(`Panel ${index + 1}`)
+        .setData(getQueryRunnerWithRandomWalkQuery({}, { maxDataPoints: 400 }))
+        .build(),
+    });
+    // hide after timeout
+    if (index % 3 === 0) {
+      setTimeout(() => {
+        item.setState({ isHidden: true });
+      }, 1000);
     }
-  );
+    return item;
+  });
 }
 
 export interface TemplateSelectorState extends SceneObjectState {

--- a/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
+++ b/packages/scenes-app/src/demos/cssGridLayoutDemo.tsx
@@ -81,10 +81,10 @@ function getLayoutChildren(count: number) {
         .build(),
     });
     // hide after timeout
-    if (index % 3 === 0) {
+    if (index % 4 === 0) {
       setTimeout(() => {
         item.setState({ isHidden: true });
-      }, 1000);
+      }, 3000);
     }
     return item;
   });

--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -60,14 +60,13 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
       };
     });
 
-    // If the element was loaded, we add the `hideEmpty` class to potentially
-    // hide the LazyLoader if it does not have any children. This is the case
-    // when children have the `isHidden` property set.
-    // We always include the `className` class, as this is coming from the
-    // caller of the `LazyLoader` component.
-    const classes = `${loaded ? hideEmpty : ''} ${className}`;
+    // since we will hide empty lazyloaded divs, we need to include a
+    // non-breaking space while the loader has not been loaded. after it has
+    // been loaded, we can remove the non-breaking space and show the children.
+    // If the children render empty, the whole loader will be hidden by css.
     return (
-      <div id={id} ref={innerRef} className={classes} {...rest}>
+      <div id={id} ref={innerRef} className={`${hideEmpty} ${className}`} {...rest}>
+        {!loaded && '\u00A0'}
         {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
       </div>
     );


### PR DESCRIPTION
The LazyLoader hides empty panels with the CSS `:empty` pseudo class. That does work in Chrome, but Firefox seems to have some issues with it. To test this, I changed the CSS Grid Layout demo, to hide panels after a timeout. The result in Firefox looks like this:

https://github.com/user-attachments/assets/6e573e91-16bf-49d2-a5ec-c4aa33ff1919

The fix involves bypassing the conditional CSS classes. However, since the LazyLoader will be empty from the beginning and thus would be hidden immediately, we need to add an element to it while it has not been loaded. 

This seems to fix the bug:

https://github.com/user-attachments/assets/ebc1aa6a-1ae2-43ca-a826-5d0bf413467a

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.41.1--canary.1039.13051061012.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.41.1--canary.1039.13051061012.0
  npm install @grafana/scenes@5.41.1--canary.1039.13051061012.0
  # or 
  yarn add @grafana/scenes-react@5.41.1--canary.1039.13051061012.0
  yarn add @grafana/scenes@5.41.1--canary.1039.13051061012.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
