### PR TITLE
Variables: Prevent queries from runners which are not specific to the query runner datasource

### DIFF
--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -179,6 +179,36 @@ describe('getQueriesForVariables', () => {
 
     expect(getQueriesForVariables(source)).toEqual([{ refId: 'A' }, { refId: 'AA' }, { refId: 'B' }]);
   });
+
+  it('should not retrieve queries with a different datasource than the runner', () => {
+    const runner1 = new SceneQueryRunner({
+      datasource: { uid: 'test-uid' },
+      queries: [{ refId: 'A' }, { datasource: { type: '__expr__', uid: 'Expression' }, refId: 'B' }],
+    });
+
+    const runner2 = new SceneQueryRunner({
+      datasource: { uid: 'test-uid' },
+      queries: [{ datasource: { type: '__expr__', uid: 'Expression' }, refId: 'C' }],
+    });
+
+    const source = new TestObject({ datasource: { uid: 'test-uid' } });
+    new EmbeddedScene({
+      $data: runner1,
+      body: new SceneFlexLayout({
+        children: [
+          new SceneFlexItem({
+            $data: runner2,
+            body: source,
+          }),
+        ],
+      }),
+    });
+
+    runner1.activate();
+    runner2.activate();
+    source.activate();
+    expect(getQueriesForVariables(source)).toEqual([{ refId: 'A' }]);
+  });
 });
 
 const getDataSourceListMock = jest.fn().mockImplementation((filters: GetDataSourceListFilters) => {
@@ -223,14 +253,14 @@ describe('getQueriesForVariables', () => {
       datasource: {
         uid: '${dsVar}',
       },
-      queries: [{ refId: 'A' }],
+      queries: [{ refId: 'A' }, { datasource: { type: '__expr__', uid: 'Expression' }, refId: 'C' }],
     });
 
     const runner2 = new SceneQueryRunner({
       datasource: {
         uid: '${dsVar}',
       },
-      queries: [{ refId: 'B' }],
+      queries: [{ refId: 'B' }, { datasource: { type: '__expr__', uid: 'Expression' }, refId: 'D' }],
     });
 
     const source = new TestObject({

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -260,7 +260,11 @@ describe('getQueriesForVariables', () => {
       datasource: {
         uid: '${dsVar}',
       },
-      queries: [{ refId: 'B' }, { datasource: { type: '__expr__', uid: 'Expression' }, refId: 'D' }],
+      queries: [
+        { refId: 'B' },
+        { datasource: { uid: '${dsVar}' }, refId: 'D' },
+        { datasource: { type: 'prometheus' }, refId: 'E' },
+      ],
     });
 
     const source = new TestObject({
@@ -292,7 +296,12 @@ describe('getQueriesForVariables', () => {
     runner1.activate();
     runner2.activate();
     source.activate();
-    expect(getQueriesForVariables(source)).toEqual([{ refId: 'A' }, { refId: 'B' }]);
+    expect(getQueriesForVariables(source)).toEqual([
+      { refId: 'A' },
+      { refId: 'B' },
+      { datasource: { uid: '${dsVar}' }, refId: 'D' },
+      { datasource: { type: 'prometheus' }, refId: 'E' },
+    ]);
   });
 });
 

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -120,7 +120,16 @@ export function getQueriesForVariables(
 
   const result: SceneDataQuery[] = [];
   applicableRunners.forEach((r) => {
-    result.push(...r.state.queries.filter((q) => !q.datasource || q.datasource.uid === interpolatedDsUuid));
+    result.push(
+      ...r.state.queries.filter((q) => {
+        if (!q.datasource || !q.datasource.uid) {
+          return true;
+        }
+
+        const interpolatedQueryDsUuid = sceneGraph.interpolate(sourceObject, q.datasource.uid);
+        return interpolatedQueryDsUuid === interpolatedDsUuid;
+      })
+    );
   });
 
   return result;

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -120,7 +120,7 @@ export function getQueriesForVariables(
 
   const result: SceneDataQuery[] = [];
   applicableRunners.forEach((r) => {
-    result.push(...r.state.queries.filter((q) => q.datasource === interpolatedDsUuid));
+    result.push(...r.state.queries.filter((q) => !q.datasource || q.datasource.uid === interpolatedDsUuid));
   });
 
   return result;

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -120,7 +120,7 @@ export function getQueriesForVariables(
 
   const result: SceneDataQuery[] = [];
   applicableRunners.forEach((r) => {
-    result.push(...r.state.queries);
+    result.push(...r.state.queries.filter((q) => q.datasource === interpolatedDsUuid));
   });
 
   return result;


### PR DESCRIPTION
When gathering queries for variables, the query runners can also contain queries from other datasources (i.e. Expressions). These should not be retrieved as they lead to errors (i.e. queries specific to the Expressions datasource does not contain the `expr` property but `expression`).

Hence we need to check the queries' datasource as well. If the `datasource` or `datasource.uid` properties are missing, they are inferred from the query runner. If they are present, we check the UID to see if it matches.

Fixes https://github.com/grafana/scenes/issues/1043
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.41.2--canary.1044.13114619048.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@5.41.2--canary.1044.13114619048.0
  npm install @grafana/scenes@5.41.2--canary.1044.13114619048.0
  # or 
  yarn add @grafana/scenes-react@5.41.2--canary.1044.13114619048.0
  yarn add @grafana/scenes@5.41.2--canary.1044.13114619048.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
