### PR TITLE
Themes: Fixes variable labels to support border radius

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -1,4 +1,4 @@
-import { VariableRefresh } from '@grafana/data';
+import { VariableHide, VariableRefresh } from '@grafana/data';
 import {
   SceneFlexLayout,
   SceneTimeRange,
@@ -46,6 +46,7 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                   description: 'Server name',
                   delayMs: 1000,
                   isMulti: true,
+                  hide: VariableHide.hideLabel,
                   options: [],
                   refresh: VariableRefresh.onTimeRangeChanged,
                 }),

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -1,4 +1,4 @@
-import { VariableHide, VariableRefresh } from '@grafana/data';
+import { VariableRefresh } from '@grafana/data';
 import {
   SceneFlexLayout,
   SceneTimeRange,

--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -46,7 +46,6 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                   description: 'Server name',
                   delayMs: 1000,
                   isMulti: true,
-                  hide: VariableHide.hideLabel,
                   options: [],
                   refresh: VariableRefresh.onTimeRangeChanged,
                 }),

--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -100,7 +100,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     height: theme.spacing(theme.components.height.md),
     lineHeight: theme.spacing(theme.components.height.md),
-    borderRadius: theme.shape.borderRadius(1),
+    borderRadius: `${theme.shape.radius.default} 0 0 ${theme.shape.radius.default}`,
     border: `1px solid ${theme.components.input.borderColor}`,
     position: 'relative',
     // To make the border line up with the input border

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -88,8 +88,7 @@ function VariableLabel({ variable, layout, hideLabel }: VariableSelectProps) {
 
 const containerStyle = css({
   display: 'flex',
-  // No border for second element (input)
-  // For input only variables (hidden label) it will be in pos 1
+  // No border for second element (inputs) as label and input border is shared
   '> :nth-child(2)': css({
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,

--- a/packages/scenes/src/variables/components/VariableValueSelectors.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelectors.tsx
@@ -86,5 +86,14 @@ function VariableLabel({ variable, layout, hideLabel }: VariableSelectProps) {
   );
 }
 
-const containerStyle = css({ display: 'flex' });
+const containerStyle = css({
+  display: 'flex',
+  // No border for second element (input)
+  // For input only variables (hidden label) it will be in pos 1
+  '> :nth-child(2)': css({
+    borderTopLeftRadius: 0,
+    borderBottomLeftRadius: 0,
+  }),
+});
+
 const verticalContainer = css({ display: 'flex', flexDirection: 'column' });


### PR DESCRIPTION
The new Grafanacon themes have higher borderRadius which make the variable controls look a bit bad 

Before: 
![Screenshot 2025-02-06 at 15 19 14](https://github.com/user-attachments/assets/ecfd6b84-7b40-415f-8cf7-052a28021dc7)

After: 
![Screenshot 2025-02-06 at 15 18 41](https://github.com/user-attachments/assets/0e6098b0-0d37-4c85-852b-2d30e23c076b)

