### PR TITLE
Fix the `getLegacyPanelId` method in `VizPanel`

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -375,6 +375,30 @@ describe('VizPanel', () => {
 
       expect(panel.getLegacyPanelId()).toBe(12);
     });
+
+    it('should return panel id for a panel in a clone chain', () => {
+      const panels = [
+        new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          key: 'panel-clone-0/panel-12-clone-1',
+        }),
+        new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          key: 'panel-12-clone-1',
+        }),
+        new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          key: 'panel-clone-0/grid-item-5/panel-12-clone-1',
+        }),
+        new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          key: 'panel-12-clone-0',
+        }),
+        new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          key: 'panel-12-clone-12',
+        }),
+      ];
+
+      panels.forEach((panel) => {
+        expect(panel.getLegacyPanelId()).toBe(12);
+      });
+    });
   });
 
   describe('updating options', () => {

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -181,7 +181,19 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
   }
 
   public getLegacyPanelId() {
-    const panelId = parseInt(this.state.key!.replace('panel-', ''), 10);
+    /**
+     * The `/` part is here because a panel key can be in a clone chain
+     * A clone chain looks like `panel-1-clone-0/grid-item-5/panel-14` where the last part is the panel key
+     */
+    const parts = this.state.key?.split('/') ?? [];
+
+    if (parts.length === 0) {
+      return 0;
+    }
+
+    const part = parts[parts.length - 1];
+    const panelId = parseInt(part!.replace('panel-', ''), 10);
+
     if (isNaN(panelId)) {
       return 0;
     }


### PR DESCRIPTION
Fix needed after https://github.com/grafana/grafana/pull/99300/ (rows refactor) 

The `getLegacyPanelId` method was returning the id for the first part of the key in a clone chain.

This requires a way better fix as it was already clunky from the beginning (cloned panels are having keys like `panel-X-clone-ABC` where `ABC` is now the clone index while previously it was the variable value).

For the time being this is a hotfix to solve any active/potential incidents.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.0.2--canary.1053.13305029685.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.0.2--canary.1053.13305029685.0
  npm install @grafana/scenes@6.0.2--canary.1053.13305029685.0
  # or 
  yarn add @grafana/scenes-react@6.0.2--canary.1053.13305029685.0
  yarn add @grafana/scenes@6.0.2--canary.1053.13305029685.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
