### PR TITLE
Fix issue were operators do not appear properly in adhoc vars

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1533,6 +1533,26 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   describe('operators', () => {
+    it('shows the regex operators when allowCustomValue is undefined', async () => {
+      setup();
+
+      const middleKeySelect = screen.getAllByRole('combobox')[1];
+      await userEvent.click(middleKeySelect);
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
+
+      expect(options).toEqual([
+        '=Equals',
+        '!=Not equal',
+        '=~Matches regex',
+        '!~Does not match regex',
+        '<Less than',
+        '>Greater than',
+      ]);
+    });
+
     it('shows the regex operators when allowCustomValue is set true', async () => {
       setup({
         allowCustomValue: true,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -420,7 +420,7 @@ export class AdHocFiltersVariable
   }
 
   public _getOperators() {
-    const { supportsMultiValueOperators, allowCustomValue } = this.state;
+    const { supportsMultiValueOperators, allowCustomValue = true } = this.state;
 
     return OPERATORS.filter(({ isMulti, isRegex }) => {
       if (!supportsMultiValueOperators && isMulti) {


### PR DESCRIPTION
Fixes an issue in dashboards where adhocs do not show the regex operators even though they should appear since the variable settings UI page shows `Allow custom values` true, by default. This only happens when the flag is set by default and not explicitly in the model.

To maintain backwards comp, I added the `allowCustomValues` flag and set it to true by default (as custom values worked by default before this flag), but not in the model, so that it wouldn't change the dashboard model.

If I were to have added the flag in the constructor with a default value when undefined this issue wouldn't have happened, but then all dashboards would have their models changed and a new line for allowing custom values would be serialized in adhoc vars in already saved dashboards.

