### PR TITLE
Perform history step on MultiValueVariable

### DIFF
--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -198,6 +198,7 @@ export interface SceneObjectUrlSyncHandler {
   getUrlState(): SceneObjectUrlValues;
   updateFromUrl(values: SceneObjectUrlValues): void;
   shouldCreateHistoryStep?(values: SceneObjectUrlValues): boolean;
+  performBrowserHistoryAction?(callback: () => void): void;
 }
 
 export interface DataRequestEnricher {


### PR DESCRIPTION
Small PR to "copy" the approach used in `SceneObjectUrlSyncConfig` to create history steps when the value is updated. I added the `performBrowserHistoryAction` function to the `SceneObjectUrlSyncHandler` interface and implemented it in `MultiValueUrlSyncHandler`. If this approach sounds good I can also do it for other classes implementing `SceneObjectUrlSyncHandler` like in AdHocFiltersVariable, GroupByVariable, etc.

This is needed because in [traces-drilldown](https://github.com/grafana/traces-drilldown) we make extensive use of `CustomVariable` and are trying to create history steps whenever a variable updates. 

There should be no breaking changes. 