### PR TITLE
Dashboards: Fix interaction with multi variable value pills

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -166,6 +166,11 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       tabSelectsValue={false}
       virtualized
       allowCustomValue={allowCustomValue}
+      // TODO: remove this when we update grafana-ui
+      // It'll complain about the type, but it
+      // will still pass the prop and fix the issue
+      // @ts-expect-error
+      menuShouldBlockScroll={false}
       //@ts-ignore
       toggleAllOptions={{
         enabled: true,


### PR DESCRIPTION
Fixes an issue in dashboards where the multi-var value pills could not be interacted with.  Seems to be an issue stemming from `react-select` itself.

Related fix in grafana-ui [here](https://github.com/grafana/grafana/pull/100728) 