### PR TITLE
Fallback page: fix infinite loop

### DIFF
--- a/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneApp.test.tsx
@@ -416,6 +416,30 @@ describe('SceneApp', () => {
         expect(await screen.findByTestId('custom-fallback-content')).toBeInTheDocument();
       });
     });
+
+    describe('Custom fallback page that loops on itself', () => {
+      const page: SceneAppPage = new SceneAppPage({
+        title: 'Test',
+        url: '/test',
+        routePath: 'test/*',
+        getScene: () => {
+          return new EmbeddedScene({
+            body: new SceneReactObject({
+              component: () => <div data-testid="custom-fallback-content">Loading...</div>,
+            }),
+          });
+        },
+        getFallbackPage: () => page,
+      });
+      const app = new SceneApp({
+        pages: [page],
+      });
+
+      it('should render custom loopback fallback page if url does not match', async () => {
+        renderAppInsideRouterWithStartingUrl(app, '/test/does-not-exist');
+        expect(await screen.findByTestId('custom-fallback-content')).toBeInTheDocument();
+      });
+    });
   });
 
   it('useSceneApp should cache instance', () => {

--- a/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPage.tsx
@@ -128,10 +128,7 @@ function getFallbackRoute(page: SceneAppPage) {
     <Route
       key={'fallback route'}
       path="*"
-      Component={() => {
-        const fallbackPage = page.state.getFallbackPage?.() ?? getDefaultFallbackPage();
-        return <SceneAppPageView page={fallbackPage} />;
-      }}
+      element={<SceneAppPageView page={page.state.getFallbackPage?.() ?? getDefaultFallbackPage()} />}
     ></Route>
   );
 }


### PR DESCRIPTION
:wave: 

Upgrading App O11y to scenes v6, found it's possible to get into infinite loop when a `SceneAppPage` specifies it's fallback page as itself (see test).

The use case is that we want `SceneApp` to render initialization page regardless of route to do some initial loading of metadata. Did not find a better way to do `any route` than to have a page fallback to itself, let me know if I'm missing something :bow: 

The cause of infinite loop was fallback `Route` using `Component` insted of `element`, which causes fallback page to re-mount on every render. And remounting was causing it to update `initializedScene` state prop of parent, causing further re-renders.
