### PR TITLE
SceneGridLayout: Allow to hook into `onDragStart` event

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -8,7 +8,7 @@ import { isSceneGridRow } from './SceneGridItem';
 import { SceneGridLayoutRenderer } from './SceneGridLayoutRenderer';
 
 import { SceneGridRow } from './SceneGridRow';
-import { SceneGridItemLike, SceneGridItemPlacement } from './types';
+import { SceneGridItemLike, SceneGridItemPlacement, SceneGridLayoutDragStartEvent } from './types';
 import { fitPanelsInHeight } from './utils';
 import { VizPanel } from '../../VizPanel/VizPanel';
 
@@ -26,12 +26,6 @@ interface SceneGridLayoutState extends SceneObjectState {
    * UNSAFE: This feature is experimental and it might change in the future.
    */
   UNSAFE_fitPanels?: boolean;
-  /**
-   * Useful for capturing when dragging started
-   * @param e
-   * @param panel
-   */
-  onDragStart?: (e: PointerEvent, panel: VizPanel) => void;
   children: SceneGridItemLike[];
 }
 
@@ -65,7 +59,11 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
   }
 
   public getDragHooks() {
-    return { onDragStart: this.state.onDragStart };
+    return {
+      onDragStart: (evt: PointerEvent, panel: VizPanel) => {
+        this.publishEvent(new SceneGridLayoutDragStartEvent({ evt, panel }), true);
+      },
+    };
   }
 
   public toggleRow(row: SceneGridRow) {

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -1,3 +1,4 @@
+import { PointerEvent } from 'react';
 import ReactGridLayout from 'react-grid-layout';
 
 import { SceneObjectBase } from '../../../core/SceneObjectBase';
@@ -9,6 +10,7 @@ import { SceneGridLayoutRenderer } from './SceneGridLayoutRenderer';
 import { SceneGridRow } from './SceneGridRow';
 import { SceneGridItemLike, SceneGridItemPlacement } from './types';
 import { fitPanelsInHeight } from './utils';
+import { VizPanel } from '../../VizPanel/VizPanel';
 
 interface SceneGridLayoutState extends SceneObjectState {
   /**
@@ -24,6 +26,12 @@ interface SceneGridLayoutState extends SceneObjectState {
    * UNSAFE: This feature is experimental and it might change in the future.
    */
   UNSAFE_fitPanels?: boolean;
+  /**
+   * Useful for capturing when dragging started
+   * @param e
+   * @param panel
+   */
+  onDragStart?: (e: PointerEvent, panel: VizPanel) => void;
   children: SceneGridItemLike[];
 }
 
@@ -54,6 +62,10 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
 
   public getDragClassCancel() {
     return `grid-drag-cancel`;
+  }
+
+  public getDragHooks() {
+    return { onDragStart: this.state.onDragStart };
   }
 
   public toggleRow(row: SceneGridRow) {

--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -1,4 +1,7 @@
+import { PointerEvent } from 'react';
 import { SceneObject, SceneObjectState } from '../../../core/types';
+import { BusEventWithPayload } from '@grafana/data';
+import { VizPanel } from '../../VizPanel/VizPanel';
 
 export interface SceneGridItemPlacement {
   x?: number;
@@ -17,4 +20,8 @@ export interface SceneGridItemLike extends SceneObject<SceneGridItemStateLike> {
    * Provide a custom CSS class name for the underlying DOM element when special styling (i.e. for mobile breakpoint) is required.
    **/
   getClassName?(): string;
+}
+
+export class SceneGridLayoutDragStartEvent extends BusEventWithPayload<{ evt: PointerEvent; panel: VizPanel }> {
+  public static readonly type = 'scene-grid-layout-drag-start';
 }

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -104,10 +104,12 @@ export {
 } from './components/layout/SceneFlexLayout';
 export { SceneCSSGridLayout, SceneCSSGridItem } from './components/layout/CSSGrid/SceneCSSGridLayout';
 export { SceneGridLayout } from './components/layout/grid/SceneGridLayout';
+export { SceneGridLayoutDragStartEvent } from './components/layout/grid/types';
 export { SceneGridItem } from './components/layout/grid/SceneGridItem';
 export { SceneGridRow } from './components/layout/grid/SceneGridRow';
 export { type SceneGridItemStateLike, type SceneGridItemLike } from './components/layout/grid/types';
 export { SplitLayout } from './components/layout/split/SplitLayout';
+export { LazyLoader } from './components/layout/LazyLoader';
 export {
   type SceneAppPageLike,
   type SceneRouteMatch,


### PR DESCRIPTION
Allow to hook into `onDragStart` event emitted by `PanelChrome` when dragging started.

Useful for drag'n'drop between layouts.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.1.1--canary.1059.13459243901.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.1.1--canary.1059.13459243901.0
  npm install @grafana/scenes@6.1.1--canary.1059.13459243901.0
  # or 
  yarn add @grafana/scenes-react@6.1.1--canary.1059.13459243901.0
  yarn add @grafana/scenes@6.1.1--canary.1059.13459243901.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
