### PR TITLE
Profiling: explicitly set profiling names

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -31,11 +31,11 @@ export class SceneQueryController
   public runningQueriesCount = () => {
     return this.#running.size;
   };
-  public startProfile(source: SceneObject) {
+  public startProfile(name: string) {
     if (!this.state.enableProfiling) {
       return;
     }
-    this.profiler.startProfile(source.constructor.name);
+    this.profiler.startProfile(name);
   }
 
   public queryStarted(entry: SceneQueryControllerEntry) {

--- a/packages/scenes/src/behaviors/types.ts
+++ b/packages/scenes/src/behaviors/types.ts
@@ -38,6 +38,6 @@ export interface SceneQueryControllerLike extends SceneObject<SceneQueryStateCon
 
   queryStarted(entry: SceneQueryControllerEntry): void;
   queryCompleted(entry: SceneQueryControllerEntry): void;
-  startProfile(source: SceneObject): void;
+  startProfile(name: string): void;
   runningQueriesCount(): number;
 }

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -85,7 +85,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   public onRefresh = () => {
     const queryController = sceneGraph.getQueryController(this);
 
-    queryController?.startProfile(this);
+    queryController?.startProfile('SceneRefreshPicker');
 
     if (queryController?.state.isRunning) {
       queryController.cancelAll();
@@ -191,7 +191,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
     this._intervalTimer = setInterval(() => {
       if (this.isTabVisible()) {
         const queryController = sceneGraph.getQueryController(this);
-        queryController?.startProfile(this);
+        queryController?.startProfile('SceneRefreshPicker');
         timeRange.onRefresh();
       } else {
         this._autoRefreshBlocked = true;

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -163,7 +163,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     // Only update if time range actually changed
     if (update.from !== this.state.from || update.to !== this.state.to) {
       const queryController = getQueryController(this);
-      queryController?.startProfile(this);
+      queryController?.startProfile('SceneTimeRange');
       this._urlSync.performBrowserHistoryAction(() => {
         this.setState(update);
       });

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -99,7 +99,7 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${value}`)}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!, true);
-        queryController?.startProfile(model);
+        queryController?.startProfile('VariableValueSelect');
 
         if (hasCustomValue !== newValue.__isNew__) {
           setHasCustomValue(newValue.__isNew__);
@@ -180,7 +180,7 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
       onInputChange={onInputChange}
       onBlur={() => {
         model.changeValueTo(uncommittedValue, undefined, true);
-        queryController?.startProfile(model);
+        queryController?.startProfile('VariableValueSelectMulti');
       }}
       filterOption={filterNoOp}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${uncommittedValue}`)}


### PR DESCRIPTION
It turns out when the profiling measurements are reported the name is missing. I suspect this is because of some optimization when building the prod artifacts is removing `constructor.name`.

We can instead set the profiling names explicitly to make sure they are submitted.