### PR TITLE
AdHocVariables: Allow custom value to be first

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -115,10 +115,10 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
     <Select
       virtualized
       allowCustomValue={model.state.allowCustomValue !== false ?? true}
+      createOptionPosition={model.state.allowCustomValue === 'first' ? 'first' : 'last'}
       isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
-      createOptionPosition={model.state.allowCustomValue === 'first' ? 'first' : 'last'}
       disabled={model.state.readOnly}
       className={cx(styles.value, isValuesOpen ? styles.widthWhenOpen : undefined)}
       width="auto"

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -114,10 +114,11 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
   const valueSelect = (
     <Select
       virtualized
-      allowCustomValue={model.state.allowCustomValue ?? true}
+      allowCustomValue={model.state.allowCustomValue !== false ?? true}
       isValidNewOption={(inputValue) => inputValue.trim().length > 0}
       allowCreateWhileLoading
       formatCreateLabel={(inputValue) => `Use custom value: ${inputValue}`}
+      createOptionPosition={model.state.allowCustomValue === 'first' ? 'first' : 'last'}
       disabled={model.state.readOnly}
       className={cx(styles.value, isValuesOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
@@ -173,7 +174,8 @@ export function AdHocFilterRenderer({ filter, model }: Props) {
       disabled={model.state.readOnly}
       className={cx(styles.key, isKeysOpen ? styles.widthWhenOpen : undefined)}
       width="auto"
-      allowCustomValue={model.state.allowCustomValue ?? true}
+      allowCustomValue={model.state.allowCustomValue !== false ?? true}
+      createOptionPosition={model.state.allowCustomValue === 'first' ? 'first' : 'last'}
       value={keyValue}
       placeholder={'Select label'}
       options={handleOptionGroups(keys)}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -213,11 +213,19 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
   if (allowCustomValue && filterInputType !== 'operator' && inputValue) {
-    filteredDropDownItems.push({
-      value: inputValue.trim(),
-      label: inputValue.trim(),
-      isCustom: true,
-    });
+    if(allowCustomValue === 'first'){
+      filteredDropDownItems.unshift({
+        value: inputValue.trim(),
+        label: inputValue.trim(),
+        isCustom: true,
+      });
+    }else{
+      filteredDropDownItems.push({
+        value: inputValue.trim(),
+        label: inputValue.trim(),
+        isCustom: true,
+      });
+    }
   }
 
   // Get the optional onAddCustomValue method from the AdHocFiltersVariable if defined

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -213,13 +213,13 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
   if (allowCustomValue && filterInputType !== 'operator' && inputValue) {
-    if(allowCustomValue === 'first'){
+    if (allowCustomValue === 'first') {
       filteredDropDownItems.unshift({
         value: inputValue.trim(),
         label: inputValue.trim(),
         isCustom: true,
       });
-    }else{
+    } else {
       filteredDropDownItems.push({
         value: inputValue.trim(),
         label: inputValue.trim(),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -364,8 +364,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     // should run new query when filter changed
     expect(runRequest.mock.calls.length).toBe(2);
     expect(filtersVar.state.filters[0].value).toBe('a');
-    // console.log('filtersVar.state.filters', filtersVar.state.filters)
-    // expect(filtersVar.state.filters[filtersVar.state.filters.length - 1].value).toBe('alice');
 
     await userEvent.click(selects[2]);
     await userEvent.clear(selects[2]);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -255,6 +255,137 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(options[5]).toHaveTextContent('Foo');
   });
 
+  it('can set custom value position - last', async () => {
+    const { filtersVar, runRequest } = setup({
+      getTagKeysProvider: async () => ({
+        replace: true,
+        values: [
+          {
+            text: 'Alice',
+            value: 'alice',
+          },
+          {
+            text: 'Anise',
+            value: 'anise',
+          },
+        ],
+      }),
+      getTagValuesProvider: async () => ({
+        replace: true,
+        values: [
+          {
+            text: 'Alice',
+            value: 'alice',
+          },
+          {
+            text: 'Anise',
+            value: 'anise',
+          },
+        ],
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    // Select the first value starting with "a"
+    await userEvent.type(selects[2], 'a{enter}');
+
+    // should run new query when filter changed
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe('alice');
+
+    await userEvent.click(selects[2]);
+    await userEvent.clear(selects[2]);
+    await userEvent.type(selects[2], 'a');
+    const customValueOption = screen.getByText('Use custom value: a');
+    const options = screen.getAllByRole('option')
+    expect(options[0].textContent).toEqual('Alice')
+    expect(options[1].textContent).toEqual('Anise')
+    expect(options[2].textContent).toEqual('Use custom value: a')
+
+
+    expect(customValueOption).toBeInTheDocument();
+
+    await userEvent.type(selects[2], '[ArrowDown][ArrowDown]{enter}');
+
+    // should run a new query because the value has changed
+    expect(runRequest.mock.calls.length).toBe(3);
+    expect(filtersVar.state.filters[0].value).toBe('a');
+  });
+
+  it('can set custom value position - first', async () => {
+    const { filtersVar, runRequest } = setup({
+      allowCustomValue: 'first',
+      getTagKeysProvider: async () => ({
+        replace: true,
+        values: [
+          {
+            text: 'Alice',
+            value: 'alice',
+          },
+          {
+            text: 'Anise',
+            value: 'anise',
+          },
+        ],
+      }),
+      getTagValuesProvider: async () => ({
+        replace: true,
+        values: [
+          {
+            text: 'Alice',
+            value: 'alice',
+          },
+          {
+            text: 'Anise',
+            value: 'anise',
+          },
+        ],
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    // should run initial query
+    expect(runRequest.mock.calls.length).toBe(1);
+
+    const wrapper = screen.getByTestId('AdHocFilter-key1');
+    const selects = getAllByRole(wrapper, 'combobox');
+
+    // Select the first value starting with "a"
+    await userEvent.type(selects[2], 'a{enter}');
+
+    // should run new query when filter changed
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe('a');
+    // console.log('filtersVar.state.filters', filtersVar.state.filters)
+    // expect(filtersVar.state.filters[filtersVar.state.filters.length - 1].value).toBe('alice');
+
+    await userEvent.click(selects[2]);
+    await userEvent.clear(selects[2]);
+    await userEvent.type(selects[2], 'a');
+    const customValueOption = screen.getByText('Use custom value: a');
+    const options = screen.getAllByRole('option')
+    expect(options[1].textContent).toEqual('Alice')
+    expect(options[2].textContent).toEqual('Anise')
+    expect(options[0].textContent).toEqual('Use custom value: a')
+
+
+    expect(customValueOption).toBeInTheDocument();
+
+    await userEvent.type(selects[2], '{enter}');
+
+    // should not run a new query since the value is the same
+    expect(runRequest.mock.calls.length).toBe(2);
+    expect(filtersVar.state.filters[0].value).toBe('a');
+  });
+
   it('can set the same custom value again', async () => {
     const { filtersVar, runRequest } = setup();
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -304,11 +304,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     await userEvent.clear(selects[2]);
     await userEvent.type(selects[2], 'a');
     const customValueOption = screen.getByText('Use custom value: a');
-    const options = screen.getAllByRole('option')
-    expect(options[0].textContent).toEqual('Alice')
-    expect(options[1].textContent).toEqual('Anise')
-    expect(options[2].textContent).toEqual('Use custom value: a')
-
+    const options = screen.getAllByRole('option');
+    expect(options[0].textContent).toEqual('Alice');
+    expect(options[1].textContent).toEqual('Anise');
+    expect(options[2].textContent).toEqual('Use custom value: a');
 
     expect(customValueOption).toBeInTheDocument();
 
@@ -369,11 +368,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     await userEvent.clear(selects[2]);
     await userEvent.type(selects[2], 'a');
     const customValueOption = screen.getByText('Use custom value: a');
-    const options = screen.getAllByRole('option')
-    expect(options[1].textContent).toEqual('Alice')
-    expect(options[2].textContent).toEqual('Anise')
-    expect(options[0].textContent).toEqual('Use custom value: a')
-
+    const options = screen.getAllByRole('option');
+    expect(options[1].textContent).toEqual('Alice');
+    expect(options[2].textContent).toEqual('Anise');
+    expect(options[0].textContent).toEqual('Use custom value: a');
 
     expect(customValueOption).toBeInTheDocument();
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -108,7 +108,7 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   /**
    * Flag that decides whether custom values can be added to the filter
    */
-  allowCustomValue?: boolean;
+  allowCustomValue?: boolean | 'first';
 
   /**
    * @internal state of the new filter being added


### PR DESCRIPTION
Allows pushing the custom variable to the top of the list in ad hoc variables.

Notes for reviewer:
The type for allowCustomVariable: `allowCustomValue?: boolean | 'first';` is admittedly not very ergonomic, but I wasn't sure if we wanted to add an additional state property for this.

Fixes: https://github.com/grafana/scenes/issues/1065.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.0--canary.1066.13575913588.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.2.0--canary.1066.13575913588.0
  npm install @grafana/scenes@6.2.0--canary.1066.13575913588.0
  # or 
  yarn add @grafana/scenes-react@6.2.0--canary.1066.13575913588.0
  yarn add @grafana/scenes@6.2.0--canary.1066.13575913588.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
