### PR TITLE
VizPanel: Enable customTooltip 

### DIFF
--- a/packages/scenes/README.md
+++ b/packages/scenes/README.md
@@ -29,20 +29,21 @@ To work on @grafana/scenes SDK, please follow the guides below.
 
 ### Setting up @grafana/scenes with a local Grafana instance
 
-To setup scenes with local Grafana, the following setup is required:
+To set up scenes with local Grafana, the following setup is required:
 
 1. Clone the [Grafana Scenes repository](https://github.com/grafana/scenes/).
-1. Clone the [Grafana](https://github.com/grafana/grafana/) repository and follow the [Development guide](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#developer-guide).
-1. Setup env variable `GRAFANA_PATH` to point to your Grafana repository directory, `export GRAFANA_PATH=<path-to-grafana-directory>`
-1. From Grafana Scenes root directory run `./scripts/dev.sh`. This will compile @grafana/scenes with watch mode enabled and link it to your Grafana.
-1. From Grafana directory run `yarn install`.
+2. Clone the [Grafana](https://github.com/grafana/grafana/) repository and follow the [Development guide](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#developer-guide).
+3. Setup env variable `GRAFANA_PATH` to point to your Grafana repository directory, `export GRAFANA_PATH=<path-to-grafana-directory>`
+4. From Grafana Scenes root directory run `./scripts/dev.sh`. This will compile @grafana/scenes with watch mode enabled and link it to your Grafana.
+5. From Grafana directory run `yarn install`.
+6. From Grafana directory run `make run`.
 
 ### Setting up local version of @grafana/scenes with app plugin
 
 1. Run `YARN_IGNORE_PATH=1 yarn link` from `packages/scenes` directory.
-1. Run `yarn dev` from `packages/scenes` directory.
-1. Run `yarn link @grafana/scenes` from app plugin directory.
-1. Start app plugin development server.
+2. Run `yarn dev` from `packages/scenes` directory.
+3. Run `yarn link @grafana/scenes` from app plugin directory.
+4. Start app plugin development server.
 
 ### Demo app
 

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -37,6 +37,7 @@ import { UserActionEvent } from '../../core/events';
 import { evaluateTimeRange } from '../../utils/evaluateTimeRange';
 import { LiveNowTimer } from '../../behaviors/LiveNowTimer';
 import { registerQueryWithController, wrapPromiseInStateObservable } from '../../querying/registerQueryWithController';
+import React from 'react';
 
 export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectState {
   /**
@@ -47,6 +48,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   title: string;
   description?: string;
   options: DeepPartial<TOptions>;
+  customTooltip?: React.ReactNode;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;
   displayMode?: 'default' | 'transparent';

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -48,7 +48,8 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   title: string;
   description?: string;
   options: DeepPartial<TOptions>;
-  customTooltip?: React.ReactNode;
+  /**  * When set, it disregards the <options.tooltip> in favor of a fully customizable one.*/
+  getCustomTooltip?: (props: any) => React.ReactNode;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;
   displayMode?: 'default' | 'transparent';

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -16,6 +16,9 @@ import {
   PluginType,
   renderMarkdown,
   PanelPluginDataSupport,
+  DataFrame,
+  Field,
+  LinkModel,
 } from '@grafana/data';
 import { PanelContext, SeriesVisibilityChangeMode, VizLegendOptions } from '@grafana/ui';
 import { config, getAppEvents, getPluginImportUtils } from '@grafana/runtime';
@@ -38,6 +41,26 @@ import { evaluateTimeRange } from '../../utils/evaluateTimeRange';
 import { LiveNowTimer } from '../../behaviors/LiveNowTimer';
 import { registerQueryWithController, wrapPromiseInStateObservable } from '../../querying/registerQueryWithController';
 import React from 'react';
+import { SortOrder } from '@grafana/schema';
+
+export interface PanelCustomTimeSeriesTooltip {
+  data: DataFrame[]; // Unified structure including both series & non-series data
+  isGraphable?: (field: Field) => boolean; // Optional helper to check if a field is graphable
+
+  // hovered points
+  dataIdxs: Array<number | null>;
+  // closest/hovered series
+  seriesIdx?: number | null;
+  sortOrder?: SortOrder;
+
+  isPinned: boolean;
+
+  maxHeight?: number;
+
+  replaceVariables?: InterpolateFunction;
+  dataLinks: LinkModel[];
+  hideZeros?: boolean;
+}
 
 export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneObjectState {
   /**
@@ -48,8 +71,9 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   title: string;
   description?: string;
   options: DeepPartial<TOptions>;
+  
   /**  * When set, it disregards the <options.tooltip> in favor of a fully customizable one.*/
-  getCustomTooltip?: (props: any) => React.ReactNode;
+  getCustomTooltip?: (props: PanelCustomTimeSeriesTooltip) => React.ReactNode;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;
   displayMode?: 'default' | 'transparent';

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -19,6 +19,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
     title,
     options,
+    customTooltip,
     fieldConfig,
     _pluginLoadError,
     displayMode,
@@ -214,6 +215,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                           timeRange={timeRange}
                           timeZone={timeZone}
                           options={options}
+                          customTooltip={customTooltip}
                           fieldConfig={fieldConfig}
                           transparent={false}
                           width={innerWidth}

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -19,7 +19,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
     title,
     options,
-    customTooltip,
+    getCustomTooltip,
     fieldConfig,
     _pluginLoadError,
     displayMode,
@@ -215,7 +215,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                           timeRange={timeRange}
                           timeZone={timeZone}
                           options={options}
-                          customTooltip={customTooltip}
+                          getCustomTooltip={getCustomTooltip}
                           fieldConfig={fieldConfig}
                           transparent={false}
                           width={innerWidth}

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -62,6 +62,14 @@ export class VizPanelBuilder<TOptions extends {}, TFieldConfig extends {}>
   }
 
   /**
+   * Set custom tooltip.
+   */
+  public setCustomTooltip(customTooltip: VizPanelState['customTooltip']): this {
+    this._state.customTooltip = customTooltip;
+    return this;
+  }
+
+  /**
    * Set if VizPanelMenu "kebab" icon is shown on panel hover for desktop devices. Set true to always show menu icon.
    * @param showMenuAlways
    */

--- a/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
+++ b/packages/scenes/src/core/PanelBuilders/VizPanelBuilder.ts
@@ -64,8 +64,8 @@ export class VizPanelBuilder<TOptions extends {}, TFieldConfig extends {}>
   /**
    * Set custom tooltip.
    */
-  public setCustomTooltip(customTooltip: VizPanelState['customTooltip']): this {
-    this._state.customTooltip = customTooltip;
+  public setCustomTooltip(customTooltip: VizPanelState['getCustomTooltip']): this {
+    this._state.getCustomTooltip = customTooltip;
     return this;
   }
 


### PR DESCRIPTION
Enable custom tooltip in `VizPanel`.

This PR is directly related and dependent on the[ Grafana Add support for Custom Tooltips in Dashboard Panels PR](https://github.com/grafana/grafana/pull/101090), so should be reviewed after that one is approved, merged and released, meaning it will remain as a draft in the meantime.
