### PR TITLE
SceneObjectBase: Fixes crash TypeError circular reference when stringifying scene object

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -137,7 +137,9 @@ describe('SceneObject', () => {
       nested: new TestScene({ key: 'nested' }),
     });
 
-    expect(JSON.stringify(scene)).toBe('{"key":"root","nested":{"key":"nested"}}');
+    expect(JSON.stringify(scene)).toBe(
+      '{"type":"TestScene","isActive":false,"state":{"key":"root","nested":{"type":"TestScene","isActive":false,"state":{"key":"nested"}}}}'
+    );
   });
 
   it('Cannot modify state', () => {

--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -131,6 +131,15 @@ describe('SceneObject', () => {
     expect(ref).toBe(scene.getRef());
   });
 
+  it('Can json stringify', () => {
+    const scene = new TestScene({
+      key: 'root',
+      nested: new TestScene({ key: 'nested' }),
+    });
+
+    expect(JSON.stringify(scene)).toBe('{"key":"root","nested":{"key":"nested"}}');
+  });
+
   it('Cannot modify state', () => {
     const scene = new TestScene({ name: 'name' });
     expect(() => {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -372,7 +372,11 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   }
 
   public toJSON() {
-    return this.state;
+    return {
+      type: Object.getPrototypeOf(this).constructor.name,
+      isActive: this.isActive,
+      state: this.state,
+    };
   }
 }
 

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -370,6 +370,10 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
 
     return this._ref;
   }
+
+  public toJSON() {
+    return this.state;
+  }
 }
 
 /**


### PR DESCRIPTION
We use tests a lot that verify scene object instance is what we expect, when these tests fail jest usually prints this 

```
 Test suite failed to run

    TypeError: Converting circular structure to JSON
        --> starting at object with constructor 'PanelTimeRange'
        |     property '_variableDependency' -> object with constructor 'VariableDependencyConfig'
        --- property '_sceneObject' closes the circle
        at stringify (<anonymous>)

      at messageParent (node_modules/jest-worker/build/workers/messageParent.js:29:19)
```

This PR fixes this to implement a custom toJSON function  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.0--canary.1070.13674378560.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.2.0--canary.1070.13674378560.0
  npm install @grafana/scenes@6.2.0--canary.1070.13674378560.0
  # or 
  yarn add @grafana/scenes-react@6.2.0--canary.1070.13674378560.0
  yarn add @grafana/scenes@6.2.0--canary.1070.13674378560.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
