### PR TITLE
Variables: Unify options filtering to use most up to date implementation

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -25,7 +25,6 @@ import {
 import {
   ERROR_STATE_DROPDOWN_WIDTH,
   flattenOptionGroups,
-  searchOptions,
   generateFilterUpdatePayload,
   generatePlaceholder,
   populateInputValueOnInputTypeSwitch,
@@ -39,6 +38,7 @@ import {
 import { handleOptionGroups } from '../../utils';
 import { useFloatingInteractions, MAX_MENU_HEIGHT } from './useFloatingInteractions';
 import { MultiValuePill } from './MultiValuePill';
+import { getAdhocOptionSearcher } from '../getAdhocOptionSearcher';
 
 interface AdHocComboboxProps {
   filter?: AdHocFilterWithLabels;
@@ -81,7 +81,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   const disabledIndicesRef = useRef<number[]>([]);
   const filterInputTypeRef = useRef<AdHocInputType>(!isAlwaysWip ? 'value' : 'key');
 
-  const optionsSearcher = useMemo(() => searchOptions(options), [options]);
+  const optionsSearcher = useMemo(() => getAdhocOptionSearcher(options), [options]);
 
   const isLastFilter = useMemo(() => {
     if (isAlwaysWip) {
@@ -208,7 +208,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   // operation order on fetched options:
   //    fuzzy search -> extract into groups -> flatten group labels and options
   const filteredDropDownItems = flattenOptionGroups(
-    handleOptionGroups(optionsSearcher(preventFiltering ? '' : inputValue, filterInputType))
+    handleOptionGroups(optionsSearcher(preventFiltering ? '' : inputValue))
   );
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -1,7 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { AdHocInputType } from './AdHocFiltersCombobox';
 import { AdHocFilterWithLabels, isMultiValueOperator, OnAddCustomValueFn } from '../AdHocFiltersVariable';
-import { getFuzzySearcher } from '../../utils';
 
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
 const VIRTUAL_LIST_DESCRIPTION_WIDTH_ESTIMATE_MULTIPLIER = 6;
@@ -11,27 +10,6 @@ export const VIRTUAL_LIST_ITEM_HEIGHT = 38;
 export const VIRTUAL_LIST_ITEM_HEIGHT_WITH_DESCRIPTION = 60;
 export const ERROR_STATE_DROPDOWN_WIDTH = 366;
 
-// https://catonmat.net/my-favorite-regex :)
-const REGEXP_NON_ASCII = /[^ -~]/m;
-
-export function searchOptions(options: Array<SelectableValue<string>>) {
-  const haystack = options.map((o) => o.label ?? o.value!);
-  const fuzzySearch = getFuzzySearcher(haystack);
-
-  return (search: string, filterInputType: AdHocInputType) => {
-    // fall back to substring matching for non-latin chars
-    if (REGEXP_NON_ASCII.test(search)) {
-      return options.filter((o) => o.label?.includes(search) || o.value?.includes(search) || false);
-    }
-
-    if (filterInputType === 'operator' && search !== '') {
-      // uFuzzy can only match non-alphanum chars if quoted
-      search = `"${search}"`;
-    }
-
-    return fuzzySearch(search).map((i) => options[i]);
-  };
-}
 export const flattenOptionGroups = (options: Array<SelectableValue<string>>) =>
   options.flatMap<SelectableValue<string>>((option) => (option.options ? [option, ...option.options] : [option]));
 

--- a/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
+++ b/packages/scenes/src/variables/adhoc/getAdhocOptionSearcher.ts
@@ -1,9 +1,8 @@
 import { SelectableValue } from '@grafana/data';
-import { getFuzzySearcher } from '../utils';
+import { fuzzyFind } from '../filter';
 
 export function getAdhocOptionSearcher(options: SelectableValue[]) {
   const haystack = options.map((o) => o.label ?? String(o.value));
-  const fuzzySearch = getFuzzySearcher(haystack);
 
-  return (search: string) => fuzzySearch(search).map((i) => options[i]);
+  return (search: string) => fuzzyFind<SelectableValue>(options, haystack, search);
 }

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -1,6 +1,6 @@
 import { VariableValueOption } from '../types';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
-import { getFuzzySearcher } from '../utils';
+import { fuzzyFind } from '../filter';
 
 export function getOptionSearcher(options: VariableValueOption[], includeAll = false) {
   let allOptions = options;
@@ -10,7 +10,6 @@ export function getOptionSearcher(options: VariableValueOption[], includeAll = f
   }
 
   const haystack = allOptions.map((o) => o.label);
-  const fuzzySearch = getFuzzySearcher(haystack);
 
-  return (search: string) => fuzzySearch(search).map((i) => allOptions[i]);
+  return (search: string) => fuzzyFind<VariableValueOption>(allOptions, haystack, search);
 }

--- a/packages/scenes/src/variables/filter.test.ts
+++ b/packages/scenes/src/variables/filter.test.ts
@@ -1,0 +1,74 @@
+import { fuzzyFind } from './filter';
+
+describe('filter', () => {
+  it('should properly rank by match quality', () => {
+    const needle = 'C';
+
+    const stringOptions = ['A', 'AA', 'AB', 'AC', 'BC', 'C', 'CD'];
+    const options = stringOptions.map((value) => ({ value }));
+
+    const matches = fuzzyFind(options, stringOptions, needle);
+
+    expect(matches.map((m) => m.value)).toEqual(['C', 'CD', 'AC', 'BC']);
+  });
+
+  it('orders by match quality and case sensitivity', () => {
+    const stringOptions = [
+      'client_service_namespace',
+      'namespace',
+      'alert_namespace',
+      'container_namespace',
+      'Namespace',
+      'client_k8s_namespace_name',
+      'foobar',
+    ];
+    const options = stringOptions.map((value) => ({ value }));
+
+    const matches = fuzzyFind(options, stringOptions, 'Names');
+
+    expect(matches.map((m) => m.value)).toEqual([
+      'Namespace',
+      'namespace',
+      'alert_namespace',
+      'container_namespace',
+      'client_k8s_namespace_name',
+      'client_service_namespace',
+    ]);
+  });
+
+  describe('non-ascii', () => {
+    it('should do substring match when needle is non-latin', () => {
+      const needle = '水';
+
+      const stringOptions = ['A水', 'AA', 'AB', 'AC', 'BC', 'C', 'CD'];
+      const options = stringOptions.map((value) => ({ value }));
+
+      const matches = fuzzyFind(options, stringOptions, needle);
+
+      expect(matches.map((m) => m.value)).toEqual(['A水']);
+    });
+
+    it('second case for non-latin characters', () => {
+      const stringOptions = ['台灣省', '台中市', '台北市', '台南市', '南投縣', '高雄市', '台中第一高級中學'];
+
+      const options = stringOptions.map((value) => ({ value }));
+
+      const matches = fuzzyFind(options, stringOptions, '南');
+
+      expect(matches.map((m) => m.value)).toEqual(['台南市', '南投縣']);
+    });
+  });
+
+  describe('operators', () => {
+    it('should do substring match when needle is only symbols', () => {
+      const needle = '=';
+
+      const stringOptions = ['=', '<=', '>', '!~'];
+      const options = stringOptions.map((value) => ({ value }));
+
+      const matches = fuzzyFind(options, stringOptions, needle);
+
+      expect(matches.map((m) => m.value)).toEqual(['=', '<=']);
+    });
+  });
+});

--- a/packages/scenes/src/variables/filter.ts
+++ b/packages/scenes/src/variables/filter.ts
@@ -1,0 +1,64 @@
+import { SelectableValue } from '@grafana/data';
+import uFuzzy from '@leeoniya/ufuzzy';
+import { VariableValueOption } from './types';
+
+// https://catonmat.net/my-favorite-regex :)
+const REGEXP_NON_ASCII = /[^ -~]/m;
+// https://www.asciitable.com/
+// matches only these: `~!@#$%^&*()_+-=[]\{}|;':",./<>?
+const REGEXP_ONLY_SYMBOLS = /^[\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E]+$/m;
+// limit max terms in needle that qualify for re-ordering
+const outOfOrderLimit = 5;
+// beyond 25 chars fall back to substring search
+const maxNeedleLength = 25;
+// beyond 5 terms fall back to substring match
+const maxFuzzyTerms = 5;
+// when number of matches <= 1e4, do ranking + sorting by quality
+const rankThreshold = 1e4;
+
+// typo tolerance mode
+const uf = new uFuzzy({ intraMode: 1 });
+
+export function fuzzyFind<T extends SelectableValue | VariableValueOption>(
+  options: T[],
+  haystack: string[],
+  needle: string
+) {
+  let matches: T[] = [];
+
+  if (needle === '') {
+    matches = options;
+  }
+  // fallback to substring matches to avoid badness
+  else if (
+    // contains non-ascii
+    REGEXP_NON_ASCII.test(needle) ||
+    // is only ascii symbols (operators)
+    REGEXP_ONLY_SYMBOLS.test(needle) ||
+    // too long (often copy-paste from somewhere)
+    needle.length > maxNeedleLength ||
+    uf.split(needle).length > maxFuzzyTerms
+  ) {
+    for (let i = 0; i < haystack.length; i++) {
+      let item = haystack[i];
+
+      if (item.includes(needle)) {
+        matches.push(options[i]);
+      }
+    }
+  }
+  // fuzzy search
+  else {
+    const [idxs, info, order] = uf.search(haystack, needle, outOfOrderLimit, rankThreshold);
+
+    if (idxs?.length) {
+      if (info && order) {
+        matches = order.map((idx) => options[info.idx[idx]]);
+      } else {
+        matches = idxs.map((idx) => options[idx]);
+      }
+    }
+  }
+
+  return matches;
+}

--- a/packages/scenes/src/variables/utils.test.ts
+++ b/packages/scenes/src/variables/utils.test.ts
@@ -4,12 +4,10 @@ import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLa
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObjectState } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
-import { escapeURLDelimiters, getFuzzySearcher, getQueriesForVariables } from './utils';
+import { escapeURLDelimiters, getQueriesForVariables } from './utils';
 import { SceneVariableSet } from './sets/SceneVariableSet';
 import { DataSourceVariable } from './variants/DataSourceVariable';
 import { GetDataSourceListFilters } from '@grafana/runtime';
-import { searchOptions } from './adhoc/AdHocFiltersCombobox/utils';
-import { SelectableValue } from '@grafana/data';
 
 describe('getQueriesForVariables', () => {
   it('should resolve queries', () => {
@@ -302,49 +300,6 @@ describe('getQueriesForVariables', () => {
       { datasource: { uid: '${dsVar}' }, refId: 'D' },
       { datasource: { type: 'prometheus' }, refId: 'E' },
     ]);
-  });
-});
-
-describe('getFuzzySearcher orders by match quality with case-sensitivity', () => {
-  it('Can filter options by search query', async () => {
-    const haystack = [
-      'client_service_namespace',
-      'namespace',
-      'alert_namespace',
-      'container_namespace',
-      'Namespace',
-      'client_k8s_namespace_name',
-      'foobar',
-    ];
-
-    const searcher = getFuzzySearcher(haystack);
-
-    expect(searcher('Names').map((i) => haystack[i])).toEqual([
-      'Namespace',
-      'namespace',
-      'alert_namespace',
-      'container_namespace',
-      'client_k8s_namespace_name',
-      'client_service_namespace',
-    ]);
-  });
-});
-
-describe('searchOptions falls back to substring matching for non-latin needles', () => {
-  it('Can filter options by search query', async () => {
-    const options: SelectableValue[] = [
-      '台灣省',
-      '台中市',
-      '台北市',
-      '台南市',
-      '南投縣',
-      '高雄市',
-      '台中第一高級中學',
-    ].map((v) => ({ label: v, value: v }));
-
-    const searcher = searchOptions(options);
-
-    expect(searcher('南', 'key').map((o) => o.label!)).toEqual(['台南市', '南投縣']);
   });
 });
 

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -5,7 +5,6 @@ import { sceneGraph } from '../core/sceneGraph';
 import { SceneDataQuery, SceneObject, SceneObjectState } from '../core/types';
 import { SceneQueryRunner } from '../querying/SceneQueryRunner';
 import { DataSourceRef } from '@grafana/schema';
-import uFuzzy from '@leeoniya/ufuzzy';
 
 export function isVariableValueEqual(a: VariableValue | null | undefined, b: VariableValue | null | undefined) {
   if (a === b) {
@@ -237,35 +236,4 @@ export function handleOptionGroups(values: SelectableValue[]): Array<SelectableV
   }
 
   return result;
-}
-
-export function getFuzzySearcher(haystack: string[], limit = 10_000) {
-  const ufuzzy = new uFuzzy();
-
-  const FIRST = Array.from({ length: Math.min(limit, haystack.length) }, (_, i) => i);
-
-  // returns matched indices by quality
-  return (search: string): number[] => {
-    if (search === '') {
-      return FIRST;
-    }
-
-    const [idxs, info, order] = ufuzzy.search(haystack, search);
-
-    if (idxs) {
-      if (info && order) {
-        const outIdxs = Array(Math.min(order.length, limit));
-
-        for (let i = 0; i < outIdxs.length; i++) {
-          outIdxs[i] = info.idx[order[i]];
-        }
-
-        return outIdxs;
-      }
-
-      return idxs.slice(0, limit);
-    }
-
-    return [];
-  };
 }


### PR DESCRIPTION
The recent improvement to filtering were only applied to the custom logic for the new ad hoc combobox so the issues we were solving did not apply to Select and Group By.
Therefore unifying the filtering logic and using the latest filtering implementation from the new Combobox component [link](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Combobox/filter.ts)

Note: new implementation simplifies symbol searching therefore combining the options searching for ad hoc filters into one

fixes https://github.com/grafana/grafana/issues/90459
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.1.5--canary.1071.13674684765.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.1.5--canary.1071.13674684765.0
  npm install @grafana/scenes@6.1.5--canary.1071.13674684765.0
  # or 
  yarn add @grafana/scenes-react@6.1.5--canary.1071.13674684765.0
  yarn add @grafana/scenes@6.1.5--canary.1071.13674684765.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
