### PR TITLE
fix: explore button to preserve datasource selection in mixed datasource panels

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
@@ -14,7 +14,7 @@ export interface ExploreButtonOptions {
   onClick?: () => void;
 
   // Callback to modify interpolated query before passing it to explore
-  transform?: (query: DataQuery | DataQuery[]) => DataQuery | DataQuery[];
+  transform?: (query: DataQuery) => DataQuery;
 
   // Title and href for the return to previous button
   returnToPrevious?: {

--- a/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelExploreButton.tsx
@@ -14,7 +14,7 @@ export interface ExploreButtonOptions {
   onClick?: () => void;
 
   // Callback to modify interpolated query before passing it to explore
-  transform?: (query: DataQuery) => DataQuery;
+  transform?: (query: DataQuery | DataQuery[]) => DataQuery | DataQuery[];
 
   // Title and href for the return to previous button
   returnToPrevious?: {
@@ -42,10 +42,13 @@ function VizPanelExploreButtonComponent({ model }: SceneComponentProps<VizPanelE
 
   const { from, to } = sceneGraph.getTimeRange(model).useState();
 
-  const { value: exploreLink } = useAsync(
-    async () => (data ? getExploreURL(data, model, { from, to }, options.transform) : ''),
-    [data, model, from, to]
-  );
+  const { value: exploreLink } = useAsync(async () => {
+    if (!data) {
+      return '';
+    }
+
+    return getExploreURL(data, model, { from, to }, options.transform);
+  }, [data, model, from, to]);
 
   const returnToPrevious = useReturnToPrevious();
 

--- a/packages/scenes/src/utils/explore.ts
+++ b/packages/scenes/src/utils/explore.ts
@@ -47,16 +47,6 @@ export async function getExploreURL(
     ? '-- Mixed --'
     : queries.find((query) => !!query.datasource?.uid)?.datasource?.uid;
 
-  // If there are multiple queries with different data sources, ensure all queries are included.
-  // Maintain all queries and just update the datasource for mixed case
-  if (hasMixedDatasources) {
-    queries.forEach((query) => {
-      if (!query.datasource?.uid) {
-        query.datasource = { uid: '-- Mixed --' }; // For mixed datasource, mark as "-- Mixed --"
-      }
-    });
-  }
-
   if (queries?.length && datasource && from && to) {
     const left = encodeURIComponent(
       JSON.stringify({

--- a/packages/scenes/src/utils/explore.ts
+++ b/packages/scenes/src/utils/explore.ts
@@ -37,7 +37,7 @@ export async function getExploreURL(
     .map((q) => q.value)
     .map((q) => transform?.(q) ?? q);
 
-  const queries: DataQuery[] = interpolatedQueries?.flat() ?? [];
+  const queries: DataQuery[] = interpolatedQueries ?? [];
 
   // Check if we have mixed datasources (more than one unique datasource)
   const hasMixedDatasources = new Set(queries.map((q) => q.datasource?.uid)).size > 1;

--- a/packages/scenes/src/utils/explore.ts
+++ b/packages/scenes/src/utils/explore.ts
@@ -11,7 +11,7 @@ export async function getExploreURL(
   data: PanelData,
   model: SceneObject,
   timeRange: RawTimeRange,
-  transform?: (query: DataQuery | DataQuery[]) => DataQuery | DataQuery[]
+  transform?: (query: DataQuery) => DataQuery
 ): Promise<string> {
   const targets = data.request?.targets;
   if (!targets) {


### PR DESCRIPTION
In a Time Series panel using VizPanel from Grafana Scenes, I encountered an issue when using a mixed datasource setup with both Prometheus and Loki:

- The panel itself correctly displays data from both datasources.
- However, **clicking the Explore button redirects the user to Explore mode, but only Loki queries appear, while the Prometheus queries are missing**.


This happens because `getExploreURL` was not preserving the original datasource assignments from the panel when constructing the Explore URL. Instead, it was defaulting to the last interpolated query’s datasource, causing some queries to be omitted in the Explore view.


**Solution**
- If multiple unique datasource UIDs exist, the `getExploreURL` function now marks the Explore request as` "-- Mixed --"` instead of defaulting to only one datasource. This allows all queries, including those from different datasources, to be passed correctly to Explore
Updated tests. 

**The Explore UI before/after**

![before](https://github.com/user-attachments/assets/dff7e9bc-43bc-4131-b909-2b28430c83a0)


![after](https://github.com/user-attachments/assets/1d4f350b-ddfb-4607-b9a7-229800a78a68)


Fixes issue https://github.com/grafana/grafana-dbo11y-app/issues/738
