### PR TITLE
Local dev: link to all @grafana modules in core

### DIFF
--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -75,6 +75,7 @@
     "@types/react-dom": "18.2.24",
     "@types/react-grid-layout": "1.3.2",
     "@types/react-virtualized-auto-sizer": "1.0.1",
+    "@types/systemjs": "^6.15.1",
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -510,7 +510,6 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   return (
     <div className={styles.comboboxWrapper}>
-      <div>HELLO SALKDJALKSDJLAKSJDKJL</div>
       {filter ? (
         <div className={styles.pillWrapper}>
           {/* Filter key pill render */}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -510,6 +510,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   return (
     <div className={styles.comboboxWrapper}>
+      <div>HELLO SALKDJALKSDJLAKSJDKJL</div>
       {filter ? (
         <div className={styles.pillWrapper}>
           {/* Filter key pill render */}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
+cleanup() {
+    cd $scenespath
+    # have to use `npm pkg delete` instead of `yarn remove` else it will remove it from peerDeps as well
+    npm pkg delete devDependencies.@grafana/runtime devDependencies.@grafana/data devDependencies.@grafana/ui devDependencies.@grafana/schema devDependencies.@grafana/e2e-selectors
+    cd $rootpath
+    yarn install
+}
+trap cleanup SIGINT SIGTERM
 set -e
 
 if [[ -z "${GRAFANA_PATH}" ]]; then
     echo "Set GRAFANA_PATH env variable first"
 fi
 
-scenespath=$(pwd)
+rootpath=$(pwd)
 scenespath=$(pwd)/packages/scenes
 
 echo $scenespath
+
+cd $rootpath
+# have to manually add a link here instead of using `yarn link` because it errors with peerDep conflicts
+yarn workspace @grafana/scenes add -D '@grafana/runtime'@link:$GRAFANA_PATH/packages/grafana-runtime
+yarn workspace @grafana/scenes add -D '@grafana/data'@link:$GRAFANA_PATH/packages/grafana-data
+yarn workspace @grafana/scenes add -D '@grafana/ui'@link:$GRAFANA_PATH/packages/grafana-ui
+yarn workspace @grafana/scenes add -D '@grafana/schema'@link:$GRAFANA_PATH/packages/grafana-schema
+yarn workspace @grafana/scenes add -D '@grafana/e2e-selectors'@link:$GRAFANA_PATH/packages/grafana-e2e-selectors
 
 yarn install
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,6 +3827,7 @@ __metadata:
     "@types/react-dom": "npm:18.2.24"
     "@types/react-grid-layout": "npm:1.3.2"
     "@types/react-virtualized-auto-sizer": "npm:1.0.1"
+    "@types/systemjs": "npm:^6.15.1"
     "@types/uuid": "npm:8.3.4"
     "@typescript-eslint/eslint-plugin": "npm:^4.33.0"
     "@typescript-eslint/parser": "npm:^4.33.0"
@@ -7193,6 +7194,13 @@ __metadata:
   version: 1.1.3
   resolution: "@types/string-hash@npm:1.1.3"
   checksum: 10/39a546088123efb1af9beac3854aa1eb54cf24ab75d99c8dac9ccfa7d46d70ac7c99c10983f7cc623dda1e476b6e21e7acffe6c5b3be894751ae4b9cfd103aaf
+  languageName: node
+  linkType: hard
+
+"@types/systemjs@npm:^6.15.1":
+  version: 6.15.1
+  resolution: "@types/systemjs@npm:6.15.1"
+  checksum: 10/4c29f4951299b67a287b8b21219416c4d8eee277582ae045f6a97eaaa9d27ad59789f6b608c5519adf0e42eee23f139c4027cc157f37807a16b4601b353f5442
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- updates the linking script to link to all `@grafana` core modules
- this removes the need for [webpack aliasing in core](https://github.com/grafana/grafana/blob/main/scripts/webpack/webpack.dev.js#L55-L58) when linking scenes locally to core
- adds a cleanup function to cleanup the links once the script shuts down
- adds systemjs types to devdeps to resolve the systemjs types used in data and runtime correctly otherwise this repo falls back to declarations in testing-library and gets grumpy 😠 
- see [related PR in core](https://github.com/grafana/grafana/pull/102449)