### PR TITLE
AdHocFilters: Fix removing all scopes and cleaning up the adhoc

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1391,6 +1391,95 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     getScopesBridgeSpy.mockReturnValue(undefined);
   });
 
+  it.only('Removes all scope injected filters when scopes themselves are removed', () => {
+    let getScopesBridgeSpy = jest.spyOn(sceneGraph, 'getScopesBridge');
+
+    const scopes = new SceneScopesBridge({});
+    let mockState = {
+      value: [
+        {
+          metadata: { name: `Scope` },
+          spec: {
+            title: `Scope`,
+            type: 'test',
+            description: 'Test scope',
+            category: 'test',
+            filters: [{ key: 'scopeBaseFilter', operator: 'equals', value: 'val' }],
+          },
+        },
+      ] as Scope[],
+      drawerOpened: false,
+      enabled: true,
+      loading: false,
+      readOnly: false,
+    };
+
+    scopes.updateContext({
+      state: mockState,
+      stateObservable: new BehaviorSubject(mockState),
+      changeScopes: () => {},
+      setReadOnly: () => {},
+      setEnabled: () => {},
+    });
+
+    getScopesBridgeSpy.mockReturnValue(scopes);
+
+    const { filtersVar } = setup({
+      filters: [],
+      baseFilters: [
+        {
+          key: 'baseFilter',
+          operator: '=',
+          value: 'val2',
+          values: ['val2'],
+        },
+      ],
+    });
+
+    expect(filtersVar.state.baseFilters).toEqual([
+      {
+        key: 'baseFilter',
+        operator: '=',
+        value: 'val2',
+        values: ['val2'],
+      },
+      {
+        key: 'scopeBaseFilter',
+        operator: '=',
+        value: 'val',
+        values: ['val'],
+        origin: FilterOrigin.Scopes,
+      },
+    ]);
+
+    mockState = {
+      value: [],
+      drawerOpened: false,
+      enabled: true,
+      loading: false,
+      readOnly: false,
+    };
+
+    scopes.updateContext({
+      state: mockState,
+      stateObservable: new BehaviorSubject(mockState),
+      changeScopes: () => {},
+      setReadOnly: () => {},
+      setEnabled: () => {},
+    });
+
+    expect(filtersVar.state.baseFilters).toEqual([
+      {
+        key: 'baseFilter',
+        operator: '=',
+        value: 'val2',
+        values: ['val2'],
+      },
+    ]);
+
+    getScopesBridgeSpy.mockReturnValue(undefined);
+  });
+
   it('Can override and replace getTagKeys and getTagValues', async () => {
     const { filtersVar } = setup({
       getTagKeysProvider: () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1391,7 +1391,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     getScopesBridgeSpy.mockReturnValue(undefined);
   });
 
-  it.only('Removes all scope injected filters when scopes themselves are removed', () => {
+  it('Removes all scope injected filters when scopes themselves are removed', () => {
     let getScopesBridgeSpy = jest.spyOn(sceneGraph, 'getScopesBridge');
 
     const scopes = new SceneScopesBridge({});

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -254,6 +254,13 @@ export class AdHocFiltersVariable
   };
 
   private _updateScopesFilters = (scopes: Scope[], areScopesLoading?: boolean) => {
+    if (!scopes.length) {
+      this.setState({
+        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes),
+      });
+      return;
+    }
+
     const scopeFilters = getAdHocFiltersFromScopes(scopes);
 
     if (!scopeFilters.length) {


### PR DESCRIPTION
When removing scopes from the scopes selector, there was a bug where the adhoc filter would not clean up and clear the scope injected filters.

This fix cleans the adhoc filter from the scopes injected filters when the scopes are removed entirely from a dashboard.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.5.1--canary.1078.13965220580.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.5.1--canary.1078.13965220580.0
  npm install @grafana/scenes@6.5.1--canary.1078.13965220580.0
  # or 
  yarn add @grafana/scenes-react@6.5.1--canary.1078.13965220580.0
  yarn add @grafana/scenes@6.5.1--canary.1078.13965220580.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
