### PR TITLE
Scopes: Fix panels stuck in loading on scopes remove

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -464,7 +464,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     }
 
     // Skip executing queries if scopes are in loading state
-    if (scopesBridge?.isLoading()) {
+    if (scopesBridge?.isLoading() && scopesBridge?.getValue().length) {
       writeSceneLog('SceneQueryRunner', 'Scopes are in loading state, skipping query execution');
       this.setState({ data: { ...(this.state.data ?? emptyPanelData), state: LoadingState.Loading } });
       return;


### PR DESCRIPTION
There is a bug when removing all scopes from the scopes selector where the dashboard would try to reload through the panels SceneQueryRunners but would get stuck in loading. 

It looks like the sceneQueryRunner skips query execution and sets queries in a loading state, expecting the scope filters to be also fetched before actually running the queries, but since we remove all the scopes there is no more data coming back from the observable, and the queryRunner remains hanging.

This fixes the issue by also checking if there are scopes selected, not just if it's loading. If there are scopes selected and the bridge is loading, then we can expect more data to come through when the scope filters are also loaded, but we the bridge is loading and there are no scopes, I think we can safely assume that there's nothing else coming, so we can simply let the queryRunner run.