### PR TITLE
Remove url sync from ScopesBridge

### DIFF
--- a/packages/scenes/src/core/SceneScopesBridge.ts
+++ b/packages/scenes/src/core/SceneScopesBridge.ts
@@ -6,38 +6,14 @@ import { Scope } from '@grafana/data';
 import { ScopesContextValue, useScopes } from '@grafana/runtime';
 
 import { SceneObjectBase } from './SceneObjectBase';
-import { SceneComponentProps, SceneObjectUrlValues, SceneObjectWithUrlSync } from './types';
-import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
+import { SceneComponentProps } from './types';
 
-export class SceneScopesBridge extends SceneObjectBase implements SceneObjectWithUrlSync {
+export class SceneScopesBridge extends SceneObjectBase {
   static Component = SceneScopesBridgeRenderer;
-
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['scopes'] });
 
   protected _renderBeforeActivation = true;
 
   private _contextSubject = new BehaviorSubject<ScopesContextValue | undefined>(undefined);
-
-  // Needed to maintain scopes values received from URL until the context is available
-  private _pendingScopes: string[] | null = null;
-
-  public getUrlState(): SceneObjectUrlValues {
-    return {
-      scopes: this._pendingScopes ?? (this.context?.state.value ?? []).map((scope: Scope) => scope.metadata.name),
-    };
-  }
-
-  public updateFromUrl(values: SceneObjectUrlValues) {
-    let scopes = values['scopes'] ?? [];
-    scopes = (Array.isArray(scopes) ? scopes : [scopes]).map(String);
-
-    if (!this.context) {
-      this._pendingScopes = scopes;
-      return;
-    }
-
-    this.context?.changeScopes(scopes);
-  }
 
   public getValue(): Scope[] {
     return this.context?.state.value ?? [];
@@ -98,42 +74,8 @@ export class SceneScopesBridge extends SceneObjectBase implements SceneObjectWit
    *   - If a new value is received, force a re-render to trigger the URL sync handler
    */
   public updateContext(newContext: ScopesContextValue | undefined) {
-    if (this._pendingScopes && newContext) {
-      /**
-       * The setTimeout here is needed to avoid a potential race condition in the URL sync handler
-       * One way to test this is:
-       * - navigate to a dashboard and select some scopes
-       * - navigate to a suggested dashboard and change the selected scopes
-       * - observe the URL not containing any scopes
-       */
-      setTimeout(() => {
-        newContext?.changeScopes(this._pendingScopes!);
-        this._pendingScopes = null;
-      });
-
-      /**
-       * If we return here and don't allow the context to be propagated, scopes will never get activated when
-       * navigating from a page without scopes to a page that has scopes.
-       *
-       * This is happening because the app will try to call `enable` on the context, but the context would not be available yet
-       */
-    }
-
     if (this.context !== newContext || this.context?.state !== newContext?.state) {
-      // Checking if we should trigger a re-render before pushing new value for the context
-      // Doing it here because otherwise the check would not be valid (this.context would be newContext due to the value push)
-      const shouldUpdate = this.context?.state.value !== newContext?.state.value;
-
       this._contextSubject.next(newContext);
-
-      /**
-       * Whenever we got a new set of scopes, we force a re-render in order to trigger the URL sync handler
-       * Without this, the URL would never be updated when the scopes change
-       * TODO: This is a workaround and should be removed once we have a better way to handle this (aka trigger URL sync handler on demand)
-       */
-      if (shouldUpdate) {
-        this.forceRender();
-      }
     }
   }
 


### PR DESCRIPTION
Remove the URL sync code from ScopesBridge object. The URL handling was moved to core ScopesService instead: https://github.com/grafana/grafana/pull/102469