### PR TITLE
Combobox: Support individual read-only filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -43,7 +43,7 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
           key={`${index}-${filter.key}`}
           filter={filter}
           model={model}
-          readOnly={readOnly}
+          readOnly={readOnly || filter.readOnly}
           focusOnWipInputRef={focusOnWipInputRef.current}
         />
       ))}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -41,6 +41,8 @@ export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> exten
   // this holds the original/initial value of a injected filter that
   // was edited.
   originalValue?: string[];
+  // whether this specific filter is read-only and cannot be edited
+  readOnly?: boolean;
 }
 
 export type AdHocControlsLayout = ControlsLayout | 'combobox';


### PR DESCRIPTION
Allows scenes consumers to define read only filters while keeping the variable editable. This is useful when we want to lock some filters in place and allow the user to add more filters to refine the search, without losing the initial set of filters. 


https://github.com/user-attachments/assets/27fc68eb-49d5-41ab-a388-302bb2701c7b


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.6.0--canary.1081.13995169903.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.6.0--canary.1081.13995169903.0
  npm install @grafana/scenes@6.6.0--canary.1081.13995169903.0
  # or 
  yarn add @grafana/scenes-react@6.6.0--canary.1081.13995169903.0
  yarn add @grafana/scenes@6.6.0--canary.1081.13995169903.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
