### PR TITLE
AdHocFilters: Fix issue where scope injected filter would not update properly

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -210,7 +210,6 @@ export class AdHocFiltersVariable
   private _scopedVars = { __sceneObject: wrapInSafeSerializableSceneObject(this) };
   private _dataSourceSrv = getDataSourceSrv();
   private _scopesBridge: SceneScopesBridge | undefined;
-  private _overwriteScopes: boolean | undefined;
 
   protected _urlSync = new AdHocFiltersVariableUrlSyncHandler(this);
 
@@ -264,12 +263,6 @@ export class AdHocFiltersVariable
     }
 
     const scopeFilters = getAdHocFiltersFromScopes(scopes);
-
-    if (!scopeFilters.length) {
-      this._overwriteScopes = areScopesLoading;
-      return;
-    }
-
     let finalFilters = scopeFilters;
     const scopeInjectedFilters: AdHocFilterWithLabels[] = [];
     const remainingFilters: AdHocFilterWithLabels[] = [];
@@ -282,24 +275,24 @@ export class AdHocFiltersVariable
       }
     });
 
-    if (!this._overwriteScopes) {
-      const editedScopeFilters = scopeInjectedFilters.filter((filter) => filter.originalValue?.length);
-      const editedScopeFilterKeys = editedScopeFilters.map((filter) => filter.key);
-      const scopeFilterKeys = scopeFilters.map((filter) => filter.key);
-
-      // if the scope filters contain the key of an edited scope filter, we replace
-      // with the edited filter. We also add the remaining unedited scope filters
-      // when not overwriting
-      finalFilters = [
-        ...editedScopeFilters.filter((filter) => scopeFilterKeys.includes(filter.key)),
-        ...scopeFilters.filter((filter) => !editedScopeFilterKeys.includes(filter.key)),
-      ];
-      this._overwriteScopes = false;
+    if (!scopeFilters.length) {
+      return;
     }
 
+    const editedScopeFilters = scopeInjectedFilters.filter((filter) => filter.originalValue?.length);
+    const editedScopeFilterKeys = editedScopeFilters.map((filter) => filter.key);
+    const scopeFilterKeys = scopeFilters.map((filter) => filter.key);
+
+    // if the scope filters contain the key of an edited scope filter, we replace
+    // with the edited filter. We also add the remaining unedited scope filters
+    // when not overwriting
+    finalFilters = [
+      ...editedScopeFilters.filter((filter) => scopeFilterKeys.includes(filter.key)),
+      ...scopeFilters.filter((filter) => !editedScopeFilterKeys.includes(filter.key)),
+    ];
+
     // maintain other baseFilters in the array, only update scopes ones
-    const newFilters = [...remainingFilters, ...finalFilters];
-    this.setState({ baseFilters: newFilters });
+    this.setState({ baseFilters: [...remainingFilters, ...finalFilters] });
   };
 
   public setState(update: Partial<AdHocFiltersVariableState>): void {


### PR DESCRIPTION
This PR fixes an issue with scope injected filters where setting a new scope and then trying to edit the scope injected filters associated to the new scopes would not update properly on the first try. 

Before:

https://github.com/user-attachments/assets/1fad8486-4874-45ff-82c8-bd47a2bdbcf4

After:

https://github.com/user-attachments/assets/7780511b-6fed-4f56-8d90-f0eb21b4f552

Other things that I've tested:
- Reloading dashboard or copying url to a different browser tab maintains scope filters and/or edited scope filters
- Switching between dashboards from the scopes dashboard selector maintains scope filters and/or edited scope filters
- Removing scopes and re-adding them cleans filters and re-adds scope filters.