### PR TITLE
GroupByVariable: Add browser history action support for GroupBy var

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -168,6 +168,38 @@ describe.each(['11.1.2', '11.1.1'])('GroupByVariable', (v) => {
       expect(variable.state.value).toEqual(['a', 'b,something', 'c,something']);
       expect(variable.state.text).toEqual(['A,something', 'b,something', 'C,something']);
     });
+
+    it('should work with browser history action on user action', () => {
+      const { variable } = setupTest({
+        defaultOptions: [
+          { text: 'a', value: 'a' },
+          { text: 'b', value: 'b' },
+        ],
+      });
+
+      expect(variable.state.value).toEqual('');
+      expect(variable.state.text).toEqual('');
+
+      act(() => {
+        variable.changeValueTo(['a'], undefined, true);
+      });
+
+      expect(locationService.getLocation().search).toBe('?var-test=a');
+
+      act(() => {
+        locationService.push('/?var-test=a&var-test=b');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b']);
+      expect(variable.state.text).toEqual(['a', 'b']);
+
+      act(() => {
+        locationService.push('/?var-test=a&var-test=b&var-test=c');
+      });
+
+      expect(variable.state.value).toEqual(['a', 'b', 'c']);
+      expect(variable.state.text).toEqual(['a', 'b', 'c']);
+    });
   });
 
   it('Can override and replace getTagKeys', async () => {

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -6,6 +6,8 @@ import { VariableValue } from '../types';
 export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _sceneObject: GroupByVariable) {}
 
+  protected _nextChangeShouldAddHistoryStep = false;
+
   private getKey(): string {
     return `var-${this._sceneObject.state.name}`;
   }
@@ -42,6 +44,16 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
 
       this._sceneObject.changeValueTo(values, texts);
     }
+  }
+
+  public performBrowserHistoryAction(callback: () => void) {
+    this._nextChangeShouldAddHistoryStep = true;
+    callback();
+    this._nextChangeShouldAddHistoryStep = false;
+  }
+
+  public shouldCreateHistoryStep(values: SceneObjectUrlValues): boolean {
+    return this._nextChangeShouldAddHistoryStep;
   }
 }
 

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -397,6 +397,22 @@ describe('MultiValueVariable', () => {
 
       expect(stateUpdates).toHaveLength(0);
     });
+
+    it('changes when performing browser history action on user action', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [
+          { label: 'A', value: '1' },
+          { label: 'B', value: '2' },
+        ],
+        isMulti: true,
+        optionsToReturn: [],
+        delayMs: 0,
+      });
+
+      variable.changeValueTo(['1'], undefined, true);
+      expect(variable.state.value).toEqual(['1']);
+    });
   });
 
   describe('getValue and getValueText', () => {


### PR DESCRIPTION
Builds on top of https://github.com/grafana/scenes/pull/882.

The `GroupBy` variable extends `MultiValueVariable` but uses a custom `UrlSyncHandler` so we need to also implement browser history related methods in this custom handler so `changeValueTo` calls and sets the value properly. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.6.3--canary.1087.14261442491.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.6.3--canary.1087.14261442491.0
  npm install @grafana/scenes@6.6.3--canary.1087.14261442491.0
  # or 
  yarn add @grafana/scenes-react@6.6.3--canary.1087.14261442491.0
  yarn add @grafana/scenes@6.6.3--canary.1087.14261442491.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
