### PR TITLE
Add option to add descriptions for (custom) values for AdHocFilters

### DIFF
--- a/packages/scenes-app/src/demos/variables.tsx
+++ b/packages/scenes-app/src/demos/variables.tsx
@@ -241,14 +241,17 @@ export function getVariablesDemo(defaults: SceneAppPageState) {
                       {
                         value: 'a',
                         text: 'A',
+                        description: 'Alpha'
                       },
                       {
                         value: 'b',
                         text: 'B',
+                        description: 'Bravo'
                       },
                       {
                         value: 'c',
                         text: 'C',
+                        description: 'Charlie'
                       },
                     ],
                   }),

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -93,7 +93,7 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   /**
    * Optionally provide an array of static keys that override getTagKeys
    */
-  defaultKeys?: MetricFindValue[];
+  defaultKeys?: MetricFindValue[] | CustomFindValue[];
 
   /**
    * This is the expression that the filters resulted in. Defaults to
@@ -142,16 +142,20 @@ export type OnAddCustomValueFn = (
   filter: AdHocFilterWithLabels
 ) => { value: string | undefined; valueLabels: string[] };
 
+export interface CustomFindValue extends MetricFindValue {
+  description?: string
+}
+
 export type getTagKeysProvider = (
   variable: AdHocFiltersVariable,
   currentKey: string | null,
   operators?: OperatorDefinition[]
-) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] }>;
+) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] | CustomFindValue[] }>;
 
 export type getTagValuesProvider = (
   variable: AdHocFiltersVariable,
   filter: AdHocFilterWithLabels
-) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] }>;
+) => Promise<{ replace?: boolean; values: GetTagResponse | MetricFindValue[] | CustomFindValue[]}>;
 
 export type AdHocFiltersVariableCreateHelperArgs = AdHocFiltersVariableState;
 
@@ -673,7 +677,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-export function toSelectableValue(input: MetricFindValue): SelectableValue<string> {
+export function toSelectableValue(input: MetricFindValue | CustomFindValue): SelectableValue<string> {
   const { text, value } = input;
   const result: SelectableValue<string> = {
     // converting text to string due to some edge cases where it can be a number
@@ -688,6 +692,10 @@ export function toSelectableValue(input: MetricFindValue): SelectableValue<strin
 
   if ('meta' in input) {
     result.meta = input.meta;
+  }
+
+  if ('description' in input) {
+    result.description = input.description;
   }
 
   return result;


### PR DESCRIPTION
When providing keys (or values) for a AdHoc filter it is nice to be able to add a description as well.
The operator dropdown already has that option.

This PR adds the option for keys and values as well.

I also updated the example in the scenes demo where custom/hardcoded keys are provided.
<img width="902" alt="image" src="https://github.com/user-attachments/assets/d6bc375f-e421-4763-b2c9-4f31617e3d44" />
