### PR TITLE
VariableControl: Add props needed in core dashboards

### DIFF
--- a/packages/scenes/src/utils/ControlsLabel.tsx
+++ b/packages/scenes/src/utils/ControlsLabel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Icon, IconButton, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme2, IconName } from '@grafana/data';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { LoadingIndicator } from './LoadingIndicator';
 import { ControlsLayout } from '../core/types';
 
@@ -14,6 +14,9 @@ interface ControlsLabelProps {
   error?: string;
   icon?: IconName;
   layout?: ControlsLayout;
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+  className?: string;
   onCancel?: () => void;
   onRemove?: () => void;
 }
@@ -64,7 +67,8 @@ export function ControlsLabel(props: ControlsLabelProps) {
 
   if (isVertical) {
     labelElement = (
-      <label className={styles.verticalLabel} data-testid={testId} htmlFor={props.htmlFor}>
+      <label className={cx(styles.verticalLabel, props.className)} data-testid={testId} htmlFor={props.htmlFor}>
+        {props.prefix}
         {props.label}
         {descriptionIndicator}
         {errorIndicator}
@@ -73,16 +77,19 @@ export function ControlsLabel(props: ControlsLabelProps) {
         {props.onRemove && (
           <IconButton variant="secondary" size="xs" name="times" onClick={props.onRemove} tooltip={'Remove'} />
         )}
+        {props.suffix}
       </label>
     );
   } else {
     labelElement = (
-      <label className={styles.horizontalLabel} data-testid={testId} htmlFor={props.htmlFor}>
+      <label className={cx(styles.horizontalLabel, props.className)} data-testid={testId} htmlFor={props.htmlFor}>
+        {props.prefix}
         {errorIndicator}
         {props.icon && <Icon name={props.icon} className={styles.normalIcon} />}
         {props.label}
         {descriptionIndicator}
         {loadingIndicator}
+        {props.suffix}
       </label>
     );
   }


### PR DESCRIPTION

https://github.com/grafana/grafana/pull/103451 needs these props in order not require a wrapping div (which cause issues with e2e tests) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.7.0--canary.1091.14350229100.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.7.0--canary.1091.14350229100.0
  npm install @grafana/scenes@6.7.0--canary.1091.14350229100.0
  # or 
  yarn add @grafana/scenes-react@6.7.0--canary.1091.14350229100.0
  yarn add @grafana/scenes@6.7.0--canary.1091.14350229100.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
