### PR TITLE
fix: (VizPanelRenderer) - move showMenuAlways prop to the top level

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -874,7 +874,7 @@ describe('VizPanel', () => {
     it('should toggle collapsed state', () => {
       panel.onToggleCollapse(true);
       expect(panel.state.collapsed).toBe(true);
-      
+
       panel.onToggleCollapse(false);
       expect(panel.state.collapsed).toBe(false);
     });
@@ -934,7 +934,7 @@ describe('VizPanel', () => {
     it('should toggle menu visibility', () => {
       panel.setState({ showMenuAlways: false });
       expect(panel.state.showMenuAlways).toBe(false);
-      
+
       panel.setState({ showMenuAlways: true });
       expect(panel.state.showMenuAlways).toBe(true);
     });

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -849,6 +849,96 @@ describe('VizPanel', () => {
       });
     });
   });
+
+  describe('Collapsible panel functionality', () => {
+    let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
+
+    beforeEach(async () => {
+      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+        title: 'Collapsible Panel',
+        pluginId: 'custom-plugin-id',
+        collapsible: true,
+        collapsed: false,
+        $data: getDataNodeWithTestData(),
+      });
+
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+    });
+
+    it('should initialize with correct collapsible state', () => {
+      expect(panel.state.collapsible).toBe(true);
+      expect(panel.state.collapsed).toBe(false);
+    });
+
+    it('should toggle collapsed state', () => {
+      panel.onToggleCollapse(true);
+      expect(panel.state.collapsed).toBe(true);
+      
+      panel.onToggleCollapse(false);
+      expect(panel.state.collapsed).toBe(false);
+    });
+  });
+
+  describe('Hover header functionality', () => {
+    let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
+
+    beforeEach(async () => {
+      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+        title: 'Hover Panel',
+        pluginId: 'custom-plugin-id',
+        hoverHeader: true,
+        hoverHeaderOffset: 10,
+        $data: getDataNodeWithTestData(),
+      });
+
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+    });
+
+    it('should initialize with correct hover header state', () => {
+      expect(panel.state.hoverHeader).toBe(true);
+      expect(panel.state.hoverHeaderOffset).toBe(10);
+    });
+
+    it('should update hover header offset', () => {
+      panel.setState({ hoverHeaderOffset: 20 });
+      expect(panel.state.hoverHeaderOffset).toBe(20);
+    });
+
+    it('should disable hover header', () => {
+      panel.setState({ hoverHeader: false });
+      expect(panel.state.hoverHeader).toBe(false);
+    });
+  });
+
+  describe('Menu visibility functionality', () => {
+    let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
+
+    beforeEach(async () => {
+      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+        title: 'Menu Panel',
+        pluginId: 'custom-plugin-id',
+        showMenuAlways: true,
+        $data: getDataNodeWithTestData(),
+      });
+
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+    });
+
+    it('should initialize with correct menu visibility state', () => {
+      expect(panel.state.showMenuAlways).toBe(true);
+    });
+
+    it('should toggle menu visibility', () => {
+      panel.setState({ showMenuAlways: false });
+      expect(panel.state.showMenuAlways).toBe(false);
+      
+      panel.setState({ showMenuAlways: true });
+      expect(panel.state.showMenuAlways).toBe(true);
+    });
+  });
 });
 
 function getDataNodeWithTestData() {

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -872,7 +872,7 @@ describe('VizPanel', () => {
       it('should showMenuAlways when panel is not collapsible', async () => {
         expect(panel.state.showMenuAlways).toBe(true);
         render(<panel.Component model={panel} />);
-        
+
         // The menu should be visible despite collapsible being false
         const menuButton = screen.queryByRole('button', { name: /menu/i });
         expect(menuButton).toBeInTheDocument();
@@ -923,7 +923,7 @@ describe('VizPanel', () => {
       it('should showMenuAlways when panel is not collapsible', async () => {
         expect(panel.state.showMenuAlways).toBe(true);
         render(<panel.Component model={panel} />);
-        
+
         // The menu should be visible despite collapsible being false
         const menuButton = screen.queryByRole('button', { name: /menu/i });
         expect(menuButton).toBeInTheDocument();
@@ -947,7 +947,7 @@ describe('VizPanel', () => {
       it('should not showMenuAlways', async () => {
         expect(panel.state.showMenuAlways).toBe(false);
         render(<panel.Component model={panel} />);
-        
+
         const menuButton = screen.queryByRole('button', { name: /menu/i });
         expect(menuButton).toHaveClass('show-on-hover');
       });

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -24,6 +24,7 @@ import { SeriesVisibilityChangeMode } from '@grafana/ui';
 import { SceneTimeRange } from '../../core/SceneTimeRange';
 import { act, render, screen } from '@testing-library/react';
 import { RefreshEvent } from '@grafana/runtime';
+import { VizPanelMenu } from './VizPanelMenu';
 
 let pluginToLoad: PanelPlugin | undefined;
 
@@ -850,96 +851,106 @@ describe('VizPanel', () => {
     });
   });
 
-  describe('Collapsible panel functionality', () => {
-    let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
-
-    beforeEach(async () => {
-      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
-        title: 'Collapsible Panel',
-        pluginId: 'custom-plugin-id',
-        collapsible: true,
-        collapsed: false,
-        $data: getDataNodeWithTestData(),
-      });
-
-      pluginToLoad = getTestPlugin1();
-      panel.activate();
-    });
-
-    it('should initialize with correct collapsible state', () => {
-      expect(panel.state.collapsible).toBe(true);
-      expect(panel.state.collapsed).toBe(false);
-    });
-
-    it('should toggle collapsed state', () => {
-      panel.onToggleCollapse(true);
-      expect(panel.state.collapsed).toBe(true);
-
-      panel.onToggleCollapse(false);
-      expect(panel.state.collapsed).toBe(false);
-
-      panel.setState({ showMenuAlways: true });
-      expect(panel.state.showMenuAlways).toBe(true);
-    });
-  });
-
-  describe('Hover header functionality', () => {
-    let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
-
-    beforeEach(async () => {
-      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
-        title: 'Hover Panel',
-        pluginId: 'custom-plugin-id',
-        hoverHeader: true,
-        hoverHeaderOffset: 10,
-        $data: getDataNodeWithTestData(),
-      });
-
-      pluginToLoad = getTestPlugin1();
-      panel.activate();
-    });
-
-    it('should initialize with correct hover header state', () => {
-      expect(panel.state.hoverHeader).toBe(true);
-      expect(panel.state.hoverHeaderOffset).toBe(10);
-    });
-
-    it('should update hover header offset', () => {
-      panel.setState({ hoverHeaderOffset: 20 });
-      expect(panel.state.hoverHeaderOffset).toBe(20);
-    });
-
-    it('should disable hover header', () => {
-      panel.setState({ hoverHeader: false });
-      expect(panel.state.hoverHeader).toBe(false);
-    });
-  });
-
   describe('Menu visibility functionality', () => {
     let panel: VizPanel<OptionsPlugin1, FieldConfigPlugin1>;
 
-    beforeEach(async () => {
-      panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
-        title: 'Menu Panel',
-        pluginId: 'custom-plugin-id',
-        showMenuAlways: true,
-        $data: getDataNodeWithTestData(),
+    describe('collapsible false and showMenuAlways true', () => {
+      beforeEach(async () => {
+        panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          title: 'Menu Panel',
+          pluginId: 'custom-plugin-id',
+          collapsible: false,
+          showMenuAlways: true,
+          menu: new VizPanelMenu({}),
+          $data: getDataNodeWithTestData(),
+        });
+
+        pluginToLoad = getTestPlugin1();
+        panel.activate();
       });
 
-      pluginToLoad = getTestPlugin1();
-      panel.activate();
+      it('should showMenuAlways when panel is not collapsible', async () => {
+        expect(panel.state.showMenuAlways).toBe(true);
+        render(<panel.Component model={panel} />);
+        
+        // The menu should be visible despite collapsible being false
+        const menuButton = screen.queryByRole('button', { name: /menu/i });
+        expect(menuButton).toBeInTheDocument();
+      });
     });
 
-    it('should initialize with correct menu visibility state', () => {
-      expect(panel.state.showMenuAlways).toBe(true);
+    describe('collapsible true and showMenuAlways true', () => {
+      beforeEach(async () => {
+        panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          title: 'Menu Panel',
+          pluginId: 'custom-plugin-id',
+          collapsible: true,
+          showMenuAlways: true,
+          menu: new VizPanelMenu({}),
+          $data: getDataNodeWithTestData(),
+        });
+
+        pluginToLoad = getTestPlugin1();
+        panel.activate();
+      });
+
+      it('should show showMenuAlways when panel is collapsible', async () => {
+        expect(panel.state.showMenuAlways).toBe(true);
+        render(<panel.Component model={panel} />);
+        // The menu should be visible because both collapsible and showMenuAlways are true
+        // Query for all menu buttons and select the first one
+        const menuButtons = screen.queryAllByRole('button', { name: /menu/i });
+        const firstMenuButton = menuButtons[0]; // Get the first element
+        // Check if the first menu button is in the document
+        expect(firstMenuButton).toBeInTheDocument();
+      });
     });
 
-    it('should toggle menu visibility', () => {
-      panel.setState({ showMenuAlways: false });
-      expect(panel.state.showMenuAlways).toBe(false);
+    describe('showMenuAlways true', () => {
+      beforeEach(async () => {
+        panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          title: 'Menu Panel',
+          pluginId: 'custom-plugin-id',
+          showMenuAlways: true,
+          menu: new VizPanelMenu({}),
+          $data: getDataNodeWithTestData(),
+        });
 
-      panel.setState({ showMenuAlways: true });
-      expect(panel.state.showMenuAlways).toBe(true);
+        pluginToLoad = getTestPlugin1();
+        panel.activate();
+      });
+
+      it('should showMenuAlways when panel is not collapsible', async () => {
+        expect(panel.state.showMenuAlways).toBe(true);
+        render(<panel.Component model={panel} />);
+        
+        // The menu should be visible despite collapsible being false
+        const menuButton = screen.queryByRole('button', { name: /menu/i });
+        expect(menuButton).toBeInTheDocument();
+      });
+    });
+
+    describe('showMenuAlways false', () => {
+      beforeEach(async () => {
+        panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          title: 'Menu Panel',
+          pluginId: 'custom-plugin-id',
+          showMenuAlways: false,
+          menu: new VizPanelMenu({}),
+          $data: getDataNodeWithTestData(),
+        });
+
+        pluginToLoad = getTestPlugin1();
+        panel.activate();
+      });
+
+      it('should not showMenuAlways', async () => {
+        expect(panel.state.showMenuAlways).toBe(false);
+        render(<panel.Component model={panel} />);
+        
+        const menuButton = screen.queryByRole('button', { name: /menu/i });
+        expect(menuButton).toHaveClass('show-on-hover');
+      });
     });
   });
 });

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -877,6 +877,9 @@ describe('VizPanel', () => {
 
       panel.onToggleCollapse(false);
       expect(panel.state.collapsed).toBe(false);
+
+      panel.setState({ showMenuAlways: true });
+      expect(panel.state.showMenuAlways).toBe(true);
     });
   });
 

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -192,14 +192,14 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             onDragStart={(e: React.PointerEvent) => {
               dragHooks.onDragStart?.(e, model);
             }}
-            {...(collapsible
-              ? {
-                  collapsible: Boolean(collapsible),
-                  collapsed,
-                  onToggleCollapse: model.onToggleCollapse,
-                  showMenuAlways,
-                }
-              : { hoverHeader, hoverHeaderOffset })}
+            {...{
+              ...(collapsible !== undefined && { collapsible: Boolean(collapsible) }),
+              ...(collapsed !== undefined && { collapsed }),
+              ...(model.onToggleCollapse && { onToggleCollapse: model.onToggleCollapse }),
+              ...(showMenuAlways !== undefined && { showMenuAlways }),
+              ...(hoverHeader !== undefined && { hoverHeader }),
+              ...(hoverHeaderOffset !== undefined && { hoverHeaderOffset }),
+            }}
           >
             {(innerWidth, innerHeight) => (
               <>

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -169,6 +169,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     <div className={relativeWrapper}>
       <div ref={ref as RefCallback<HTMLDivElement>} className={absoluteWrapper} data-viz-panel-key={model.state.key}>
         {width > 0 && height > 0 && (
+          // @ts-expect-error showMenuAlways remove when updating to @grafana/ui@12 fixed in https://github.com/grafana/grafana/pull/103553
           <PanelChrome
             title={titleInterpolated}
             description={description?.trim() ? model.getDescription : undefined}

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -192,14 +192,14 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             onDragStart={(e: React.PointerEvent) => {
               dragHooks.onDragStart?.(e, model);
             }}
-            {...{
-              ...(collapsible !== undefined && { collapsible: Boolean(collapsible) }),
-              ...(collapsed !== undefined && { collapsed }),
-              ...(model.onToggleCollapse && { onToggleCollapse: model.onToggleCollapse }),
-              ...(showMenuAlways !== undefined && { showMenuAlways }),
-              ...(hoverHeader !== undefined && { hoverHeader }),
-              ...(hoverHeaderOffset !== undefined && { hoverHeaderOffset }),
-            }}
+            showMenuAlways={showMenuAlways}
+            {...(collapsible
+              ? {
+                  collapsible: Boolean(collapsible),
+                  collapsed,
+                  onToggleCollapse: model.onToggleCollapse,
+                }
+              : { hoverHeader, hoverHeaderOffset })}
           >
             {(innerWidth, innerHeight) => (
               <>


### PR DESCRIPTION
# Description
Move showMenuAlways VizPanelRenderer.tsx prop out of collapse conditional. In Logs Drilldown we have a situation where we'd like to `showMenuAlways` but do not use collapsible. [upgrade to Scenes6](https://github.com/grafana/logs-drilldown/pull/1019/files#diff-0c9eb85b8eb906fbac0d474a7c68685514172ee72d0597664fa8618f27826087)
I'm not totally familiar with the change to making `showMenuAlways` conditional on the `collapsible` property [PR](https://github.com/grafana/scenes/pull/1040/files#diff-b4e762e26aeb297a8f36c1ada3213ecd5a9bcd972799a753018dccf96fc75a30R195
).🤔 @tskarhed let me know what you think. 
