### PR TITLE
AdHocFilters: Dashboard level filters

### DIFF
--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -270,7 +270,7 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
                   datasource: { uid: 'gdev-prometheus' },
                   filters: [{ key: 'job', operator: '=', value: 'has no text', condition: '' }],
                   baseFilters: [
-                    { key: 'dbFilterKey', operator: '=', value: 'dbFilterValue', origin: FilterOrigin.Dashboards },
+                    { key: 'dbFilterKey', operator: '=', value: 'dbFilterValue', origin: FilterOrigin.Dashboard },
                   ],
                   layout: 'combobox',
                   supportsMultiValueOperators: true,

--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -269,9 +269,7 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
                   hide: VariableHide.hideLabel,
                   datasource: { uid: 'gdev-prometheus' },
                   filters: [{ key: 'job', operator: '=', value: 'has no text', condition: '' }],
-                  baseFilters: [
-                    { key: 'dbFilterKey', operator: '=', value: 'dbFilterValue', origin: FilterOrigin.Dashboard },
-                  ],
+                  baseFilters: [{ key: 'dbFilterKey', operator: '=', value: 'dbFilterValue', origin: 'dashboard' }],
                   layout: 'combobox',
                   supportsMultiValueOperators: true,
                 }),

--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -15,6 +15,7 @@ import {
   SceneObjectBase,
   SceneObjectState,
   SceneObjectRef,
+  FilterOrigin,
 } from '@grafana/scenes';
 import { Button, Stack } from '@grafana/ui';
 import React from 'react';
@@ -226,6 +227,63 @@ export function getAdhocFiltersDemo(defaults: SceneAppPageState) {
                   ySizing: 'content',
                   body: new SceneCanvasText({
                     text: `The query below is interpolated to ALERTS{$ComboboxFilters}`,
+                    fontSize: 14,
+                  }),
+                }),
+                new SceneFlexItem({
+                  body: PanelBuilders.table()
+                    .setTitle('ALERTS')
+                    .setData(
+                      new SceneQueryRunner({
+                        datasource: { uid: 'gdev-prometheus' },
+                        queries: [
+                          {
+                            refId: 'A',
+                            expr: 'ALERTS',
+                            format: 'table',
+                            instant: true,
+                          },
+                        ],
+                      })
+                    )
+                    .build(),
+                }),
+              ],
+            }),
+            $timeRange: new SceneTimeRange(),
+          });
+        },
+      }),
+      new SceneAppPage({
+        title: 'Dashboard level filters',
+        routePath: `db-filters`,
+        url: `${defaults.url}/db-filters`,
+        getScene: () => {
+          return new EmbeddedScene({
+            ...getEmbeddedSceneDefaults(),
+            $variables: new SceneVariableSet({
+              variables: [
+                new AdHocFiltersVariable({
+                  name: 'ComboboxFilters',
+                  label: 'Without add filter button text',
+                  hide: VariableHide.hideLabel,
+                  datasource: { uid: 'gdev-prometheus' },
+                  filters: [{ key: 'job', operator: '=', value: 'has no text', condition: '' }],
+                  baseFilters: [
+                    { key: 'dbFilterKey', operator: '=', value: 'dbFilterValue', origin: FilterOrigin.Dashboards },
+                  ],
+                  layout: 'combobox',
+                  supportsMultiValueOperators: true,
+                }),
+              ],
+            }),
+            body: new SceneFlexLayout({
+              direction: 'column',
+              children: [
+                new SceneFlexItem({
+                  ySizing: 'content',
+                  body: new SceneCanvasText({
+                    text: `The query below is interpolated to ALERTS{ComboboxFilters}`,
                     fontSize: 14,
                   }),
                 }),

--- a/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
+++ b/packages/scenes-app/src/demos/adhocFiltersDemo.tsx
@@ -15,7 +15,6 @@ import {
   SceneObjectBase,
   SceneObjectState,
   SceneObjectRef,
-  FilterOrigin,
 } from '@grafana/scenes';
 import { Button, Stack } from '@grafana/ui';
 import React from 'react';

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -72,7 +72,7 @@ export {
 } from './variables/variants/MultiValueVariable';
 export { LocalValueVariable } from './variables/variants/LocalValueVariable';
 export { IntervalVariable } from './variables/variants/IntervalVariable';
-export { AdHocFiltersVariable, FilterOrigin } from './variables/adhoc/AdHocFiltersVariable';
+export { AdHocFiltersVariable } from './variables/adhoc/AdHocFiltersVariable';
 export type { AdHocFilterWithLabels } from './variables/adhoc/AdHocFiltersVariable';
 export { GroupByVariable } from './variables/groupby/GroupByVariable';
 export { type MacroVariableConstructor } from './variables/macros/types';

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -27,7 +27,7 @@ import { SceneTimeRangeCompare } from '../components/SceneTimeRangeCompare';
 import { SceneDataLayerSet } from './SceneDataLayerSet';
 import { TestAlertStatesDataLayer, TestAnnotationsDataLayer } from './layers/TestDataLayer';
 import { TestSceneWithRequestEnricher } from '../utils/test/TestSceneWithRequestEnricher';
-import { AdHocFiltersVariable, FilterOrigin } from '../variables/adhoc/AdHocFiltersVariable';
+import { AdHocFiltersVariable } from '../variables/adhoc/AdHocFiltersVariable';
 import { emptyPanelData } from '../core/SceneDataNode';
 import { GroupByVariable } from '../variables/groupby/GroupByVariable';
 import { SceneQueryController } from '../behaviors/SceneQueryController';

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -541,7 +541,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
         datasource: { uid: 'test-uid' },
         applyMode: 'auto',
         filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
-        baseFilters: [{ key: 'C', operator: '=', value: 'D', condition: '', origin: FilterOrigin.Scopes }],
+        baseFilters: [{ key: 'C', operator: '=', value: 'D', condition: '', origin: FilterOrigin.Scope }],
       });
 
       const scene = new EmbeddedScene({

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -541,7 +541,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
         datasource: { uid: 'test-uid' },
         applyMode: 'auto',
         filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
-        baseFilters: [{ key: 'C', operator: '=', value: 'D', condition: '', origin: FilterOrigin.Scope }],
+        baseFilters: [{ key: 'C', operator: '=', value: 'D', condition: '', origin: 'scope' }],
       });
 
       const scene = new EmbeddedScene({

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -93,9 +93,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           </Tooltip>
         )}
 
-        {!readOnly &&
-        !filter.matchAllFilter &&
-        (filter.origin === undefined || filter.origin === FilterOrigin.Dashboards) ? (
+        {!readOnly && !filter.matchAllFilter && (!filter.origin || filter.origin === FilterOrigin.Dashboards) ? (
           <IconButton
             onClick={(e) => {
               e.stopPropagation();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -97,14 +97,23 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           <IconButton
             onClick={(e) => {
               e.stopPropagation();
-              model._removeFilter(filter);
+              if (filter.origin && filter.origin === FilterOrigin.Dashboards) {
+                model.updateToMatchAll(filter);
+              } else {
+                model._removeFilter(filter);
+              }
+
               setTimeout(() => focusOnWipInputRef?.());
             }}
             onKeyDownCapture={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();
                 e.stopPropagation();
-                model._removeFilter(filter);
+                if (filter.origin && filter.origin === FilterOrigin.Dashboards) {
+                  model.updateToMatchAll(filter);
+                } else {
+                  model._removeFilter(filter);
+                }
                 setTimeout(() => focusOnWipInputRef?.());
               }
             }}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -117,7 +117,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           />
         ) : null}
 
-        {filter.origin && !filter.originalValue && (
+        {filter.origin && !filter.isEdited && (
           <IconButton
             name="info-circle"
             size="md"
@@ -126,7 +126,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           />
         )}
 
-        {filter.origin && filter.originalValue && (
+        {filter.origin && filter.isEdited && (
           <IconButton
             onClick={(e) => {
               e.stopPropagation();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, IconButton, Tooltip } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, AdHocFiltersVariable } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin } from '../AdHocFiltersVariable';
 
 const LABEL_MAX_VISIBLE_LENGTH = 20;
 
@@ -93,7 +93,9 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           </Tooltip>
         )}
 
-        {!readOnly && !filter.origin ? (
+        {!readOnly &&
+        !filter.matchAllFilter &&
+        (filter.origin === undefined || filter.origin === FilterOrigin.Dashboards) ? (
           <IconButton
             onClick={(e) => {
               e.stopPropagation();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -1,9 +1,9 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, IconButton, Tooltip } from '@grafana/ui';
+import { useStyles2, IconButton, Tooltip, Icon } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin, isMatchAllFilter } from '../AdHocFiltersVariable';
 
 const LABEL_MAX_VISIBLE_LENGTH = 20;
 
@@ -68,7 +68,11 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
     );
     return (
       <div
-        className={cx(styles.combinedFilterPill, readOnly && styles.readOnlyCombinedFilter)}
+        className={cx(
+          styles.combinedFilterPill,
+          readOnly && styles.readOnlyCombinedFilter,
+          isMatchAllFilter(filter) && styles.matchAllPill
+        )}
         onClick={(e) => {
           e.stopPropagation();
           setPopulateInputOnEdit(true);
@@ -125,12 +129,9 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         ) : null}
 
         {filter.origin && !filter.restorable && (
-          <IconButton
-            name="info-circle"
-            size="md"
-            className={styles.pillIcon}
-            tooltip={`This is a ${filter.origin} injected filter`}
-          />
+          <Tooltip content={`This is a ${filter.origin} injected filter`} placement={'bottom'}>
+            <Icon name="info-circle" size="md" className={styles.infoPillIcon} />
+          </Tooltip>
         )}
 
         {filter.origin && filter.restorable && (
@@ -148,7 +149,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
             }}
             name="history"
             size="md"
-            className={styles.pillIcon}
+            className={isMatchAllFilter(filter) ? styles.matchAllPillIcon : styles.pillIcon}
             tooltip={`Restore filter to its original value`}
           />
         )}
@@ -209,5 +210,22 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   tooltipText: css({
     textAlign: 'center',
+  }),
+  infoPillIcon: css({
+    marginInline: theme.spacing(0.5),
+    cursor: 'pointer',
+  }),
+  matchAllPillIcon: css({
+    marginInline: theme.spacing(0.5),
+    cursor: 'pointer',
+    color: theme.colors.text.disabled,
+  }),
+  matchAllPill: css({
+    background: theme.colors.action.selected,
+    color: theme.colors.text.disabled,
+    border: 0,
+    '&:hover': {
+      background: theme.colors.action.selected,
+    },
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, IconButton, Tooltip, Icon } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin, isMatchAllFilter } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable } from '../AdHocFiltersVariable';
 
 const LABEL_MAX_VISIBLE_LENGTH = 20;
 
@@ -97,11 +97,11 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           </Tooltip>
         )}
 
-        {!readOnly && !filter.matchAllFilter && (!filter.origin || filter.origin === FilterOrigin.Dashboard) ? (
+        {!readOnly && !filter.matchAllFilter && (!filter.origin || filter.origin === 'dashboard') ? (
           <IconButton
             onClick={(e) => {
               e.stopPropagation();
-              if (filter.origin && filter.origin === FilterOrigin.Dashboard) {
+              if (filter.origin && filter.origin === 'dashboard') {
                 model.updateToMatchAll(filter);
               } else {
                 model._removeFilter(filter);
@@ -113,7 +113,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
               if (e.key === 'Enter') {
                 e.preventDefault();
                 e.stopPropagation();
-                if (filter.origin && filter.origin === FilterOrigin.Dashboard) {
+                if (filter.origin && filter.origin === 'dashboard') {
                   model.updateToMatchAll(filter);
                 } else {
                   model._removeFilter(filter);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -93,11 +93,11 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           </Tooltip>
         )}
 
-        {!readOnly && !filter.matchAllFilter && (!filter.origin || filter.origin === FilterOrigin.Dashboards) ? (
+        {!readOnly && !filter.matchAllFilter && (!filter.origin || filter.origin === FilterOrigin.Dashboard) ? (
           <IconButton
             onClick={(e) => {
               e.stopPropagation();
-              if (filter.origin && filter.origin === FilterOrigin.Dashboards) {
+              if (filter.origin && filter.origin === FilterOrigin.Dashboard) {
                 model.updateToMatchAll(filter);
               } else {
                 model._removeFilter(filter);
@@ -109,7 +109,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
               if (e.key === 'Enter') {
                 e.preventDefault();
                 e.stopPropagation();
-                if (filter.origin && filter.origin === FilterOrigin.Dashboards) {
+                if (filter.origin && filter.origin === FilterOrigin.Dashboard) {
                   model.updateToMatchAll(filter);
                 } else {
                   model._removeFilter(filter);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, IconButton, Tooltip, Icon } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, AdHocFiltersVariable } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, isMatchAllFilter } from '../AdHocFiltersVariable';
 
 const LABEL_MAX_VISIBLE_LENGTH = 20;
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -117,7 +117,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           />
         ) : null}
 
-        {filter.origin && !filter.isEdited && (
+        {filter.origin && !filter.restorable && (
           <IconButton
             name="info-circle"
             size="md"
@@ -126,7 +126,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
           />
         )}
 
-        {filter.origin && filter.isEdited && (
+        {filter.origin && filter.restorable && (
           <IconButton
             onClick={(e) => {
               e.stopPropagation();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -110,6 +110,10 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       filterMultiValues: Array<SelectableValue<string>>,
       preventFocus?: boolean
     ) => {
+      if (!filterMultiValues.length && filter.origin) {
+        model.updateToMatchAll(filter);
+      }
+
       if (filterMultiValues.length) {
         const valueLabels: string[] = [];
         const values: string[] = [];
@@ -121,6 +125,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
         model._updateFilter(filter!, { valueLabels, values, value: values[0] });
         setFilterMultiValues([]);
       }
+
       if (!preventFocus) {
         setTimeout(() => refs.domReference.current?.focus());
       }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -807,9 +807,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable?
-    expect(locationService.getLocation().search).toBe(
-      '?var-filters=baseKey1%7C%21%3D%7CnewValue%23scopes%23restorable'
-    );
+    expect(locationService.getLocation().search).toBe('?var-filters=baseKey1%7C%21%3D%7CnewValue%23scope%23restorable');
 
     clearScopes();
   });
@@ -837,7 +835,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable?
     expect(locationService.getLocation().search).toBe(
-      '?var-filters=baseKey1%7C%21%3D__gfp__%7CnewValue1%7CnewValue2%23scopes%23restorable'
+      '?var-filters=baseKey1%7C%21%3D__gfp__%7CnewValue1%7CnewValue2%23scope%23restorable'
     );
 
     clearScopes();
@@ -864,7 +862,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable
     expect(locationService.getLocation().search).toBe(
-      '?var-filters=baseKey1%7C%3D%7CnewValue1__gfh__%23scopes%23restorable'
+      '?var-filters=baseKey1%7C%3D%7CnewValue1__gfh__%23scope%23restorable'
     );
 
     clearScopes();
@@ -888,7 +886,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     const urlValues = {
-      'var-filters': ['dbFilterKey|=~|.*#dashboards#restorable'],
+      'var-filters': ['dbFilterKey|=~|.*#dashboard#restorable'],
     };
 
     act(() => {
@@ -916,7 +914,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     // url contains a modified scope injected filter carried from somewhere else
     const urlValues = {
-      'var-filters': ['scopesFilterKey1|=|newScopesFilterValue1#scopes#restorable'],
+      'var-filters': ['scopesFilterKey1|=|newScopesFilterValue1#scope#restorable'],
     };
 
     act(() => {
@@ -941,7 +939,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     // but the URL sends a modified dashboard level filter
     const urlValues = {
-      'var-filters': ['dbFilterKey|!=|newDbFilterValue#dashboards#restorable'],
+      'var-filters': ['dbFilterKey|!=|newDbFilterValue#dashboard#restorable'],
     };
 
     act(() => {
@@ -1034,9 +1032,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     const urlValues = {
       'var-filters': [
-        'dbFilterKey|!=|newDbFilterValue#dashboards#restorable',
+        'dbFilterKey|!=|newDbFilterValue#dashboard#restorable',
         'filterKey|!=|newFilterValue',
-        'scopeFilterKey1|=|newScopeFilterValue#scopes#restorable',
+        'scopeFilterKey1|=|newScopeFilterValue#scope#restorable',
       ],
     };
 
@@ -1128,7 +1126,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     expect(locationService.getLocation().search).toBe(
-      '?var-filters=someFilter%7C%3D%7CsomeValue&var-filters=dbFilter%7C%3D%7CnewDbValue%23dashboards%23restorable'
+      '?var-filters=someFilter%7C%3D%7CsomeValue&var-filters=dbFilter%7C%3D%7CnewDbValue%23dashboard%23restorable'
     );
 
     // restore it, URL should be cleaned

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -870,6 +870,44 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     clearScopes();
   });
 
+  it('sets url dashboard injected filter as a matchAll filter if it has the correct structure', () => {
+    const { filtersVar } = setup({
+      baseFilters: [
+        {
+          key: 'baseFilters',
+          operator: '=',
+          value: 'baseValue',
+        },
+        {
+          key: 'dbFilterKey',
+          operator: '=',
+          value: 'dbFilterValue',
+          origin: FilterOrigin.Dashboards,
+        },
+      ],
+    });
+
+    const urlValues = {
+      'var-filters': ['dbFilterKey|=~|.*#dashboards#restorable'],
+    };
+
+    act(() => {
+      locationService.partial(urlValues);
+    });
+
+    expect(filtersVar.state.baseFilters![1]).toEqual({
+      condition: '',
+      key: 'dbFilterKey',
+      keyLabel: 'dbFilterKey',
+      operator: '=~',
+      value: '.*',
+      valueLabels: ['.*'],
+      restorable: true,
+      matchAllFilter: true,
+      origin: FilterOrigin.Dashboards,
+    });
+  });
+
   it('should maintain modified scopes and reconciliate after scopes update', () => {
     // scope filters are fully emitted sometimes after urlSync happens, so we maintain all
     // scope filters we find in the URL even tho at that point there are no scope

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -764,7 +764,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'baseValue1',
           valueLabels: ['baseValue1'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'baseKey2',
@@ -772,7 +772,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '!=',
           value: 'baseValue2',
           valueLabels: ['baseValue2'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         // no origin, so this does not get synced
         { key: 'baseKey3', keyLabel: 'baseKey3', operator: '!=', value: 'baseValue3', valueLabels: ['baseValue3'] },
@@ -882,7 +882,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilterKey',
           operator: '=',
           value: 'dbFilterValue',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
       ],
     });
@@ -904,7 +904,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       valueLabels: ['.*'],
       restorable: true,
       matchAllFilter: true,
-      origin: FilterOrigin.Dashboards,
+      origin: FilterOrigin.Dashboard,
     });
   });
 
@@ -930,7 +930,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       value: 'newScopesFilterValue1',
       valueLabels: ['newScopesFilterValue1'],
       restorable: true,
-      origin: FilterOrigin.Scopes,
+      origin: FilterOrigin.Scope,
       condition: '',
     });
   });
@@ -965,7 +965,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilterKey',
           operator: '=',
           value: 'dbFilterValue',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
       ],
     });
@@ -989,7 +989,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       operator: '!=',
       value: 'newDbFilterValue',
       valueLabels: ['newDbFilterValue'],
-      origin: FilterOrigin.Dashboards,
+      origin: FilterOrigin.Dashboard,
       condition: '',
       restorable: true,
     });
@@ -1027,7 +1027,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilterKey',
           operator: '=',
           value: 'dbFilterValue',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
       ],
     });
@@ -1062,7 +1062,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       value: 'newScopeFilterValue',
       valueLabels: ['newScopeFilterValue'],
       restorable: true,
-      origin: FilterOrigin.Scopes,
+      origin: FilterOrigin.Scope,
       condition: '',
     });
 
@@ -1071,7 +1071,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       operator: '=',
       value: 'scopeFilterValue2',
       values: ['scopeFilterValue2'],
-      origin: FilterOrigin.Scopes,
+      origin: FilterOrigin.Scope,
     });
 
     // normal baseFilters are simply maintained if they exist in the adhoc
@@ -1089,7 +1089,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       value: 'newDbFilterValue',
       valueLabels: ['newDbFilterValue'],
       restorable: true,
-      origin: FilterOrigin.Dashboards,
+      origin: FilterOrigin.Dashboard,
       condition: '',
     });
 
@@ -1115,7 +1115,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilter',
           operator: '=',
           value: 'dbValue',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
       ],
     });
@@ -1168,13 +1168,13 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbKey1',
           operator: '=',
           value: 'dbValue1',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
         {
           key: 'dbKey2',
           operator: '=',
           value: 'dbValue2',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
       ],
     });
@@ -1223,14 +1223,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilter1',
           operator: '=',
           value: 'dbValue1',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
         // this is restorable, so should be restored on unmount
         {
           key: 'dbFilter2',
           operator: '!=',
           value: 'dbValue2',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
           restorable: true,
         },
         // just a normal baseFilter,
@@ -1260,7 +1260,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilter1',
           operator: '=',
           value: 'dbValue1',
-          origin: FilterOrigin.Dashboards,
+          origin: FilterOrigin.Dashboard,
         },
       ],
     });
@@ -1480,7 +1480,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=|',
           value: 'baseValue1',
           values: ['baseValue1'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
       ],
     });
@@ -1508,14 +1508,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'scopeBaseFilter2',
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
           restorable: true,
         },
       ],
@@ -1532,7 +1532,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
           restorable: true,
         },
         {
@@ -1540,14 +1540,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'scopeBaseFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'nonScopeBaseFilter',
@@ -1572,21 +1572,21 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'scopeBaseFilter2',
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'scopeBaseFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
       ],
     ],
@@ -1622,7 +1622,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
       ],
       [[{ key: 'scopeBaseFilter3', operator: 'equals', value: 'val' }]],
@@ -1632,7 +1632,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
         {
           key: 'nonScopeBaseFilter',
@@ -1649,7 +1649,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
           restorable: true,
         },
       ],
@@ -1660,7 +1660,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
           restorable: true,
         },
       ],
@@ -1672,7 +1672,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
       ],
       [[{ key: 'scopeBaseFilter2', operator: 'equals', value: 'val' }]],
@@ -1682,7 +1682,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scopes,
+          origin: FilterOrigin.Scope,
         },
       ],
     ],
@@ -1788,7 +1788,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         operator: '=',
         value: 'val',
         values: ['val'],
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
       },
       {
         key: 'baseFilter',
@@ -2108,7 +2108,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         applyMode: 'manual',
         filters: [{ key: 'key2', operator: '=', value: 'val2' }],
         baseFilters: [
-          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: FilterOrigin.Scopes },
+          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: FilterOrigin.Scope },
           { key: 'baseKey2', operator: '=', value: 'baseVal2' },
         ],
       });
@@ -2119,7 +2119,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         datasource: { uid: 'hello' },
         applyMode: 'manual',
         baseFilters: [
-          { key: 'baseKey3', operator: '=', value: 'baseVal3', origin: FilterOrigin.Scopes },
+          { key: 'baseKey3', operator: '=', value: 'baseVal3', origin: FilterOrigin.Scope },
           { key: 'baseKey4', operator: '=', value: 'baseVal4' },
         ],
       });
@@ -2142,7 +2142,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
       variable.setState({
         baseFilters: [
-          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: FilterOrigin.Scopes },
+          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: FilterOrigin.Scope },
           { key: 'baseKey2', operator: '=', value: 'baseVal2' },
         ],
       });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { act, getAllByRole, render, waitFor, screen } from '@testing-library/react';
 import { SceneVariableValueChangedEvent } from '../types';
-import {
-  AdHocFiltersVariable,
-  AdHocFiltersVariableState,
-  AdHocFilterWithLabels,
-  FilterOrigin,
-} from './AdHocFiltersVariable';
+import { AdHocFiltersVariable, AdHocFiltersVariableState, AdHocFilterWithLabels } from './AdHocFiltersVariable';
 import {
   DataSourceSrv,
   config,
@@ -764,7 +759,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'baseValue1',
           valueLabels: ['baseValue1'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'baseKey2',
@@ -772,7 +767,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '!=',
           value: 'baseValue2',
           valueLabels: ['baseValue2'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         // no origin, so this does not get synced
         { key: 'baseKey3', keyLabel: 'baseKey3', operator: '!=', value: 'baseValue3', valueLabels: ['baseValue3'] },
@@ -880,7 +875,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilterKey',
           operator: '=',
           value: 'dbFilterValue',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
       ],
     });
@@ -902,7 +897,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       valueLabels: ['.*'],
       restorable: true,
       matchAllFilter: true,
-      origin: FilterOrigin.Dashboard,
+      origin: 'dashboard',
     });
   });
 
@@ -928,7 +923,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       value: 'newScopesFilterValue1',
       valueLabels: ['newScopesFilterValue1'],
       restorable: true,
-      origin: FilterOrigin.Scope,
+      origin: 'scope',
       condition: '',
     });
   });
@@ -963,7 +958,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilterKey',
           operator: '=',
           value: 'dbFilterValue',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
       ],
     });
@@ -987,7 +982,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       operator: '!=',
       value: 'newDbFilterValue',
       valueLabels: ['newDbFilterValue'],
-      origin: FilterOrigin.Dashboard,
+      origin: 'dashboard',
       condition: '',
       restorable: true,
     });
@@ -1025,7 +1020,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilterKey',
           operator: '=',
           value: 'dbFilterValue',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
       ],
     });
@@ -1060,7 +1055,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       value: 'newScopeFilterValue',
       valueLabels: ['newScopeFilterValue'],
       restorable: true,
-      origin: FilterOrigin.Scope,
+      origin: 'scope',
       condition: '',
     });
 
@@ -1069,7 +1064,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       operator: '=',
       value: 'scopeFilterValue2',
       values: ['scopeFilterValue2'],
-      origin: FilterOrigin.Scope,
+      origin: 'scope',
     });
 
     // normal baseFilters are simply maintained if they exist in the adhoc
@@ -1087,7 +1082,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       value: 'newDbFilterValue',
       valueLabels: ['newDbFilterValue'],
       restorable: true,
-      origin: FilterOrigin.Dashboard,
+      origin: 'dashboard',
       condition: '',
     });
 
@@ -1113,7 +1108,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilter',
           operator: '=',
           value: 'dbValue',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
       ],
     });
@@ -1166,13 +1161,13 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbKey1',
           operator: '=',
           value: 'dbValue1',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
         {
           key: 'dbKey2',
           operator: '=',
           value: 'dbValue2',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
       ],
     });
@@ -1221,14 +1216,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilter1',
           operator: '=',
           value: 'dbValue1',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
         // this is restorable, so should be restored on unmount
         {
           key: 'dbFilter2',
           operator: '!=',
           value: 'dbValue2',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
           restorable: true,
         },
         // just a normal baseFilter,
@@ -1258,7 +1253,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           key: 'dbFilter1',
           operator: '=',
           value: 'dbValue1',
-          origin: FilterOrigin.Dashboard,
+          origin: 'dashboard',
         },
       ],
     });
@@ -1478,7 +1473,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=|',
           value: 'baseValue1',
           values: ['baseValue1'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
       ],
     });
@@ -1506,14 +1501,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'scopeBaseFilter2',
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
           restorable: true,
         },
       ],
@@ -1530,7 +1525,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
           restorable: true,
         },
         {
@@ -1538,14 +1533,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'scopeBaseFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'nonScopeBaseFilter',
@@ -1570,21 +1565,21 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'scopeBaseFilter2',
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'scopeBaseFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
       ],
     ],
@@ -1620,7 +1615,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
       ],
       [[{ key: 'scopeBaseFilter3', operator: 'equals', value: 'val' }]],
@@ -1630,7 +1625,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
         {
           key: 'nonScopeBaseFilter',
@@ -1647,7 +1642,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
           restorable: true,
         },
       ],
@@ -1658,7 +1653,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
           restorable: true,
         },
       ],
@@ -1670,7 +1665,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
       ],
       [[{ key: 'scopeBaseFilter2', operator: 'equals', value: 'val' }]],
@@ -1680,7 +1675,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           operator: '=',
           value: 'val',
           values: ['val'],
-          origin: FilterOrigin.Scope,
+          origin: 'scope',
         },
       ],
     ],
@@ -1724,7 +1719,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     const { filtersVar } = setup({
       filters: [],
-      baseFilters,
+      baseFilters: baseFilters as AdHocFilterWithLabels[],
     });
 
     filtersVar.state.baseFilters?.forEach((filter, index) => {
@@ -1786,7 +1781,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         operator: '=',
         value: 'val',
         values: ['val'],
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
       },
       {
         key: 'baseFilter',
@@ -2106,7 +2101,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         applyMode: 'manual',
         filters: [{ key: 'key2', operator: '=', value: 'val2' }],
         baseFilters: [
-          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: FilterOrigin.Scope },
+          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: 'scope' },
           { key: 'baseKey2', operator: '=', value: 'baseVal2' },
         ],
       });
@@ -2117,7 +2112,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         datasource: { uid: 'hello' },
         applyMode: 'manual',
         baseFilters: [
-          { key: 'baseKey3', operator: '=', value: 'baseVal3', origin: FilterOrigin.Scope },
+          { key: 'baseKey3', operator: '=', value: 'baseVal3', origin: 'scope' },
           { key: 'baseKey4', operator: '=', value: 'baseVal4' },
         ],
       });
@@ -2140,7 +2135,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
       variable.setState({
         baseFilters: [
-          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: FilterOrigin.Scope },
+          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: 'scope' },
           { key: 'baseKey2', operator: '=', value: 'baseVal2' },
         ],
       });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -211,6 +211,9 @@ export class AdHocFiltersVariable
   private _scopedVars = { __sceneObject: wrapInSafeSerializableSceneObject(this) };
   private _dataSourceSrv = getDataSourceSrv();
   private _scopesBridge: SceneScopesBridge | undefined;
+  // holds the originalValues of all baseFilters in a map. The values
+  // are set on construct and used to restore a baseFilter with an origin
+  // to its original value if edited at some point
   private _originalValues: Map<string, { value: string[]; operator: string }> = new Map();
 
   protected _urlSync = new AdHocFiltersVariableUrlSyncHandler(this);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -288,14 +288,9 @@ export class AdHocFiltersVariable
 
   private _updateScopesFilters(scopes: Scope[]) {
     if (!scopes.length) {
-      const remainingBaseFilters = this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes);
-
-      if (remainingBaseFilters?.length) {
-        this.setState({
-          baseFilters: remainingBaseFilters,
-        });
-      }
-
+      this.setState({
+        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes),
+      });
       return;
     }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -258,7 +258,7 @@ export class AdHocFiltersVariable
     }
 
     const sub = this._scopesBridge?.subscribeToValue((n, _) => {
-      this._updateScopesFilters(n, true);
+      this._updateScopesFilters(n);
     });
 
     this._updateFiltersIfRestorable();
@@ -296,7 +296,7 @@ export class AdHocFiltersVariable
     });
   }
 
-  private _updateScopesFilters = (scopes: Scope[], overwriteScopes?: boolean) => {
+  private _updateScopesFilters(scopes: Scope[]) {
     if (!scopes.length) {
       this.setState({
         baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes),
@@ -330,27 +330,21 @@ export class AdHocFiltersVariable
       }
     });
 
-    // when changing scopes alltogether, we might still have some filters from the previous
-    // scope with the same keys, but potentially different values. We don't want to keep
-    // those (and add a restore button to the new scope filters) but overwrite them
-    // alltogether
-    if (!overwriteScopes) {
-      const editedScopeFilters = scopeInjectedFilters.filter((filter) => filter.restorable);
-      const editedScopeFilterKeys = editedScopeFilters.map((filter) => filter.key);
-      const scopeFilterKeys = scopeFilters.map((filter) => filter.key);
+    const editedScopeFilters = scopeInjectedFilters.filter((filter) => filter.restorable);
+    const editedScopeFilterKeys = editedScopeFilters.map((filter) => filter.key);
+    const scopeFilterKeys = scopeFilters.map((filter) => filter.key);
 
-      // if the scope filters contain the key of an edited scope filter, we replace
-      // with the edited filter. We also add the remaining unedited scope filters
-      // when not overwriting
-      finalFilters = [
-        ...editedScopeFilters.filter((filter) => scopeFilterKeys.includes(filter.key)),
-        ...scopeFilters.filter((filter) => !editedScopeFilterKeys.includes(filter.key)),
-      ];
-    }
+    // if the scope filters contain the key of an edited scope filter, we replace
+    // with the edited filter. We also add the remaining unedited scope filters
+    // when not overwriting
+    finalFilters = [
+      ...editedScopeFilters.filter((filter) => scopeFilterKeys.includes(filter.key)),
+      ...scopeFilters.filter((filter) => !editedScopeFilterKeys.includes(filter.key)),
+    ];
 
     // maintain other baseFilters in the array, only update scopes ones
     this.setState({ baseFilters: [...finalFilters, ...remainingFilters] });
-  };
+  }
 
   public setState(update: Partial<AdHocFiltersVariableState>): void {
     let filterExpressionChanged = false;

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -426,6 +426,11 @@ export class AdHocFiltersVariable
       const originalValues = this._originalValues.get(filter.key);
       const updateValues = update.values || (update.value ? [update.value] : undefined);
 
+      // if we don't have the restorable prop set but values differ we set it true
+      // this happens when editing the value of an injected filter
+      // we also make sure to set restorable false if values are the same as original
+      // e.g.: if we edit the value of a filter to whatever the original was, manually
+      // 'restoring' the filter
       const isRestorableOverride = update.hasOwnProperty('restorable');
       if (
         !isRestorableOverride &&

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -265,8 +265,11 @@ export class AdHocFiltersVariable
 
     return () => {
       sub?.unsubscribe();
+      this.setState({
+        baseFilters: [...(this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes) ?? [])],
+      });
       this.state.baseFilters?.forEach((filter) => {
-        if (filter.restorable) {
+        if (filter.origin === FilterOrigin.Dashboards) {
           this.restoreOriginalFilter(filter);
         }
       });
@@ -275,6 +278,10 @@ export class AdHocFiltersVariable
 
   private _updateFiltersIfRestorable() {
     this.state.baseFilters?.forEach((filter) => {
+      if (!filter.origin) {
+        return;
+      }
+
       const update: { restorable?: boolean; matchAllFilter?: boolean } = {};
 
       if (this.isRestorableFilters(filter)) {
@@ -328,7 +335,7 @@ export class AdHocFiltersVariable
     // those (and add a restore button to the new scope filters) but overwrite them
     // alltogether
     if (!overwriteScopes) {
-      const editedScopeFilters = scopeInjectedFilters.filter((filter) => this.isRestorableFilters(filter));
+      const editedScopeFilters = scopeInjectedFilters.filter((filter) => filter.restorable);
       const editedScopeFilterKeys = editedScopeFilters.map((filter) => filter.key);
       const scopeFilterKeys = scopeFilters.map((filter) => filter.key);
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -48,10 +48,7 @@ export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> exten
 
 export type AdHocControlsLayout = ControlsLayout | 'combobox';
 
-export enum FilterOrigin {
-  Scope = 'scope',
-  Dashboard = 'dashboard',
-}
+export type FilterOrigin = 'dashboard' | 'scope';
 
 export interface AdHocFiltersVariableState extends SceneVariableState {
   /** Optional text to display on the 'add filter' button */
@@ -240,7 +237,7 @@ export class AdHocFiltersVariable
 
     // set dashboard lvl original values in constructor, since we have them from schema
     this.state.baseFilters?.forEach((baseFilter) => {
-      if (baseFilter.origin === FilterOrigin.Dashboard) {
+      if (baseFilter.origin === 'dashboard') {
         this._originalValues.set(baseFilter.key, {
           operator: baseFilter.operator,
           value: baseFilter.values ?? [baseFilter.value],
@@ -275,13 +272,13 @@ export class AdHocFiltersVariable
       // has the changed value in the schema, unless we reset it here
       if (this.state.baseFilters?.length) {
         this.setState({
-          baseFilters: [...this.state.baseFilters.filter((filter) => filter.origin !== FilterOrigin.Scope)],
+          baseFilters: [...this.state.baseFilters.filter((filter) => filter.origin !== 'scope')],
         });
         // same for dashboard level filters if we edit one and go to another dashboard, reset to whatever initial value is there
         // and come back to the initial one it will use the last modified value it has, since URL is empty from the reset done
         // before
         this.state.baseFilters?.forEach((filter) => {
-          if (filter.origin === FilterOrigin.Dashboard && filter.restorable) {
+          if (filter.origin === 'dashboard' && filter.restorable) {
             this.restoreOriginalFilter(filter);
           }
         });
@@ -292,7 +289,7 @@ export class AdHocFiltersVariable
   private _updateScopesFilters(scopes: Scope[]) {
     if (!scopes.length) {
       this.setState({
-        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scope),
+        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== 'scope'),
       });
       return;
     }
@@ -316,7 +313,7 @@ export class AdHocFiltersVariable
     });
 
     this.state.baseFilters?.forEach((filter) => {
-      if (filter.origin === FilterOrigin.Scope) {
+      if (filter.origin === 'scope') {
         scopeInjectedFilters.push(filter);
       } else {
         remainingFilters.push(filter);
@@ -632,7 +629,7 @@ export class AdHocFiltersVariable
 
     // if current filter is a scope injected one we need to filter out
     // filters with same key in scopes prop, similar to how we do in adhocFilters prop
-    if (filter.origin === FilterOrigin.Scope) {
+    if (filter.origin === 'scope') {
       scopes = scopes?.map((scope) => {
         return {
           ...scope,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -265,6 +265,11 @@ export class AdHocFiltersVariable
 
     return () => {
       sub?.unsubscribe();
+      this.state.baseFilters?.forEach((filter) => {
+        if (filter.restorable) {
+          this.restoreOriginalFilter(filter);
+        }
+      });
     };
   };
 
@@ -430,7 +435,6 @@ export class AdHocFiltersVariable
       const originalValues = this._originalValues.get(filter.key);
       const updateValues = update.values || (update.value ? [update.value] : undefined);
 
-      console.log(originalValues, updateValues);
       const isRestorableOverride = update.hasOwnProperty('restorable');
       if (
         !isRestorableOverride &&
@@ -439,8 +443,6 @@ export class AdHocFiltersVariable
       ) {
         update.restorable = true;
       } else if (updateValues && isEqual(updateValues, originalValues?.value)) {
-        // todo test this out. We don't need to verify operator, that will never be
-        // manually changed
         update.restorable = false;
       }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -270,25 +270,32 @@ export class AdHocFiltersVariable
       // we reset the value, and then come back to the initial dashboard, that dashboard still has the edited scope
       // because the URL will not hold any value, since on reset we clear the url, but the initial dashboard still
       // has the changed value in the schema, unless we reset it here
-      this.setState({
-        baseFilters: [...(this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes) ?? [])],
-      });
-      // same for dashboard level filters if we edit one and go to another dashboard, reset to whatever initial value is there
-      // and come back to the initial one it will use the last modified value it has, since URL is empty from the reset done
-      // before
-      this.state.baseFilters?.forEach((filter) => {
-        if (filter.origin === FilterOrigin.Dashboards && filter.restorable) {
-          this.restoreOriginalFilter(filter);
-        }
-      });
+      if (this.state.baseFilters?.length) {
+        this.setState({
+          baseFilters: [...this.state.baseFilters.filter((filter) => filter.origin !== FilterOrigin.Scopes)],
+        });
+        // same for dashboard level filters if we edit one and go to another dashboard, reset to whatever initial value is there
+        // and come back to the initial one it will use the last modified value it has, since URL is empty from the reset done
+        // before
+        this.state.baseFilters?.forEach((filter) => {
+          if (filter.origin === FilterOrigin.Dashboards && filter.restorable) {
+            this.restoreOriginalFilter(filter);
+          }
+        });
+      }
     };
   };
 
   private _updateScopesFilters(scopes: Scope[]) {
     if (!scopes.length) {
-      this.setState({
-        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes),
-      });
+      const remainingBaseFilters = this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes);
+
+      if (remainingBaseFilters?.length) {
+        this.setState({
+          baseFilters: remainingBaseFilters,
+        });
+      }
+
       return;
     }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -745,6 +745,10 @@ export function toSelectableValue(input: MetricFindValue): SelectableValue<strin
   return result;
 }
 
+export function isMatchAllFilter(filter: AdHocFilterWithLabels): boolean {
+  return filter.operator === '=~' && filter.value === '.*';
+}
+
 export function isFilterComplete(filter: AdHocFilterWithLabels): boolean {
   return filter.key !== '' && filter.operator !== '' && filter.value !== '';
 }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -49,8 +49,8 @@ export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> exten
 export type AdHocControlsLayout = ControlsLayout | 'combobox';
 
 export enum FilterOrigin {
-  Scopes = 'scopes',
-  Dashboards = 'dashboards',
+  Scope = 'scope',
+  Dashboard = 'dashboard',
 }
 
 export interface AdHocFiltersVariableState extends SceneVariableState {
@@ -240,7 +240,7 @@ export class AdHocFiltersVariable
 
     // set dashboard lvl original values in constructor, since we have them from schema
     this.state.baseFilters?.forEach((baseFilter) => {
-      if (baseFilter.origin === FilterOrigin.Dashboards) {
+      if (baseFilter.origin === FilterOrigin.Dashboard) {
         this._originalValues.set(baseFilter.key, {
           operator: baseFilter.operator,
           value: baseFilter.values ?? [baseFilter.value],
@@ -275,13 +275,13 @@ export class AdHocFiltersVariable
       // has the changed value in the schema, unless we reset it here
       if (this.state.baseFilters?.length) {
         this.setState({
-          baseFilters: [...this.state.baseFilters.filter((filter) => filter.origin !== FilterOrigin.Scopes)],
+          baseFilters: [...this.state.baseFilters.filter((filter) => filter.origin !== FilterOrigin.Scope)],
         });
         // same for dashboard level filters if we edit one and go to another dashboard, reset to whatever initial value is there
         // and come back to the initial one it will use the last modified value it has, since URL is empty from the reset done
         // before
         this.state.baseFilters?.forEach((filter) => {
-          if (filter.origin === FilterOrigin.Dashboards && filter.restorable) {
+          if (filter.origin === FilterOrigin.Dashboard && filter.restorable) {
             this.restoreOriginalFilter(filter);
           }
         });
@@ -292,7 +292,7 @@ export class AdHocFiltersVariable
   private _updateScopesFilters(scopes: Scope[]) {
     if (!scopes.length) {
       this.setState({
-        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scopes),
+        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== FilterOrigin.Scope),
       });
       return;
     }
@@ -316,7 +316,7 @@ export class AdHocFiltersVariable
     });
 
     this.state.baseFilters?.forEach((filter) => {
-      if (filter.origin === FilterOrigin.Scopes) {
+      if (filter.origin === FilterOrigin.Scope) {
         scopeInjectedFilters.push(filter);
       } else {
         remainingFilters.push(filter);
@@ -632,7 +632,7 @@ export class AdHocFiltersVariable
 
     // if current filter is a scope injected one we need to filter out
     // filters with same key in scopes prop, similar to how we do in adhocFilters prop
-    if (filter.origin === FilterOrigin.Scopes) {
+    if (filter.origin === FilterOrigin.Scope) {
       scopes = scopes?.map((scope) => {
         return {
           ...scope,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -38,15 +38,6 @@ export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> exten
   // filter origin, it can be either scopes, dashboards or undefined,
   // which means it won't appear in the UI
   origin?: FilterOrigin;
-  // this holds the original/initial value of an injected filter that
-  // was edited.
-  // originalValue?: string[];
-  // // this holds the original operator on an injected filter
-  // // Note: a user cannot manually override the operator of an injected filter
-  // // but in some cases the operator will be changed and we need to save the original.
-  // // This can happen for dashboard injected filters that are set to match-all or when
-  // // changing dashboards and there is some other filter with the same key but different operator
-  // originalOperator?: string;
   // whether this is basically a cancelled filter through filter-key =~ .*
   matchAllFilter?: boolean;
   // whether this specific filter is read-only and cannot be edited

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -44,7 +44,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
     }
 
     if (baseFilters?.length) {
-      // injected filters stored in the following format: normal|adhoc|values#filterOrigin
+      // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable
       value.push(
         ...baseFilters
           ?.filter(isFilterComplete)
@@ -80,15 +80,19 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       if (foundBaseFilterIndex > -1) {
         if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === FilterOrigin.Dashboards) {
           filters[i].origin = FilterOrigin.Dashboards;
+          filters[i].restorable = true;
         }
 
         baseFilters[foundBaseFilterIndex] = filters[i];
       } else if (filters[i].origin === FilterOrigin.Dashboards) {
         // if it was originating from a dashoard but has no match in the new dashboard
         // remove it's origin, turn it into a normal filter to be set below
-        filters[i].origin = undefined;
+        delete filters[i].origin;
+        delete filters[i].restorable;
       } else if (foundBaseFilterIndex === -1 && filters[i].origin === FilterOrigin.Scopes && filters[i].restorable) {
-        // if the URL contains a modified scope filter than we persist that
+        // scopes are being set sometimes (when the observable emits actual filters) after urlSync
+        // so we maintain all modified scopes in the adhoc
+        // and leave the scopes update to reconciliate on what filters will actually show up
         baseFilters.push(filters[i]);
       }
     }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -79,8 +79,8 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       // some dashboard lvl filter we maintain it as dashboard lvl filter in the
       // new dashboard
       if (foundBaseFilterIndex > -1) {
-        if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === FilterOrigin.Dashboards) {
-          filters[i].origin = FilterOrigin.Dashboards;
+        if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === FilterOrigin.Dashboard) {
+          filters[i].origin = FilterOrigin.Dashboard;
           filters[i].restorable = true;
         }
 
@@ -89,12 +89,12 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
         }
 
         baseFilters[foundBaseFilterIndex] = filters[i];
-      } else if (filters[i].origin === FilterOrigin.Dashboards) {
+      } else if (filters[i].origin === FilterOrigin.Dashboard) {
         // if it was originating from a dashoard but has no match in the new dashboard
         // remove it's origin, turn it into a normal filter to be set below
         delete filters[i].origin;
         delete filters[i].restorable;
-      } else if (foundBaseFilterIndex === -1 && filters[i].origin === FilterOrigin.Scopes && filters[i].restorable) {
+      } else if (foundBaseFilterIndex === -1 && filters[i].origin === FilterOrigin.Scope && filters[i].restorable) {
         // scopes are being set sometimes (when the observable emits actual filters) after urlSync
         // so we maintain all modified scopes in the adhoc
         // and leave the scopes update to reconciliate on what filters will actually show up
@@ -164,7 +164,7 @@ function toFilter(urlValue: string | number | boolean | undefined | null): AdHoc
 }
 
 function isFilterOrigin(value: string): value is FilterOrigin {
-  return value === FilterOrigin.Scopes || value === FilterOrigin.Dashboards;
+  return value === FilterOrigin.Scope || value === FilterOrigin.Dashboard;
 }
 
 function isFilter(filter: AdHocFilterWithLabels | null): filter is AdHocFilterWithLabels {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -79,8 +79,8 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       // some dashboard lvl filter we maintain it as dashboard lvl filter in the
       // new dashboard
       if (foundBaseFilterIndex > -1) {
-        if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === FilterOrigin.Dashboard) {
-          filters[i].origin = FilterOrigin.Dashboard;
+        if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === 'dashboard') {
+          filters[i].origin = 'dashboard';
           filters[i].restorable = true;
         }
 
@@ -89,12 +89,12 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
         }
 
         baseFilters[foundBaseFilterIndex] = filters[i];
-      } else if (filters[i].origin === FilterOrigin.Dashboard) {
+      } else if (filters[i].origin === 'dashboard') {
         // if it was originating from a dashoard but has no match in the new dashboard
         // remove it's origin, turn it into a normal filter to be set below
         delete filters[i].origin;
         delete filters[i].restorable;
-      } else if (foundBaseFilterIndex === -1 && filters[i].origin === FilterOrigin.Scope && filters[i].restorable) {
+      } else if (foundBaseFilterIndex === -1 && filters[i].origin === 'scope' && filters[i].restorable) {
         // scopes are being set sometimes (when the observable emits actual filters) after urlSync
         // so we maintain all modified scopes in the adhoc
         // and leave the scopes update to reconciliate on what filters will actually show up
@@ -164,7 +164,7 @@ function toFilter(urlValue: string | number | boolean | undefined | null): AdHoc
 }
 
 function isFilterOrigin(value: string): value is FilterOrigin {
-  return value === FilterOrigin.Scope || value === FilterOrigin.Dashboard;
+  return value === 'scope' || value === 'dashboard';
 }
 
 function isFilter(filter: AdHocFilterWithLabels | null): filter is AdHocFilterWithLabels {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -13,7 +13,7 @@ import {
   unescapeUrlDelimiters,
 } from '../utils';
 
-const FILTER_EDITED_FLAG = 'edited';
+const RESTORABLE_FILTER_FLAG = 'edited';
 
 export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _variable: AdHocFiltersVariable) {}
@@ -55,7 +55,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
             toArray(filter)
               .map(escapeInjectedFilterUrlDelimiters)
               .join('|')
-              .concat(`#${filter.origin}${filter.isEdited ? `#${FILTER_EDITED_FLAG}` : ''}`)
+              .concat(`#${filter.origin}${filter.restorable ? `#${RESTORABLE_FILTER_FLAG}` : ''}`)
           )
       );
     }
@@ -77,7 +77,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       // if a dashboard filter is not edited, we do not carry it over
       const filters = deserializeUrlToFilters(urlValue).filter(
         (filter) =>
-          filter.origin !== FilterOrigin.Dashboards || (filter.origin === FilterOrigin.Dashboards && filter.isEdited)
+          filter.origin !== FilterOrigin.Dashboards || (filter.origin === FilterOrigin.Dashboards && filter.restorable)
       );
       const baseFilters = [...(this._variable.state.baseFilters || [])];
 
@@ -138,7 +138,7 @@ function toFilter(urlValue: string | number | boolean | undefined | null): AdHoc
     return null;
   }
 
-  const [filter, origin, isEdited] = urlValue.split('#');
+  const [filter, origin, restorable] = urlValue.split('#');
   const [key, keyLabel, operator, _operatorLabel, ...values] = filter
     .split('|')
     .reduce<string[]>((acc, v) => {
@@ -159,7 +159,7 @@ function toFilter(urlValue: string | number | boolean | undefined | null): AdHoc
     valueLabels: values.filter((_, index) => index % 2 === 1),
     condition: '',
     origin: isFilterOrigin(origin) ? origin : undefined,
-    isEdited: !!isEdited,
+    restorable: !!restorable,
   };
 }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -4,6 +4,7 @@ import {
   AdHocFilterWithLabels,
   FilterOrigin,
   isFilterComplete,
+  isMatchAllFilter,
   isMultiValueOperator,
 } from './AdHocFiltersVariable';
 import {
@@ -81,6 +82,10 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
         if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === FilterOrigin.Dashboards) {
           filters[i].origin = FilterOrigin.Dashboards;
           filters[i].restorable = true;
+        }
+
+        if (isMatchAllFilter(filters[i])) {
+          filters[i].matchAllFilter = true;
         }
 
         baseFilters[foundBaseFilterIndex] = filters[i];

--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.test.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.test.ts
@@ -1,6 +1,5 @@
 import { Scope, ScopeSpecFilter } from '@grafana/data';
 import { getAdHocFiltersFromScopes } from './getAdHocFiltersFromScopes';
-import { FilterOrigin } from './AdHocFiltersVariable';
 
 describe('getAdHocFiltersFromScopes', () => {
   it('should return empty filters when no scopes are provided', () => {
@@ -24,15 +23,15 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scope, values: ['value1'] },
-      { key: 'key2', value: 'value2', operator: '!=', origin: FilterOrigin.Scope, values: ['value2'] },
-      { key: 'key3', value: 'value3', operator: '!~', origin: FilterOrigin.Scope, values: ['value3'] },
+      { key: 'key1', value: 'value1', operator: '=', origin: 'scope', values: ['value1'] },
+      { key: 'key2', value: 'value2', operator: '!=', origin: 'scope', values: ['value2'] },
+      { key: 'key3', value: 'value3', operator: '!~', origin: 'scope', values: ['value3'] },
     ]);
 
     scopes = generateScopes([[{ key: 'key3', value: 'value3', operator: 'regex-match' }]]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key3', value: 'value3', operator: '=~', origin: FilterOrigin.Scope, values: ['value3'] },
+      { key: 'key3', value: 'value3', operator: '=~', origin: 'scope', values: ['value3'] },
     ]);
   });
 
@@ -43,8 +42,8 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scope, values: ['value1'] },
-      { key: 'key2', value: 'value2', operator: '=~', origin: FilterOrigin.Scope, values: ['value2'] },
+      { key: 'key1', value: 'value1', operator: '=', origin: 'scope', values: ['value1'] },
+      { key: 'key2', value: 'value2', operator: '=~', origin: 'scope', values: ['value2'] },
     ]);
   });
 
@@ -61,10 +60,10 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scope, values: ['value1'] },
-      { key: 'key2', value: 'value2', operator: '!=', origin: FilterOrigin.Scope, values: ['value2'] },
-      { key: 'key3', value: 'value3', operator: '=~', origin: FilterOrigin.Scope, values: ['value3'] },
-      { key: 'key4', value: 'value4', operator: '=~', origin: FilterOrigin.Scope, values: ['value4'] },
+      { key: 'key1', value: 'value1', operator: '=', origin: 'scope', values: ['value1'] },
+      { key: 'key2', value: 'value2', operator: '!=', origin: 'scope', values: ['value2'] },
+      { key: 'key3', value: 'value3', operator: '=~', origin: 'scope', values: ['value3'] },
+      { key: 'key4', value: 'value4', operator: '=~', origin: 'scope', values: ['value4'] },
     ]);
   });
 
@@ -86,10 +85,10 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value1', 'value3', 'value5'],
       },
-      { key: 'key2', value: 'value2', operator: '!=|', origin: FilterOrigin.Scope, values: ['value2', 'value4'] },
+      { key: 'key2', value: 'value2', operator: '!=|', origin: 'scope', values: ['value2', 'value4'] },
     ]);
   });
 
@@ -105,14 +104,14 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value1', 'value3'],
       },
       {
         key: 'key1',
         value: 'value2',
         operator: '!=',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value2'],
       },
     ]);
@@ -136,22 +135,22 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value1'],
       },
-      { key: 'key2', value: 'value2', operator: '!=|', origin: FilterOrigin.Scope, values: ['value2', 'value4'] },
+      { key: 'key2', value: 'value2', operator: '!=|', origin: 'scope', values: ['value2', 'value4'] },
       {
         key: 'key1',
         value: 'value3',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value3'],
       },
       {
         key: 'key1',
         value: 'value5',
         operator: '=',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value5'],
       },
     ]);
@@ -167,21 +166,21 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value1'],
       },
       {
         key: 'key1',
         value: 'value5',
         operator: '=',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value5'],
       },
       {
         key: 'key1',
         value: 'value3',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value3'],
       },
     ]);
@@ -199,14 +198,14 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value1', 'value3'],
       },
       {
         key: 'key1',
         value: 'value2',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value2'],
       },
     ]);
@@ -239,28 +238,28 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value1', 'value3', 'value7', 'value9'],
       },
       {
         key: 'key2',
         value: 'value2',
         operator: '=|',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value2', 'value4', 'value6', 'value10'],
       },
       {
         key: 'key1',
         value: 'value5',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value5'],
       },
       {
         key: 'key2',
         value: 'value8',
         operator: '=~',
-        origin: FilterOrigin.Scope,
+        origin: 'scope',
         values: ['value8'],
       },
     ]);

--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.test.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.test.ts
@@ -24,15 +24,15 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scopes, values: ['value1'] },
-      { key: 'key2', value: 'value2', operator: '!=', origin: FilterOrigin.Scopes, values: ['value2'] },
-      { key: 'key3', value: 'value3', operator: '!~', origin: FilterOrigin.Scopes, values: ['value3'] },
+      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scope, values: ['value1'] },
+      { key: 'key2', value: 'value2', operator: '!=', origin: FilterOrigin.Scope, values: ['value2'] },
+      { key: 'key3', value: 'value3', operator: '!~', origin: FilterOrigin.Scope, values: ['value3'] },
     ]);
 
     scopes = generateScopes([[{ key: 'key3', value: 'value3', operator: 'regex-match' }]]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key3', value: 'value3', operator: '=~', origin: FilterOrigin.Scopes, values: ['value3'] },
+      { key: 'key3', value: 'value3', operator: '=~', origin: FilterOrigin.Scope, values: ['value3'] },
     ]);
   });
 
@@ -43,8 +43,8 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scopes, values: ['value1'] },
-      { key: 'key2', value: 'value2', operator: '=~', origin: FilterOrigin.Scopes, values: ['value2'] },
+      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scope, values: ['value1'] },
+      { key: 'key2', value: 'value2', operator: '=~', origin: FilterOrigin.Scope, values: ['value2'] },
     ]);
   });
 
@@ -61,10 +61,10 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
 
     expect(getAdHocFiltersFromScopes(scopes)).toEqual([
-      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scopes, values: ['value1'] },
-      { key: 'key2', value: 'value2', operator: '!=', origin: FilterOrigin.Scopes, values: ['value2'] },
-      { key: 'key3', value: 'value3', operator: '=~', origin: FilterOrigin.Scopes, values: ['value3'] },
-      { key: 'key4', value: 'value4', operator: '=~', origin: FilterOrigin.Scopes, values: ['value4'] },
+      { key: 'key1', value: 'value1', operator: '=', origin: FilterOrigin.Scope, values: ['value1'] },
+      { key: 'key2', value: 'value2', operator: '!=', origin: FilterOrigin.Scope, values: ['value2'] },
+      { key: 'key3', value: 'value3', operator: '=~', origin: FilterOrigin.Scope, values: ['value3'] },
+      { key: 'key4', value: 'value4', operator: '=~', origin: FilterOrigin.Scope, values: ['value4'] },
     ]);
   });
 
@@ -86,10 +86,10 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value1', 'value3', 'value5'],
       },
-      { key: 'key2', value: 'value2', operator: '!=|', origin: FilterOrigin.Scopes, values: ['value2', 'value4'] },
+      { key: 'key2', value: 'value2', operator: '!=|', origin: FilterOrigin.Scope, values: ['value2', 'value4'] },
     ]);
   });
 
@@ -105,14 +105,14 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value1', 'value3'],
       },
       {
         key: 'key1',
         value: 'value2',
         operator: '!=',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value2'],
       },
     ]);
@@ -136,22 +136,22 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value1'],
       },
-      { key: 'key2', value: 'value2', operator: '!=|', origin: FilterOrigin.Scopes, values: ['value2', 'value4'] },
+      { key: 'key2', value: 'value2', operator: '!=|', origin: FilterOrigin.Scope, values: ['value2', 'value4'] },
       {
         key: 'key1',
         value: 'value3',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value3'],
       },
       {
         key: 'key1',
         value: 'value5',
         operator: '=',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value5'],
       },
     ]);
@@ -167,21 +167,21 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value1'],
       },
       {
         key: 'key1',
         value: 'value5',
         operator: '=',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value5'],
       },
       {
         key: 'key1',
         value: 'value3',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value3'],
       },
     ]);
@@ -199,14 +199,14 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value1', 'value3'],
       },
       {
         key: 'key1',
         value: 'value2',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value2'],
       },
     ]);
@@ -239,28 +239,28 @@ describe('getAdHocFiltersFromScopes', () => {
         key: 'key1',
         value: 'value1',
         operator: '=|',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value1', 'value3', 'value7', 'value9'],
       },
       {
         key: 'key2',
         value: 'value2',
         operator: '=|',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value2', 'value4', 'value6', 'value10'],
       },
       {
         key: 'key1',
         value: 'value5',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value5'],
       },
       {
         key: 'key2',
         value: 'value8',
         operator: '=~',
-        origin: FilterOrigin.Scopes,
+        origin: FilterOrigin.Scope,
         values: ['value8'],
       },
     ]);

--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
@@ -1,5 +1,5 @@
 import { Scope, ScopeFilterOperator, ScopeSpecFilter, scopeFilterOperatorMap } from '@grafana/data';
-import { AdHocFilterWithLabels, FilterOrigin } from './AdHocFiltersVariable';
+import { AdHocFilterWithLabels } from './AdHocFiltersVariable';
 
 export type EqualityOrMultiOperator = Extract<ScopeFilterOperator, 'equals' | 'not-equals' | 'one-of' | 'not-one-of'>;
 
@@ -53,7 +53,7 @@ function processFilter(
       operator: reverseScopeFilterOperatorMap[filter.operator],
       value: filter.value,
       values: filter.values ?? [filter.value],
-      origin: FilterOrigin.Scope,
+      origin: 'scope',
     });
   } else {
     duplicatedFilters.push({
@@ -61,7 +61,7 @@ function processFilter(
       operator: reverseScopeFilterOperatorMap[filter.operator],
       value: filter.value,
       values: filter.values ?? [filter.value],
-      origin: FilterOrigin.Scope,
+      origin: 'scope',
     });
   }
 }

--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
@@ -53,7 +53,7 @@ function processFilter(
       operator: reverseScopeFilterOperatorMap[filter.operator],
       value: filter.value,
       values: filter.values ?? [filter.value],
-      origin: FilterOrigin.Scopes,
+      origin: FilterOrigin.Scope,
     });
   } else {
     duplicatedFilters.push({
@@ -61,7 +61,7 @@ function processFilter(
       operator: reverseScopeFilterOperatorMap[filter.operator],
       value: filter.value,
       values: filter.values ?? [filter.value],
-      origin: FilterOrigin.Scopes,
+      origin: FilterOrigin.Scope,
     });
   }
 }


### PR DESCRIPTION
This PR adds support for dashboard level filters, which are filters set in the schema, under the adhoc variables `baseFilter` property. This new type of baseFilter will need a specific `origin: 'dashboards'` property to indicate it is a dashboard level filter.

Dashboard level filters will stick on your dashboard, they can be cleared (become a regex match-all filter) but not removed, their value can be edited and afterwards restored. Going to another dashboard with this filter will maintain it if there is another dashboard level filter with the same key or remove it, unless the filter is edited. If it is edited it will maintain it across dashboards as a normal filter.

This PR also simplifies the code a bit by not carrying original values (the values that an edited filter restores to), but instead keeping originals in runtime and setting a flag on edited filters as `restorable`. Modified `baseFilters` will be maintained in the URL so they can be moved between dashboards.


https://github.com/user-attachments/assets/3c524f32-fbfa-40f3-b7d0-c7734308719b


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.10.0--canary.1095.14635793130.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.10.0--canary.1095.14635793130.0
  npm install @grafana/scenes@6.10.0--canary.1095.14635793130.0
  # or 
  yarn add @grafana/scenes-react@6.10.0--canary.1095.14635793130.0
  yarn add @grafana/scenes@6.10.0--canary.1095.14635793130.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
