### PR TITLE
Variables: Switch between multi and single select if state changes

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -132,7 +132,7 @@ export { VizPanelBuilder } from './core/PanelBuilders/VizPanelBuilder';
 export { SceneDebugger } from './components/SceneDebugger/SceneDebugger';
 export { VariableValueSelectWrapper } from './variables/components/VariableValueSelectors';
 export { ControlsLabel } from './utils/ControlsLabel';
-export { renderSelectForVariable } from './variables/components/VariableValueSelect';
+export { MultiOrSingleValueSelect as renderSelectForVariable } from './variables/components/VariableValueSelect';
 export { VizConfigBuilder } from './core/PanelBuilders/VizConfigBuilder';
 export { VizConfigBuilders } from './core/PanelBuilders/VizConfigBuilders';
 export { type VizConfig } from './core/PanelBuilders/types';

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -1,4 +1,4 @@
-import { VariableValueSelect, VariableValueSelectMulti } from './VariableValueSelect';
+import { MultiOrSingleValueSelect } from './VariableValueSelect';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
@@ -39,7 +39,7 @@ describe('VariableValueSelect', () => {
   });
 
   it('should render VariableValueSelect component', async () => {
-    render(<VariableValueSelect model={model} />);
+    render(<MultiOrSingleValueSelect model={model} />);
     const variableValueSelectElement = screen.getByTestId(
       selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${model.state.value}`)
     );
@@ -71,7 +71,7 @@ describe('VariableValueSelect', () => {
 
     scene.activate();
 
-    render(<VariableValueSelectMulti model={model} />);
+    render(<MultiOrSingleValueSelect model={model} />);
     const variableValueSelectElement = screen.getByTestId(
       selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${model.state.value}`)
     );
@@ -106,7 +106,7 @@ describe('VariableValueSelect', () => {
 
     scene.activate();
 
-    render(<VariableValueSelect model={model} />);
+    render(<MultiOrSingleValueSelect model={model} />);
     const variableValueSelectElement = screen.getByTestId(
       selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${model.state.value}`)
     );
@@ -117,7 +117,7 @@ describe('VariableValueSelect', () => {
   });
 
   it('should render options in VariableValueSelect component', async () => {
-    render(<VariableValueSelect model={model} />);
+    render(<MultiOrSingleValueSelect model={model} />);
     const variableValueSelectElement = screen.getByTestId(
       selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${model.state.value}`)
     );
@@ -133,7 +133,7 @@ describe('VariableValueSelect', () => {
   });
 
   it('should render custom values in VariableValueSelect component', async () => {
-    render(<VariableValueSelect model={model} />);
+    render(<MultiOrSingleValueSelect model={model} />);
     const variableValueSelectElement = screen.getByTestId(
       selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${model.state.value}`)
     );
@@ -153,7 +153,7 @@ describe('VariableValueSelect', () => {
   it('should not render custom values when allowCustomValue is false in VariableValueSelect component', async () => {
     model.setState({ allowCustomValue: false });
 
-    render(<VariableValueSelect model={model} />);
+    render(<MultiOrSingleValueSelect model={model} />);
     const variableValueSelectElement = screen.getByTestId(
       selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${model.state.value}`)
     );

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -11,8 +11,7 @@ import {
   useTheme2,
 } from '@grafana/ui';
 
-import { SceneComponentProps } from '../../core/types';
-import { MultiValueVariable } from '../variants/MultiValueVariable';
+import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
 import { VariableValue, VariableValueSingle } from '../types';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
@@ -47,8 +46,8 @@ export function toSelectableValue<T>(value: T, label?: string): SelectableValue<
   };
 }
 
-export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVariable>) {
-  const { value, text, key, options, includeAll, isReadOnly, allowCustomValue = true } = model.useState();
+export function VariableValueSelect({ model, state }: { model: MultiValueVariable; state: MultiValueVariableState }) {
+  const { value, text, key, options, includeAll, isReadOnly, allowCustomValue = true } = state;
   const [inputValue, setInputValue] = useState('');
   const [hasCustomValue, setHasCustomValue] = useState(false);
   const selectValue = toSelectableValue(value, String(text));
@@ -109,7 +108,13 @@ export function VariableValueSelect({ model }: SceneComponentProps<MultiValueVar
   );
 }
 
-export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiValueVariable>) {
+export function VariableValueSelectMulti({
+  model,
+  state,
+}: {
+  model: MultiValueVariable;
+  state: MultiValueVariableState;
+}) {
   const {
     value,
     options,
@@ -119,7 +124,7 @@ export function VariableValueSelectMulti({ model }: SceneComponentProps<MultiVal
     includeAll,
     isReadOnly,
     allowCustomValue = true,
-  } = model.useState();
+  } = state;
   const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
   // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
   const [uncommittedValue, setUncommittedValue] = useState(arrayValue);
@@ -256,10 +261,12 @@ const getOptionStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-export function renderSelectForVariable(model: MultiValueVariable) {
-  if (model.state.isMulti) {
-    return <VariableValueSelectMulti model={model} />;
+export function MultiOrSingleValueSelect({ model }: { model: MultiValueVariable }) {
+  const state = model.useState();
+
+  if (state.isMulti) {
+    return <VariableValueSelectMulti model={model} state={state} />;
   } else {
-    return <VariableValueSelect model={model} />;
+    return <VariableValueSelect model={model} state={state} />;
   }
 }

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -2,11 +2,12 @@ import { Observable, of } from 'rxjs';
 
 import { SceneComponentProps } from '../../core/types';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
-import { renderSelectForVariable } from '../components/VariableValueSelect';
+import { MultiOrSingleValueSelect } from '../components/VariableValueSelect';
 import { VariableValueOption } from '../types';
 
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from './MultiValueVariable';
 import { sceneGraph } from '../../core/sceneGraph';
+import React from 'react';
 
 export interface CustomVariableState extends MultiValueVariableState {
   query: string;
@@ -52,6 +53,6 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
   }
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
-    return renderSelectForVariable(model);
+    return <MultiOrSingleValueSelect model={model} />;
   };
 }

--- a/packages/scenes/src/variables/variants/DataSourceVariable.tsx
+++ b/packages/scenes/src/variables/variants/DataSourceVariable.tsx
@@ -6,10 +6,11 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { sceneGraph } from '../../core/sceneGraph';
 import { SceneComponentProps } from '../../core/types';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
-import { renderSelectForVariable } from '../components/VariableValueSelect';
+import { MultiOrSingleValueSelect } from '../components/VariableValueSelect';
 import { VariableValueOption } from '../types';
 
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from './MultiValueVariable';
+import React from 'react';
 
 export interface DataSourceVariableState extends MultiValueVariableState {
   /**
@@ -81,7 +82,7 @@ export class DataSourceVariable extends MultiValueVariable<DataSourceVariableSta
   }
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
-    return renderSelectForVariable(model);
+    return <MultiOrSingleValueSelect model={model} />;
   };
 }
 

--- a/packages/scenes/src/variables/variants/TestVariable.tsx
+++ b/packages/scenes/src/variables/variants/TestVariable.tsx
@@ -4,7 +4,7 @@ import { sceneGraph } from '../../core/sceneGraph';
 import { SceneComponentProps } from '../../core/types';
 import { queryMetricTree } from '../../utils/metricTree';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
-import { renderSelectForVariable } from '../components/VariableValueSelect';
+import { MultiOrSingleValueSelect } from '../components/VariableValueSelect';
 import { VariableValueOption } from '../types';
 
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from './MultiValueVariable';
@@ -12,6 +12,7 @@ import { VariableRefresh } from '@grafana/data';
 import { getClosest } from '../../core/sceneGraph/utils';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { SceneQueryControllerEntry } from '../../behaviors/types';
+import React from 'react';
 
 export interface TestVariableState extends MultiValueVariableState {
   query: string;
@@ -136,6 +137,6 @@ export class TestVariable extends MultiValueVariable<TestVariableState> {
   }
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
-    return renderSelectForVariable(model);
+    return <MultiOrSingleValueSelect model={model} />;
   };
 }

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -14,7 +14,7 @@ import {
 import { sceneGraph } from '../../../core/sceneGraph';
 import { SceneComponentProps, SceneDataQuery } from '../../../core/types';
 import { VariableDependencyConfig } from '../../VariableDependencyConfig';
-import { renderSelectForVariable } from '../../components/VariableValueSelect';
+import { MultiOrSingleValueSelect } from '../../components/VariableValueSelect';
 import { VariableValueOption } from '../../types';
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from '../MultiValueVariable';
 
@@ -28,6 +28,7 @@ import { SEARCH_FILTER_VARIABLE } from '../../constants';
 import { debounce } from 'lodash';
 import { registerQueryWithController } from '../../../querying/registerQueryWithController';
 import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
+import React from 'react';
 
 export interface QueryVariableState extends MultiValueVariableState {
   type: 'query';
@@ -152,7 +153,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
   }, 400);
 
   public static Component = ({ model }: SceneComponentProps<MultiValueVariable>) => {
-    return renderSelectForVariable(model);
+    return <MultiOrSingleValueSelect model={model} />;
   };
 }
 


### PR DESCRIPTION

* In order to switch betwen single and multi select while visible (mounted) we need to subscribe to state on a higher level than we did
* Renamed renderSelectForVariable MultiOrSingleValueSelect and made it a proper react component, it now subscribe to state. Removed state subscription from the lower level components, they get the state instead. 
* This is for the live editing of variable options in the edit pane 