### PR TITLE
AdHocFilters: Removing multi-values from origin filters turns them to match-all filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -110,6 +110,10 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       filterMultiValues: Array<SelectableValue<string>>,
       preventFocus?: boolean
     ) => {
+      if (!filterMultiValues.length && filter.origin) {
+        model.updateToMatchAll(filter);
+      }
+
       if (filterMultiValues.length) {
         const valueLabels: string[] = [];
         const values: string[] = [];
@@ -121,6 +125,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
         model._updateFilter(filter!, { valueLabels, values, value: values[0] });
         setFilterMultiValues([]);
       }
+
       if (!preventFocus) {
         setTimeout(() => refs.domReference.current?.focus());
       }


### PR DESCRIPTION
Through this PR, origin filters such as scope or dashboard originated filters will now allow a user to remove all mulit-values on edit. On removal of all values, the edited filter will become a match-all filter basically cancelling it alltogether.


https://github.com/user-attachments/assets/5de0cf4c-0fd7-4ede-961b-5a454c23fbf2

NOTE: Builds on top of this [PR](https://github.com/grafana/scenes/pull/1095)