### PR TITLE
AdHocFIlters: New designs for match-all filter

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, IconButton, Tooltip } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin, isMatchAllFilter } from '../AdHocFiltersVariable';
 
 const LABEL_MAX_VISIBLE_LENGTH = 20;
 
@@ -68,7 +68,11 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
     );
     return (
       <div
-        className={cx(styles.combinedFilterPill, readOnly && styles.readOnlyCombinedFilter)}
+        className={cx(
+          styles.combinedFilterPill,
+          readOnly && styles.readOnlyCombinedFilter,
+          isMatchAllFilter(filter) && styles.matchAllPill
+        )}
         onClick={(e) => {
           e.stopPropagation();
           setPopulateInputOnEdit(true);
@@ -148,7 +152,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
             }}
             name="history"
             size="md"
-            className={styles.pillIcon}
+            className={isMatchAllFilter(filter) ? styles.matchAllPillIcon : styles.pillIcon}
             tooltip={`Restore filter to its original value`}
           />
         )}
@@ -209,5 +213,18 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   tooltipText: css({
     textAlign: 'center',
+  }),
+  matchAllPillIcon: css({
+    marginInline: theme.spacing(0.5),
+    cursor: 'pointer',
+    color: theme.colors.text.disabled,
+  }),
+  matchAllPill: css({
+    background: theme.colors.action.selected,
+    color: theme.colors.text.disabled,
+    border: 0,
+    '&:hover': {
+      background: theme.colors.action.selected,
+    },
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, IconButton, Tooltip } from '@grafana/ui';
+import { useStyles2, IconButton, Tooltip, Icon } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
 import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin, isMatchAllFilter } from '../AdHocFiltersVariable';
@@ -129,12 +129,9 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         ) : null}
 
         {filter.origin && !filter.restorable && (
-          <IconButton
-            name="info-circle"
-            size="md"
-            className={styles.pillIcon}
-            tooltip={`This is a ${filter.origin} injected filter`}
-          />
+          <Tooltip content={`This is a ${filter.origin} injected filter`} placement={'bottom'}>
+            <Icon name="info-circle" size="md" className={styles.infoPillIcon} />
+          </Tooltip>
         )}
 
         {filter.origin && filter.restorable && (
@@ -213,6 +210,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   tooltipText: css({
     textAlign: 'center',
+  }),
+  infoPillIcon: css({
+    marginInline: theme.spacing(0.5),
+    cursor: 'pointer',
   }),
   matchAllPillIcon: css({
     marginInline: theme.spacing(0.5),


### PR DESCRIPTION
This PR changes the look of match-all filters, which are basically cleared filters that still show in the list of filters.

![Screenshot 2025-04-14 at 10 13 03](https://github.com/user-attachments/assets/a6fa9656-8086-4988-aacc-8b0b4f0b0a3a)

Also turns the info icon that shows information about injected filters into a normal icon without a hover effect.


https://github.com/user-attachments/assets/c3b14686-68e5-436d-873f-47978bac6a46

