### PR TITLE
SceneTimeRange: Fix calculatePercentOfInterval

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -358,5 +358,22 @@ describe('SceneTimeRange', () => {
       simulateDelay(mocked10sLater, scene);
       expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mocked10sLater);
     });
+
+    it('should invalidate stale time range with custom percent', () => {
+      const timeRange = new SceneTimeRange({
+        from: 'now-10m',
+        to: 'now',
+        refreshOnActivate: { percent: 1 },
+      });
+      const scene = new EmbeddedScene({
+        $timeRange: timeRange,
+        body: new SceneReactObject({}),
+      });
+
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mockedNow);
+      simulateDelay(mocked10sLater, scene);
+      // Should be stale since 1% of 10m is 6s
+      expect(scene.state.$timeRange?.state.value.to.utc().toISOString()).toEqual(mocked10sLater);
+    });
   });
 });

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -117,7 +117,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
 
   private calculatePercentOfInterval(percent: number): number {
     const intervalMs = this.state.value.to.diff(this.state.value.from, 'milliseconds');
-    return Math.ceil(intervalMs / percent);
+    return Math.ceil((intervalMs / 100) * percent);
   }
 
   public getTimeZone(): TimeZone {


### PR DESCRIPTION
Fixes incorrect percent of interval calculation.

`intervalMs / percent` works for the default ` { percent: 10 }` `refreshOnActivate` value but not any other value.

Found the problem by setting it to 1% which should have invalidated my 5m time range in 2.4s but it didn't.