### PR TITLE
WIP: SceneDataTransformer: Add original transformations to context

### DIFF
--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -58,8 +58,13 @@
   "devDependencies": {
     "@emotion/css": "11.10.5",
     "@emotion/react": "11.10.5",
+    "@grafana/data": "link:/Users/kristinadurivage/development/grafana/packages/grafana-data",
+    "@grafana/e2e-selectors": "link:/Users/kristinadurivage/development/grafana/packages/grafana-e2e-selectors",
     "@grafana/eslint-config": "5.1.0",
+    "@grafana/runtime": "link:/Users/kristinadurivage/development/grafana/packages/grafana-runtime",
+    "@grafana/schema": "link:/Users/kristinadurivage/development/grafana/packages/grafana-schema",
     "@grafana/tsconfig": "^1.3.0-rc1",
+    "@grafana/ui": "link:/Users/kristinadurivage/development/grafana/packages/grafana-ui",
     "@swc/core": "^1.2.162",
     "@swc/jest": "^0.2.36",
     "@testing-library/dom": "9.3.4",

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -1,4 +1,4 @@
-import { DataTopic, DataTransformerConfig, LoadingState, PanelData, transformDataFrame } from '@grafana/data';
+import { DataTopic, DataTransformContext, DataTransformerConfig, LoadingState, PanelData, transformDataFrame } from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
 import { catchError, forkJoin, map, of, ReplaySubject, Unsubscribable } from 'rxjs';
 import { sceneGraph } from '../core/sceneGraph';
@@ -175,10 +175,11 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
       this._transformSub.unsubscribe();
     }
 
-    const ctx = {
+    const ctx: DataTransformContext = {
       interpolate: (value: string) => {
         return sceneGraph.interpolate(this, value, data.request?.scopedVars);
       },
+      originalTransformations: this.state.transformations as DataTransformerConfig[]
     };
 
     let streams = [transformDataFrame(seriesTransformations, data.series, ctx)];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,6 +3448,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/data@link:/Users/kristinadurivage/development/grafana/packages/grafana-data::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes":
+  version: 0.0.0-use.local
+  resolution: "@grafana/data@link:/Users/kristinadurivage/development/grafana/packages/grafana-data::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes"
+  languageName: node
+  linkType: soft
+
 "@grafana/data@npm:11.5.0, @grafana/data@npm:^11.5.0":
   version: 11.5.0
   resolution: "@grafana/data@npm:11.5.0"
@@ -3482,6 +3488,12 @@ __metadata:
   checksum: 10/0f40b74227ab4957dae620d7887163c9fd2bd9735cc0651bbf5d2695c55a8b10a7f685eb9b57dc13744112360f31b851c814918e06ee3362de526b4c3066e14c
   languageName: node
   linkType: hard
+
+"@grafana/e2e-selectors@link:/Users/kristinadurivage/development/grafana/packages/grafana-e2e-selectors::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes":
+  version: 0.0.0-use.local
+  resolution: "@grafana/e2e-selectors@link:/Users/kristinadurivage/development/grafana/packages/grafana-e2e-selectors::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes"
+  languageName: node
+  linkType: soft
 
 "@grafana/e2e-selectors@npm:11.5.0, @grafana/e2e-selectors@npm:^11.5.0":
   version: 11.5.0
@@ -3592,6 +3604,12 @@ __metadata:
   checksum: 10/468e7289ea9e7e00c75469ca558d723f385d5282dfdba66ba963b22381557c3c5f02f7725a0a61d2532929ac9b4132967549ccce67d235d01fad4500e78c6a7d
   languageName: node
   linkType: hard
+
+"@grafana/runtime@link:/Users/kristinadurivage/development/grafana/packages/grafana-runtime::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes":
+  version: 0.0.0-use.local
+  resolution: "@grafana/runtime@link:/Users/kristinadurivage/development/grafana/packages/grafana-runtime::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes"
+  languageName: node
+  linkType: soft
 
 "@grafana/runtime@npm:^11.5.0":
   version: 11.5.0
@@ -3707,8 +3725,13 @@ __metadata:
     "@emotion/css": "npm:11.10.5"
     "@emotion/react": "npm:11.10.5"
     "@floating-ui/react": "npm:^0.26.16"
+    "@grafana/data": "link:/Users/kristinadurivage/development/grafana/packages/grafana-data"
+    "@grafana/e2e-selectors": "link:/Users/kristinadurivage/development/grafana/packages/grafana-e2e-selectors"
     "@grafana/eslint-config": "npm:5.1.0"
+    "@grafana/runtime": "link:/Users/kristinadurivage/development/grafana/packages/grafana-runtime"
+    "@grafana/schema": "link:/Users/kristinadurivage/development/grafana/packages/grafana-schema"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"
+    "@grafana/ui": "link:/Users/kristinadurivage/development/grafana/packages/grafana-ui"
     "@leeoniya/ufuzzy": "npm:^1.0.16"
     "@swc/core": "npm:^1.2.162"
     "@swc/jest": "npm:^0.2.36"
@@ -3773,6 +3796,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana/schema@link:/Users/kristinadurivage/development/grafana/packages/grafana-schema::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes":
+  version: 0.0.0-use.local
+  resolution: "@grafana/schema@link:/Users/kristinadurivage/development/grafana/packages/grafana-schema::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes"
+  languageName: node
+  linkType: soft
+
 "@grafana/schema@npm:11.5.0, @grafana/schema@npm:^11.5.0":
   version: 11.5.0
   resolution: "@grafana/schema@npm:11.5.0"
@@ -3802,6 +3831,12 @@ __metadata:
   checksum: 10/81e3c07e2f3f01e70b3e73a5f7e71871dc3a14c683b1d760828e0c4d609f55adf5111ff72b9148b7a7af3cdeb6199af1fdd295140b003ef2ff74f01a8b77bd09
   languageName: node
   linkType: hard
+
+"@grafana/ui@link:/Users/kristinadurivage/development/grafana/packages/grafana-ui::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes":
+  version: 0.0.0-use.local
+  resolution: "@grafana/ui@link:/Users/kristinadurivage/development/grafana/packages/grafana-ui::locator=%40grafana%2Fscenes%40workspace%3Apackages%2Fscenes"
+  languageName: node
+  linkType: soft
 
 "@grafana/ui@npm:11.5.0, @grafana/ui@npm:^11.5.0":
   version: 11.5.0


### PR DESCRIPTION
This is a draft so I can have some help with the typing. I will unlink everything before moving this off draft.

Please see https://github.com/grafana/grafana/issues/103826 for a definition of the bug. Also please see https://github.com/grafana/grafana/pull/104016 for the accompanying change in Grafana that will use the data we pass through here.

---

Typing issue: Scenes has transformations as `Array<DataTransformerConfig | CustomTransformerDefinition>`
https://github.com/grafana/scenes/blob/main/packages/scenes/src/querying/SceneDataTransformer.ts#L14

`CustomTransformerDefinition` does not exist in Grafana - Transformations is simply `DataTransformerConfig[]`
https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/dashboard.ts#L44

How can I get around using a type assertion?

---

In some cases, we may need the transformation information before interpolation. Since Scenes does this interpolation very early when loading a dashboard panel, we lose access from what the original setting was. This PR adds the original transformation data to the context that gets passed so areas of Grafana can use it if needed.