### PR TITLE
Variables: Notify scene objects in depth order

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -383,6 +383,25 @@ describe('SceneObject', () => {
       });
     });
   });
+
+  describe('forEachChild', () => {
+    it('should loop through behaviors first', () => {
+      const scene = new TestScene({
+        name: 'root',
+        nested: new TestScene({ name: 'nested2' }),
+        $behaviors: [new TestScene({ name: 'behavior1' })],
+      });
+
+      const found: string[] = [];
+      scene.forEachChild((child) => {
+        if (child instanceof TestScene) {
+          found.push(child.state.name!);
+        }
+      });
+
+      expect(found).toEqual(['behavior1', 'nested2']);
+    });
+  });
 });
 
 describe('useSceneObjectState', () => {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -421,18 +421,35 @@ export function useSceneObjectState<TState extends SceneObjectState>(
   return model.state;
 }
 
-function forEachChild<T extends object>(state: T, callback: (child: SceneObjectBase) => void) {
-  for (const propValue of Object.values(state)) {
+function forEachChild<T extends SceneObjectState>(state: T, callback: (child: SceneObjectBase) => void) {
+  // Loop through behaviors first as that can be important when wanting to
+  // traverse the tree and want to process behaviors before other children
+  if (state.$behaviors) {
+    state.$behaviors.forEach((behavior) => {
+      if (behavior instanceof SceneObjectBase) {
+        callback(behavior);
+      }
+    });
+  }
+
+  Object.keys(state).forEach((key) => {
+    if (key === '$behaviors') {
+      // We have already processed $behaviors
+      return;
+    }
+
+    const propValue = (state as any)[key];
+
     if (propValue instanceof SceneObjectBase) {
       callback(propValue);
     }
 
     if (Array.isArray(propValue)) {
-      for (const child of propValue) {
+      propValue.forEach((child) => {
         if (child instanceof SceneObjectBase) {
           callback(child);
         }
-      }
+      });
     }
-  }
+  });
 }

--- a/packages/scenes/src/variables/TestScene.ts
+++ b/packages/scenes/src/variables/TestScene.ts
@@ -7,6 +7,7 @@ import { VariableDependencyConfig } from './VariableDependencyConfig';
  */
 export interface TestSceneState extends SceneObjectState {
   nested?: SceneObject;
+  nested2?: SceneObject;
   /** To test logic for inactive scene objects  */
   hidden?: SceneObject;
 }
@@ -17,6 +18,8 @@ interface TestSceneObjectState extends SceneObjectState {
   title: string;
   variableValueChanged: number;
   didSomethingCount: number;
+  onReferencedVariableValueChanged?: () => void;
+  nested?: TestObjectWithVariableDependency;
 }
 
 export class TestObjectWithVariableDependency extends SceneObjectBase<TestSceneObjectState> {
@@ -27,6 +30,7 @@ export class TestObjectWithVariableDependency extends SceneObjectBase<TestSceneO
     },
     onReferencedVariableValueChanged: () => {
       this.setState({ variableValueChanged: this.state.variableValueChanged + 1 });
+      this.state.onReferencedVariableValueChanged?.();
     },
   });
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -308,40 +308,42 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
-    this._traverseSceneAndNotify(this.parent, variable, this._variablesThatHaveChanged.has(variable));
-    this._variablesThatHaveChanged.delete(variable);
-  }
+    const nodeQueue: SceneObject[] = [this.parent];
+    const hasChanged = this._variablesThatHaveChanged.has(variable);
 
-  /**
-   * Recursivly walk the full scene object graph and notify all objects with dependencies that include any of changed variables
-   */
-  private _traverseSceneAndNotify(sceneObject: SceneObject, variable: SceneVariable, hasChanged: boolean) {
-    // No need to notify variables under this SceneVariableSet
-    if (this === sceneObject) {
-      return;
-    }
+    while (nodeQueue.length > 0) {
+      const node = nodeQueue.pop()!;
+      let localVariable = variable;
 
-    // Skip non active scene objects
-    if (!sceneObject.isActive) {
-      return;
-    }
-
-    // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
-    if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
-      const localVar = sceneObject.state.$variables.getByName(variable.state.name);
-      // If local variable is viewed as loading when ancestor is loading we propagate a change
-      if (localVar?.isAncestorLoading) {
-        variable = localVar;
-      } else if (localVar) {
-        return;
+      // ignore ourselfs
+      if (this === node) {
+        continue;
       }
+
+      // Skip non active scene objects
+      if (!node.isActive) {
+        continue;
+      }
+
+      // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
+      if (node.state.$variables && node.state.$variables !== this) {
+        const localVar = node.state.$variables.getByName(variable.state.name);
+        // If local variable is viewed as loading when ancestor is loading we propagate a change
+        if (localVar?.isAncestorLoading) {
+          localVariable = localVar;
+        } else if (localVar) {
+          return;
+        }
+      }
+
+      if (node.variableDependency) {
+        node.variableDependency.variableUpdateCompleted(variable, hasChanged);
+      }
+
+      node.forEachChild((child) => nodeQueue.push(child));
     }
 
-    if (sceneObject.variableDependency) {
-      sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
-    }
-
-    sceneObject.forEachChild((child) => this._traverseSceneAndNotify(child, variable, hasChanged));
+    this._variablesThatHaveChanged.delete(variable);
   }
 
   /**

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -337,7 +337,7 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       }
 
       if (node.variableDependency) {
-        node.variableDependency.variableUpdateCompleted(variable, hasChanged);
+        node.variableDependency.variableUpdateCompleted(localVariable, hasChanged);
       }
 
       node.forEachChild((child) => nodeQueue.push(child));

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -308,42 +308,51 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
-    const nodeQueue: SceneObject[] = [this.parent];
     const hasChanged = this._variablesThatHaveChanged.has(variable);
+    this._traverseSceneAndNotify(this.parent, variable, hasChanged, false);
+    this._traverseSceneAndNotify(this.parent, variable, hasChanged, true);
 
-    while (nodeQueue.length > 0) {
-      const node = nodeQueue.shift()!;
-      let variableThatChanged = variable;
+    this._variablesThatHaveChanged.delete(variable);
+  }
 
-      // ignore ourselfs
-      if (this === node) {
-        continue;
-      }
+  /**
+   * Recursivly walk the full scene object graph and notify all objects with dependencies that include any of changed variables
+   */
+  private _traverseSceneAndNotify(
+    sceneObject: SceneObject,
+    variable: SceneVariable,
+    hasChanged: boolean,
+    childrenOnly: boolean
+  ) {
+    // No need to notify variables under this SceneVariableSet
+    if (this === sceneObject) {
+      return;
+    }
 
-      // Skip non active scene objects
-      if (!node.isActive) {
-        continue;
-      }
+    // Skip non active scene objects
+    if (!sceneObject.isActive) {
+      return;
+    }
 
+    if (childrenOnly) {
+      sceneObject.forEachChild((child) => this._traverseSceneAndNotify(child, variable, hasChanged, false));
+      sceneObject.forEachChild((child) => this._traverseSceneAndNotify(child, variable, hasChanged, true));
+    } else {
       // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
-      if (node.state.$variables && node.state.$variables !== this) {
-        const localVar = node.state.$variables.getByName(variable.state.name);
+      if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
+        const localVar = sceneObject.state.$variables.getByName(variable.state.name);
         // If local variable is viewed as loading when ancestor is loading we propagate a change
         if (localVar?.isAncestorLoading) {
-          variableThatChanged = localVar;
+          variable = localVar;
         } else if (localVar) {
           return;
         }
       }
 
-      if (node.variableDependency) {
-        node.variableDependency.variableUpdateCompleted(variableThatChanged, hasChanged);
+      if (sceneObject.variableDependency) {
+        sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
       }
-
-      node.forEachChild((child) => nodeQueue.push(child));
     }
-
-    this._variablesThatHaveChanged.delete(variable);
   }
 
   /**

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -312,8 +312,8 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
     const hasChanged = this._variablesThatHaveChanged.has(variable);
 
     while (nodeQueue.length > 0) {
-      const node = nodeQueue.pop()!;
-      let localVariable = variable;
+      const node = nodeQueue.shift()!;
+      let variableThatChanged = variable;
 
       // ignore ourselfs
       if (this === node) {
@@ -330,14 +330,14 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
         const localVar = node.state.$variables.getByName(variable.state.name);
         // If local variable is viewed as loading when ancestor is loading we propagate a change
         if (localVar?.isAncestorLoading) {
-          localVariable = localVar;
+          variableThatChanged = localVar;
         } else if (localVar) {
           return;
         }
       }
 
       if (node.variableDependency) {
-        node.variableDependency.variableUpdateCompleted(localVariable, hasChanged);
+        node.variableDependency.variableUpdateCompleted(variableThatChanged, hasChanged);
       }
 
       node.forEachChild((child) => nodeQueue.push(child));


### PR DESCRIPTION
The problem is that we notified scene objects in a recursive way, meaning whatever first child we start with we notify it's children, and it's children. 

This means that if we have something higher up in the scene tree that removes scene objects when a variable value change this reaction will not trigger until after the nested children have received the variable value change notification. 


Example

* Row 
  * Row repeat behavior    
  * GridItem
    * VizPanel
        *  VizPanelQueryRunner 
   

When the variable value changed we want the row repeat behavior to get notified before GridItem children. This code change makes sure we go down each level and notify in depth order. 

    
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.9.1--canary.1104.14589006500.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.9.1--canary.1104.14589006500.0
  npm install @grafana/scenes@6.9.1--canary.1104.14589006500.0
  # or 
  yarn add @grafana/scenes-react@6.9.1--canary.1104.14589006500.0
  yarn add @grafana/scenes@6.9.1--canary.1104.14589006500.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

Fixes: https://github.com/grafana/grafana/issues/104172
Ref: https://github.com/grafana/support-escalations/issues/15682
