### PR TITLE
Revert "Variables: Notify scene objects in depth order"

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.test.ts
+++ b/packages/scenes/src/core/SceneObjectBase.test.ts
@@ -383,25 +383,6 @@ describe('SceneObject', () => {
       });
     });
   });
-
-  describe('forEachChild', () => {
-    it('should loop through behaviors first', () => {
-      const scene = new TestScene({
-        name: 'root',
-        nested: new TestScene({ name: 'nested2' }),
-        $behaviors: [new TestScene({ name: 'behavior1' })],
-      });
-
-      const found: string[] = [];
-      scene.forEachChild((child) => {
-        if (child instanceof TestScene) {
-          found.push(child.state.name!);
-        }
-      });
-
-      expect(found).toEqual(['behavior1', 'nested2']);
-    });
-  });
 });
 
 describe('useSceneObjectState', () => {

--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -421,35 +421,18 @@ export function useSceneObjectState<TState extends SceneObjectState>(
   return model.state;
 }
 
-function forEachChild<T extends SceneObjectState>(state: T, callback: (child: SceneObjectBase) => void) {
-  // Loop through behaviors first as that can be important when wanting to
-  // traverse the tree and want to process behaviors before other children
-  if (state.$behaviors) {
-    state.$behaviors.forEach((behavior) => {
-      if (behavior instanceof SceneObjectBase) {
-        callback(behavior);
-      }
-    });
-  }
-
-  Object.keys(state).forEach((key) => {
-    if (key === '$behaviors') {
-      // We have already processed $behaviors
-      return;
-    }
-
-    const propValue = (state as any)[key];
-
+function forEachChild<T extends object>(state: T, callback: (child: SceneObjectBase) => void) {
+  for (const propValue of Object.values(state)) {
     if (propValue instanceof SceneObjectBase) {
       callback(propValue);
     }
 
     if (Array.isArray(propValue)) {
-      propValue.forEach((child) => {
+      for (const child of propValue) {
         if (child instanceof SceneObjectBase) {
           callback(child);
         }
-      });
+      }
     }
-  });
+  }
 }

--- a/packages/scenes/src/variables/TestScene.ts
+++ b/packages/scenes/src/variables/TestScene.ts
@@ -7,7 +7,6 @@ import { VariableDependencyConfig } from './VariableDependencyConfig';
  */
 export interface TestSceneState extends SceneObjectState {
   nested?: SceneObject;
-  nested2?: SceneObject;
   /** To test logic for inactive scene objects  */
   hidden?: SceneObject;
 }
@@ -18,8 +17,6 @@ interface TestSceneObjectState extends SceneObjectState {
   title: string;
   variableValueChanged: number;
   didSomethingCount: number;
-  onReferencedVariableValueChanged?: () => void;
-  nested?: TestObjectWithVariableDependency;
 }
 
 export class TestObjectWithVariableDependency extends SceneObjectBase<TestSceneObjectState> {
@@ -30,7 +27,6 @@ export class TestObjectWithVariableDependency extends SceneObjectBase<TestSceneO
     },
     onReferencedVariableValueChanged: () => {
       this.setState({ variableValueChanged: this.state.variableValueChanged + 1 });
-      this.state.onReferencedVariableValueChanged?.();
     },
   });
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -877,42 +877,4 @@ describe('SceneVariableList', () => {
       expect(C.state.value).toBe('ABBA');
     });
   });
-
-  describe('When propagating variable value changes', () => {
-    it('Should notify scene tree in depth order', async () => {
-      const A = new TestVariable({ name: 'A', query: 'A.*', value: 'A', text: '', options: [], delayMs: 0 });
-
-      let value = 1;
-
-      // So the nested.nested object multiplies value by 10 in value changed handler
-      // The nested2 handler adds 2 to the value
-      // This allows us to verify that the value is propagated in depth order
-
-      const scene = new TestScene({
-        $variables: new SceneVariableSet({ variables: [A] }),
-        nested: new TestObjectWithVariableDependency({
-          nested: new TestObjectWithVariableDependency({
-            title: '$A',
-            onReferencedVariableValueChanged: () => {
-              // Multiply value by 10
-              value *= 10;
-            },
-          }),
-        }),
-        nested2: new TestObjectWithVariableDependency({
-          title: '$A',
-          onReferencedVariableValueChanged: () => {
-            // Add 1
-            value += 1;
-          },
-        }),
-      });
-
-      activateFullSceneTree(scene);
-
-      A.changeValueTo('B');
-
-      expect(value).toBe(20);
-    });
-  });
 });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -308,42 +308,40 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
-    const nodeQueue: SceneObject[] = [this.parent];
-    const hasChanged = this._variablesThatHaveChanged.has(variable);
+    this._traverseSceneAndNotify(this.parent, variable, this._variablesThatHaveChanged.has(variable));
+    this._variablesThatHaveChanged.delete(variable);
+  }
 
-    while (nodeQueue.length > 0) {
-      const node = nodeQueue.shift()!;
-      let variableThatChanged = variable;
-
-      // ignore ourselfs
-      if (this === node) {
-        continue;
-      }
-
-      // Skip non active scene objects
-      if (!node.isActive) {
-        continue;
-      }
-
-      // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
-      if (node.state.$variables && node.state.$variables !== this) {
-        const localVar = node.state.$variables.getByName(variable.state.name);
-        // If local variable is viewed as loading when ancestor is loading we propagate a change
-        if (localVar?.isAncestorLoading) {
-          variableThatChanged = localVar;
-        } else if (localVar) {
-          return;
-        }
-      }
-
-      if (node.variableDependency) {
-        node.variableDependency.variableUpdateCompleted(variableThatChanged, hasChanged);
-      }
-
-      node.forEachChild((child) => nodeQueue.push(child));
+  /**
+   * Recursivly walk the full scene object graph and notify all objects with dependencies that include any of changed variables
+   */
+  private _traverseSceneAndNotify(sceneObject: SceneObject, variable: SceneVariable, hasChanged: boolean) {
+    // No need to notify variables under this SceneVariableSet
+    if (this === sceneObject) {
+      return;
     }
 
-    this._variablesThatHaveChanged.delete(variable);
+    // Skip non active scene objects
+    if (!sceneObject.isActive) {
+      return;
+    }
+
+    // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
+    if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
+      const localVar = sceneObject.state.$variables.getByName(variable.state.name);
+      // If local variable is viewed as loading when ancestor is loading we propagate a change
+      if (localVar?.isAncestorLoading) {
+        variable = localVar;
+      } else if (localVar) {
+        return;
+      }
+    }
+
+    if (sceneObject.variableDependency) {
+      sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
+    }
+
+    sceneObject.forEachChild((child) => this._traverseSceneAndNotify(child, variable, hasChanged));
   }
 
   /**


### PR DESCRIPTION
Reverts grafana/scenes#1104

I just had realisation that we don't need this change, going to test https://github.com/grafana/grafana/pull/104312 without it 