### PR TITLE
Use log util.  Direct console.warn fails tests in grafana.

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -11,6 +11,7 @@ import { evaluateTimeRange } from '../utils/evaluateTimeRange';
 import { config, locationService, RefreshEvent } from '@grafana/runtime';
 import { isValid } from '../utils/date';
 import { getQueryController } from './sceneGraph/getQueryController';
+import { writeSceneLog } from '../utils/writeSceneLog';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
@@ -278,6 +279,6 @@ function getValidTimeZone(timeZone?: string): string | undefined {
   if (getZone(timeZone)) {
     return timeZone;
   }
-  console.warn(`Invalid timeZone "${timeZone}" provided.`);
+  writeSceneLog('SceneTimeRange', `Invalid timeZone "${timeZone}" provided.`)
   return;
 }


### PR DESCRIPTION
console.warn causes build failures in grafana.  use the log utility instead

```
 PublicDashboardPageProxy › when scene feature enabled › should render PublicDashboardScenePage if publicDashboardsScene is enabled

    Expected test not to call console.warn().
```