### PR TITLE
SceneFlexItem: respect `wrap` property

### DIFF
--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -134,10 +134,12 @@ function applyItemStyles(style: CSSObject, state: SceneFlexItemPlacement, parent
 
     if (state.wrap) {
       style.flexWrap = state.wrap;
-      if (parentDirection === 'row' && state.wrap !== 'nowrap') {
-        style.rowGap = '8px';
-      } else {
-        style.columnGap = '8px';
+      if (state.wrap !== 'nowrap') {
+        if (parentDirection === 'row') {
+          style.rowGap = '8px';
+        } else {
+          style.columnGap = '8px';
+        }
       }
     }
   }

--- a/packages/scenes/src/components/layout/SceneFlexLayout.tsx
+++ b/packages/scenes/src/components/layout/SceneFlexLayout.tsx
@@ -131,6 +131,15 @@ function applyItemStyles(style: CSSObject, state: SceneFlexItemPlacement, parent
     } else {
       style.flexGrow = xSizing === 'fill' ? 1 : 0;
     }
+
+    if (state.wrap) {
+      style.flexWrap = state.wrap;
+      if (parentDirection === 'row' && state.wrap !== 'nowrap') {
+        style.rowGap = '8px';
+      } else {
+        style.columnGap = '8px';
+      }
+    }
   }
 
   style.minWidth = state.minWidth;


### PR DESCRIPTION
`SceneFlexItem` accepts `wrap` property but does not do anything with it. However I have a use case for it when rendering `VariableValueSelectors()` inside a `SceneFlexItem` :) 