### PR TITLE
fix: GroupBy Select receives null

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -324,7 +324,7 @@ export function GroupByVariableRenderer({ model }: SceneComponentProps<GroupByVa
       placeholder={'Select value'}
       width="auto"
       inputValue={inputValue}
-      value={uncommittedValue}
+      value={uncommittedValue && uncommittedValue.length > 0 ? uncommittedValue : null}
       allowCustomValue={allowCustomValue}
       noMultiValueWrap={true}
       maxVisibleValues={maxVisibleValues ?? 5}


### PR DESCRIPTION
**What is this feature?**
This PR addresses an edge case in the react-select integration where programmatic clearing of the input value (undefined) does not fully reset the internal state of the component. This caused stale UI states where the selected option would still appear visually, or the clear button remained visible despite no value being present.


📚 Background
In most usage patterns, react-select behaves predictably:
- A user selects an option.
- The input reflects the selection.
- The user can clear it using the clear button or another manual interaction.

However, in db-o11y, we encountered a sync issue in a specific flow:

1. A user groups data by schema
![group](https://github.com/user-attachments/assets/4903beec-f261-45af-99ee-75a33070b8af)


2. Then clicks a label in a chart tooltip to add a new filter
<img width="357" alt="click" src="https://github.com/user-attachments/assets/ac781d77-12ba-4f8d-92da-4528db4e4845" />


3. At this point, the selected [groupBy value](https://github.com/grafana/scenes/blob/6ed48bfb7bdc89d7a694976930dc37f04a77007a/packages/scenes/src/variables/groupby/GroupByVariable.tsx#L320) should be cleared to allow a new filter context
![expected-behaviour](https://github.com/user-attachments/assets/ae92d57b-33d2-472f-99e1-3118184739d9)

**But internally, the Select still holds onto the stale selection due to how it handles undefined values.**

**Solution**
Fix the Select to receive a `null` if no value.

**Before**

https://github.com/user-attachments/assets/0d588e1f-cb79-424a-ab0f-2280b6776636


**After**

https://github.com/user-attachments/assets/b7974ecf-f688-43ba-babe-bdb5c0a7d1d8

