### PR TITLE
AdHocVariable: Add more suggestive injected filters tooltips

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, IconButton, Tooltip, Icon } from '@grafana/ui';
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
-import { AdHocFilterWithLabels, AdHocFiltersVariable, isMatchAllFilter } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, FilterOrigin, isMatchAllFilter } from '../AdHocFiltersVariable';
 
 const LABEL_MAX_VISIBLE_LENGTH = 20;
 
@@ -60,17 +60,27 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
     }
   }, [viewMode]);
 
-  if (viewMode) {
-    let injectedInfoText = '';
-    let injectedRestoreText = '';
+  const getOriginFilterRestoreTooltip = (origin: FilterOrigin) => {
     if (filter.origin === 'dashboard') {
-      injectedInfoText = 'Applied by default in this dashboard. If edited, it carries over to other dashboards.';
-      injectedRestoreText = 'Restore the value defined by this dashboard.';
+      return 'Restore the value defined by this dashboard.';
     } else if (filter.origin === 'scope') {
-      injectedInfoText = 'Applied automatically from your selected scope.';
-      injectedRestoreText = 'Restore the value set by your selected scope.';
+      return 'Restore the value set by your selected scope.';
+    } else {
+      return `Restore filter to its original value.`;
     }
+  };
 
+  const getOriginFilterInfoTooltip = (origin: FilterOrigin) => {
+    if (filter.origin === 'dashboard') {
+      return 'Applied by default in this dashboard. If edited, it carries over to other dashboards.';
+    } else if (filter.origin === 'scope') {
+      return 'Applied automatically from your selected scope.';
+    } else {
+      return `This is a ${origin} injected filter.`;
+    }
+  };
+
+  if (viewMode) {
     const pillTextContent = `${keyLabel} ${filter.operator} ${valueLabel}`;
     const pillText = <span className={styles.pillText}>{pillTextContent}</span>;
 
@@ -144,7 +154,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         )}
 
         {filter.origin && !filter.restorable && !filter.readOnly && (
-          <Tooltip content={injectedInfoText} placement={'bottom'}>
+          <Tooltip content={getOriginFilterInfoTooltip(filter.origin)} placement={'bottom'}>
             <Icon name="info-circle" size="md" className={styles.infoPillIcon} />
           </Tooltip>
         )}
@@ -165,7 +175,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
             name="history"
             size="md"
             className={isMatchAllFilter(filter) ? styles.matchAllPillIcon : styles.pillIcon}
-            tooltip={injectedRestoreText}
+            tooltip={getOriginFilterRestoreTooltip(filter.origin)}
           />
         )}
       </div>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -60,23 +60,22 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
     }
   }, [viewMode]);
 
-  const getOriginFilterRestoreTooltip = (origin: FilterOrigin) => {
-    if (filter.origin === 'dashboard') {
-      return 'Restore the value set by this dashboard.';
-    } else if (filter.origin === 'scope') {
-      return 'Restore the value set by your selected scope.';
+  const getOriginFilterTooltips = (origin: FilterOrigin): { info: string; restore: string } => {
+    if (origin === 'dashboard') {
+      return {
+        info: 'Restore the value set by this dashboard.',
+        restore: 'Applied by default in this dashboard. If edited, it carries over to other dashboards.',
+      };
+    } else if (origin === 'scope') {
+      return {
+        info: 'Restore the value set by your selected scope.',
+        restore: 'Applied automatically from your selected scope.',
+      };
     } else {
-      return `Restore filter to its original value.`;
-    }
-  };
-
-  const getOriginFilterInfoTooltip = (origin: FilterOrigin) => {
-    if (filter.origin === 'dashboard') {
-      return 'Applied by default in this dashboard. If edited, it carries over to other dashboards.';
-    } else if (filter.origin === 'scope') {
-      return 'Applied automatically from your selected scope.';
-    } else {
-      return `This is a ${origin} injected filter.`;
+      return {
+        info: `Restore filter to its original value.`,
+        restore: `This is a ${origin} injected filter.`,
+      };
     }
   };
 
@@ -154,7 +153,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         )}
 
         {filter.origin && !filter.restorable && !filter.readOnly && (
-          <Tooltip content={getOriginFilterInfoTooltip(filter.origin)} placement={'bottom'}>
+          <Tooltip content={getOriginFilterTooltips(filter.origin).info} placement={'bottom'}>
             <Icon name="info-circle" size="md" className={styles.infoPillIcon} />
           </Tooltip>
         )}
@@ -175,7 +174,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
             name="history"
             size="md"
             className={isMatchAllFilter(filter) ? styles.matchAllPillIcon : styles.pillIcon}
-            tooltip={getOriginFilterRestoreTooltip(filter.origin)}
+            tooltip={getOriginFilterTooltips(filter.origin).restore}
           />
         )}
       </div>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -63,18 +63,18 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
   const getOriginFilterTooltips = (origin: FilterOrigin): { info: string; restore: string } => {
     if (origin === 'dashboard') {
       return {
-        info: 'Restore the value set by this dashboard.',
-        restore: 'Applied by default in this dashboard. If edited, it carries over to other dashboards.',
+        info: 'Applied by default in this dashboard. If edited, it carries over to other dashboards.',
+        restore: 'Restore the value set by this dashboard.',
       };
     } else if (origin === 'scope') {
       return {
-        info: 'Restore the value set by your selected scope.',
-        restore: 'Applied automatically from your selected scope.',
+        info: 'Applied automatically from your selected scope.',
+        restore: 'Restore the value set by your selected scope.',
       };
     } else {
       return {
-        info: `Restore filter to its original value.`,
-        restore: `This is a ${origin} injected filter.`,
+        info: `This is a ${origin} injected filter.`,
+        restore: `Restore filter to its original value.`,
       };
     }
   };

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -62,7 +62,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
 
   const getOriginFilterRestoreTooltip = (origin: FilterOrigin) => {
     if (filter.origin === 'dashboard') {
-      return 'Restore the value defined by this dashboard.';
+      return 'Restore the value set by this dashboard.';
     } else if (filter.origin === 'scope') {
       return 'Restore the value set by your selected scope.';
     } else {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -74,7 +74,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
       injectedRestoreText = 'Restore the value defined by this dashboard.';
     } else if (filter.origin === 'scope') {
       injectedInfoText = 'Applied automatically from your selected scope.';
-      injectedRestoreText = 'Restore the value set by your selected scope';
+      injectedRestoreText = 'Restore the value set by your selected scope.';
     }
 
     return (

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -66,6 +66,17 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         {keyLabel} {filter.operator} {valueLabel}
       </span>
     );
+
+    let injectedInfoText = '';
+    let injectedRestoreText = '';
+    if (filter.origin === 'dashboard') {
+      injectedInfoText = 'Applied by default in this dashboard. If edited, it carries over to other dashboards.';
+      injectedRestoreText = 'Restore the value defined by this dashboard.';
+    } else if (filter.origin === 'scope') {
+      injectedInfoText = 'Applied automatically from your selected scope.';
+      injectedRestoreText = 'Restore the value set by your selected scope';
+    }
+
     return (
       <div
         className={cx(
@@ -129,7 +140,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
         ) : null}
 
         {filter.origin && !filter.restorable && (
-          <Tooltip content={`This is a ${filter.origin} injected filter`} placement={'bottom'}>
+          <Tooltip content={injectedInfoText} placement={'bottom'}>
             <Icon name="info-circle" size="md" className={styles.infoPillIcon} />
           </Tooltip>
         )}
@@ -150,7 +161,7 @@ export function AdHocFilterPill({ filter, model, readOnly, focusOnWipInputRef }:
             name="history"
             size="md"
             className={isMatchAllFilter(filter) ? styles.matchAllPillIcon : styles.pillIcon}
-            tooltip={`Restore filter to its original value`}
+            tooltip={injectedRestoreText}
           />
         )}
       </div>


### PR DESCRIPTION
Adds better tooltips for the new injected filters.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.10.4--canary.1118.14886789462.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.10.4--canary.1118.14886789462.0
  npm install @grafana/scenes@6.10.4--canary.1118.14886789462.0
  # or 
  yarn add @grafana/scenes-react@6.10.4--canary.1118.14886789462.0
  yarn add @grafana/scenes@6.10.4--canary.1118.14886789462.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
