### PR TITLE
Chore: Moving towards workflow federation instead of secrets

### DIFF
--- a/.github/workflows/deploy-to-dev-portal-dev.yml
+++ b/.github/workflows/deploy-to-dev-portal-dev.yml
@@ -16,13 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           persist-credentials: false
+      
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -34,10 +35,10 @@ jobs:
       - name: Build documentation website
         run: yarn docs:build:dev
 
-      - id: 'auth'
-        uses: 'google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193' #v2.1.10
+      - uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0
+        id: login-to-gcs
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
+          service_account: 'github-developer-portal-dev@grafanalabs-workload-identity.iam.gserviceaccount.com'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a' #v2.1.4

--- a/.github/workflows/deploy-to-dev-portal-prod.yml
+++ b/.github/workflows/deploy-to-dev-portal-prod.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -34,10 +34,10 @@ jobs:
       - name: Build documentation website
         run: yarn docs:build
 
-      - id: 'auth'
-        uses: 'google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193' #v2.1.10
+      - uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0
+        id: login-to-gcs
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: 'github-developer-portal@grafanalabs-workload-identity.iam.gserviceaccount.com'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a' #v2.1.4
@@ -45,5 +45,3 @@ jobs:
       - name: 'Deploy to Developer Portal Bucket'
         run: |
           gsutil -m rsync -r -d -c ./docusaurus/website/build/ gs://grafana-developer-portal/scenes
-        with:
-          persist-credentials: false


### PR DESCRIPTION
This PR moves to using github workflow federation (short lived tokens) instead of secrets.

Once this is merged and working you can delete the `secrets.GCP_SA_KEY_DEV` and `secrets.GCP_SA_KEY` in the repository settings.