### PR TITLE
VizPanel: Allow passing partial state when cloning

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -556,9 +556,9 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
     );
   };
 
-  public clone() {
+  public clone(withState?: Partial<VizPanelState>) {
     // Clear _pluginInstanceState and _pluginLoadError as it's not safe to clone
-    return super.clone({ _pluginInstanceState: undefined, _pluginLoadError: undefined });
+    return super.clone({ _pluginInstanceState: undefined, _pluginLoadError: undefined, ...withState });
   }
 
   private buildPanelContext(): PanelContext {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.11.1--canary.1127.15046943713.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.11.1--canary.1127.15046943713.0
  npm install @grafana/scenes@6.11.1--canary.1127.15046943713.0
  # or 
  yarn add @grafana/scenes-react@6.11.1--canary.1127.15046943713.0
  yarn add @grafana/scenes@6.11.1--canary.1127.15046943713.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
