### PR TITLE
ScopesVariable: Only emit value changed when value has changed

### DIFF
--- a/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
@@ -12,6 +12,7 @@ import { BehaviorSubject } from 'rxjs';
 import { SceneCSSGridLayout } from '../../components/layout/CSSGrid/SceneCSSGridLayout';
 import { SceneCanvasText } from '../../components/SceneCanvasText';
 import { sceneInterpolator } from '../interpolation/sceneInterpolator';
+import { SceneVariableValueChangedEvent } from '../types';
 
 describe('ScopesVariable', () => {
   it('Should enable scopes on render and disable on unmount when enable: true', async () => {
@@ -55,6 +56,21 @@ describe('ScopesVariable', () => {
     // Interpolate using sceneInterpolator and the variable set as context
     expect(sceneInterpolator(scene, '${__scopes:queryparam}')).toEqual('scope=scope1&scope=scope2');
     expect(sceneInterpolator(scene, '${__scopes}')).toEqual('scope1, scope2');
+  });
+
+  it('Should not emit value changed when scopes are the same', async () => {
+    const { scopesContext, variable } = renderTestScene({ initialScopes: ['scope1', 'scope2'] });
+    let valueChangedCount = 0;
+
+    variable.subscribeToEvent(SceneVariableValueChangedEvent, () => valueChangedCount++);
+
+    act(() => scopesContext.changeScopes(['scope3', 'scope4']));
+
+    expect(valueChangedCount).toEqual(1);
+
+    act(() => scopesContext.changeScopes(['scope3', 'scope4']));
+
+    expect(valueChangedCount).toEqual(1);
   });
 });
 

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -12,6 +12,7 @@ import { ScopesContext, ScopesContextValue } from '@grafana/runtime';
 import { useContext, useEffect } from 'react';
 import { VariableFormatID, VariableHide } from '@grafana/schema';
 import { SCOPES_VARIABLE_NAME } from '../constants';
+import { isEqual } from 'lodash';
 
 export interface ScopesVariableState extends SceneVariableState {
   /**
@@ -92,9 +93,11 @@ export class ScopesVariable extends SceneObjectBase<ScopesVariableState> impleme
   public updateStateFromContext(state: { loading: boolean; value: Scope[] }) {
     // There was logic in SceneQueryRunner that said if there are no scopes then loading state should not block query execution
     const loading = state.value.length === 0 ? false : state.loading;
+    const oldValue = this.state.scopes;
+
     this.setState({ scopes: state.value, loading });
 
-    if (!loading) {
+    if (!loading && !isEqual(oldValue, state.value)) {
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     }
   }


### PR DESCRIPTION
For some reason I think ScopesService in core is changing value state even when scope names have not changed. I find the core ScopesService and ScopesSelectorService a bit hard to follow so opting to add this change to be on the safe side on the scenes part at least. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.14.0--canary.1130.15248914373.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.14.0--canary.1130.15248914373.0
  npm install @grafana/scenes@6.14.0--canary.1130.15248914373.0
  # or 
  yarn add @grafana/scenes-react@6.14.0--canary.1130.15248914373.0
  yarn add @grafana/scenes@6.14.0--canary.1130.15248914373.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
