### PR TITLE
AdHocVariable: Refactor origin filters

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -530,7 +530,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(runRequestCall2[1].filters).toEqual(filtersVar.state.filters);
     });
 
-    it('should pass adhoc baseFilters via request object if they have a source defined', async () => {
+    it('should pass adhoc origin filter via request object if they have a source defined', async () => {
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'test-uid' },
         queries: [{ refId: 'A' }],
@@ -540,7 +540,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
         datasource: { uid: 'test-uid' },
         applyMode: 'auto',
         filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
-        baseFilters: [{ key: 'C', operator: '=', value: 'D', condition: '', origin: 'scope' }],
+        originFilters: [{ key: 'C', operator: '=', value: 'D', condition: '', origin: 'scope' }],
       });
 
       const scene = new EmbeddedScene({
@@ -556,36 +556,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
 
       const runRequestCall = runRequestMock.mock.calls[0];
 
-      expect(runRequestCall[1].filters).toEqual([...filtersVar.state.baseFilters!, ...filtersVar.state.filters]);
-    });
-
-    it('should not pass adhoc baseFilters via request object if they do not have a source defined', async () => {
-      const queryRunner = new SceneQueryRunner({
-        datasource: { uid: 'test-uid' },
-        queries: [{ refId: 'A' }],
-      });
-
-      const filtersVar = new AdHocFiltersVariable({
-        datasource: { uid: 'test-uid' },
-        applyMode: 'auto',
-        filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
-        baseFilters: [{ key: 'C', operator: '=', value: 'D', condition: '' }],
-      });
-
-      const scene = new EmbeddedScene({
-        $data: queryRunner,
-        $variables: new SceneVariableSet({ variables: [filtersVar] }),
-        body: new SceneCanvasText({ text: 'hello' }),
-      });
-
-      const deactivate = activateFullSceneTree(scene);
-      deactivationHandlers.push(deactivate);
-
-      await new Promise((r) => setTimeout(r, 1));
-
-      const runRequestCall = runRequestMock.mock.calls[0];
-
-      expect(runRequestCall[1].filters).toEqual(filtersVar.state.filters);
+      expect(runRequestCall[1].filters).toEqual([...filtersVar.state.originFilters!, ...filtersVar.state.filters]);
     });
 
     it('only passes fully completed adhoc filters', async () => {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -534,16 +534,12 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     };
 
     if (this._adhocFiltersVar) {
-      request.filters = [];
-
-      if (this._adhocFiltersVar.state.baseFilters?.length) {
-        const injectedBaseFilters = this._adhocFiltersVar.state.baseFilters.filter((filter) => filter.origin);
-        request.filters = request.filters.concat(injectedBaseFilters);
-      }
-
       // only pass filters that have both key and value
       // @ts-ignore (Temporary ignore until we update @grafana/data)
-      request.filters = request.filters.concat(this._adhocFiltersVar.state.filters.filter(isFilterComplete));
+      request.filters = [
+        ...(this._adhocFiltersVar.state.originFilters ?? []),
+        ...this._adhocFiltersVar.state.filters,
+      ].filter(isFilterComplete);
     }
 
     if (this._groupByVar) {

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -57,7 +57,7 @@ exports[`SceneQueryRunner when running query should build DataQueryRequest objec
     "from": "now-6h",
     "to": "now",
   },
-  "requestId": "SQR182",
+  "requestId": "SQR181",
   "scopes": undefined,
   "startTime": 1689063488000,
   "targets": [

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRenderer({ model }: Props) {
-  const { baseFilters, filters, readOnly } = model.useState();
+  const { originFilters, filters, readOnly } = model.useState();
   const styles = useStyles2(getStyles);
 
   // ref that focuses on the always wip filter input
@@ -27,7 +27,7 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
     >
       <Icon name="filter" className={styles.filterIcon} size="lg" />
 
-      {baseFilters?.map((filter, index) =>
+      {originFilters?.map((filter, index) =>
         filter.origin ? (
           <AdHocFilterPill
             key={`${index}-${filter.key}`}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -780,7 +780,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(locationService.getLocation().search).toBe('?var-filters=newKey%7C%3D%7Cval1');
   });
 
-  it('url syncs base filters as injected filters together with original value', async () => {
+  it('syncs single-value origin filter', async () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
         key: 'baseKey1',
@@ -793,11 +793,13 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         filters: [],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
 
+    scopesVariable.update();
+
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newValue',
         valueLabels: ['newValue'],
       });
@@ -807,7 +809,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(locationService.getLocation().search).toBe('?var-filters=baseKey1%7C%21%3D%7CnewValue%23scope%23restorable');
   });
 
-  it('url syncs multi-value base filters as injected filters', async () => {
+  it('syncs multi-value origin filter', async () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
         key: 'baseKey1',
@@ -822,23 +824,25 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         filters: [],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
 
+    scopesVariable.update();
+
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newValue1',
         values: ['newValue1', 'newValue2'],
       });
     });
 
-    // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable?
+    // origin filters stored in the following format: normal|adhoc|values#filterOrigin#restorable?
     expect(locationService.getLocation().search).toBe(
       '?var-filters=baseKey1%7C%21%3D__gfp__%7CnewValue1%7CnewValue2%23scope%23restorable'
     );
   });
 
-  it('will properly escape injected filter hash delimiter if found within values', () => {
+  it('will properly escape injected filter hash delimiter', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
         key: 'baseKey1',
@@ -852,29 +856,50 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         filters: [],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
 
+    scopesVariable.update();
+
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newValue1#',
       });
     });
 
-    // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable
+    // origin filters stored in the following format: normal|adhoc|values#filterOrigin#restorable
     expect(locationService.getLocation().search).toBe(
       '?var-filters=baseKey1%7C%3D%7CnewValue1__gfh__%23scope%23restorable'
     );
   });
 
-  it('sets url dashboard injected filter as a matchAll filter if it has the correct structure', () => {
+  it('should maintain modified scopes and reconciliate after scopes update', () => {
+    const { filtersVar } = setup();
+
+    // url contains a modified scope injected filter carried from somewhere else
+    const urlValues = {
+      'var-filters': ['scopesFilterKey1|=|newScopesFilterValue1#scope#restorable'],
+    };
+
+    act(() => {
+      locationService.partial(urlValues);
+    });
+
+    expect(filtersVar.state.originFilters![0]).toEqual({
+      key: 'scopesFilterKey1',
+      keyLabel: 'scopesFilterKey1',
+      operator: '=',
+      value: 'newScopesFilterValue1',
+      valueLabels: ['newScopesFilterValue1'],
+      restorable: true,
+      origin: 'scope',
+      condition: '',
+    });
+  });
+
+  it('sets origin filter as match-all', () => {
     const { filtersVar } = setup({
-      baseFilters: [
-        {
-          key: 'baseFilters',
-          operator: '=',
-          value: 'baseValue',
-        },
+      originFilters: [
         {
           key: 'dbFilterKey',
           operator: '=',
@@ -892,7 +917,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       locationService.partial(urlValues);
     });
 
-    expect(filtersVar.state.baseFilters![1]).toEqual({
+    expect(filtersVar.state.originFilters![0]).toEqual({
       condition: '',
       key: 'dbFilterKey',
       keyLabel: 'dbFilterKey',
@@ -905,34 +930,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
-  it('should maintain modified scopes and reconciliate after scopes update', () => {
-    // scope filters are fully emitted sometimes after urlSync happens, so we maintain all
-    // scope filters we find in the URL even tho at that point there are no scope
-    // injected filters actually saved in the adhoc
-    const { filtersVar } = setup();
-
-    // url contains a modified scope injected filter carried from somewhere else
-    const urlValues = {
-      'var-filters': ['scopesFilterKey1|=|newScopesFilterValue1#scope#restorable'],
-    };
-
-    act(() => {
-      locationService.partial(urlValues);
-    });
-
-    expect(filtersVar.state.baseFilters![0]).toEqual({
-      key: 'scopesFilterKey1',
-      keyLabel: 'scopesFilterKey1',
-      operator: '=',
-      value: 'newScopesFilterValue1',
-      valueLabels: ['newScopesFilterValue1'],
-      restorable: true,
-      origin: 'scope',
-      condition: '',
-    });
-  });
-
-  it('should maintain dashboard injected filter as a normal filter if there is no match', () => {
+  it('should maintain dashboard originated filter as a normal filter if there is no match', () => {
     // this dashboard has no baseFilters
     const { filtersVar } = setup();
 
@@ -955,9 +953,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
-  it('should turn normal filter with same key as dashboard injected one to a dashboard one that can be restored', () => {
+  it('filters are matched to origin ones if keys match', () => {
     const { filtersVar } = setup({
-      baseFilters: [
+      originFilters: [
         {
           key: 'dbFilterKey',
           operator: '=',
@@ -980,7 +978,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     // new filter will take values from the URL normal filter
     // but keep it as a dashboard level filter
-    expect(filtersVar.state.baseFilters![0]).toEqual({
+    expect(filtersVar.state.originFilters![0]).toEqual({
       key: 'dbFilterKey',
       keyLabel: 'dbFilterKey',
       operator: '!=',
@@ -992,7 +990,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
-  it('url updates injected filters properly', async () => {
+  it('url updates origin filters properly', async () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
         key: 'scopeFilterKey1',
@@ -1015,12 +1013,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
             value: 'filterValue',
           },
         ],
-        baseFilters: [
-          {
-            key: 'baseFilterKey',
-            operator: '=',
-            value: 'baseFilterValue',
-          },
+        originFilters: [
           {
             key: 'dbFilterKey',
             operator: '=',
@@ -1030,8 +1023,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         ],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
+
+    scopesVariable.update();
 
     const urlValues = {
       'var-filters': [
@@ -1056,7 +1051,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     // so are scope filters from the URL
-    expect(filtersVar.state.baseFilters![0]).toEqual({
+    expect(filtersVar.state.originFilters![0]).toEqual({
       key: 'scopeFilterKey1',
       keyLabel: 'scopeFilterKey1',
       operator: '=',
@@ -1067,7 +1062,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       condition: '',
     });
 
-    expect(filtersVar.state.baseFilters![1]).toEqual({
+    expect(filtersVar.state.originFilters![1]).toEqual({
       key: 'scopeFilterKey2',
       operator: '=',
       value: 'scopeFilterValue2',
@@ -1075,15 +1070,8 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       origin: 'scope',
     });
 
-    // normal baseFilters are simply maintained if they exist in the adhoc
-    expect(filtersVar.state.baseFilters![2]).toEqual({
-      key: 'baseFilterKey',
-      operator: '=',
-      value: 'baseFilterValue',
-    });
-
     // db injected filters are also updated
-    expect(filtersVar.state.baseFilters![3]).toEqual({
+    expect(filtersVar.state.originFilters![2]).toEqual({
       key: 'dbFilterKey',
       keyLabel: 'dbFilterKey',
       operator: '!=',
@@ -1095,7 +1083,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
-  it('show dashboard injected filters in the URL only if they have been changed', () => {
+  it('show dashboard originated filters in the URL only if they have been changed', () => {
     const { filtersVar } = setup({
       filters: [
         {
@@ -1104,12 +1092,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           value: 'someValue',
         },
       ],
-      baseFilters: [
-        {
-          key: 'baseFilters',
-          operator: '=',
-          value: 'baseValue',
-        },
+      originFilters: [
         {
           key: 'dbFilter',
           operator: '=',
@@ -1121,7 +1104,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     //update the dashboard filter value
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![1], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newDbValue',
       });
     });
@@ -1132,7 +1115,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     // restore it, URL should be cleaned
     act(() => {
-      filtersVar.restoreOriginalFilter(filtersVar.state.baseFilters![1]);
+      filtersVar.restoreOriginalFilter(filtersVar.state.originFilters![0]);
     });
 
     expect(locationService.getLocation().search).toBe('?var-filters=someFilter%7C%3D%7CsomeValue');
@@ -1152,7 +1135,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(locationService.getLocation().search).toBe('?var-filters=');
   });
 
-  it('will set original values for dashboard/scope injected filters on adhoc constructor', () => {
+  it('will set original values for dashboard/scope injected filters on init', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
         key: 'scopeKey',
@@ -1163,7 +1146,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     const { filtersVar } = setup(
       {
-        baseFilters: [
+        originFilters: [
           {
             key: 'dbKey1',
             operator: '=',
@@ -1179,48 +1162,19 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         ],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
+
+    scopesVariable.update();
 
     expect(filtersVar['_originalValues'].get('dbKey1')).toEqual({ value: ['dbValue1'], operator: '=' });
     expect(filtersVar['_originalValues'].get('dbKey2')).toEqual({ value: ['dbValue2'], operator: '=' });
     expect(filtersVar['_originalValues'].get('scopeKey')).toEqual({ value: ['scopeValue'], operator: '=' });
   });
 
-  it('should clear scope filters from adhoc on unmount', () => {
-    const scopesVariable = newScopesVariableFromScopeFilters([
-      {
-        key: 'scopeKey1',
-        operator: 'equals',
-        value: 'scopeValue1',
-        values: ['scopeValue1'],
-      },
-    ]);
-
-    const { filtersVar, unmount } = setup(
-      {
-        filters: [],
-        baseFilters: [
-          // no origin, so this does not get updated
-          { key: 'baseKey2', keyLabel: 'baseKey2', operator: '!=', value: 'baseValue2' },
-        ],
-      },
-      undefined,
-      scopesVariable
-    );
-
-    expect(filtersVar.state.baseFilters![0].value).toBe('scopeValue1');
-    expect(filtersVar.state.baseFilters![1].value).toBe('baseValue2');
-
-    unmount();
-
-    expect(filtersVar.state.baseFilters!.length).toBe(1);
-    expect(filtersVar.state.baseFilters![0].value).toBe('baseValue2');
-  });
-
   it('should reset dashboard level filters if they are edited on unmount', () => {
     const { filtersVar, unmount } = setup({
-      baseFilters: [
+      originFilters: [
         // this one is not restorable, thus has no edits and should not be restored
         {
           key: 'dbFilter1',
@@ -1245,20 +1199,20 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       ],
     });
 
-    expect(filtersVar.state.baseFilters!.length).toBe(3);
+    expect(filtersVar.state.originFilters!.length).toBe(3);
 
     const restoreFilterSpyOn = jest.spyOn(filtersVar, 'restoreOriginalFilter');
 
     unmount();
 
-    expect(filtersVar.state.baseFilters!.length).toBe(3);
-    expect(filtersVar.state.baseFilters![1].restorable).toBe(false);
+    expect(filtersVar.state.originFilters!.length).toBe(3);
+    expect(filtersVar.state.originFilters![1].restorable).toBe(false);
     expect(restoreFilterSpyOn).toHaveBeenCalledTimes(1);
   });
 
   it('should restore dashboard filter to its original value', () => {
     const { filtersVar } = setup({
-      baseFilters: [
+      originFilters: [
         {
           key: 'dbFilter1',
           operator: '=',
@@ -1270,253 +1224,225 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     act(() => {
       // will turn it into a matchall filter, on update it will set restorable true
-      filtersVar.updateToMatchAll(filtersVar.state.baseFilters![0]);
+      filtersVar.updateToMatchAll(filtersVar.state.originFilters![0]);
     });
 
-    expect(filtersVar.state.baseFilters![0].key).toBe('dbFilter1');
-    expect(filtersVar.state.baseFilters![0].value).toBe('.*');
-    expect(filtersVar.state.baseFilters![0].operator).toBe('=~');
-    expect(filtersVar.state.baseFilters![0].restorable).toBe(true);
+    expect(filtersVar.state.originFilters![0].key).toBe('dbFilter1');
+    expect(filtersVar.state.originFilters![0].value).toBe('.*');
+    expect(filtersVar.state.originFilters![0].operator).toBe('=~');
+    expect(filtersVar.state.originFilters![0].restorable).toBe(true);
 
     act(() => {
-      filtersVar.restoreOriginalFilter(filtersVar.state.baseFilters![0]);
+      filtersVar.restoreOriginalFilter(filtersVar.state.originFilters![0]);
     });
 
-    expect(filtersVar.state.baseFilters![0].key).toBe('dbFilter1');
-    expect(filtersVar.state.baseFilters![0].value).toBe('dbValue1');
-    expect(filtersVar.state.baseFilters![0].valueLabels).toEqual(['dbValue1']);
-    expect(filtersVar.state.baseFilters![0].operator).toBe('=');
-    expect(filtersVar.state.baseFilters![0].restorable).toBe(false);
+    expect(filtersVar.state.originFilters![0].key).toBe('dbFilter1');
+    expect(filtersVar.state.originFilters![0].value).toBe('dbValue1');
+    expect(filtersVar.state.originFilters![0].valueLabels).toEqual(['dbValue1']);
+    expect(filtersVar.state.originFilters![0].operator).toBe('=');
+    expect(filtersVar.state.originFilters![0].restorable).toBe(false);
   });
 
-  it('will save the original value and set baseFilter as restorable if it has an origin', () => {
+  it('will save the original value and set filter as restorable if it has an origin', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
-        key: 'baseKey1',
+        key: 'originKey1',
         operator: 'equals',
-        value: 'baseValue1',
-        values: ['baseValue1'],
+        value: 'originValue1',
+        values: ['originValue1'],
       },
     ]);
 
     const { filtersVar } = setup(
       {
         filters: [],
-        baseFilters: [
-          // no origin, so this does not get updated
-          { key: 'baseKey3', keyLabel: 'baseKey3', operator: '!=', value: 'baseValue3' },
-        ],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
 
+    scopesVariable.update();
+
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newValue1',
       });
-
-      // no origin, so this does not get updated
-      filtersVar._updateFilter(filtersVar.state.baseFilters![1], {
-        value: 'newValue3',
-      });
     });
 
-    expect(filtersVar.state.baseFilters![0].value).toBe('newValue1');
-    expect(filtersVar.state.baseFilters![1].value).toBe('baseValue3');
-    expect(filtersVar.state.baseFilters![0].restorable).toEqual(true);
-    expect(filtersVar.state.baseFilters![1].restorable).toBe(undefined);
+    expect(filtersVar.state.originFilters![0].value).toBe('newValue1');
+    expect(filtersVar.state.originFilters![0].restorable).toEqual(true);
   });
 
-  it('will save the original multi values in base filter if it has origin so it can be later restored', () => {
+  it('will save the original multi values if it has origin so it can be later restored', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
-        key: 'baseKey1',
+        key: 'originKey1',
         operator: 'one-of',
-        value: 'baseValue1',
-        values: ['baseValue1', 'baseValue2'],
+        value: 'originValue1',
+        values: ['originValue1', 'originValue2'],
       },
     ]);
 
     const { filtersVar } = setup(
       {
         filters: [],
-        baseFilters: [
-          // no origin, so this does not get updated
-          { key: 'baseKey3', keyLabel: 'baseKey3', operator: '!=', value: 'baseValue3' },
-        ],
       },
       undefined,
-      scopesVariable
+      scopesVariable.scopesVar
     );
 
+    scopesVariable.update();
+
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newValue1',
         values: ['newValue1'],
       });
-
-      // no origin, so this does not get updated
-      filtersVar._updateFilter(filtersVar.state.baseFilters![1], {
-        value: 'newValue3',
-      });
     });
 
-    expect(filtersVar.state.baseFilters![0].value).toBe('newValue1');
-    expect(filtersVar.state.baseFilters![0].values).toEqual(['newValue1']);
-    expect(filtersVar.state.baseFilters![1].value).toBe('baseValue3');
-    expect(filtersVar['_originalValues'].get(filtersVar.state.baseFilters![0].key)!.value).toEqual([
-      'baseValue1',
-      'baseValue2',
+    expect(filtersVar.state.originFilters![0].value).toBe('newValue1');
+    expect(filtersVar.state.originFilters![0].values).toEqual(['newValue1']);
+    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.value).toEqual([
+      'originValue1',
+      'originValue2',
     ]);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.baseFilters![0].key)!.operator).toEqual('=|');
-    expect(filtersVar['_originalValues'].get(filtersVar.state.baseFilters![1].key)).toBe(undefined);
+    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.operator).toEqual('=|');
   });
 
-  it('does not update set filter as restorable if new and old filter changes are the same', () => {
+  it('updated filter with no changes does not become restorable', async () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
-        key: 'baseKey1',
-        operator: 'one-of',
-        value: 'baseValue1',
-        values: ['baseValue1', 'baseValue2'],
+        key: 'originKey1',
+        operator: 'equals',
+        value: 'originValue1',
+        values: ['originValue1'],
       },
     ]);
 
-    const { filtersVar } = setup(
-      {
-        filters: [],
-        baseFilters: [
-          // no origin, so this does not get updated
-          { key: 'baseKey3', keyLabel: 'baseKey3', operator: '!=', value: 'baseValue3' },
-        ],
-      },
-      undefined,
-      scopesVariable
-    );
+    const { filtersVar } = setup({}, undefined, scopesVariable.scopesVar);
+
+    scopesVariable.update();
 
     act(() => {
       // same value, so no change
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
-        value: 'baseValue1',
-        values: ['baseValue1', 'baseValue2'],
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
+        value: 'originValue1',
+        values: ['originValue1'],
       });
     });
 
-    expect(filtersVar.state.baseFilters![0].value).toBe('baseValue1');
-    expect(filtersVar.state.baseFilters![0].values).toEqual(['baseValue1', 'baseValue2']);
-    expect(filtersVar.state.baseFilters![0].restorable).toEqual(false);
+    expect(filtersVar.state.originFilters![0].value).toBe('originValue1');
+    expect(filtersVar.state.originFilters![0].values).toEqual(['originValue1']);
+    expect(filtersVar.state.originFilters![0].restorable).toEqual(false);
   });
 
   it('sets filter as non restorable if we set the original value manually', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
-        key: 'baseKey1',
+        key: 'originKey1',
         operator: 'equals',
-        value: 'baseValue1',
-        values: ['baseValue1'],
+        value: 'originValue1',
+        values: ['originValue1'],
       },
     ]);
 
-    const { filtersVar } = setup({}, undefined, scopesVariable);
+    const { filtersVar } = setup({}, undefined, scopesVariable.scopesVar);
+
+    scopesVariable.update();
 
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
         value: 'newValue1',
         values: ['newValue1'],
       });
     });
 
-    expect(filtersVar.state.baseFilters![0].restorable).toEqual(true);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.baseFilters![0].key)!.value).toEqual(['baseValue1']);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.baseFilters![0].key)!.operator).toEqual('=');
+    expect(filtersVar.state.originFilters![0].restorable).toEqual(true);
+    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.value).toEqual(['originValue1']);
+    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.operator).toEqual('=');
 
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
-        value: 'baseValue1',
-        values: ['baseValue1'],
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
+        value: 'originValue1',
+        values: ['originValue1'],
       });
     });
 
     // like a manual restore, but done from the UI by manually picking the same value
     // as the original
-    expect(filtersVar.state.baseFilters![0].restorable).toEqual(false);
+    expect(filtersVar.state.originFilters![0].restorable).toEqual(false);
   });
 
   it('restores original value if it exists', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {
-        key: 'baseKey1',
+        key: 'originalKey1',
         operator: 'one-of',
         value: 'originalValue1',
         values: ['originalValue1'],
       },
     ]);
 
-    const { filtersVar } = setup({}, undefined, scopesVariable);
+    const { filtersVar } = setup({}, undefined, scopesVariable.scopesVar);
+
+    scopesVariable.update();
 
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.baseFilters![0], {
-        value: 'baseValue1',
-        values: ['baseValue1'],
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
+        value: 'newValue1',
+        values: ['newValue1'],
       });
     });
 
-    expect(filtersVar.state.baseFilters![0].value).toEqual('baseValue1');
-    expect(filtersVar.state.baseFilters![0].values).toEqual(['baseValue1']);
-    expect(filtersVar.state.baseFilters![0].restorable).toBe(true);
+    expect(filtersVar.state.originFilters![0].value).toEqual('newValue1');
+    expect(filtersVar.state.originFilters![0].values).toEqual(['newValue1']);
+    expect(filtersVar.state.originFilters![0].restorable).toBe(true);
 
     act(() => {
-      filtersVar.restoreOriginalFilter(filtersVar.state.baseFilters![0]);
+      filtersVar.restoreOriginalFilter(filtersVar.state.originFilters![0]);
     });
 
-    expect(filtersVar.state.baseFilters![0].value).toEqual('originalValue1');
-    expect(filtersVar.state.baseFilters![0].values).toEqual(['originalValue1']);
-    expect(filtersVar.state.baseFilters![0].restorable).toBe(false);
+    expect(filtersVar.state.originFilters![0].value).toEqual('originalValue1');
+    expect(filtersVar.state.originFilters![0].values).toEqual(['originalValue1']);
+    expect(filtersVar.state.originFilters![0].restorable).toBe(false);
   });
 
   it('does not restore original value if it does not exists', () => {
     const { filtersVar } = setup({
       filters: [],
-      baseFilters: [
+      originFilters: [
         {
-          key: 'baseKey1',
-          keyLabel: 'baseKey1',
+          key: 'originalKey1',
+          keyLabel: 'originalKey1',
           operator: '=|',
-          value: 'baseValue1',
-          values: ['baseValue1'],
+          value: 'originalValue1',
+          values: ['originalValue1'],
           origin: 'scope',
         },
       ],
     });
 
     act(() => {
-      filtersVar.restoreOriginalFilter(filtersVar.state.baseFilters![0]);
+      filtersVar.restoreOriginalFilter(filtersVar.state.originFilters![0]);
     });
 
-    expect(filtersVar.state.baseFilters![0].value).toEqual('baseValue1');
-    expect(filtersVar.state.baseFilters![0].values).toEqual(['baseValue1']);
-    expect(filtersVar.state.baseFilters![0].restorable).toBe(false);
+    expect(filtersVar.state.originFilters![0].value).toEqual('originalValue1');
+    expect(filtersVar.state.originFilters![0].values).toEqual(['originalValue1']);
+    expect(filtersVar.state.originFilters![0].restorable).toBe(undefined);
   });
 
   it.each([
     [
       [
         {
-          key: 'nonScopeBaseFilter',
-          operator: '=',
-          value: 'val',
-          values: ['val'],
-        },
-        {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
         },
         {
-          key: 'scopeBaseFilter2',
+          key: 'scopeOriginFilter2',
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
@@ -1526,14 +1452,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       ],
       [
         [
-          { key: 'scopeBaseFilter1', operator: 'equals', value: 'val' },
-          { key: 'scopeBaseFilter2', operator: 'equals', value: 'val' },
+          { key: 'scopeOriginFilter1', operator: 'equals', value: 'val' },
+          { key: 'scopeOriginFilter2', operator: 'equals', value: 'val' },
         ],
-        [{ key: 'scopeBaseFilter3', operator: 'equals', value: 'val' }],
+        [{ key: 'scopeOriginFilter3', operator: 'equals', value: 'val' }],
       ],
       [
         {
-          key: 'scopeBaseFilter2',
+          key: 'scopeOriginFilter2',
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
@@ -1541,24 +1467,18 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           restorable: true,
         },
         {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
         },
         {
-          key: 'scopeBaseFilter3',
+          key: 'scopeOriginFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
-        },
-        {
-          key: 'nonScopeBaseFilter',
-          operator: '=',
-          value: 'val',
-          values: ['val'],
         },
       ],
     ],
@@ -1566,28 +1486,28 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       [],
       [
         [
-          { key: 'scopeBaseFilter1', operator: 'equals', value: 'val' },
-          { key: 'scopeBaseFilter2', operator: 'equals', value: 'val' },
+          { key: 'scopeOriginFilter1', operator: 'equals', value: 'val' },
+          { key: 'scopeOriginFilter2', operator: 'equals', value: 'val' },
         ],
-        [{ key: 'scopeBaseFilter3', operator: 'equals', value: 'val' }],
+        [{ key: 'scopeOriginFilter3', operator: 'equals', value: 'val' }],
       ],
       [
         {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
         },
         {
-          key: 'scopeBaseFilter2',
+          key: 'scopeOriginFilter2',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
         },
         {
-          key: 'scopeBaseFilter3',
+          key: 'scopeOriginFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
@@ -1598,59 +1518,28 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     [
       [
         {
-          key: 'nonScopeBaseFilter',
-          operator: '=',
-          value: 'val',
-          values: ['val'],
-        },
-      ],
-      [],
-      [
-        {
-          key: 'nonScopeBaseFilter',
-          operator: '=',
-          value: 'val',
-          values: ['val'],
-        },
-      ],
-    ],
-    [
-      [
-        {
-          key: 'nonScopeBaseFilter',
-          operator: '=',
-          value: 'val',
-          values: ['val'],
-        },
-        {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
         },
       ],
-      [[{ key: 'scopeBaseFilter3', operator: 'equals', value: 'val' }]],
+      [[{ key: 'scopeOriginFilter3', operator: 'equals', value: 'val' }]],
       [
         {
-          key: 'scopeBaseFilter3',
+          key: 'scopeOriginFilter3',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
-        },
-        {
-          key: 'nonScopeBaseFilter',
-          operator: '=',
-          value: 'val',
-          values: ['val'],
         },
       ],
     ],
     [
       [
         {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
@@ -1658,10 +1547,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           restorable: true,
         },
       ],
-      [[{ key: 'scopeBaseFilter1', operator: 'equals', value: 'val' }]],
+      [[{ key: 'scopeOriginFilter1', operator: 'equals', value: 'val' }]],
       [
         {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'editedVal',
           values: ['editedVal'],
@@ -1673,17 +1562,17 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     [
       [
         {
-          key: 'scopeBaseFilter1',
+          key: 'scopeOriginFilter1',
           operator: '=',
           value: 'val',
           values: ['val'],
           origin: 'scope',
         },
       ],
-      [[{ key: 'scopeBaseFilter2', operator: 'equals', value: 'val' }]],
+      [[{ key: 'scopeOriginFilter2', operator: 'equals', value: 'val' }]],
       [
         {
-          key: 'scopeBaseFilter2',
+          key: 'scopeOriginFilter2',
           operator: '=',
           value: 'val',
           values: ['val'],
@@ -1692,40 +1581,46 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       ],
     ],
     [[], [], []],
-  ])('maintains correct filters and scope injected filters on activation', (baseFilters, scopeFilters, expected) => {
-    // in this scenario we need to preserve whatever non injected filters exist, together
-    // with either edited scope injected filters or directly filters pulled from scopes
-    const scopes: Scope[] = [];
+  ])(
+    'maintains correct filters and scope originated filters on activation',
+    (originFilters, scopeFilters, expected) => {
+      // we need to preserve either edited scope injected filters or directly filters pulled from scopes
+      const scopes: Scope[] = [];
 
-    for (let i = 0; i < scopeFilters.length; i++) {
-      scopes.push({
-        metadata: { name: `Scope ${i}` },
-        spec: {
-          title: `Scope ${i}`,
-          type: 'test',
-          description: 'Test scope',
-          category: 'test',
-          filters: scopeFilters[i] as ScopeSpecFilter[],
+      for (let i = 0; i < scopeFilters.length; i++) {
+        scopes.push({
+          metadata: { name: `Scope ${i}` },
+          spec: {
+            title: `Scope ${i}`,
+            type: 'test',
+            description: 'Test scope',
+            category: 'test',
+            filters: scopeFilters[i] as ScopeSpecFilter[],
+          },
+        });
+      }
+      const scopesVar = new ScopesVariable({});
+
+      const { filtersVar } = setup(
+        {
+          filters: [],
+          originFilters: originFilters as AdHocFilterWithLabels[],
         },
+        undefined,
+        scopesVar
+      );
+
+      act(() => {
+        scopesVar.updateStateFromContext({ value: scopes, loading: false });
+      });
+
+      filtersVar.state.originFilters?.forEach((filter, index) => {
+        expect(filter).toEqual(expected[index]);
       });
     }
-    const scopesVar = new ScopesVariable({ scopes });
+  );
 
-    const { filtersVar } = setup(
-      {
-        filters: [],
-        baseFilters: baseFilters as AdHocFilterWithLabels[],
-      },
-      undefined,
-      scopesVar
-    );
-
-    filtersVar.state.baseFilters?.forEach((filter, index) => {
-      expect(filter).toEqual(expected[index]);
-    });
-  });
-
-  it('Removes all scope injected filters when scopes themselves are removed', () => {
+  it('Removes scope originated filters when scopes themselves are removed', () => {
     const scopes: Scope[] = [
       {
         metadata: { name: `Scope` },
@@ -1734,7 +1629,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           type: 'test',
           description: 'Test scope',
           category: 'test',
-          filters: [{ key: 'scopeBaseFilter', operator: 'equals', value: 'val' }],
+          filters: [{ key: 'scopeOriginFilter', operator: 'equals', value: 'val' }],
         },
       },
     ];
@@ -1742,13 +1637,13 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     const scopesVar = new ScopesVariable({ scopes });
     const { filtersVar } = setup(
       {
-        filters: [],
-        baseFilters: [
+        originFilters: [
           {
-            key: 'baseFilter',
+            key: 'scopeOriginFilter',
             operator: '=',
-            value: 'val2',
-            values: ['val2'],
+            value: 'val',
+            values: ['val'],
+            origin: 'scope',
           },
         ],
       },
@@ -1756,34 +1651,11 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       scopesVar
     );
 
-    expect(filtersVar.state.baseFilters).toEqual([
-      {
-        key: 'scopeBaseFilter',
-        operator: '=',
-        value: 'val',
-        values: ['val'],
-        origin: 'scope',
-      },
-      {
-        key: 'baseFilter',
-        operator: '=',
-        value: 'val2',
-        values: ['val2'],
-      },
-    ]);
-
     act(() => {
       scopesVar.updateStateFromContext({ value: [], loading: false });
     });
 
-    expect(filtersVar.state.baseFilters).toEqual([
-      {
-        key: 'baseFilter',
-        operator: '=',
-        value: 'val2',
-        values: ['val2'],
-      },
-    ]);
+    expect(filtersVar.state.originFilters).toEqual([]);
   });
 
   it('Can override and replace getTagKeys and getTagValues', async () => {
@@ -2066,24 +1938,18 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         datasource: { uid: 'hello' },
         applyMode: 'manual',
         filters: [{ key: 'key2', operator: '=', value: 'val2' }],
-        baseFilters: [
-          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: 'scope' },
-          { key: 'baseKey2', operator: '=', value: 'baseVal2' },
-        ],
+        originFilters: [{ key: 'originKey1', operator: '=', value: 'originVal1', origin: 'scope' }],
       });
 
-      expect(variable2.getValue()).toBe(`baseKey1="baseVal1",key2="val2"`);
+      expect(variable2.getValue()).toBe(`originKey1="originVal1",key2="val2"`);
 
       const variable3 = new AdHocFiltersVariable({
         datasource: { uid: 'hello' },
         applyMode: 'manual',
-        baseFilters: [
-          { key: 'baseKey3', operator: '=', value: 'baseVal3', origin: 'scope' },
-          { key: 'baseKey4', operator: '=', value: 'baseVal4' },
-        ],
+        originFilters: [{ key: 'originKey3', operator: '=', value: 'originVal3', origin: 'scope' }],
       });
 
-      expect(variable3.getValue()).toBe(`baseKey3="baseVal3"`);
+      expect(variable3.getValue()).toBe(`originKey3="originVal3"`);
     });
 
     it('renders correct filterExpression when baseFilters are added and they have an origin on setState', () => {
@@ -2100,14 +1966,11 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(stateUpdates.length).toBe(0);
 
       variable.setState({
-        baseFilters: [
-          { key: 'baseKey1', operator: '=', value: 'baseVal1', origin: 'scope' },
-          { key: 'baseKey2', operator: '=', value: 'baseVal2' },
-        ],
+        originFilters: [{ key: 'originKey1', operator: '=', value: 'originVal1', origin: 'scope' }],
       });
 
       expect(stateUpdates).toHaveLength(1);
-      expect(stateUpdates[0].filterExpression).toBe('baseKey1="baseVal1",key1="val1"');
+      expect(stateUpdates[0].filterExpression).toBe('originKey1="originVal1",key1="val1"');
     });
 
     it('Renders correct expression when passed an expression builder', () => {
@@ -2791,7 +2654,7 @@ function setup(
   return { scene, filtersVar, unmount, runRequest: runRequestMock.fn, getTagKeysSpy, getTagValuesSpy, timeRange };
 }
 
-function newScopesVariableFromScopeFilters(filters: ScopeSpecFilter[]): ScopesVariable {
+function newScopesVariableFromScopeFilters(filters: ScopeSpecFilter[]) {
   const scopes: Scope[] = [
     {
       metadata: { name: `Scope 1` },
@@ -2804,5 +2667,15 @@ function newScopesVariableFromScopeFilters(filters: ScopeSpecFilter[]): ScopesVa
       },
     },
   ];
-  return new ScopesVariable({ scopes });
+
+  const scopesVar = new ScopesVariable({});
+
+  return {
+    scopesVar,
+    update: () => {
+      act(() => {
+        scopesVar.updateStateFromContext({ value: scopes, loading: false });
+      });
+    },
+  };
 }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { AdHocVariableFilter, GetTagResponse, GrafanaTheme2, MetricFindValue, SelectableValue } from '@grafana/data';
+import {
+  AdHocVariableFilter,
+  GetTagResponse,
+  GrafanaTheme2,
+  MetricFindValue,
+  Scope,
+  SelectableValue,
+} from '@grafana/data';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneVariable, SceneVariableState, SceneVariableValueChangedEvent, VariableValue } from '../types';
 import { ControlsLayout, SceneComponentProps } from '../../core/types';
@@ -50,6 +57,8 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   filters: AdHocFilterWithLabels[];
   /** Base filters to always apply when looking up keys*/
   baseFilters?: AdHocFilterWithLabels[];
+  /** Filters originated from a source */
+  originFilters?: AdHocFilterWithLabels[];
   /** Datasource to use for getTagKeys and getTagValues and also controls which scene queries the filters should apply to */
   datasource: DataSourceRef | null;
   /** Controls if the filters can be changed */
@@ -204,6 +213,7 @@ export class AdHocFiltersVariable
   // are set on construct and used to restore a baseFilter with an origin
   // to its original value if edited at some point
   private _originalValues: Map<string, { value: string[]; operator: string }> = new Map();
+  private _prevScopes: Scope[] = [];
 
   /** Needed for scopes dependency */
   protected _variableDependency = new VariableDependencyConfig(this, {
@@ -222,10 +232,7 @@ export class AdHocFiltersVariable
       applyMode: 'auto',
       filterExpression:
         state.filterExpression ??
-        renderExpression(state.expressionBuilder, [
-          ...(state.baseFilters?.filter((filter) => filter.origin) ?? []),
-          ...(state.filters ?? []),
-        ]),
+        renderExpression(state.expressionBuilder, [...(state.originFilters ?? []), ...(state.filters ?? [])]),
       ...state,
     });
 
@@ -233,55 +240,32 @@ export class AdHocFiltersVariable
       patchGetAdhocFilters(this);
     }
 
-    // set dashboard lvl original values in constructor, since we have them from schema
-    this.state.baseFilters?.forEach((baseFilter) => {
-      if (baseFilter.origin === 'dashboard') {
-        this._originalValues.set(baseFilter.key, {
-          operator: baseFilter.operator,
-          value: baseFilter.values ?? [baseFilter.value],
-        });
-      }
+    this.state.originFilters?.forEach((filter) => {
+      this._originalValues.set(filter.key, {
+        operator: filter.operator,
+        value: filter.values ?? [filter.value],
+      });
     });
 
     this.addActivationHandler(this._activationHandler);
   }
 
   private _activationHandler = () => {
-    this._updateScopesFilters();
-
     return () => {
-      // we clear both scopes and dashboard level filters before leaving a dashboard to maintain accuracy for both
-      // when/if we return to the same dashboard
-      // e.g.: we edit a scope filter and go to another dashboard, it gets carried over, but then on that dashboard
-      // we reset the value, and then come back to the initial dashboard, that dashboard still has the edited scope
-      // because the URL will not hold any value, since on reset we clear the url, but the initial dashboard still
-      // has the changed value in the schema, unless we reset it here
-      if (this.state.baseFilters?.length) {
-        this.setState({
-          baseFilters: [...this.state.baseFilters.filter((filter) => filter.origin !== 'scope')],
-        });
-        // same for dashboard level filters if we edit one and go to another dashboard, reset to whatever initial value is there
-        // and come back to the initial one it will use the last modified value it has, since URL is empty from the reset done
-        // before
-        this.state.baseFilters?.forEach((filter) => {
-          if (filter.origin === 'dashboard' && filter.restorable) {
-            this.restoreOriginalFilter(filter);
-          }
-        });
-      }
+      this.state.originFilters?.forEach((filter) => {
+        if (filter.restorable) {
+          this.restoreOriginalFilter(filter);
+        }
+      });
     };
   };
 
   private _updateScopesFilters() {
     const scopes = sceneGraph.getScopes(this);
 
-    if (!scopes) {
-      return;
-    }
-
-    if (!scopes.length) {
+    if (!scopes || !scopes.length) {
       this.setState({
-        baseFilters: this.state.baseFilters?.filter((filter) => filter.origin !== 'scope'),
+        originFilters: this.state.originFilters?.filter((filter) => filter.origin !== 'scope'),
       });
       return;
     }
@@ -304,13 +288,19 @@ export class AdHocFiltersVariable
       });
     });
 
-    this.state.baseFilters?.forEach((filter) => {
+    this.state.originFilters?.forEach((filter) => {
       if (filter.origin === 'scope') {
         scopeInjectedFilters.push(filter);
       } else {
         remainingFilters.push(filter);
       }
     });
+
+    if (this._prevScopes.length) {
+      this.setState({ originFilters: [...finalFilters, ...remainingFilters] });
+      this._prevScopes = scopes;
+      return;
+    }
 
     const editedScopeFilters = scopeInjectedFilters.filter((filter) => filter.restorable);
     const editedScopeFilterKeys = editedScopeFilters.map((filter) => filter.key);
@@ -324,8 +314,9 @@ export class AdHocFiltersVariable
       ...scopeFilters.filter((filter) => !editedScopeFilterKeys.includes(filter.key)),
     ];
 
-    // maintain other baseFilters in the array, only update scopes ones
-    this.setState({ baseFilters: [...finalFilters, ...remainingFilters] });
+    // maintain other originFilters in the array, only update scopes ones
+    this.setState({ originFilters: [...finalFilters, ...remainingFilters] });
+    this._prevScopes = scopes;
   }
 
   public setState(update: Partial<AdHocFiltersVariableState>): void {
@@ -333,16 +324,13 @@ export class AdHocFiltersVariable
 
     if (
       ((update.filters && update.filters !== this.state.filters) ||
-        (update.baseFilters && update.baseFilters !== this.state.baseFilters)) &&
+        (update.originFilters && update.originFilters !== this.state.originFilters)) &&
       !update.filterExpression
     ) {
       const filters = update.filters ?? this.state.filters;
-      const baseFilters = update.baseFilters ?? this.state.baseFilters;
+      const originFilters = update.originFilters ?? this.state.originFilters;
 
-      update.filterExpression = renderExpression(this.state.expressionBuilder, [
-        ...(baseFilters?.filter((filter) => filter.origin) ?? []),
-        ...(filters ?? []),
-      ]);
+      update.filterExpression = renderExpression(this.state.expressionBuilder, [...(originFilters ?? []), ...filters]);
       filterExpressionChanged = update.filterExpression !== this.state.filterExpression;
     }
 
@@ -370,7 +358,7 @@ export class AdHocFiltersVariable
 
     if (filters && filters !== this.state.filters) {
       filterExpression = renderExpression(this.state.expressionBuilder, [
-        ...(this.state.baseFilters?.filter((filter) => filter.origin) ?? []),
+        ...(this.state.originFilters ?? []),
         ...filters,
       ]);
       filterExpressionChanged = filterExpression !== this.state.filterExpression;
@@ -395,16 +383,17 @@ export class AdHocFiltersVariable
     if (filter.restorable) {
       const originalFilter = this._originalValues.get(filter.key);
 
+      if (!originalFilter) {
+        return;
+      }
+
       original.value = originalFilter?.value[0];
       original.values = originalFilter?.value;
-      // we don't care much about the labels in this injected filters scenario
-      // but this is needed to rerender the filter with the proper values
-      // in the UI. E.g.: in a multi-value on hover, it shows the correct values
       original.valueLabels = originalFilter?.value;
       original.operator = originalFilter?.operator;
-    }
 
-    this._updateFilter(filter, original);
+      this._updateFilter(filter, original);
+    }
   }
 
   public getValue(): VariableValue | undefined {
@@ -412,33 +401,26 @@ export class AdHocFiltersVariable
   }
 
   public _updateFilter(filter: AdHocFilterWithLabels, update: Partial<AdHocFilterWithLabels>) {
-    const { baseFilters, filters, _wip } = this.state;
+    const { originFilters, filters, _wip } = this.state;
 
     if (filter.origin) {
       const originalValues = this._originalValues.get(filter.key);
       const updateValues = update.values || (update.value ? [update.value] : undefined);
 
-      // if we don't have the restorable prop set but values differ we set it true
-      // this happens when editing the value of an injected filter
-      // we also make sure to set restorable false if values are the same as original
-      // e.g.: if we edit the value of a filter to whatever the original was, manually
-      // 'restoring' the filter
-      const isRestorableOverride = update.hasOwnProperty('restorable');
       if (
-        !isRestorableOverride &&
-        ((updateValues && !isEqual(updateValues, originalValues?.value)) ||
-          (update.operator && update.operator !== originalValues?.operator))
+        (updateValues && !isEqual(updateValues, originalValues?.value)) ||
+        (update.operator && update.operator !== originalValues?.operator)
       ) {
         update.restorable = true;
       } else if (updateValues && isEqual(updateValues, originalValues?.value)) {
         update.restorable = false;
       }
 
-      const updatedBaseFilters =
-        baseFilters?.map((f) => {
+      const updatedFilters =
+        originFilters?.map((f) => {
           return f === filter ? { ...f, ...update } : f;
         }) ?? [];
-      this.setState({ baseFilters: updatedBaseFilters });
+      this.setState({ originFilters: updatedFilters });
 
       return;
     }
@@ -519,9 +501,9 @@ export class AdHocFiltersVariable
           return [...acc, f];
         }, []),
       });
-    } else if (this.state.baseFilters?.length) {
+    } else if (this.state.originFilters?.length) {
       // default forceEdit last filter (when triggering from wip filter)
-      let filterToForceIndex = this.state.baseFilters.length - 1;
+      let filterToForceIndex = this.state.originFilters.length - 1;
 
       // adjust filterToForceIndex index to -1 if backspace triggered from non wip filter
       //  to avoid triggering forceEdit logic
@@ -530,7 +512,7 @@ export class AdHocFiltersVariable
       }
 
       this.setState({
-        baseFilters: this.state.baseFilters.reduce<AdHocFilterWithLabels[]>((acc, f, index) => {
+        originFilters: this.state.originFilters.reduce<AdHocFilterWithLabels[]>((acc, f, index) => {
           // adjust forceEdit of preceding filter
           if (index === filterToForceIndex && !f.readOnly) {
             return [
@@ -615,16 +597,16 @@ export class AdHocFiltersVariable
       return [];
     }
 
-    const filteredBaseFilters = this.state.baseFilters?.filter((f) => f.origin && f.key !== filter.key) ?? [];
+    const originFilters = this.state.originFilters?.filter((f) => f.key !== filter.key) ?? [];
     // Filter out the current filter key from the list of all filters
-    const otherFilters = this.state.filters.filter((f) => f.key !== filter.key).concat(filteredBaseFilters);
+    const otherFilters = this.state.filters.filter((f) => f.key !== filter.key).concat(originFilters);
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const queries = this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined;
 
     let scopes = sceneGraph.getScopes(this);
 
-    // if current filter is a scope injected one we need to filter out
+    // if current filter is a scope originated one we need to filter out
     // filters with same key in scopes prop, similar to how we do in adhocFilters prop
     if (filter.origin === 'scope') {
       scopes = scopes?.map((scope) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -8,7 +8,7 @@ import {
   isMultiValueOperator,
 } from './AdHocFiltersVariable';
 import {
-  escapeInjectedFilterUrlDelimiters,
+  escapeOriginFilterUrlDelimiters,
   escapeUrlPipeDelimiters,
   toUrlCommaDelimitedString,
   unescapeUrlDelimiters,
@@ -27,11 +27,11 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
 
   public getUrlState(): SceneObjectUrlValues {
     const filters = this._variable.state.filters;
-    const baseFilters = this._variable.state.baseFilters;
+    const originFilters = this._variable.state.originFilters;
 
     let value = [];
 
-    if (filters.length === 0 && baseFilters?.length === 0) {
+    if (filters.length === 0 && originFilters?.length === 0) {
       return { [this.getKey()]: [''] };
     }
 
@@ -44,14 +44,14 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
       );
     }
 
-    if (baseFilters?.length) {
+    if (originFilters?.length) {
       // injected filters stored in the following format: normal|adhoc|values#filterOrigin#restorable
       value.push(
-        ...baseFilters
+        ...originFilters
           ?.filter(isFilterComplete)
           .filter((filter) => !filter.hidden && filter.origin && filter.restorable)
           .map((filter) =>
-            toArray(filter).map(escapeInjectedFilterUrlDelimiters).join('|').concat(`#${filter.origin}#restorable`)
+            toArray(filter).map(escapeOriginFilterUrlDelimiters).join('|').concat(`#${filter.origin}#restorable`)
           )
       );
     }
@@ -69,44 +69,49 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
     }
 
     const filters = deserializeUrlToFilters(urlValue);
-    const baseFilters = [...(this._variable.state.baseFilters || [])];
-
-    for (let i = 0; i < filters.length; i++) {
-      const foundBaseFilterIndex = baseFilters.findIndex((f) => f.key === filters[i].key);
-
-      // if we find a match we update baseFilter with what's in the URL.
-      // If there is a normal filter without an origin that matches keys with
-      // some dashboard lvl filter we maintain it as dashboard lvl filter in the
-      // new dashboard
-      if (foundBaseFilterIndex > -1) {
-        if (!filters[i].origin && baseFilters[foundBaseFilterIndex].origin === 'dashboard') {
-          filters[i].origin = 'dashboard';
-          filters[i].restorable = true;
-        }
-
-        if (isMatchAllFilter(filters[i])) {
-          filters[i].matchAllFilter = true;
-        }
-
-        baseFilters[foundBaseFilterIndex] = filters[i];
-      } else if (filters[i].origin === 'dashboard') {
-        // if it was originating from a dashoard but has no match in the new dashboard
-        // remove it's origin, turn it into a normal filter to be set below
-        delete filters[i].origin;
-        delete filters[i].restorable;
-      } else if (foundBaseFilterIndex === -1 && filters[i].origin === 'scope' && filters[i].restorable) {
-        // scopes are being set sometimes (when the observable emits actual filters) after urlSync
-        // so we maintain all modified scopes in the adhoc
-        // and leave the scopes update to reconciliate on what filters will actually show up
-        baseFilters.push(filters[i]);
-      }
-    }
+    const originFilters = updateOriginFilters([...(this._variable.state.originFilters || [])], filters);
 
     this._variable.setState({
       filters: filters.filter((f) => !f.origin),
-      baseFilters,
+      originFilters,
     });
   }
+}
+
+function updateOriginFilters(prevOriginFilters: AdHocFilterWithLabels[], filters: AdHocFilterWithLabels[]) {
+  const updatedOriginFilters: AdHocFilterWithLabels[] = [...prevOriginFilters];
+
+  for (let i = 0; i < filters.length; i++) {
+    const foundOriginFilterIndex = prevOriginFilters.findIndex((f) => f.key === filters[i].key);
+
+    // if we find a match we update originFilters with what's in the URL.
+    // If there is a normal filter without an origin that matches keys with
+    // some dashboard lvl filter we maintain it as dashboard lvl filter in the
+    // new dashboard
+    if (foundOriginFilterIndex > -1) {
+      if (!filters[i].origin && prevOriginFilters[foundOriginFilterIndex].origin === 'dashboard') {
+        filters[i].origin = 'dashboard';
+        filters[i].restorable = true;
+      }
+
+      if (isMatchAllFilter(filters[i])) {
+        filters[i].matchAllFilter = true;
+      }
+
+      updatedOriginFilters[foundOriginFilterIndex] = filters[i];
+    } else if (filters[i].origin === 'dashboard') {
+      // if it was originating from a dashoard but has no match in the new dashboard
+      // remove it's origin, turn it into a normal filter to be set below
+      delete filters[i].origin;
+      delete filters[i].restorable;
+    } else if (foundOriginFilterIndex === -1 && filters[i].origin === 'scope' && filters[i].restorable) {
+      // scopes are being set urlSync so we maintain all modified scopes in the adhoc
+      // and leave the scopes update to reconciliate on what filters will actually show up
+      updatedOriginFilters.push(filters[i]);
+    }
+  }
+
+  return updatedOriginFilters;
 }
 
 function deserializeUrlToFilters(value: SceneObjectUrlValue): AdHocFilterWithLabels[] {

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -188,7 +188,7 @@ export function escapeUrlHashDelimiters(value: string | undefined): string {
   return /#/g[Symbol.replace](value, '__gfh__');
 }
 
-export function escapeInjectedFilterUrlDelimiters(value: string | undefined): string {
+export function escapeOriginFilterUrlDelimiters(value: string | undefined): string {
   return escapeUrlHashDelimiters(escapeUrlPipeDelimiters(value));
 }
 


### PR DESCRIPTION
Origin filters have been moved to a separate property within the adhoc variable - `originFilters`. 
This change and other refactors in this PR are aiming to simplify the logic related to origin filters.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.19.0--canary.1132.15579595251.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.19.0--canary.1132.15579595251.0
  npm install @grafana/scenes@6.19.0--canary.1132.15579595251.0
  # or 
  yarn add @grafana/scenes-react@6.19.0--canary.1132.15579595251.0
  yarn add @grafana/scenes@6.19.0--canary.1132.15579595251.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
