### PR TITLE
docs: fix missing comma in advanced-time-range-comparison example

### DIFF
--- a/docusaurus/docs/advanced-time-range-comparison.md
+++ b/docusaurus/docs/advanced-time-range-comparison.md
@@ -49,7 +49,7 @@ Use `SceneTimePicker` object to display and control time range of a scene:
 const scene = new EmbeddedScene({
   $data: queryRunner,
   $timeRange: new SceneTimeRange({ from: 'now-5m', to: 'now' }),
-  controls: [new SceneTimePicker({})]
+  controls: [new SceneTimePicker({})],
   body: new SceneFlexLayout({
     direction: 'row',
     children: [


### PR DESCRIPTION
Fixes a missing comma in the `EmbeddedScene` example within the `advanced-time-range-comparison` documentation.