### PR TITLE
ScopesVariable: Fixes diff check issue

### DIFF
--- a/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
@@ -66,9 +66,13 @@ describe('ScopesVariable', () => {
 
     act(() => scopesContext.changeScopes(['scope3', 'scope4']));
 
+    // await new Promise((resolve) => setTimeout(resolve, 10));
+
     expect(valueChangedCount).toEqual(1);
 
     act(() => scopesContext.changeScopes(['scope3', 'scope4']));
+
+    //await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(valueChangedCount).toEqual(1);
   });
@@ -124,7 +128,12 @@ export class FakeScopesContext {
 
   changeScopes = (scopeNames: string[]) => {
     const value = scopeNames.map((name) => ({ spec: { title: name }, metadata: { name } } as Scope));
-    this.state = { ...this.state, value };
+    this.state = { ...this.state, value, loading: true };
+    this.stateObservable.next(this.state);
+
+    // Simulate how the real context behaves, setting loading true and updating scopes
+    // Then switching to loading false after meta data added
+    this.state = { ...this.state, loading: false };
     this.stateObservable.next(this.state);
   };
 }

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -96,10 +96,12 @@ export class ScopesVariable extends SceneObjectBase<ScopesVariableState> impleme
     const oldScopes = this.state.scopes.map((scope) => scope.metadata.name);
     const newScopes = state.value.map((scope) => scope.metadata.name);
 
-    this.setState({ scopes: state.value, loading });
-
+    // Only update scopes value state when loading is false and the scopes have changed
     if (!loading && !isEqual(oldScopes, newScopes)) {
+      this.setState({ scopes: state.value, loading });
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
+    } else {
+      this.setState({ loading });
     }
   }
 }


### PR DESCRIPTION
Should have tested https://github.com/grafana/scenes/pull/1131 before merging. 

It makes it so the value changed event is never emitted / so scope value changes does not trigger any reload. 

It's because scope context updates the scope value with loading=true, then switches to loading: false when scope metadata has been fetched. 

For this equality check https://github.com/grafana/scenes/pull/1131 that only compare names to work we cannot update the scope value unless loading: false 