### PR TITLE
ScopesVariable: Emit value changed when there no scopes selected

### DIFF
--- a/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
@@ -59,18 +59,20 @@ describe('ScopesVariable', () => {
   });
 
   it('Should not emit value changed when scopes are the same', async () => {
-    const { scopesContext, variable } = renderTestScene({ initialScopes: ['scope1', 'scope2'] });
-    let valueChangedCount = 0;
-
-    variable.subscribeToEvent(SceneVariableValueChangedEvent, () => valueChangedCount++);
+    const { scopesContext, valueChangedCount } = renderTestScene({ initialScopes: ['scope1', 'scope2'] });
 
     act(() => scopesContext.changeScopes(['scope3', 'scope4']));
 
-    expect(valueChangedCount).toEqual(1);
+    expect(valueChangedCount.value).toEqual(2);
 
     act(() => scopesContext.changeScopes(['scope3', 'scope4']));
 
-    expect(valueChangedCount).toEqual(1);
+    expect(valueChangedCount.value).toEqual(2);
+  });
+
+  it('Should emit value changed when scopes are empty on first mount', async () => {
+    const { valueChangedCount } = renderTestScene({ initialScopes: [] });
+    expect(valueChangedCount.value).toEqual(1);
   });
 });
 
@@ -94,13 +96,16 @@ function renderTestScene(options: SetupOptions = {}) {
     scopesContext.changeScopes(options.initialScopes);
   }
 
+  const valueChangedCount = { value: 0 };
+  variable.subscribeToEvent(SceneVariableValueChangedEvent, () => (valueChangedCount.value += 1));
+
   const { unmount } = render(
     <ScopesContext.Provider value={scopesContext}>
       <scene.Component model={scene} />
     </ScopesContext.Provider>
   );
 
-  return { unmount, scene, variable, scopesContext };
+  return { unmount, scene, variable, scopesContext, valueChangedCount };
 }
 
 export class FakeScopesContext {

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -95,9 +95,10 @@ export class ScopesVariable extends SceneObjectBase<ScopesVariableState> impleme
     const loading = state.value.length === 0 ? false : state.loading;
     const oldScopes = this.state.scopes.map((scope) => scope.metadata.name);
     const newScopes = state.value.map((scope) => scope.metadata.name);
+    const scopesHaveChanged = !isEqual(oldScopes, newScopes);
 
     // Only update scopes value state when loading is false and the scopes have changed
-    if (!loading && !isEqual(oldScopes, newScopes)) {
+    if (!loading && (scopesHaveChanged || newScopes.length === 0)) {
       this.setState({ scopes: state.value, loading });
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     } else {


### PR DESCRIPTION
The reload behavior is waiting for scopes (as it always set to loading initially until state from context is read) 

But we need to emit the value changed event even when scopes is empty for this scenario to also always prompt a reload  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.17.0--canary.1136.15305220090.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.17.0--canary.1136.15305220090.0
  npm install @grafana/scenes@6.17.0--canary.1136.15305220090.0
  # or 
  yarn add @grafana/scenes-react@6.17.0--canary.1136.15305220090.0
  yarn add @grafana/scenes@6.17.0--canary.1136.15305220090.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
