### PR TITLE
chore: unify license change in #327

### DIFF
--- a/packages/scenes-app/package.json
+++ b/packages/scenes-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "6.10.2",
   "author": "Grafana Labs",
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "description": "A basic grafana app plugin",
   "scripts": {
     "build": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -c ./webpack.config.ts --env production",

--- a/packages/scenes-react/package.json
+++ b/packages/scenes-react/package.json
@@ -3,7 +3,7 @@
   "version": "6.10.2",
   "description": "Grafana framework for building dynamic dashboards",
   "author": "Grafana Labs",
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "homepage": "https://grafana.com/developers/scenes",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -3,7 +3,7 @@
   "version": "6.10.2",
   "description": "Grafana framework for building dynamic dashboards",
   "author": "Grafana Labs",
-  "license": "AGPL-3.0-only",
+  "license": "Apache-2.0",
   "homepage": "https://grafana.com/developers/scenes",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
We only updated the main package.json in #327, but npm is still saying AGPL-3. Lets unify these licenses so there's no ambiguity that scenes is licensed under Apache-2.0.