### PR TITLE
AdHocFiltersVariableUrlSyncHandler: fix url state containing `#` char

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -701,6 +701,45 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
+  it('url sync with both key and value labels with hash', async () => {
+    const { filtersVar } = setup();
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.filters[0], { key: 'new#Key', keyLabel: 'New#Key' });
+      filtersVar._updateFilter(filtersVar.state.filters[0], { value: 'new#Value', valueLabels: ['New#Value'] });
+    });
+
+    expect(locationService.getLocation().search).toBe(
+      '?var-filters=new__gfh__Key,New__gfh__Key%7C%3D%7Cnew__gfh__Value,New__gfh__Value&var-filters=key2%7C%3D%7Cval2'
+    );
+
+    act(() => {
+      locationService.partial({
+        'var-filters': [
+          'new__gfh__Key,New__gfh__Key|=|new__gfh__Value,New__gfh__Value',
+          'new__gfh__Key__gfh__2,New__gfh__Key__gfh__2|=~|new__gfh__Value__gfh__2,New__gfh__Value__gfh__2',
+        ],
+      });
+    });
+
+    expect(filtersVar.state.filters[0]).toEqual({
+      key: 'new#Key',
+      keyLabel: 'New#Key',
+      operator: '=',
+      value: 'new#Value',
+      valueLabels: ['New#Value'],
+      condition: '',
+    });
+    expect(filtersVar.state.filters[1]).toEqual({
+      key: 'new#Key#2',
+      keyLabel: 'New#Key#2',
+      operator: '=~',
+      value: 'new#Value#2',
+      valueLabels: ['New#Value#2'],
+      condition: '',
+    });
+  });
+
   it('url sync with identical key and value labels', async () => {
     const { filtersVar } = setup();
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -7,12 +7,7 @@ import {
   isMatchAllFilter,
   isMultiValueOperator,
 } from './AdHocFiltersVariable';
-import {
-  escapeInjectedFilterUrlDelimiters, escapeUrlHashDelimiters,
-  escapeUrlPipeDelimiters,
-  toUrlCommaDelimitedString,
-  unescapeUrlDelimiters,
-} from '../utils';
+import { escapeInjectedFilterUrlDelimiters, toUrlCommaDelimitedString, unescapeUrlDelimiters } from '../utils';
 
 export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHandler {
   public constructor(private _variable: AdHocFiltersVariable) {}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -40,7 +40,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
         ...filters
           .filter(isFilterComplete)
           .filter((filter) => !filter.hidden)
-          .map((filter) => toArray(filter).map(v => escapeUrlPipeDelimiters(escapeUrlHashDelimiters(v))).join('|'))
+          .map((filter) => toArray(filter).map(escapeInjectedFilterUrlDelimiters).join('|'))
       );
     }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -8,7 +8,7 @@ import {
   isMultiValueOperator,
 } from './AdHocFiltersVariable';
 import {
-  escapeInjectedFilterUrlDelimiters,
+  escapeInjectedFilterUrlDelimiters, escapeUrlHashDelimiters,
   escapeUrlPipeDelimiters,
   toUrlCommaDelimitedString,
   unescapeUrlDelimiters,
@@ -40,7 +40,7 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
         ...filters
           .filter(isFilterComplete)
           .filter((filter) => !filter.hidden)
-          .map((filter) => toArray(filter).map(escapeUrlPipeDelimiters).join('|'))
+          .map((filter) => toArray(filter).map(v => escapeUrlPipeDelimiters(escapeUrlHashDelimiters(v))).join('|'))
       );
     }
 

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -193,7 +193,7 @@ export function escapeInjectedFilterUrlDelimiters(value: string | undefined): st
 }
 
 export function escapeURLDelimiters(value: string | undefined): string {
-  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(escapeUrlHashDelimiters(value)));
+  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(value));
 }
 
 export function unescapeUrlDelimiters(value: string | undefined): string {

--- a/packages/scenes/src/variables/utils.ts
+++ b/packages/scenes/src/variables/utils.ts
@@ -193,7 +193,7 @@ export function escapeInjectedFilterUrlDelimiters(value: string | undefined): st
 }
 
 export function escapeURLDelimiters(value: string | undefined): string {
-  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(value));
+  return escapeUrlCommaDelimiters(escapeUrlPipeDelimiters(escapeUrlHashDelimiters(value)));
 }
 
 export function unescapeUrlDelimiters(value: string | undefined): string {


### PR DESCRIPTION
Escapes hash chars in AdHoc variable values.

Fixes https://github.com/grafana/scenes/issues/1138

