### PR TITLE
GroupBy: Fix edge cases on dashboard default values

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -208,7 +208,7 @@ describe.each(['11.1.2', '11.1.1'])('GroupByVariable', (v) => {
       });
 
       expect(variable.state.value).toEqual(['defaultVal1']);
-      expect(locationService.getLocation().search).toBe('?var-test=defaultVal1');
+      expect(locationService.getLocation().search).toBe('?var-test=defaultVal1&restorable-var-test=false');
     });
 
     it('should set default values as current values if none are set', () => {

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -21,7 +21,7 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
       return [];
     }
 
-    return [this.getKey(), ...(this._sceneObject.state.defaultValue ? [this.getRestorableKey()] : [])];
+    return [this.getKey(), this.getRestorableKey()];
   }
 
   public getUrlState(): SceneObjectUrlValues {
@@ -31,11 +31,11 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
 
     return {
       [this.getKey()]: toUrlValues(this._sceneObject.state.value, this._sceneObject.state.text),
-      ...(this._sceneObject.state.defaultValue
-        ? {
-            [this.getRestorableKey()]: this._sceneObject.state.restorable ? 'true' : undefined,
-          }
-        : {}),
+      [this.getRestorableKey()]: this._sceneObject.state.defaultValue
+        ? this._sceneObject.state.restorable
+          ? 'true'
+          : 'false'
+        : null,
     };
   }
 
@@ -54,7 +54,21 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
 
       const { values, texts } = fromUrlValues(urlValue);
 
-      if (this._sceneObject.state.defaultValue && !restorableValue) {
+      if (restorableValue === 'false') {
+        if (this._sceneObject.state.defaultValue) {
+          this._sceneObject.changeValueTo(
+            this._sceneObject.state.defaultValue?.value,
+            this._sceneObject.state.defaultValue?.text,
+            false
+          );
+          return;
+        }
+
+        this._sceneObject.changeValueTo([], []);
+        return;
+      }
+
+      if (restorableValue === undefined && this._sceneObject.state.defaultValue) {
         this._sceneObject.changeValueTo(
           this._sceneObject.state.defaultValue?.value,
           this._sceneObject.state.defaultValue?.text,


### PR DESCRIPTION
Fixes an edge case where moving from a dashboard with an unmodified default value will carry that value to another dashboard that does not have default values. This is undesired, when moving with an unmodified default value, we do not want to carry the filter to another dashboard within the scope dashboard selector.