### PR TITLE
Scopes: Add annotation query support

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -1,6 +1,6 @@
 import { DataQueryRequest, DataQueryResponse, DataSourceApi, Field, PanelData, toDataFrame } from '@grafana/data';
 import { AnnotationQuery, LoadingState } from '@grafana/schema';
-import { map, Observable, of, from } from 'rxjs';
+import { map, Observable, of } from 'rxjs';
 import { SceneFlexLayout } from '../../../components/layout/SceneFlexLayout';
 import { SceneTimeRange } from '../../../core/SceneTimeRange';
 import { SceneVariableSet } from '../../../variables/sets/SceneVariableSet';
@@ -42,7 +42,7 @@ const runRequestMock = jest.fn().mockImplementation((ds: DataSourceApi, request:
     timeRange: request.range,
   };
 
-  return from(ds.query(request) as unknown as Observable<DataQueryResponse>).pipe(
+  return (ds.query(request) as unknown as Observable<DataQueryResponse>).pipe(
     map((packet) => {
       result.state = LoadingState.Done;
       result.annotations = packet.data;

--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts
@@ -19,6 +19,7 @@ import { Dashboard, LoadingState } from '@grafana/schema';
 import { SceneObject, SceneTimeRangeLike } from '../../../core/types';
 import { getEnrichedDataRequest } from '../../getEnrichedDataRequest';
 import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
+import { sceneGraph } from '../../../core/sceneGraph';
 
 let counter = 100;
 function getNextRequestId() {
@@ -118,6 +119,7 @@ export function executeAnnotationQuery(
         refId: 'Anno',
       },
     ],
+    scopes: sceneGraph.getScopes(layer),
     ...getEnrichedDataRequest(layer),
   };
 


### PR DESCRIPTION
This exposes `scopes` in the DS query method when there is an annotation query

Related to https://github.com/grafana/hyperion-planning/issues/246
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.18.2--canary.1144.15561582453.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.18.2--canary.1144.15561582453.0
  npm install @grafana/scenes@6.18.2--canary.1144.15561582453.0
  # or 
  yarn add @grafana/scenes-react@6.18.2--canary.1144.15561582453.0
  yarn add @grafana/scenes@6.18.2--canary.1144.15561582453.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
