### PR TITLE
fix groupBy edge case

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.tsx
@@ -169,7 +169,7 @@ export class GroupByVariable extends MultiValueVariable<GroupByVariableState> {
         partial.restorable = false;
       }
 
-      if (this.state.defaultValue && this.checkIfRestorable(this.state.value)) {
+      if (this.checkIfRestorable(this.state.value)) {
         partial.restorable = true;
       }
 

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -56,11 +56,7 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
 
       if (restorableValue === 'false') {
         if (this._sceneObject.state.defaultValue) {
-          this._sceneObject.changeValueTo(
-            this._sceneObject.state.defaultValue?.value,
-            this._sceneObject.state.defaultValue?.text,
-            false
-          );
+          updateToDefaultValue(this._sceneObject);
           return;
         }
 
@@ -69,15 +65,14 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
       }
 
       if (restorableValue === undefined && this._sceneObject.state.defaultValue) {
-        this._sceneObject.changeValueTo(
-          this._sceneObject.state.defaultValue?.value,
-          this._sceneObject.state.defaultValue?.text,
-          false
-        );
+        updateToDefaultValue(this._sceneObject);
         return;
       }
 
       this._sceneObject.changeValueTo(values, texts);
+    } else if (this._sceneObject.state.defaultValue) {
+      updateToDefaultValue(this._sceneObject);
+      return;
     }
   }
 
@@ -90,6 +85,14 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
   public shouldCreateHistoryStep(values: SceneObjectUrlValues): boolean {
     return this._nextChangeShouldAddHistoryStep;
   }
+}
+
+function updateToDefaultValue(groupByVar: GroupByVariable) {
+  groupByVar.changeValueTo(
+    groupByVar.state.defaultValue?.value ?? [],
+    groupByVar.state.defaultValue?.text ?? [],
+    false
+  );
 }
 
 function toUrlValues(values: VariableValue, texts: VariableValue): string[] {


### PR DESCRIPTION
Builds on top of https://github.com/grafana/scenes/pull/1142

Fixes another edge case that happens on first load of a dashboard without a default groupBy or any value set on it, then moving to a dashboard with a default value, but instead of showing the default value it shows whatever value was saved on the groupBy with the possibility to restore. This is not desired and should show the default value since there are no other values in the URL from the transition.

All these scenarios will benefit a lot from some E2Es that I will be working on as soon as possible to cover both groupBys and adHocs.