### PR TITLE
LazyLoading: Unmount panels out of view

### DIFF
--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -12,7 +12,7 @@ export function useUniqueId(): string {
 }
 
 export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'children'> {
-  children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
+  children: React.ReactNode;
   key: string;
   onLoad?: () => void;
   onChange?: (isInView: boolean) => void;
@@ -66,8 +66,8 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
     // If the children render empty, the whole loader will be hidden by css.
     return (
       <div id={id} ref={innerRef} className={`${hideEmpty} ${className}`} {...rest}>
-        {!loaded && '\u00A0'}
-        {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
+        {!isInView && '\u00A0'}
+        {loaded && isInView && children}
       </div>
     );
   }


### PR DESCRIPTION
A quick test to improve lazy loading in scenes. 

Lazy loading in the old architecture is actually much better as it lazy loads the panels on first load and does not cause queries to be issued for panels out of view while in scenes we only do lazy loading for initial load. 

A quick solution would be to unmount when things go out of view, but a big drawback to this simple approach is that now queries will be cancelled when you scroll a loading panel out of view so in order to see the results of a panel that takes a long time to load you have to keep it in view. 

Think we also need to to do a quick poc on passing isInView as a prop to viz panel rendering and scene query runner 
