### PR TITLE
LazyLoading: Do not issue queries for panels outside view port

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { RefCallback, useCallback, useMemo } from 'react';
+import React, { RefCallback, useCallback, useEffect, useMemo } from 'react';
 import { useMeasure } from 'react-use';
 
 // @ts-ignore
@@ -14,6 +14,8 @@ import { VizPanel } from './VizPanel';
 import { css, cx } from '@emotion/css';
 import { debounce } from 'lodash';
 import { VizPanelSeriesLimit } from './VizPanelSeriesLimit';
+import { useLazyLoaderIsInView } from '../layout/LazyLoader';
+import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
 
 export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const {
@@ -61,9 +63,16 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const timeZone = sceneTimeRange.getTimeZone();
   const timeRange = model.getTimeRange(dataWithFieldConfig);
 
+  // Switch to manual query execution if the panel it outside viewport
+  const isInView = useLazyLoaderIsInView();
+  useEffect(() => {
+    if (dataObject.isInViewChanged) {
+      dataObject.isInViewChanged(isInView);
+    }
+  }, [isInView, dataObject]);
+
   // Interpolate title
   const titleInterpolated = model.interpolate(title, undefined, 'text');
-
   const alertStateStyles = useStyles2(getAlertStateStyles);
 
   if (!plugin) {

--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -12,7 +12,7 @@ export function useUniqueId(): string {
 }
 
 export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'children'> {
-  children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
+  children: React.ReactNode;
   key: string;
   onLoad?: () => void;
   onChange?: (isInView: boolean) => void;
@@ -67,7 +67,7 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
     return (
       <div id={id} ref={innerRef} className={`${hideEmpty} ${className}`} {...rest}>
         {!loaded && '\u00A0'}
-        {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
+        {loaded && <LazyLoaderInViewContext.Provider value={isInView}>{children}</LazyLoaderInViewContext.Provider>}
       </div>
     );
   }
@@ -96,3 +96,9 @@ LazyLoader.observer = new IntersectionObserver(
   },
   { rootMargin: '100px' }
 );
+
+export const LazyLoaderInViewContext = React.createContext<boolean>(true);
+
+export function useLazyLoaderIsInView(): boolean {
+  return React.useContext(LazyLoaderInViewContext);
+}

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -243,6 +243,10 @@ export interface SceneDataProvider<T extends SceneObjectState = SceneDataState> 
   isDataReadyToDisplay?: () => boolean;
   cancelQuery?: () => void;
   getResultsStream(): Observable<SceneDataProviderResult>;
+  /**
+   * Can be used to disable query execution for scene elements that are out of view
+   */
+  isInViewChanged?(isInView: boolean): void;
 }
 
 export interface SceneDataLayerProviderState extends SceneDataState {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -420,6 +420,13 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       return;
     }
 
+    if (this.isQueryModeAuto() && !this._isInView) {
+      this._queryNotExecutedWhenOutOfView = true;
+      return;
+    }
+
+    this._queryNotExecutedWhenOutOfView = false;
+
     // If data layers subscription doesn't exist, create one
     if (!this._dataLayersSub) {
       this._handleDataLayers();
@@ -695,6 +702,17 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
   private isQueryModeAuto(): boolean {
     return (this.state.runQueriesMode ?? 'auto') === 'auto';
+  }
+
+  private _isInView: boolean = true;
+  private _queryNotExecutedWhenOutOfView = false;
+
+  public isInViewChanged(isInView: boolean): void {
+    this._isInView = isInView;
+
+    if (isInView && this._queryNotExecutedWhenOutOfView) {
+      this.runQueries();
+    }
   }
 }
 


### PR DESCRIPTION
Alternative to https://github.com/grafana/scenes/pull/1147 

* Adds LazyLoaderInViewContext with simple boolean value (if something is in view)
* New function isInViewChanged on DataProvider interface so that viz panel can forward it 

One big requested feature is a ability to scroll to and highlight a panel (in a dashboard or scene app), but because the lazy loading is on the layout level the panels out of view are not rendered so there is no panel level key/ref we can easily scroll. I am thinking we should move the lazy loader to be on the panel level (that way we do not need it on layout level) 