### PR TITLE
AdHocFiltersVariable: Fix scopes crashing when scope filters are undefined

### DIFF
--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.test.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.test.ts
@@ -47,6 +47,15 @@ describe('getAdHocFiltersFromScopes', () => {
     ]);
   });
 
+  it('should not process if filter is undefined', () => {
+    let scopes = generateScopes([
+      // @ts-ignore
+      [undefined],
+    ]);
+
+    expect(getAdHocFiltersFromScopes(scopes)).toEqual([]);
+  });
+
   it('should return filters formatted for adHoc from multiple scopes with multiple values', () => {
     let scopes = generateScopes([
       [

--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
@@ -40,6 +40,10 @@ function processFilter(
   duplicatedFilters: AdHocFilterWithLabels[],
   filter: ScopeSpecFilter
 ) {
+  if (!filter) {
+    return;
+  }
+
   const existingFilter = formattedFilters.get(filter.key);
 
   if (existingFilter && canValueBeMerged(existingFilter.operator, filter.operator)) {


### PR DESCRIPTION
Fixes an issue where the dashboard crashes if the scope filters are undefined.