### PR TITLE
Chore: Move NPM_TOKEN to Vault

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -50,13 +50,16 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - id: get-secrets
+      - name: Get secrets from vault
+        id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           # Secrets placed in the ci/repo/grafana/scenes/ path in Vault
           repo_secrets: |
             GITHUB_APP_ID=github-app:app-id
             GITHUB_APP_PRIVATE_KEY=github-app:private-key
+            NPM_TOKEN=npm:token
+
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v1
@@ -87,5 +90,5 @@ jobs:
         run: yarn auto shipit
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+          NPM_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.20.3--canary.1154.15712349855.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.20.3--canary.1154.15712349855.0
  npm install @grafana/scenes@6.20.3--canary.1154.15712349855.0
  # or 
  yarn add @grafana/scenes-react@6.20.3--canary.1154.15712349855.0
  yarn add @grafana/scenes@6.20.3--canary.1154.15712349855.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
