### PR TITLE
SceneQueryRunner: Detect local variable change

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -338,7 +338,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     this._timeSubRange = undefined;
     this._adhocFiltersVar = undefined;
     this._groupByVar = undefined;
-    this._variableValueRecorder.recordCurrentDependencyValuesForSceneObject(this);
   }
 
   public setContainerWidth(width: number) {
@@ -434,6 +433,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       this.setState({ data: { ...(this.state.data ?? emptyPanelData), state: LoadingState.Loading } });
       return;
     }
+
+    this._variableValueRecorder.recordCurrentDependencyValuesForSceneObject(this);
 
     const { queries } = this.state;
 

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -57,7 +57,7 @@ exports[`SceneQueryRunner when running query should build DataQueryRequest objec
     "from": "now-6h",
     "to": "now",
   },
-  "requestId": "SQR181",
+  "requestId": "SQR183",
   "scopes": undefined,
   "startTime": 1689063488000,
   "targets": [

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -718,6 +718,7 @@ describe('SceneVariableList', () => {
       expect(C.state.loading).toBe(false);
       expect(C.state.error).toBe('Error in C');
     });
+
     it('Should complete updating chained variables in case of error in the first variable', () => {
       const A = new TestVariable({
         name: 'A',
@@ -883,6 +884,38 @@ describe('SceneVariableList', () => {
       topLevelVar.changeValueTo('E');
 
       expect(nestedScene.state.didSomethingCount).toBe(2);
+      expect(nestedScene.state.variableValueChanged).toBe(1);
+    });
+
+    it('When adding local variable value should propagate change', () => {
+      const topLevelVar = new TestVariable({
+        name: 'test',
+        options: [],
+        value: 'B',
+        optionsToReturn: [{ label: 'B', value: 'B' }],
+        delayMs: 0,
+      });
+
+      const nestedScene = new TestObjectWithVariableDependency({
+        title: '$test',
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [topLevelVar] }),
+        nested: nestedScene,
+      });
+
+      activateFullSceneTree(scene);
+
+      expect(nestedScene.state.variableValueChanged).toBe(0);
+
+      // Add local variable
+      nestedScene.setState({
+        $variables: new SceneVariableSet({
+          variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
+        }),
+      });
+
       expect(nestedScene.state.variableValueChanged).toBe(1);
     });
   });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -886,38 +886,6 @@ describe('SceneVariableList', () => {
       expect(nestedScene.state.didSomethingCount).toBe(2);
       expect(nestedScene.state.variableValueChanged).toBe(1);
     });
-
-    it('When adding local variable value should propagate change', () => {
-      const topLevelVar = new TestVariable({
-        name: 'test',
-        options: [],
-        value: 'B',
-        optionsToReturn: [{ label: 'B', value: 'B' }],
-        delayMs: 0,
-      });
-
-      const nestedScene = new TestObjectWithVariableDependency({
-        title: '$test',
-      });
-
-      const scene = new TestScene({
-        $variables: new SceneVariableSet({ variables: [topLevelVar] }),
-        nested: nestedScene,
-      });
-
-      activateFullSceneTree(scene);
-
-      expect(nestedScene.state.variableValueChanged).toBe(0);
-
-      // Add local variable
-      nestedScene.setState({
-        $variables: new SceneVariableSet({
-          variables: [new LocalValueVariable({ name: 'test', value: 'nestedValue' })],
-        }),
-      });
-
-      expect(nestedScene.state.variableValueChanged).toBe(1);
-    });
   });
 
   describe('When changing a dependency while variable is loading', () => {

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -11,14 +11,7 @@ export interface SceneVariableState extends SceneObjectState {
   label?: string;
   hide?: VariableHide;
   skipUrlSync?: boolean;
-  /**
-   * True when possible values are being fetched
-   */
   loading?: boolean;
-  /**
-   * True when current value is not yet validated/updated and a dependency is in loading state
-   **/
-  dependencyLoading?: boolean;
   error?: any | null;
   description?: string | null;
 }

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -11,7 +11,14 @@ export interface SceneVariableState extends SceneObjectState {
   label?: string;
   hide?: VariableHide;
   skipUrlSync?: boolean;
+  /**
+   * True when possible values are being fetched
+   */
   loading?: boolean;
+  /**
+   * True when current value is not yet validated/updated and a dependency is in loading state
+   **/
+  dependencyLoading?: boolean;
   error?: any | null;
   description?: string | null;
 }


### PR DESCRIPTION
This is related to row repeats: https://github.com/grafana/grafana/pull/104312 

The issue with the current way scene query runner records variable values on deactive, is that it can then record a value that was either just set or removed. So it will record a value that has not actually been used in a query. 

By changing to record values on every query we can be sure that when the scene query runner re-activates that it will compare against the variables that it used when it last issued a query. 

This scenario is mainly relevant for row / tab repeats where the first row get's a local variable value or it get's removed, this should trigger a new query on the first row but because scene query runner records the value on deactivate it records the new value and when it- reactivates it thinks nothing has changed 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.22.0--canary.1155.15756683630.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.22.0--canary.1155.15756683630.0
  npm install @grafana/scenes@6.22.0--canary.1155.15756683630.0
  # or 
  yarn add @grafana/scenes-react@6.22.0--canary.1155.15756683630.0
  yarn add @grafana/scenes@6.22.0--canary.1155.15756683630.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
