### PR TITLE
SceneTimeRangeCompare: Add option to hide checkbox

### DIFF
--- a/packages/scenes/jest.config.ts
+++ b/packages/scenes/jest.config.ts
@@ -3,6 +3,7 @@ const esModules = ['ol', 'd3', 'd3-color', 'd3-interpolate', 'delaunator', 'inte
 module.exports = {
   moduleNameMapper: {
     '\\.css$': '<rootDir>/utils/test/__mocks__/style.ts',
+    '\\.svg$': '<rootDir>/utils/test/__mocks__/style.ts',
     'react-inlinesvg': '<rootDir>/utils/test/__mocks__/react-inlinesvg.tsx',
   },
   testEnvironment: 'jsdom',

--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
@@ -26,7 +26,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
               [
                 {
-                  "label": "No comparison",
+                  "label": "None",
                   "value": "__noPeriod",
                 },
                 {
@@ -63,7 +63,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
               [
                 {
-                  "label": "No comparison",
+                  "label": "None",
                   "value": "__noPeriod",
                 },
                 {
@@ -104,7 +104,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
               [
                 {
-                  "label": "No comparison",
+                  "label": "None",
                   "value": "__noPeriod",
                 },
                 {
@@ -137,7 +137,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
               [
                 {
-                  "label": "No comparison",
+                  "label": "None",
                   "value": "__noPeriod",
                 },
                 {
@@ -170,7 +170,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
                 [
                   {
-                    "label": "No comparison",
+                    "label": "None",
                     "value": "__noPeriod",
                   },
                   {
@@ -206,7 +206,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
                   [
                     {
-                      "label": "No comparison",
+                      "label": "None",
                       "value": "__noPeriod",
                     },
                     {
@@ -235,7 +235,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
                     [
                       {
-                        "label": "No comparison",
+                        "label": "None",
                         "value": "__noPeriod",
                       },
                       {
@@ -264,7 +264,7 @@ describe('SceneTimeRangeCompare', () => {
         expect(result).toMatchInlineSnapshot(`
               [
                 {
-                  "label": "No comparison",
+                  "label": "None",
                   "value": "__noPeriod",
                 },
                 {

--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
@@ -405,4 +405,62 @@ describe('SceneTimeRangeCompare', () => {
     // Default value should be previously compared value
     expect(comparer.state.compareWith).toBe('1w');
   });
+
+  describe('hideCheckbox functionality', () => {
+    test('should properly initialize with hideCheckbox true', () => {
+      const comparer = new SceneTimeRangeCompare({
+        hideCheckbox: true,
+      });
+
+      // Should have hideCheckbox set to true
+      expect(comparer.state.hideCheckbox).toBe(true);
+    });
+
+    test('should properly initialize with hideCheckbox false', () => {
+      const comparer = new SceneTimeRangeCompare({
+        hideCheckbox: false,
+      });
+
+      // Should have hideCheckbox set to false
+      expect(comparer.state.hideCheckbox).toBe(false);
+    });
+
+    test('should default hideCheckbox to undefined when not specified', () => {
+      const comparer = new SceneTimeRangeCompare({});
+
+      // Should have hideCheckbox as undefined (default behavior)
+      expect(comparer.state.hideCheckbox).toBeUndefined();
+    });
+
+    test('should handle comparison state changes with hideCheckbox enabled', () => {
+      const comparer = new SceneTimeRangeCompare({
+        hideCheckbox: true,
+      });
+
+      // Initially no comparison
+      expect(comparer.state.compareWith).toBeUndefined();
+
+      // Should be able to set a comparison
+      comparer.onCompareWithChanged('1w');
+      expect(comparer.state.compareWith).toBe('1w');
+
+      // Should be able to clear comparison
+      comparer.onClearCompare();
+      expect(comparer.state.compareWith).toBeUndefined();
+    });
+
+    test('should handle NO_PERIOD_VALUE correctly with hideCheckbox', () => {
+      const comparer = new SceneTimeRangeCompare({
+        hideCheckbox: true,
+        compareWith: '1w',
+      });
+
+      // Initially has a comparison
+      expect(comparer.state.compareWith).toBe('1w');
+
+      // Should clear comparison when NO_PERIOD_VALUE is passed
+      comparer.onCompareWithChanged('__noPeriod');
+      expect(comparer.state.compareWith).toBeUndefined();
+    });
+  });
 });

--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -28,7 +28,7 @@ export const PREVIOUS_PERIOD_COMPARE_OPTION = {
 };
 
 export const NO_COMPARE_OPTION = {
-  label: 'No comparison',
+  label: 'None',
   value: NO_PERIOD_VALUE,
 };
 
@@ -244,6 +244,15 @@ function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeR
   const selectValue = hideCheckbox && !compareWith ? NO_COMPARE_OPTION : value;
   const showSelect = hideCheckbox || enabled;
 
+  // Create display value with "Comparison" prefix when hideCheckbox is true
+  const displayValue =
+    hideCheckbox && selectValue
+      ? {
+          ...selectValue,
+          label: `Comparison: ${selectValue.label}`,
+        }
+      : selectValue;
+
   return (
     <ButtonGroup>
       {!hideCheckbox && (
@@ -264,7 +273,7 @@ function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeR
       {showSelect ? (
         <ButtonSelect
           variant="canvas"
-          value={selectValue}
+          value={displayValue}
           options={compareOptions}
           onChange={(v) => {
             model.onCompareWithChanged(v.value!);

--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -16,6 +16,7 @@ import { of } from 'rxjs';
 interface SceneTimeRangeCompareState extends SceneObjectState {
   compareWith?: string;
   compareOptions: Array<{ label: string; value: string }>;
+  hideCheckbox?: boolean;
 }
 
 const PREVIOUS_PERIOD_VALUE = '__previousPeriod';
@@ -222,7 +223,7 @@ const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary
 
 function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeRangeCompare>) {
   const styles = useStyles2(getStyles);
-  const { compareWith, compareOptions } = model.useState();
+  const { compareWith, compareOptions, hideCheckbox } = model.useState();
 
   const [previousCompare, setPreviousCompare] = React.useState(compareWith);
   const previousValue = compareOptions.find(({ value }) => value === previousCompare) ?? PREVIOUS_PERIOD_COMPARE_OPTION;
@@ -239,25 +240,31 @@ function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeR
     }
   };
 
+  // When hideCheckbox is true, always show select and use NO_COMPARE_OPTION when no comparison is active
+  const selectValue = hideCheckbox && !compareWith ? NO_COMPARE_OPTION : value;
+  const showSelect = hideCheckbox || enabled;
+
   return (
     <ButtonGroup>
-      <ToolbarButton
-        variant="canvas"
-        tooltip="Enable time frame comparison"
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          onClick();
-        }}
-      >
-        <Checkbox label=" " value={enabled} onClick={onClick} />
-        Comparison
-      </ToolbarButton>
+      {!hideCheckbox && (
+        <ToolbarButton
+          variant="canvas"
+          tooltip="Enable time frame comparison"
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            onClick();
+          }}
+        >
+          <Checkbox label=" " value={enabled} onClick={onClick} />
+          Comparison
+        </ToolbarButton>
+      )}
 
-      {enabled ? (
+      {showSelect ? (
         <ButtonSelect
           variant="canvas"
-          value={value}
+          value={selectValue}
           options={compareOptions}
           onChange={(v) => {
             model.onCompareWithChanged(v.value!);


### PR DESCRIPTION
Related to: https://github.com/grafana/grafana/pull/104672

For some use cases of `SceneTimeRangeCompare`, requiring the checkbox to toggle the comparison selection is redundant. For example, if time comparison is enabled in panel options (like in the PR above), it becomes an additional step to enable time comparison selection, especially considering that `NO_PERIOD_VALUE` is always included in the select options and can be used to turn comparison off.

In this PR, we add optional `hideCheckbox` option to `SceneTimeRangeCompare`.

Before (now the default behavior, hideCheckbox undefined):
![Jun-17-2025 17-47-48](https://github.com/user-attachments/assets/527a4dce-2b2e-4ca2-b54b-c6ecb76b6511)

After (hideCheckbox = true):
![Jun-17-2025 17-48-17](https://github.com/user-attachments/assets/2937c6f1-dc73-474a-9984-5f7c8344c95e)
