### PR TITLE
i18n: fixes peer dependencies

### DIFF
--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@grafana/data": ">=10.4",
     "@grafana/e2e-selectors": ">=10.4",
-    "@grafana/i18n": ">=12.1.0",
+    "@grafana/i18n": "*",
     "@grafana/runtime": ">=10.4",
     "@grafana/schema": ">=10.4",
     "@grafana/ui": ">=10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4021,7 +4021,7 @@ __metadata:
   peerDependencies:
     "@grafana/data": ">=10.4"
     "@grafana/e2e-selectors": ">=10.4"
-    "@grafana/i18n": ">=12.1.0"
+    "@grafana/i18n": "*"
     "@grafana/runtime": ">=10.4"
     "@grafana/schema": ">=10.4"
     "@grafana/ui": ">=10.4"


### PR DESCRIPTION
Scenes is currently targetting `@grafana/i18n` `>=12.1.0` for peerDependencies but any package manager that automatically installs peer deps will now fail on install as 12.1.0 doesn't exist in the registry. This PR sets it to `*` so installs complete whilst we wait on the 12.1.0 release.