### PR TITLE
sceneGraph: findObject should return first match

### DIFF
--- a/packages/scenes/src/core/SceneObjectBase.tsx
+++ b/packages/scenes/src/core/SceneObjectBase.tsx
@@ -357,6 +357,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = SceneObj
   /**
    * Loop through state and call callback for each direct child scene object.
    * Checks 1 level deep properties and arrays. So a scene object hidden in a nested plain object will not be detected.
+   * Return false to exit loop early.
    */
   public forEachChild(callback: (child: SceneObjectBase) => void) {
     forEachChild(this.state, callback);
@@ -421,17 +422,30 @@ export function useSceneObjectState<TState extends SceneObjectState>(
   return model.state;
 }
 
-function forEachChild<T extends object>(state: T, callback: (child: SceneObjectBase) => void) {
+function forEachChild<T extends object>(state: T, callback: (child: SceneObjectBase) => void | false) {
   for (const propValue of Object.values(state)) {
     if (propValue instanceof SceneObjectBase) {
-      callback(propValue);
+      const result = callback(propValue);
+      if (result === false) {
+        break;
+      }
     }
 
     if (Array.isArray(propValue)) {
+      let exitEarly = false;
+
       for (const child of propValue) {
         if (child instanceof SceneObjectBase) {
-          callback(child);
+          const result = callback(child);
+          if (result === false) {
+            exitEarly = true;
+            break;
+          }
         }
+      }
+
+      if (exitEarly) {
+        break;
       }
     }
   }

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -43,6 +43,20 @@ describe('sceneGraph', () => {
     expect(sceneGraph.findObject(item2, (s) => s.state.key === 'time-picker')).toBe(timePicker);
   });
 
+  it('Returns first match', () => {
+    const item1 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A' }) });
+    const item2 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A2' }) });
+
+    const scene = new EmbeddedScene({
+      body: new SceneFlexLayout({
+        children: [item1, item2],
+      }),
+    });
+
+    // from root
+    expect(sceneGraph.findObject(scene, (s) => s.state.key === 'A')).toBe(item1);
+  });
+
   it('Can find all objects given a predicate', () => {
     const data = new SceneDataNode();
     const item1 = new SceneFlexItem({ key: 'A', body: new SceneCanvasText({ text: 'A' }), $data: data });
@@ -379,7 +393,7 @@ describe('sceneGraph', () => {
       expect(hasVariableDependencyInLoadingState(loadingDependecies)).toBe(true);
     });
 
-    it.only('should return false if the variable is a QueryVariable and it is loading because is refering itself', () => {
+    it('should return false if the variable is a QueryVariable and it is loading because is refering itself', () => {
       const logSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const loadingVariable = new QueryVariable({
         name: 'loadingVar',

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -118,7 +118,11 @@ function findObjectInternal(
     let maybe = findObjectInternal(child, check);
     if (maybe) {
       found = maybe;
+      // break (exit early) the foreach loop
+      return false;
     }
+
+    return;
   });
 
   if (found) {

--- a/packages/scenes/src/core/types.ts
+++ b/packages/scenes/src/core/types.ts
@@ -120,8 +120,9 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /**
    * Loop through state and call callback for each direct child scene object.
    * Checks 1 level deep properties and arrays. So a scene object hidden in a nested plain object will not be detected.
+   * Return false to exit loop early.
    */
-  forEachChild(callback: (child: SceneObject) => void): void;
+  forEachChild(callback: (child: SceneObject) => void): void | false;
 
   /**
    * Useful for edge cases when you want to move a scene object to another parent.


### PR DESCRIPTION
Noticed that findObject would always return the last match (if multiple objects match predicate), this fixes it by adding support for early exit from forEachChild (by returning false, same way lodash forEach works )
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.23.0--canary.1165.15877190588.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.23.0--canary.1165.15877190588.0
  npm install @grafana/scenes@6.23.0--canary.1165.15877190588.0
  # or 
  yarn add @grafana/scenes-react@6.23.0--canary.1165.15877190588.0
  yarn add @grafana/scenes@6.23.0--canary.1165.15877190588.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
