### PR TITLE
AdHocFiltersCombobox: Update z-index

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -808,7 +808,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.primary,
     boxShadow: theme.shadows.z2,
     overflowY: 'auto',
-    zIndex: theme.zIndex.dropdown,
+    zIndex: theme.zIndex.portal,
   }),
   inputStyle: css({
     paddingBlock: 0,


### PR DESCRIPTION
- updates the `z-index` of the `AdHocFiltersCombobox`
- this ensures it can correctly render within `Drawer`/`Modal` components which currently have [lower z-indices](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/themes/zIndex.ts#L7)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.24.1--canary.1166.15878540264.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.24.1--canary.1166.15878540264.0
  npm install @grafana/scenes@6.24.1--canary.1166.15878540264.0
  # or 
  yarn add @grafana/scenes-react@6.24.1--canary.1166.15878540264.0
  yarn add @grafana/scenes@6.24.1--canary.1166.15878540264.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
