### PR TITLE
fix: infinite focus loop

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -616,7 +616,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       {optionsLoading ? <Spinner className={styles.loadingIndicator} inline={true} /> : null}
       <FloatingPortal>
         {open && (
-          <FloatingFocusManager context={context} initialFocus={-1} visuallyHiddenDismiss modal={false}>
+          <FloatingFocusManager context={context} initialFocus={-1} visuallyHiddenDismiss modal={true}>
             <>
               <div
                 style={{


### PR DESCRIPTION
* Updates the `FloatingFocusManager` `modal` prop to true, which seems to fix the infinite focus loop.
* Without changes from https://github.com/grafana/scenes/pull/1166, the combobox dropdown will not be visible.

Fixes: https://github.com/grafana/scenes/issues/1167

