### PR TITLE
TableNG: expose configured transparent value instead of false

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -229,7 +229,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                           timeZone={timeZone}
                           options={options}
                           fieldConfig={fieldConfig}
-                          transparent={false}
+                          transparent={displayMode === 'transparent'}
                           width={innerWidth}
                           height={innerHeight}
                           renderCounter={_renderCounter}


### PR DESCRIPTION
In working through some styling issues with the new TableNG component, we realized that the `transparent` prop that's part of `PanelProps` is always false when scenes is enabled. This is a problem for `TableNG`, because react-data-grid can't render its table with a transparent background, so we need to simulate transparency using theme colors based on this attribute.