### PR TITLE
MultiValueVariable: Support field path array index

### DIFF
--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -129,6 +129,8 @@ describe('sceneInterpolator', () => {
     });
 
     expect(sceneInterpolator(scene, 'test.${test}.asd')).toBe('test.{hello,world}.asd');
+    // Can use fieldPath index to access specific array value
+    expect(sceneInterpolator(scene, 'test.${test.1}.asd')).toBe('test.world.asd');
   });
 
   it('Can format multi valued values using text formatter', () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -479,6 +479,18 @@ describe('MultiValueVariable', () => {
       // Should not ignore url encoding
       expect(value.formatter(VariableFormatID.PercentEncode)).toBe('.%2A');
     });
+
+    it('GetValue should support index fieldPath', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        value: ['1', '2'],
+        isMulti: true,
+        optionsToReturn: [],
+        delayMs: 0,
+      });
+
+      expect(variable.getValue('1')).toBe('2');
+    });
   });
 
   describe('getOptionsForSelect', () => {

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -208,16 +208,25 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     this.skipNextValidation = false;
   }
 
-  public getValue(): VariableValue {
+  public getValue(fieldPath?: string): VariableValue {
+    let value = this.state.value;
+
     if (this.hasAllValue()) {
       if (this.state.allValue) {
         return new CustomAllValue(this.state.allValue, this);
       }
 
-      return this.state.options.map((x) => x.value);
+      value = this.state.options.map((x) => x.value);
     }
 
-    return this.state.value;
+    if (fieldPath != null && Array.isArray(value)) {
+      const index = parseInt(fieldPath, 10);
+      if (!isNaN(index) && index >= 0 && index < value.length) {
+        return value[index];
+      }
+    }
+
+    return value;
   }
 
   public getValueText(): string {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/96336 
Fixes https://github.com/grafana/support-escalations/issues/17059 

Got a bit interested in why scenes changed this behavior, and it's because in scenes the fieldPath is interpolated by the variables (instead of in a later state), this was a good change as it enables new dynamic features but because MultiValueVariable does not support object values it did not implement any support for fieldPath. 

When value is an array I think we can preserve this behavior. It should be easy to support long-term. There is a downside in that, ideally, we should have different syntax for property vs array index lookup. But think this should be fine.