### PR TITLE
Annotations: Don't run annotation query if it is disabled

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -451,6 +451,26 @@ describe.each(['11.1.2', '11.1.1'])('AnnotationsDataLayer', (v) => {
       expect(sentRequest?.scopes).toBeUndefined();
     });
   });
+
+  it('should not run query when enable is false', async () => {
+    const layer = new AnnotationsDataLayer({
+      name: 'Test layer',
+      query: { name: 'Test', enable: false, iconColor: 'red', theActualQuery: '$A' },
+    });
+
+    const scene = new TestScene({
+      $timeRange: new SceneTimeRange(),
+      $data: new SceneDataLayerSet({
+        layers: [layer],
+      }),
+    });
+
+    scene.activate();
+
+    await new Promise((r) => setTimeout(r, 1));
+
+    expect(runRequestMock).toHaveBeenCalledTimes(0);
+  });
 });
 
 function newScopesVariableFromScopeFilters(filters: ScopeSpecFilter[]) {

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
@@ -71,6 +71,10 @@ export class AnnotationsDataLayer
   private async runWithTimeRange(timeRange: SceneTimeRangeLike) {
     const { query } = this.state;
 
+    if (!query.enable) {
+      return;
+    }
+
     if (this.querySub) {
       this.querySub.unsubscribe();
     }


### PR DESCRIPTION
I assume this is the behavior we want for this property.
Related to https://github.com/grafana/hyperion-planning/issues/275

To compare behaviors turn on and off the `scopeFilters` feature flag without the fix.

The root cause for this is because of the scopes dependency introduced in https://github.com/grafana/scenes/pull/1144, things are being executed on initial load (which they normally aren't). We might need to revisit if there is something we can/should do about that. For now, this fix highlights a bug withing the AnnotationsDataLayer, which I still think is valid.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.26.1--canary.1174.15999849116.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.26.1--canary.1174.15999849116.0
  npm install @grafana/scenes@6.26.1--canary.1174.15999849116.0
  # or 
  yarn add @grafana/scenes-react@6.26.1--canary.1174.15999849116.0
  yarn add @grafana/scenes@6.26.1--canary.1174.15999849116.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
