### PR TITLE
[HOLD] Chore: Decouple `hideFrom.viz` and `hideFrom.tooltip`

### DIFF
--- a/packages/scenes/src/components/VizPanel/seriesVisibilityConfigFactory.ts
+++ b/packages/scenes/src/components/VizPanel/seriesVisibilityConfigFactory.ts
@@ -97,7 +97,7 @@ function createOverride(
     value: {
       viz: true,
       legend: false,
-      tooltip: false,
+      tooltip: true,
     },
   };
 
@@ -118,7 +118,7 @@ function createOverride(
         value: {
           viz: true,
           legend: false,
-          tooltip: false,
+          tooltip: true,
         },
       },
     ],


### PR DESCRIPTION
This PR is part of the changes requested for https://github.com/grafana/grafana/pull/106857 - it mirrors the changes made in `public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts`


Hold until https://github.com/grafana/grafana/pull/106857/ goes in. (12.2)