### PR TITLE
Variables: Add support for custom delimiter in variable formatting

### DIFF
--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -329,6 +329,24 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
+      id: VariableFormatID.Delimiter,
+      name: 'Custom Delimiter',
+      description: 'Join values using a custom delimiter. Example value1;value2',
+      formatter: (value, _args) => {
+        const delimiter = _args[0] ?? ','; // default to comma if no delimiter provided
+
+        if (typeof value === 'string') {
+          return value;
+        }
+
+        if (Array.isArray(value)) {
+          return value.join(delimiter);
+        }
+
+        return String(value);
+      },
+    },
+    {
       id: VariableFormatID.UriEncode,
       name: 'Percent encode as URI',
       description: t(


### PR DESCRIPTION
### Description

This PR adds support for a new variable format called `delimiter` that allows joining single- or multi-valued variables using a custom delimiter. By default, it uses a comma (`,`) if no delimiter is specified.

### Changes

- Implemented a `delimiter` formatter that takes an optional delimiter argument.
- Supports joining array values with the provided delimiter string.
- Returns the string value as-is if a single string is provided.

### Example usage

Using semicolon as a delimiter:
```bash
servers = ["s1", "s2"]
String to interpolate: '${servers:delimiter:;}'
Interpolation result: "s1;s2"
```

Using space as a delimiter:
```bash
servers = ["s1", "s2"]
String to interpolate: '${servers:delimiter: }'
Interpolation result: "s1 s2"
```

Related to [#83014](https://github.com/grafana/grafana/issues/83014) and [#91411](https://github.com/grafana/grafana/issues/91411)