### PR TITLE
QueryVariable: Add ability to provide custom static options

### DIFF
--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -19,7 +19,7 @@ import { VariableValueOption } from '../../types';
 import { MultiValueVariable, MultiValueVariableState, VariableGetOptionsArgs } from '../MultiValueVariable';
 
 import { createQueryVariableRunner } from './createQueryVariableRunner';
-import { metricNamesToVariableValues } from './utils';
+import { metricNamesToVariableValues, sortVariableValues } from './utils';
 import { toMetricFindValues } from './toMetricFindValues';
 import { getDataSource } from '../../../utils/getDataSource';
 import { safeStringifyValue } from '../../utils';
@@ -37,6 +37,12 @@ export interface QueryVariableState extends MultiValueVariableState {
   regex: string;
   refresh: VariableRefresh;
   sort: VariableSort;
+
+  // works the same as query for custom variable, adding additional static options to ones returned by data source query
+  staticOptions?: VariableValueOption[];
+
+  // how to order static options in relation to options returned by query
+  staticOptionsOrder?: 'before' | 'after' | 'sorted';
   /** @internal Only for use inside core dashboards */
   definition?: string;
 }
@@ -99,7 +105,19 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
             if (this.state.regex) {
               regex = sceneGraph.interpolate(this, this.state.regex, undefined, 'regex');
             }
-            return of(metricNamesToVariableValues(regex, this.state.sort, values));
+            let options = metricNamesToVariableValues(regex, this.state.sort, values);
+            if (this.state.staticOptions) {
+              const customOptions = this.state.staticOptions;
+              options = options.filter((option) => !customOptions.find((custom) => custom.value === option.value));
+              if (this.state.staticOptionsOrder === 'after') {
+                options.push(...customOptions);
+              } else if (this.state.staticOptionsOrder === 'sorted') {
+                options = sortVariableValues(options.concat(customOptions), this.state.sort);
+              } else {
+                options.unshift(...customOptions);
+              }
+            }
+            return of(options);
           }),
           catchError((error) => {
             if (error.cancelled) {


### PR DESCRIPTION
One day hackathon effort :) 

Adds ability to add addition "static" options to query variable options, defined in the same way as custom variable options.
They are prepended by default, but can be optionally appened or sorted in per defined sort order.

Use case is to be able to add options like `{ label: "not set", value: "" }` or `{ label: "any production cluster", value: ".*-prod-.*"}`

This is needed for https://github.com/grafana/grafana/issues/102229, with Grafana PR to follow.