### PR TITLE
TextBoxVariable: Support skipUrlSync

### DIFF
--- a/packages/scenes/src/variables/variants/TextBoxVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/TextBoxVariable.test.tsx
@@ -36,4 +36,11 @@ describe('TextBoxVariable', () => {
 
     expect(variable.urlSync?.getKeys()).toEqual(['var-newName']);
   });
+
+  it('Can disable url sync', () => {
+    const variable = new TextBoxVariable({ name: 'search', skipUrlSync: true });
+
+    expect(variable.urlSync?.getUrlState()).toEqual({});
+    expect(variable.urlSync?.getKeys()).toEqual([]);
+  });
 });

--- a/packages/scenes/src/variables/variants/TextBoxVariable.tsx
+++ b/packages/scenes/src/variables/variants/TextBoxVariable.tsx
@@ -21,7 +21,7 @@ export class TextBoxVariable
       ...initialState,
     });
 
-    this._urlSync = new SceneObjectUrlSyncConfig(this, { keys: () => [this.getKey()] });
+    this._urlSync = new SceneObjectUrlSyncConfig(this, { keys: () => this.getKeys() });
   }
 
   public getValue(): VariableValue {
@@ -39,7 +39,19 @@ export class TextBoxVariable
     return `var-${this.state.name}`;
   }
 
+  public getKeys(): string[] {
+    if (this.state.skipUrlSync) {
+      return [];
+    }
+
+    return [this.getKey()];
+  }
+
   public getUrlState() {
+    if (this.state.skipUrlSync) {
+      return {};
+    }
+
     return { [this.getKey()]: this.state.value };
   }
 


### PR DESCRIPTION
This PR adds the ability to skip the URL sync in textbox variable. Although textbox variable has `skipUrlSync` property, this property was meaningless because it wasn't applied during runtime. 

Fixes: https://github.com/grafana/support-escalations/issues/17195