### PR TITLE
 Add customqueryparam templating format for joining arrays with a custom separator 

### DIFF
--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -110,9 +110,16 @@ describe('formatRegistry', () => {
     expect(formatValue('customqueryparam', 'api', 'text', ['p-server'])).toBe('p-server=api'); // custom name, optional value
     // @ts-expect-error
     expect(formatValue('customqueryparam', 'api', 'text', ['p-server', 'v-'])).toBe('p-server=v-api'); // value prefix
-    expect(formatValue('customqueryparam', 'mysql&postgres', 'text', ['p-server', 'v-'])).toBe(
-      'p-server=v-mysql%26postgres'
-    ); // value prefix
+
+    // customqueryparam - url encoding
+    // @ts-expect-error
+    expect(formatValue('customqueryparam', ['mysql&postgres', 'databases!'], 'text', ['p-server', 'v-'])).toBe(
+      'p-server=v-mysql%26postgres&p-server=v-databases%21'
+    ); // variable value encoded
+    expect(
+      // @ts-expect-error
+      formatValue('customqueryparam', ['mysql&postgres', 'databases!'], 'text', ['space & ampersand!', 'v& '])
+    ).toBe('space%20%26%20ampersand%21=v%26%20mysql%26postgres&space%20%26%20ampersand%21=v%26%20databases%21'); // custom name + prefix encoded
 
     expect(formatValue(VariableFormatID.UriEncode, '/any-path/any-second-path?query=foo()bar BAZ')).toBe(
       '/any-path/any-second-path?query=foo%28%29bar%20BAZ'

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -346,8 +346,8 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       description:
         'Format variables as URL parameters with custom name and value prefix. Example in multi-variable scenario A + B + C => p-foo=x-A&p-foo=x-B&p-foo=x-C.',
       formatter: (value, args, variable) => {
-        const name = args[0] || variable.state.name;
-        const valuePrefix = args[1] || '';
+        const name = encodeURIComponentStrict(args[0] || variable.state.name);
+        const valuePrefix = encodeURIComponentStrict(args[1] || '');
 
         if (Array.isArray(value)) {
           return value.map((v) => customFormatQueryParameter(name, v, valuePrefix)).join('&');


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/97570

Adds a new templating formatter for customising query parameter strings. It supports two arguments, which are both optional:
 - arg 1: parameter name, defaults to exactly the variable name (without the `var-` prefix)
 - arg 2: value prefix

| Value                 | Template                                   | Result                                  |
| --------------------- | ------------------------------------------ | --------------------------------------- |
| `['api']`             | `?${servers:customqueryparam}`             | `?servers=api`                          |
| `['api']`             | `?${servers:customqueryparam:p-server}`    | `?p-server=api`                         |
| `['api']`             | `?${servers:customqueryparam:p-server:x-}` | `?p-server=x-api`                       |
| `['api', 'database']` | `?${servers:customqueryparam:p-server:x-}` | `?p-server=x-api&p-server=x-database`   |
| `['api', 'mysql db']` | `?${servers:customqueryparam:p-server:x-}` | `?p-server=x-api&p-server=x-mysql%20db` |


Reviewer questions:
 - Instead of a new format, could we just add these arguments to the already existing `queryparam` format?
   - It wouldn't have an option to default to the plain variable name, you would need to specify that explicitly
 - If we keep the seperate format, thoughts on the name? I went for `customqueryparam` to match the existing `queryparam`, but it is quite long!