### PR TITLE
AdHocFilters: Refactor original values to take origin in key as well

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1206,9 +1206,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     scopesVariable.update();
 
-    expect(filtersVar['_originalValues'].get('dbKey1')).toEqual({ value: ['dbValue1'], operator: '=' });
-    expect(filtersVar['_originalValues'].get('dbKey2')).toEqual({ value: ['dbValue2'], operator: '=' });
-    expect(filtersVar['_originalValues'].get('scopeKey')).toEqual({ value: ['scopeValue'], operator: '=' });
+    expect(filtersVar['_originalValues'].get('dbKey1-dashboard')).toEqual({ value: ['dbValue1'], operator: '=' });
+    expect(filtersVar['_originalValues'].get('dbKey2-dashboard')).toEqual({ value: ['dbValue2'], operator: '=' });
+    expect(filtersVar['_originalValues'].get('scopeKey-scope')).toEqual({ value: ['scopeValue'], operator: '=' });
   });
 
   it('should reset dashboard level filters if they are edited on unmount', () => {
@@ -1341,11 +1341,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     expect(filtersVar.state.originFilters![0].value).toBe('newValue1');
     expect(filtersVar.state.originFilters![0].values).toEqual(['newValue1']);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.value).toEqual([
-      'originValue1',
-      'originValue2',
-    ]);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.operator).toEqual('=|');
+    const key = `${filtersVar.state.originFilters![0].key}-${filtersVar.state.originFilters![0].origin}`;
+    expect(filtersVar['_originalValues'].get(key)!.value).toEqual(['originValue1', 'originValue2']);
+    expect(filtersVar['_originalValues'].get(key)!.operator).toEqual('=|');
   });
 
   it('updated filter with no changes does not become restorable', async () => {
@@ -1397,8 +1395,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     expect(filtersVar.state.originFilters![0].restorable).toEqual(true);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.value).toEqual(['originValue1']);
-    expect(filtersVar['_originalValues'].get(filtersVar.state.originFilters![0].key)!.operator).toEqual('=');
+    const key = `${filtersVar.state.originFilters![0].key}-${filtersVar.state.originFilters![0].origin}`;
+    expect(filtersVar['_originalValues'].get(key)!.value).toEqual(['originValue1']);
+    expect(filtersVar['_originalValues'].get(key)!.operator).toEqual('=');
 
     act(() => {
       filtersVar._updateFilter(filtersVar.state.originFilters![0], {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -249,7 +249,7 @@ export class AdHocFiltersVariable
     }
 
     this.state.originFilters?.forEach((filter) => {
-      this._originalValues.set(filter.key, {
+      this._originalValues.set(`${filter.key}-${filter.origin}`, {
         operator: filter.operator,
         value: filter.values ?? [filter.value],
       });
@@ -292,7 +292,7 @@ export class AdHocFiltersVariable
 
     // set original values for scope filters as well
     finalFilters.forEach((scopeFilter) => {
-      this._originalValues.set(scopeFilter.key, {
+      this._originalValues.set(`${scopeFilter.key}-${scopeFilter.origin}`, {
         value: scopeFilter.values ?? [scopeFilter.value],
         operator: scopeFilter.operator,
       });
@@ -391,7 +391,7 @@ export class AdHocFiltersVariable
     };
 
     if (filter.restorable) {
-      const originalFilter = this._originalValues.get(filter.key);
+      const originalFilter = this._originalValues.get(`${filter.key}-${filter.origin}`);
 
       if (!originalFilter) {
         return;
@@ -415,7 +415,7 @@ export class AdHocFiltersVariable
     const { originFilters, filters, _wip } = this.state;
 
     if (filter.origin) {
-      const originalValues = this._originalValues.get(filter.key);
+      const originalValues = this._originalValues.get(`${filter.key}-${filter.origin}`);
       const updateValues = update.values || (update.value ? [update.value] : undefined);
 
       if (
@@ -588,7 +588,7 @@ export class AdHocFiltersVariable
           f.nonApplicable = true;
         }
 
-        const originalValue = this._originalValues.get(f.key);
+        const originalValue = this._originalValues.get(`${f.key}-${f.origin}`);
         if (originalValue) {
           originalValue.nonApplicable = true;
         }


### PR DESCRIPTION
Set the key in the originalValues map to also contain the origin for cases where we have 2 filters with the same key originating from 2 different origins.