### PR TITLE
Time zone selection: When selecting Default in time zone picker, interpolate timezone from user profile setting

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -1,4 +1,4 @@
-import { toUtc, dateMath } from '@grafana/data';
+import { toUtc, dateMath, InternalTimeZones } from '@grafana/data';
 import { SceneFlexItem, SceneFlexLayout } from '../components/layout/SceneFlexLayout';
 import { PanelBuilders } from './PanelBuilders';
 import { SceneTimeRange } from './SceneTimeRange';
@@ -163,7 +163,7 @@ describe('SceneTimeRange', () => {
     describe('when user selects default time zone', () => {
       it(`should return default time zone set in user profile settings`, () => {
         const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
-        timeRange.onTimeZoneChange('');
+        timeRange.onTimeZoneChange(InternalTimeZones.default);
         expect(timeRange.getTimeZone()).toBe(USER_PROFILE_DEFAULT_TIME_ZONE);
       });
     });

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -5,7 +5,7 @@ import { SceneTimeRange } from './SceneTimeRange';
 import { RefreshEvent, config } from '@grafana/runtime';
 import { EmbeddedScene } from '../components/EmbeddedScene';
 import { SceneReactObject } from '../components/SceneReactObject';
-import { defaultTimeZone } from '@grafana/schema';
+import { defaultTimeZone as browserTimeZone } from '@grafana/schema';
 
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
@@ -16,7 +16,9 @@ function simulateDelay(newDateString: string, scene: EmbeddedScene) {
   scene.activate();
 }
 
-config.bootData = { user: { weekStart: 'monday' } } as any;
+const USER_PROFILE_DEFAULT_TIME_ZONE = 'Australia/Sydney';
+
+config.bootData = { user: { weekStart: 'monday', timezone: USER_PROFILE_DEFAULT_TIME_ZONE } } as any;
 
 describe('SceneTimeRange', () => {
   it('when created should evaluate time range', () => {
@@ -58,7 +60,7 @@ describe('SceneTimeRange', () => {
     expect(timeRange.urlSync?.getUrlState()).toEqual({
       from: 'now-1h',
       to: 'now',
-      timezone: defaultTimeZone,
+      timezone: browserTimeZone,
     });
   });
 
@@ -67,7 +69,7 @@ describe('SceneTimeRange', () => {
     timeRange.urlSync?.updateFromUrl({
       from: '2021-01-01T10:00:00.000Z',
       to: '2021-02-03T01:20:00.000Z',
-      timezone: defaultTimeZone,
+      timezone: USER_PROFILE_DEFAULT_TIME_ZONE,
     });
 
     expect(timeRange.state.from).toEqual('2021-01-01T10:00:00.000Z');
@@ -140,7 +142,7 @@ describe('SceneTimeRange', () => {
     describe('when time zone is not specified', () => {
       it('should return default time zone', () => {
         const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
-        expect(timeRange.getTimeZone()).toBe(defaultTimeZone);
+        expect(timeRange.getTimeZone()).toBe(browserTimeZone);
       });
       it('should return time zone of the closest range with time zone specified ', () => {
         const outerTimeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'America/New_York' });
@@ -188,19 +190,19 @@ describe('SceneTimeRange', () => {
       });
     });
     describe('when time zone is not valid', () => {
-      it(`should default to ${defaultTimeZone}`, () => {
+      it(`should default to ${browserTimeZone}`, () => {
         const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'junk' });
-        expect(timeRange.getTimeZone()).toBe(defaultTimeZone);
+        expect(timeRange.getTimeZone()).toBe(browserTimeZone);
 
         timeRange.onTimeZoneChange('junk');
-        expect(timeRange.getTimeZone()).toBe(defaultTimeZone);
+        expect(timeRange.getTimeZone()).toBe(browserTimeZone);
       });
-      it(`should default to ${defaultTimeZone} on update`, () => {
+      it(`should default to ${browserTimeZone} on update`, () => {
         const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'utc' });
         expect(timeRange.getTimeZone()).toBe('utc');
 
         timeRange.onTimeZoneChange('junk');
-        expect(timeRange.getTimeZone()).toBe(defaultTimeZone);
+        expect(timeRange.getTimeZone()).toBe(browserTimeZone);
       });
     });
   });
@@ -398,6 +400,8 @@ describe('SceneTimeRange', () => {
     it('should display the correct start time in the time start panel and time picker tooltip', () => {
       const timeRange = new SceneTimeRange({ from: '2025-01-01T00:00:00.000Z', to: '2025-12-31T23:59:59.999Z' });
       timeRange.onTimeZoneChange('Africa/Addis_Ababa');
+
+      expect(timeRange.getTimeZone()).toBe('Africa/Addis_Ababa');
 
       // Verify the time start panel reads the correct start time
       expect(timeRange.state.value.from.format('YYYY-MM-DD HH:mm:ss')).toBe('2025-01-01 00:00:00');

--- a/packages/scenes/src/core/SceneTimeRange.test.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.test.tsx
@@ -160,6 +160,13 @@ describe('SceneTimeRange', () => {
         expect(innerTimeRange.getTimeZone()).toEqual(outerTimeRange.getTimeZone());
       });
     });
+    describe('when user selects default time zone', () => {
+      it(`should return default time zone set in user profile settings`, () => {
+        const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+        timeRange.onTimeZoneChange('');
+        expect(timeRange.getTimeZone()).toBe(USER_PROFILE_DEFAULT_TIME_ZONE);
+      });
+    });
     describe('when time zone is specified', () => {
       it('should return own time zone', () => {
         const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'America/New_York' });

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -12,6 +12,7 @@ import { config, locationService, RefreshEvent } from '@grafana/runtime';
 import { isValid } from '../utils/date';
 import { getQueryController } from './sceneGraph/getQueryController';
 import { writeSceneLog } from '../utils/writeSceneLog';
+import { isEmpty } from 'lodash';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
@@ -282,15 +283,22 @@ function getTimeWindow(time: string, timeWindow: string) {
  * @returns {string | undefined} - Returns the input time zone if it is valid, or undefined if the input is invalid or not provided.
  */
 function getValidTimeZone(timeZone?: string): string | undefined {
-  if (timeZone === undefined || timeZone === '') {
+  if (timeZone === undefined) {
     return undefined;
   }
+
+  if (isEmpty(timeZone)) {
+    return config.bootData.user.timezone;
+  }
+
   if (timeZone === defaultTimeZone) {
     return timeZone;
   }
+
   if (getZone(timeZone)) {
     return timeZone;
   }
+
   writeSceneLog('SceneTimeRange', `Invalid timeZone "${timeZone}" provided.`);
   return;
 }


### PR DESCRIPTION
This PR fixes a bug where user couldn't select default timezone. See the issue below for additional info and steps to reproduce. 

Fixes: https://github.com/grafana/grafana/issues/107734

This notion of default time zone is a bit confusing because [here](https://github.com/grafana/grafana/blob/e14c17ef69ca86bf5397a6c0d0d2459316f1cf0a/packages/grafana-data/src/datetime/timezones.ts#L8-#L12) we have default as empty string - and in the old arch when we have this empty string we resolve it to default time zone from user profile using `config.bootData.user.timezone` [here](https://github.com/grafana/grafana/blob/20c700dd52373c7b4e6f9560d0c2e35985308cfb/public/app/features/profile/state/reducers.ts#L113-L115).

But in https://github.com/grafana/scenes/pull/1109, we've introduced defaulting to browser and started relying on [defaultTimeZone](https://github.com/grafana/grafana/blob/0fdcae4e264bd9bba70024d7505ee46eacd0f255/packages/grafana-schema/src/common/common.gen.ts) from grafana-schema, which is set to browser.