### PR TITLE
Accessibility: Add `role="menuitem"` to `VizPanelMenu` items

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelMenu.tsx
@@ -52,6 +52,7 @@ function VizPanelMenuRenderer({ model }: SceneComponentProps<VizPanelMenu>) {
           return (
             <Menu.Item
               key={item.text}
+              role="menuitem"
               label={item.text}
               icon={item.iconClassName}
               childItems={item.subMenu ? renderItems(item.subMenu) : undefined}


### PR DESCRIPTION
- adds `role="menuitem"` to all `VizPanelMenu` items
- that's all the items in this menu:
  <img width="457" height="367" alt="image" src="https://github.com/user-attachments/assets/1f4ce0a9-6757-42da-bfd4-685dc1fe5981" />
- @ckbedwell i've read through https://github.com/grafana/grafana/pull/86886, and it sounds like this is fine/desired for this particular implementation of menu/menuitem. but i'd appreciate your 👀 just to make sure 🙏 

Fixes https://github.com/grafana/grafana/issues/106223
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.27.3--canary.1189.16466706909.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.27.3--canary.1189.16466706909.0
  npm install @grafana/scenes@6.27.3--canary.1189.16466706909.0
  # or 
  yarn add @grafana/scenes-react@6.27.3--canary.1189.16466706909.0
  yarn add @grafana/scenes@6.27.3--canary.1189.16466706909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
