### PR TITLE
Custom variable: support newline separated options

### DIFF
--- a/packages/scenes/src/variables/variants/CustomVariable.test.ts
+++ b/packages/scenes/src/variables/variants/CustomVariable.test.ts
@@ -64,6 +64,28 @@ describe('CustomVariable', () => {
       ]);
     });
 
+    it('Should generate correctly the options for key:value pairs with newline', async () => {
+      const variable = new CustomVariable({
+        name: 'test',
+        options: [],
+        value: '',
+        text: '',
+        query: `label-1 : value-1,
+label-2 : value-2,
+label-3 : value-3,`,
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.state.value).toEqual('value-1');
+      expect(variable.state.text).toEqual('label-1');
+      expect(variable.state.options).toEqual([
+        { label: 'label-1', value: 'value-1' },
+        { label: 'label-2', value: 'value-2' },
+        { label: 'label-3', value: 'value-3' },
+      ]);
+    });
+
     it('Should generate correctly the options for key:value pairs with special characters', async () => {
       const variable = new CustomVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -36,7 +36,7 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
 
     const options = match.map((text) => {
       text = text.replace(/\\,/g, ',');
-      const textMatch = /^\n?(.+)\s:\s(.+)$/g.exec(text) ?? [];
+      const textMatch = /^\s*(.+)\s:\s(.+)$/g.exec(text) ?? [];
       if (textMatch.length === 3) {
         const [, key, value] = textMatch;
         return { label: key.trim(), value: value.trim() };

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -36,7 +36,7 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
 
     const options = match.map((text) => {
       text = text.replace(/\\,/g, ',');
-      const textMatch = /^\n?(.+)\s:\s(.+)?$/g.exec(text) ?? [];
+      const textMatch = /^\n?(.+)\s:\s(.+)$/g.exec(text) ?? [];
       if (textMatch.length === 3) {
         const [, key, value] = textMatch;
         return { label: key.trim(), value: value.trim() };

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -36,7 +36,7 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
 
     const options = match.map((text) => {
       text = text.replace(/\\,/g, ',');
-      const textMatch = /^(.+)\s:\s(.+)$/g.exec(text) ?? [];
+      const textMatch = /^\n?(.+)\s:\s(.+)?$/g.exec(text) ?? [];
       if (textMatch.length === 3) {
         const [, key, value] = textMatch;
         return { label: key.trim(), value: value.trim() };


### PR DESCRIPTION
It was pointed out (as a bug) that custom variable does not properly recognize options separated with new line, like so:

```
label-1 : value-1,
label-2 : value-2,
label-3 : value-3,
```

Seems easy enough to fix 