### PR TITLE
Time zone selection: Default to undefined is user profile setting is somehow not set

### DIFF
--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -287,8 +287,8 @@ function getValidTimeZone(timeZone?: string): string | undefined {
     return undefined;
   }
 
-  if (isEmpty(timeZone)) {
-    return config.bootData.user?.timezone;
+  if (isEmpty(timeZone) && config.bootData.user) {
+    return config.bootData.user.timezone;
   }
 
   if (timeZone === defaultTimeZone) {


### PR DESCRIPTION
Adds an extra check on top of https://github.com/grafana/scenes/pull/1186 for verifying user data exists as tests were failing due to user profile settings not being set even though they aren't optional
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.28.2--canary.1194.16495109548.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.28.2--canary.1194.16495109548.0
  npm install @grafana/scenes@6.28.2--canary.1194.16495109548.0
  # or 
  yarn add @grafana/scenes-react@6.28.2--canary.1194.16495109548.0
  yarn add @grafana/scenes@6.28.2--canary.1194.16495109548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
