### PR TITLE
Enhance `SceneRenderProfiler` with additional interaction tracking

### DIFF
--- a/packages/scenes/src/behaviors/SceneRenderProfiler.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.ts
@@ -35,7 +35,7 @@ export class SceneRenderProfiler {
         this.#profileStartTs = performance.now();
         writeSceneLog(this.constructor.name, 'Profile started:', this.#profileInProgress, this.#profileStartTs);
       } else {
-        // If there i a profile in progress but tail recording is not started, add a crumb to the current profile
+        // If there is a profile in progress but tail recording is not started, add a crumb to the current profile
         // and consider this a continuation of an interaction.
         this.addCrumb(name);
       }

--- a/packages/scenes/src/behaviors/SceneRenderProfiler.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.ts
@@ -22,16 +22,28 @@ export class SceneRenderProfiler {
   public constructor(private queryController: SceneQueryControllerLike) {}
 
   public startProfile(name: string) {
-    if (this.#trailAnimationFrameId) {
-      cancelAnimationFrame(this.#trailAnimationFrameId);
-      this.#trailAnimationFrameId = null;
+    if (this.#profileInProgress) {
+      // When profile is in tail recording phase, we need to stop it and start a new profile
+      // TODO: consider capturing the profile that was in progress and marking it as canceled or sth like that.
+      if (this.#trailAnimationFrameId) {
+        cancelAnimationFrame(this.#trailAnimationFrameId);
+        this.#trailAnimationFrameId = null;
 
-      writeSceneLog(this.constructor.name, 'New profile: Stopped recording frames');
+        writeSceneLog(this.constructor.name, 'New profile: Stopped recording frames ');
+
+        this.#profileInProgress = { origin: name, crumbs: [] };
+        this.#profileStartTs = performance.now();
+        writeSceneLog(this.constructor.name, 'Profile started:', this.#profileInProgress, this.#profileStartTs);
+      } else {
+        // If there i a profile in progress but tail recording is not started, add a crumb to the current profile
+        // and consider this a continuation of an interaction.
+        this.addCrumb(name);
+      }
+    } else {
+      this.#profileInProgress = { origin: name, crumbs: [] };
+      this.#profileStartTs = performance.now();
+      writeSceneLog(this.constructor.name, 'Profile started:', this.#profileInProgress, this.#profileStartTs);
     }
-
-    this.#profileInProgress = { origin: name, crumbs: [] };
-    this.#profileStartTs = performance.now();
-    writeSceneLog(this.constructor.name, 'Profile started:', this.#profileInProgress, this.#profileStartTs);
   }
 
   private recordProfileTail(measurementStartTime: number, profileStartTs: number) {
@@ -72,14 +84,9 @@ export class SceneRenderProfiler {
       );
       this.#trailAnimationFrameId = null;
 
-      // performance.measure('DashboardInteraction tail', {
-      //   start: measurementStartTs,
-      //   end: measurementStartTs + n,
-      // });
-
       const profileEndTs = profileStartTs + profileDuration + slowFramesTime;
 
-      performance.measure('DashboardInteraction', {
+      performance.measure(`DashboardInteraction ${this.#profileInProgress!.origin}`, {
         start: profileStartTs,
         end: profileEndTs,
       });
@@ -99,6 +106,7 @@ export class SceneRenderProfiler {
           // @ts-ignore
           totalJSHeapSize: performance.memory ? performance.memory.totalJSHeapSize : 0,
         });
+        this.#profileInProgress = null;
       }
       // @ts-ignore
       if (window.__runs) {
@@ -113,7 +121,6 @@ export class SceneRenderProfiler {
 
   public tryCompletingProfile() {
     writeSceneLog(this.constructor.name, 'Trying to complete profile', this.#profileInProgress);
-
     if (this.queryController.runningQueriesCount() === 0 && this.#profileInProgress) {
       writeSceneLog(this.constructor.name, 'All queries completed, stopping profile');
       this.recordProfileTail(performance.now(), this.#profileStartTs!);
@@ -133,6 +140,7 @@ export class SceneRenderProfiler {
 
   public addCrumb(crumb: string) {
     if (this.#profileInProgress) {
+      writeSceneLog(this.constructor.name, 'Adding crumb:', crumb);
       this.#profileInProgress.crumbs.push(crumb);
     }
   }
@@ -196,3 +204,12 @@ export function calculateNetworkTime(requests: PerformanceResourceTiming[]): num
 
   return totalNetworkTime;
 }
+
+export const REFRESH_INTERACTION = 'refresh';
+export const TIME_RANGE_CHANGE_INTERACTION = 'time-range-change';
+export const FILTER_ADDED_INTERACTION = 'filter-added';
+export const FILTER_REMOVED_INTERACTION = 'filter-removed';
+export const FILTER_CHANGED_INTERACTION = 'filter-changed';
+export const FILTER_RESTORED_INTERACTION = 'filter-restored';
+export const VARIABLE_VALUE_CHANGED_INTERACTION = 'variable-value-changed';
+export const SCOPES_CHANGED_INTERACTION = 'scopes-changed';

--- a/packages/scenes/src/behaviors/SceneRenderProfiler.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.ts
@@ -206,10 +206,10 @@ export function calculateNetworkTime(requests: PerformanceResourceTiming[]): num
 }
 
 export const REFRESH_INTERACTION = 'refresh';
-export const TIME_RANGE_CHANGE_INTERACTION = 'time-range-change';
-export const FILTER_ADDED_INTERACTION = 'filter-added';
-export const FILTER_REMOVED_INTERACTION = 'filter-removed';
-export const FILTER_CHANGED_INTERACTION = 'filter-changed';
-export const FILTER_RESTORED_INTERACTION = 'filter-restored';
-export const VARIABLE_VALUE_CHANGED_INTERACTION = 'variable-value-changed';
-export const SCOPES_CHANGED_INTERACTION = 'scopes-changed';
+export const TIME_RANGE_CHANGE_INTERACTION = 'time_range_change';
+export const FILTER_ADDED_INTERACTION = 'filter_added';
+export const FILTER_REMOVED_INTERACTION = 'filter_removed';
+export const FILTER_CHANGED_INTERACTION = 'filter_changed';
+export const FILTER_RESTORED_INTERACTION = 'filter_restored';
+export const VARIABLE_VALUE_CHANGED_INTERACTION = 'variable_value_changed';
+export const SCOPES_CHANGED_INTERACTION = 'scopes_changed';

--- a/packages/scenes/src/behaviors/types.ts
+++ b/packages/scenes/src/behaviors/types.ts
@@ -13,7 +13,7 @@ export interface SceneQueryControllerEntry {
   cancel?: () => void;
 }
 
-export type SceneQueryControllerEntryType = 'data' | 'annotations' | 'variable' | 'alerts' | 'plugin';
+export type SceneQueryControllerEntryType = 'data' | 'annotations' | 'variable' | 'alerts' | 'plugin' | string;
 
 export interface SceneInteractionProfileEvent {
   origin: string;

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -8,6 +8,7 @@ import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneObject, SceneObjectState, SceneObjectUrlValues } from '../core/types';
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
+import { REFRESH_INTERACTION } from '../behaviors/SceneRenderProfiler';
 
 export const DEFAULT_INTERVALS = ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'];
 
@@ -85,7 +86,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   public onRefresh = () => {
     const queryController = sceneGraph.getQueryController(this);
 
-    queryController?.startProfile('SceneRefreshPicker');
+    queryController?.startProfile(REFRESH_INTERACTION);
 
     if (queryController?.state.isRunning) {
       queryController.cancelAll();
@@ -191,7 +192,7 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
     this._intervalTimer = setInterval(() => {
       if (this.isTabVisible()) {
         const queryController = sceneGraph.getQueryController(this);
-        queryController?.startProfile('SceneRefreshPicker');
+        queryController?.startProfile(REFRESH_INTERACTION);
         timeRange.onRefresh();
       } else {
         this._autoRefreshBlocked = true;

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -165,7 +165,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
         const queryControler = sceneGraph.getQueryController(this);
         if (queryControler && queryControler.state.enableProfiling) {
           wrapPromiseInStateObservable(panelPromise)
-            .pipe(registerQueryWithController({ type: 'plugin', origin: this }))
+            .pipe(registerQueryWithController({ type: `plugin/${pluginId}`, origin: this }))
             .subscribe(() => {});
         }
 

--- a/packages/scenes/src/core/SceneTimeRange.tsx
+++ b/packages/scenes/src/core/SceneTimeRange.tsx
@@ -13,6 +13,7 @@ import { isValid } from '../utils/date';
 import { getQueryController } from './sceneGraph/getQueryController';
 import { writeSceneLog } from '../utils/writeSceneLog';
 import { isEmpty } from 'lodash';
+import { TIME_RANGE_CHANGE_INTERACTION } from '../behaviors/SceneRenderProfiler';
 
 export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> implements SceneTimeRangeLike {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['from', 'to', 'timezone', 'time', 'time.window'] });
@@ -165,7 +166,7 @@ export class SceneTimeRange extends SceneObjectBase<SceneTimeRangeState> impleme
     // Only update if time range actually changed
     if (update.from !== this.state.from || update.to !== this.state.to) {
       const queryController = getQueryController(this);
-      queryController?.startProfile('SceneTimeRange');
+      queryController?.startProfile(TIME_RANGE_CHANGE_INTERACTION);
       this._urlSync.performBrowserHistoryAction(() => {
         this.setState(update);
       });

--- a/packages/scenes/src/utils/getDataSource.ts
+++ b/packages/scenes/src/utils/getDataSource.ts
@@ -29,7 +29,7 @@ export async function getDataSource(
       wrapPromiseInStateObservable(dsPromise)
         .pipe(
           registerQueryWithController({
-            type: 'plugin',
+            type: `plugin/${datasource?.type ?? 'unknown'}`,
             origin: scopedVars.__sceneObject.value.valueOf() as SceneObject,
           })
         )

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -14,7 +14,12 @@ import { FloatingFocusManager, FloatingPortal, UseFloatingOptions } from '@float
 import { Spinner, Text, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
-import { AdHocFilterWithLabels, AdHocFiltersVariable, isMultiValueOperator } from '../AdHocFiltersVariable';
+import {
+  AdHocFilterWithLabels,
+  AdHocFiltersVariable,
+  isFilterComplete,
+  isMultiValueOperator,
+} from '../AdHocFiltersVariable';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   DropdownItem,
@@ -40,6 +45,8 @@ import { handleOptionGroups } from '../../utils';
 import { useFloatingInteractions, MAX_MENU_HEIGHT } from './useFloatingInteractions';
 import { MultiValuePill } from './MultiValuePill';
 import { getAdhocOptionSearcher } from '../getAdhocOptionSearcher';
+import { getQueryController } from '../../../core/sceneGraph/getQueryController';
+import { FILTER_REMOVED_INTERACTION, FILTER_CHANGED_INTERACTION } from '../../../behaviors/SceneRenderProfiler';
 
 interface AdHocComboboxProps {
   filter?: AdHocFilterWithLabels;
@@ -122,6 +129,17 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           valueLabels.push(item.label ?? item.value!);
           values.push(item.value!);
         });
+
+        // Only update if values have changed
+        let shouldUpdate = true;
+        if (Array.isArray(filter.values) && filter.values.length === values.length) {
+          shouldUpdate = !filter.values.every((v, i) => v === values[i]);
+        }
+
+        if (shouldUpdate) {
+          const queryController = getQueryController(model);
+          queryController?.startProfile(FILTER_CHANGED_INTERACTION);
+        }
 
         model._updateFilter(filter!, { valueLabels, values, value: values[0] });
         setFilterMultiValues([]);
@@ -306,6 +324,11 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
         // focus back on alway wip input when you delete filter with backspace
         focusOnWipInputRef?.();
 
+        if (isFilterComplete(filter!)) {
+          const queryController = getQueryController(model);
+          queryController?.startProfile(FILTER_REMOVED_INTERACTION);
+        }
+
         model._handleComboboxBackspace(filter!);
 
         if (isAlwaysWip) {
@@ -381,16 +404,21 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           handleLocalMultiValueChange(selectedItem);
           setInputValue('');
         } else {
-          model._updateFilter(
-            filter!,
-            generateFilterUpdatePayload({
-              filterInputType,
-              item: selectedItem,
-              filter: filter!,
-              setFilterMultiValues,
-              onAddCustomValue,
-            })
-          );
+          const payload = generateFilterUpdatePayload({
+            filterInputType,
+            item: selectedItem,
+            filter: filter!,
+            setFilterMultiValues,
+            onAddCustomValue,
+          });
+
+          // Only start profile if value has changed
+          if (filterInputType === 'value' && payload.value !== filter?.value) {
+            const queryController = getQueryController(model);
+            queryController?.startProfile(FILTER_CHANGED_INTERACTION);
+          }
+
+          model._updateFilter(filter!, payload);
 
           populateInputValueOnInputTypeSwitch({
             populateInputOnEdit,
@@ -688,6 +716,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                               if (filterInputType !== 'value') {
                                 event.stopPropagation();
                               }
+
                               if (isMultiValueEdit) {
                                 event.preventDefault();
                                 event.stopPropagation();
@@ -695,16 +724,19 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                                 setInputValue('');
                                 refs.domReference.current?.focus();
                               } else {
-                                model._updateFilter(
-                                  filter!,
-                                  generateFilterUpdatePayload({
-                                    filterInputType,
-                                    item,
-                                    filter: filter!,
-                                    setFilterMultiValues,
-                                    onAddCustomValue,
-                                  })
-                                );
+                                const payload = generateFilterUpdatePayload({
+                                  filterInputType,
+                                  item,
+                                  filter: filter!,
+                                  setFilterMultiValues,
+                                  onAddCustomValue,
+                                });
+
+                                if (filterInputType === 'value' && payload.value !== filter?.value) {
+                                  const queryController = getQueryController(model);
+                                  queryController?.startProfile(FILTER_CHANGED_INTERACTION);
+                                }
+                                model._updateFilter(filter!, payload);
 
                                 populateInputValueOnInputTypeSwitch({
                                   populateInputOnEdit,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -28,6 +28,8 @@ import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSeriali
 import { isEqual } from 'lodash';
 import { getAdHocFiltersFromScopes } from './getAdHocFiltersFromScopes';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
+import { getQueryController } from '../../core/sceneGraph/getQueryController';
+import { FILTER_REMOVED_INTERACTION, FILTER_RESTORED_INTERACTION } from '../../behaviors/SceneRenderProfiler';
 
 export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> extends AdHocVariableFilter {
   keyLabel?: string;
@@ -413,7 +415,8 @@ export class AdHocFiltersVariable
       original.valueLabels = originalFilter?.value;
       original.operator = originalFilter?.operator;
       original.nonApplicable = originalFilter?.nonApplicable;
-
+      const queryController = getQueryController(this);
+      queryController?.startProfile(FILTER_RESTORED_INTERACTION);
       this._updateFilter(filter, original);
     }
   }
@@ -485,6 +488,8 @@ export class AdHocFiltersVariable
       this.setState({ _wip: undefined });
       return;
     }
+    const queryController = getQueryController(this);
+    queryController?.startProfile(FILTER_REMOVED_INTERACTION);
 
     this._setStateWithFiltersApplicabilityCheck({
       filters: this.state.filters.filter((f) => f !== filter),

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -19,6 +19,7 @@ import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { getOptionSearcher } from './getOptionSearcher';
 import { sceneGraph } from '../../core/sceneGraph';
+import { VARIABLE_VALUE_CHANGED_INTERACTION } from '../../behaviors/SceneRenderProfiler';
 
 const filterNoOp = () => true;
 
@@ -99,7 +100,7 @@ export function VariableValueSelect({ model, state }: { model: MultiValueVariabl
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${value}`)}
       onChange={(newValue) => {
         model.changeValueTo(newValue.value!, newValue.label!, true);
-        queryController?.startProfile('VariableValueSelect');
+        queryController?.startProfile(VARIABLE_VALUE_CHANGED_INTERACTION);
 
         if (hasCustomValue !== newValue.__isNew__) {
           setHasCustomValue(newValue.__isNew__);
@@ -186,7 +187,7 @@ export function VariableValueSelectMulti({
       onInputChange={onInputChange}
       onBlur={() => {
         model.changeValueTo(uncommittedValue, undefined, true);
-        queryController?.startProfile('VariableValueSelectMulti');
+        queryController?.startProfile(VARIABLE_VALUE_CHANGED_INTERACTION);
       }}
       filterOption={filterNoOp}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${uncommittedValue}`)}

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -187,7 +187,6 @@ export function VariableValueSelectMulti({
       onInputChange={onInputChange}
       onBlur={() => {
         model.changeValueTo(uncommittedValue, undefined, true);
-        queryController?.startProfile(VARIABLE_VALUE_CHANGED_INTERACTION);
       }}
       filterOption={filterNoOp}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${uncommittedValue}`)}

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -131,7 +131,6 @@ export function VariableValueSelectMulti({
   // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
   const [uncommittedValue, setUncommittedValue] = useState(arrayValue);
   const [inputValue, setInputValue] = useState('');
-  const queryController = sceneGraph.getQueryController(model);
 
   const optionSearcher = useMemo(() => getOptionSearcher(options, includeAll), [options, includeAll]);
 

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -20,6 +20,8 @@ import { formatRegistry } from '../interpolation/formatRegistry';
 import { VariableFormatID } from '@grafana/schema';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { setBaseClassState } from '../../utils/utils';
+import { VARIABLE_VALUE_CHANGED_INTERACTION } from '../../behaviors/SceneRenderProfiler';
+import { getQueryController } from '../../core/sceneGraph/getQueryController';
 
 export interface MultiValueVariableState extends SceneVariableState {
   value: VariableValue; // old current.text
@@ -311,12 +313,13 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
     }
 
     const stateChangeAction = () => this.setStateHelper({ value, text, loading: false });
-
     /**
      * Because variable state changes can cause a whole chain of downstream state changes in other variables (that also cause URL update)
      * Only some variable changes should add new history items to make sure the browser history contains valid URL states to go back to.
      */
     if (isUserAction) {
+      const queryController = getQueryController(this);
+      queryController?.startProfile(VARIABLE_VALUE_CHANGED_INTERACTION);
       this._urlSync.performBrowserHistoryAction?.(stateChangeAction);
     } else {
       stateChangeAction();

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -13,6 +13,8 @@ import { useContext, useEffect } from 'react';
 import { VariableFormatID, VariableHide } from '@grafana/schema';
 import { SCOPES_VARIABLE_NAME } from '../constants';
 import { isEqual } from 'lodash';
+import { getQueryController } from '../../core/sceneGraph/getQueryController';
+import { SCOPES_CHANGED_INTERACTION } from '../../behaviors/SceneRenderProfiler';
 
 export interface ScopesVariableState extends SceneVariableState {
   /**
@@ -99,6 +101,8 @@ export class ScopesVariable extends SceneObjectBase<ScopesVariableState> impleme
 
     // Only update scopes value state when loading is false and the scopes have changed
     if (!loading && (scopesHaveChanged || newScopes.length === 0)) {
+      const queryController = getQueryController(this);
+      queryController?.startProfile(SCOPES_CHANGED_INTERACTION);
       this.setState({ scopes: state.value, loading });
       this.publishEvent(new SceneVariableValueChangedEvent(this), true);
     } else {


### PR DESCRIPTION
This PR improves the `SceneRenderProfiler` by adding new interactions tracking and better profile management.

### Key Changes
####  Enhanced Profiler logic
- Improved `startProfile` method to handle overlapping profiles by continuing existing profiles with crumbs or properly stopping tail recording phases

#### Standardized interaction types
- Added interaction type constants for consistent profiling:
  - `REFRESH_INTERACTION` for manual and auto refresh actions
  - `TIME_RANGE_CHANGE_INTERACTION` for time range modifications
  - `FILTER_*_INTERACTION` for ad-hoc filter operations (add/remove/change/restore)
  - `VARIABLE_VALUE_CHANGED_INTERACTION` for variable value changes
  - `SCOPES_CHANGED_INTERACTION` for scopes modifications

#### Expanded Coverage
- Added profiling to previously untracked interactions: ad-hoc filter manipulations, variable value selections, and scopes changes
- Enhanced plugin crimbs tracking with specific plugin types



To test this, see PR in grafana repo: https://github.com/grafana/grafana/pull/108658

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.28.3--canary.1195.16590049708.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.28.3--canary.1195.16590049708.0
  npm install @grafana/scenes@6.28.3--canary.1195.16590049708.0
  # or 
  yarn add @grafana/scenes-react@6.28.3--canary.1195.16590049708.0
  yarn add @grafana/scenes@6.28.3--canary.1195.16590049708.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
