### PR TITLE
Add option to replace variable macros

### DIFF
--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -30,7 +30,7 @@ export const macrosIndex = new Map<string, MacroVariableConstructor>([
  * @returns a function that unregisters the macro
  */
 export function registerVariableMacro(name: string, macro: MacroVariableConstructor, replace = false): () => void {
-  if (!replace &&macrosIndex.get(name)) {
+  if (!replace && macrosIndex.get(name)) {
     throw new Error(`Macro already registered ${name}`);
   }
 


### PR DESCRIPTION
In special circumstances we need to be able to replace built in macros.  This PR adds a replace parameter to the registerVariableMacro that allows us to do that. The replaced macro will be restored if the macro is unregistered.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.28.4--canary.1196.16600049151.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.28.4--canary.1196.16600049151.0
  npm install @grafana/scenes@6.28.4--canary.1196.16600049151.0
  # or 
  yarn add @grafana/scenes-react@6.28.4--canary.1196.16600049151.0
  yarn add @grafana/scenes@6.28.4--canary.1196.16600049151.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
