### PR TITLE
LazyLoader: Improve the lazy loading mechanism

### DIFF
--- a/packages/scenes/src/components/layout/LazyLoader.tsx
+++ b/packages/scenes/src/components/layout/LazyLoader.tsx
@@ -4,6 +4,7 @@ import { useEffectOnce } from 'react-use';
 import { uniqueId } from 'lodash';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
+import { t } from '@grafana/i18n';
 
 export function useUniqueId(): string {
   const idRefLazy = useRef<string | undefined>(undefined);
@@ -12,7 +13,7 @@ export function useUniqueId(): string {
 }
 
 export interface Props extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'children'> {
-  children: React.ReactNode | (({ isInView }: { isInView: boolean }) => React.ReactNode);
+  children: React.ReactNode;
   key: string;
   onLoad?: () => void;
   onChange?: (isInView: boolean) => void;
@@ -66,8 +67,7 @@ export const LazyLoader: LazyLoaderType = React.forwardRef<HTMLDivElement, Props
     // If the children render empty, the whole loader will be hidden by css.
     return (
       <div id={id} ref={innerRef} className={`${hideEmpty} ${className}`} {...rest}>
-        {!loaded && '\u00A0'}
-        {loaded && (typeof children === 'function' ? children({ isInView }) : children)}
+        {!loaded || !isInView ? t('grafana-scenes.components.lazy-loader.placeholder', '\u00A0') : children}
       </div>
     );
   }


### PR DESCRIPTION
The lazy loader was migrated as-was from Grafana core and it was a little bit buggy and also it contained some unnecessary features.

This PR brings some changes to it:
- Remove function-type children as we don't need it. There is no need to pass a function that propagates the `isInView` property
- Load the content only when it is in view. With this change we aim at:
   - improving the runtime performance given that we don't need to keep the
   - removing the number of queries that we execute

There is a follow up PR that I'll open in Grafana core where this can be seen in action.