### PR TITLE
Make `SceneRenderProfiler` optional and injectable

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -74,7 +74,7 @@ export class SceneQueryController
     if (dir === 1 && this.state.enableProfiling) {
       if (entry) {
         // Collect profile crumbs, variables, annotations, queries and plugins
-        this.profiler?.addCrumb(`${entry.origin.constructor.name}/${entry.type}`);
+        this.profiler?.addCrumb(`${entry.type}`);
       }
       if (this.profiler?.isTailRecording()) {
         writeSceneLog('SceneQueryController', 'New query started, cancelling tail recording');

--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -13,14 +13,18 @@ export class SceneQueryController
   implements SceneQueryControllerLike
 {
   public isQueryController: true = true;
-  private profiler = new SceneRenderProfiler(this);
 
   #running = new Set<SceneQueryControllerEntry>();
 
   #tryCompleteProfileFrameId: number | null = null;
 
-  public constructor(state: Partial<SceneQueryStateControllerState> = {}) {
+  public constructor(state: Partial<SceneQueryStateControllerState> = {}, private profiler?: SceneRenderProfiler) {
     super({ ...state, isRunning: false });
+
+    if (profiler) {
+      this.profiler = profiler;
+      profiler.setQueryController(this);
+    }
 
     // Clear running state on deactivate
     this.addActivationHandler(() => {
@@ -35,7 +39,7 @@ export class SceneQueryController
     if (!this.state.enableProfiling) {
       return;
     }
-    this.profiler.startProfile(name);
+    this.profiler?.startProfile(name);
   }
 
   public queryStarted(entry: SceneQueryControllerEntry) {
@@ -70,11 +74,11 @@ export class SceneQueryController
     if (dir === 1 && this.state.enableProfiling) {
       if (entry) {
         // Collect profile crumbs, variables, annotations, queries and plugins
-        this.profiler.addCrumb(`${entry.origin.constructor.name}/${entry.type}`);
+        this.profiler?.addCrumb(`${entry.origin.constructor.name}/${entry.type}`);
       }
-      if (this.profiler.isTailRecording()) {
-        writeSceneLog(this.constructor.name, 'New query started, cancelling tail recording');
-        this.profiler.cancelTailRecording();
+      if (this.profiler?.isTailRecording()) {
+        writeSceneLog('SceneQueryController', 'New query started, cancelling tail recording');
+        this.profiler?.cancelTailRecording();
       }
     }
 
@@ -86,7 +90,7 @@ export class SceneQueryController
       }
 
       this.#tryCompleteProfileFrameId = requestAnimationFrame(() => {
-        this.profiler.tryCompletingProfile();
+        this.profiler?.tryCompletingProfile();
       });
     }
   }

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -165,7 +165,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
         const queryControler = sceneGraph.getQueryController(this);
         if (queryControler && queryControler.state.enableProfiling) {
           wrapPromiseInStateObservable(panelPromise)
-            .pipe(registerQueryWithController({ type: `plugin/${pluginId}`, origin: this }))
+            .pipe(registerQueryWithController({ type: `VizPanel/loadPlugin/${pluginId}`, origin: this }))
             .subscribe(() => {});
         }
 

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -52,6 +52,7 @@ export type {
   SceneQueryControllerEntry,
   SceneInteractionProfileEvent,
 } from './behaviors/types';
+export { SceneRenderProfiler } from './behaviors/SceneRenderProfiler';
 
 export * from './variables/types';
 export { VariableDependencyConfig } from './variables/VariableDependencyConfig';

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -470,7 +470,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
       stream = stream.pipe(
         registerQueryWithController({
-          type: 'data',
+          type: 'SceneQueryRunner/runQueries',
           request: primary,
           origin: this,
           cancel: () => this.cancelQuery(),

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
@@ -89,7 +89,7 @@ export class AnnotationsDataLayer
 
       let stream = executeAnnotationQuery(ds, timeRange, query, this).pipe(
         registerQueryWithController({
-          type: 'annotations',
+          type: 'AnnotationsDataLayer/annotationsLoading',
           origin: this,
           cancel: () => this.cancelQuery(),
         }),

--- a/packages/scenes/src/utils/getDataSource.ts
+++ b/packages/scenes/src/utils/getDataSource.ts
@@ -29,7 +29,7 @@ export async function getDataSource(
       wrapPromiseInStateObservable(dsPromise)
         .pipe(
           registerQueryWithController({
-            type: `plugin/${datasource?.type ?? 'unknown'}`,
+            type: `getDataSource/${datasource?.type ?? 'unknown'}`,
             origin: scopedVars.__sceneObject.value.valueOf() as SceneObject,
           })
         )

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -87,7 +87,7 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
         return runner.runRequest({ variable: this, searchFilter: args.searchFilter }, request).pipe(
           registerQueryWithController({
-            type: 'variable',
+            type: 'QueryVariable/getValueOptions',
             request: request,
             origin: this,
           }),


### PR DESCRIPTION
## Make `SceneRenderProfiler` optional and injectable

This refactoring improves the modularity of the `SceneRenderProfiler` by making it optional and supporting dependency injection patterns.

### Changes
- **SceneQueryController**: Accept optional `profiler` parameter in constructor instead of auto-instantiating
- **SceneRenderProfiler**: Make `queryController` optional and add `setQueryController()` method
- **API**: Export `SceneRenderProfiler` class for external use (see https://github.com/grafana/grafana/pull/108658)
- **Cleanup**: Simplify `startProfile` logic and improve logging consistency

No breaking changes to existing API.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.28.5--canary.1198.16615923333.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.28.5--canary.1198.16615923333.0
  npm install @grafana/scenes@6.28.5--canary.1198.16615923333.0
  # or 
  yarn add @grafana/scenes-react@6.28.5--canary.1198.16615923333.0
  yarn add @grafana/scenes@6.28.5--canary.1198.16615923333.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
