### PR TITLE
SceneRenderProfiler: add start and end timestamps to profile events

### DIFF
--- a/packages/scenes/src/behaviors/SceneRenderProfiler.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.ts
@@ -76,7 +76,6 @@ export class SceneRenderProfiler {
       this.#trailAnimationFrameId = null;
 
       const profileEndTs = profileStartTs + profileDuration + slowFramesTime;
-
       performance.measure(`DashboardInteraction ${this.#profileInProgress!.origin}`, {
         start: profileStartTs,
         end: profileEndTs,
@@ -90,6 +89,8 @@ export class SceneRenderProfiler {
           crumbs: this.#profileInProgress!.crumbs,
           duration: profileDuration + slowFramesTime,
           networkDuration,
+          startTs: profileStartTs,
+          endTs: profileEndTs,
           // @ts-ignore
           jsHeapSizeLimit: performance.memory ? performance.memory.jsHeapSizeLimit : 0,
           // @ts-ignore

--- a/packages/scenes/src/behaviors/types.ts
+++ b/packages/scenes/src/behaviors/types.ts
@@ -23,6 +23,8 @@ export interface SceneInteractionProfileEvent {
   usedJSHeapSize: number;
   totalJSHeapSize: number;
   crumbs: string[];
+  startTs: number;
+  endTs: number;
   // add more granular data,i.e. network times? slow frames?
 }
 


### PR DESCRIPTION
- Add startTs and endTs fields to SceneInteractionProfileEvent interface
- Include profile start and end timestamps in onProfileComplete callback