### PR TITLE
ScenesDataTransformer: Allow passthrough set of ScopedVars to interpolate

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -1,4 +1,4 @@
-import { DataTopic, DataTransformerConfig, LoadingState, PanelData, transformDataFrame } from '@grafana/data';
+import { DataTopic, DataTransformerConfig, LoadingState, PanelData, ScopedVars, transformDataFrame } from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
 import { catchError, forkJoin, map, of, ReplaySubject, Unsubscribable } from 'rxjs';
 import { sceneGraph } from '../core/sceneGraph';
@@ -12,6 +12,7 @@ export interface SceneDataTransformerState extends SceneDataState {
    * Array of standard transformation configs and custom transform operators
    */
   transformations: Array<DataTransformerConfig | CustomTransformerDefinition>;
+
 }
 
 /**
@@ -176,8 +177,8 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
     }
 
     const ctx = {
-      interpolate: (value: string) => {
-        return sceneGraph.interpolate(this, value, data.request?.scopedVars);
+      interpolate: (value: string, scopedVarsOverride?: ScopedVars) => {
+        return sceneGraph.interpolate(this, value, scopedVarsOverride ?? data.request?.scopedVars);
       },
     };
 

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -12,7 +12,6 @@ export interface SceneDataTransformerState extends SceneDataState {
    * Array of standard transformation configs and custom transform operators
    */
   transformations: Array<DataTransformerConfig | CustomTransformerDefinition>;
-
 }
 
 /**
@@ -177,8 +176,8 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
     }
 
     const ctx = {
-      interpolate: (value: string, scopedVarsOverride?: ScopedVars) => {
-        return sceneGraph.interpolate(this, value, scopedVarsOverride ?? data.request?.scopedVars);
+      interpolate: (value: string, scopedVars?: ScopedVars) => {
+        return sceneGraph.interpolate(this, value, {...data.request?.scopedVars, ...scopedVars});
       },
     };
 


### PR DESCRIPTION
In some transformations, we would want the ability to have variables for interpolation outside of the dashboard variables. The `interpolate` function provided via the context already allows you to pass a set of variables, but scenes limits it to whatever was sent through the request, which would be at the query level. 

We have a feature request to allow for a template transformation, meaning both the variables at the dashboard level and the individual field values should both be allowed as variables. A sample PR of how this will be used is available at TODO. 

This is an example of what we would do with this added extensibility in the transformation. We will still pass in and interpolate the dashboard variable `testVar` with `Sample Value`, but also create and pass in the field values per row to be interpolated, meaning `${value}` will be interpolated with whatever the value is.
<img width="558" height="445" alt="Screenshot 2025-08-02 at 1 29 27 PM" src="https://github.com/user-attachments/assets/42edc9a3-f085-4db2-ad8b-7461d353f8ac" />
