### PR TITLE
Feat: Add `showInControlsMenu` to `SceneVariableState`

### DIFF
--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -14,7 +14,7 @@ export interface SceneVariableState extends SceneObjectState {
   loading?: boolean;
   error?: any | null;
   description?: string | null;
-  displayInDropdownMenu?: boolean;
+  showInControlsMenu?: boolean;
 }
 
 export interface SceneVariable<TState extends SceneVariableState = SceneVariableState> extends SceneObject<TState> {

--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -14,6 +14,7 @@ export interface SceneVariableState extends SceneObjectState {
   loading?: boolean;
   error?: any | null;
   description?: string | null;
+  displayInDropdownMenu?: boolean;
 }
 
 export interface SceneVariable<TState extends SceneVariableState = SceneVariableState> extends SceneObject<TState> {


### PR DESCRIPTION
**Related Grafana PR:** https://github.com/grafana/grafana/pull/109225

### What changed?
Extended the state of the scene variables to have a new option called `showInControlsMenu`. This option can be used to render the variable under a dropdown menu instead of the default dashboard controls (currently only supported by Grafana dashboards). 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.31.0--canary.1208.17233161250.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.31.0--canary.1208.17233161250.0
  npm install @grafana/scenes@6.31.0--canary.1208.17233161250.0
  # or 
  yarn add @grafana/scenes-react@6.31.0--canary.1208.17233161250.0
  yarn add @grafana/scenes@6.31.0--canary.1208.17233161250.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
