### PR TITLE
SceneRenderProfiler: Only capture network requests within measurement window

### DIFF
--- a/packages/scenes/src/behaviors/SceneRenderProfiler.test.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.test.ts
@@ -1,4 +1,4 @@
-import { calculateNetworkTime, processRecordedSpans } from './SceneRenderProfiler';
+import { calculateNetworkTime, processRecordedSpans, captureNetwork } from './SceneRenderProfiler';
 
 describe('calculateNetworkTime', () => {
   it('should return the duration of a single request', () => {
@@ -65,5 +65,272 @@ describe('processRecordedSpans', () => {
   it('should return only the first element if all are below or equal to 30', () => {
     const spans = [10, 20, 15, 5];
     expect(processRecordedSpans(spans)).toEqual([10]);
+  });
+});
+
+describe('captureNetwork', () => {
+  let mockEntries: PerformanceResourceTiming[];
+
+  beforeEach(() => {
+    mockEntries = [];
+
+    // Clear any previous mock calls
+    jest.clearAllMocks();
+
+    // Set up our mock data for the global performance mocks
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should capture network requests that start and end within the time window', () => {
+    // Request that starts and ends within the window [100, 300]
+    mockEntries = [
+      {
+        name: 'request1.js',
+        startTime: 150,
+        responseEnd: 250,
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.getEntriesByType).toHaveBeenCalledWith('resource');
+    expect(global.performance.clearResourceTimings).toHaveBeenCalled();
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry request1.js', {
+      start: 150,
+      end: 250,
+    });
+    expect(result).toBe(100); // Duration: 250 - 150 = 100
+  });
+
+  it('should NOT capture requests that start within window but end after endTs', () => {
+    // Request starts within window but ends after endTs
+    mockEntries = [
+      {
+        name: 'long-request.js',
+        startTime: 200, // Within [100, 300]
+        responseEnd: 400, // After endTs=300
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).not.toHaveBeenCalled();
+    expect(result).toBe(0); // No requests captured
+  });
+
+  it('should NOT capture requests that start before startTs but end within window', () => {
+    // Request starts before window but ends within window
+    mockEntries = [
+      {
+        name: 'early-request.js',
+        startTime: 50, // Before startTs=100
+        responseEnd: 200, // Within [100, 300]
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).not.toHaveBeenCalled();
+    expect(result).toBe(0); // No requests captured
+  });
+
+  it('should NOT capture requests that start and end outside the time window', () => {
+    mockEntries = [
+      {
+        name: 'early-request.js',
+        startTime: 50,
+        responseEnd: 80, // Both before window [100, 300]
+      } as PerformanceResourceTiming,
+      {
+        name: 'late-request.js',
+        startTime: 400,
+        responseEnd: 500, // Both after window [100, 300]
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).not.toHaveBeenCalled();
+    expect(result).toBe(0); // No requests captured
+  });
+
+  it('should capture multiple valid requests within the time window', () => {
+    mockEntries = [
+      {
+        name: 'request1.js',
+        startTime: 110,
+        responseEnd: 150,
+      } as PerformanceResourceTiming,
+      {
+        name: 'request2.css',
+        startTime: 160,
+        responseEnd: 200,
+      } as PerformanceResourceTiming,
+      {
+        name: 'request3.png',
+        startTime: 250,
+        responseEnd: 290,
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).toHaveBeenCalledTimes(3);
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry request1.js', {
+      start: 110,
+      end: 150,
+    });
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry request2.css', {
+      start: 160,
+      end: 200,
+    });
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry request3.png', {
+      start: 250,
+      end: 290,
+    });
+    // Total duration: (150-110) + (200-160) + (290-250) = 40 + 40 + 40 = 120
+    expect(result).toBe(120);
+  });
+
+  it('should filter out invalid requests and capture only valid ones', () => {
+    mockEntries = [
+      {
+        name: 'valid-request.js',
+        startTime: 120,
+        responseEnd: 180, // Valid: within [100, 300]
+      } as PerformanceResourceTiming,
+      {
+        name: 'invalid-early.js',
+        startTime: 50,
+        responseEnd: 150, // Invalid: starts before window
+      } as PerformanceResourceTiming,
+      {
+        name: 'invalid-late.js',
+        startTime: 200,
+        responseEnd: 400, // Invalid: ends after window
+      } as PerformanceResourceTiming,
+      {
+        name: 'valid-request2.css',
+        startTime: 220,
+        responseEnd: 260, // Valid: within [100, 300]
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).toHaveBeenCalledTimes(2);
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry valid-request.js', {
+      start: 120,
+      end: 180,
+    });
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry valid-request2.css', {
+      start: 220,
+      end: 260,
+    });
+    // Total duration: (180-120) + (260-220) = 60 + 40 = 100
+    expect(result).toBe(100);
+  });
+
+  it('should handle overlapping valid requests correctly', () => {
+    mockEntries = [
+      {
+        name: 'request1.js',
+        startTime: 110,
+        responseEnd: 160,
+      } as PerformanceResourceTiming,
+      {
+        name: 'request2.css',
+        startTime: 140,
+        responseEnd: 200, // Overlaps with request1
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).toHaveBeenCalledTimes(2);
+    // Total overlapping duration: 110 to 200 = 90ms
+    expect(result).toBe(90);
+  });
+
+  it('should handle edge case where request starts and ends exactly at window boundaries', () => {
+    mockEntries = [
+      {
+        name: 'boundary-request.js',
+        startTime: 100, // Exactly at startTs
+        responseEnd: 300, // Exactly at endTs
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry boundary-request.js', {
+      start: 100,
+      end: 300,
+    });
+    expect(result).toBe(200); // Duration: 300 - 100 = 200
+  });
+
+  it('should return 0 when no network entries exist', () => {
+    mockEntries = [];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.getEntriesByType).toHaveBeenCalledWith('resource');
+    expect(global.performance.clearResourceTimings).toHaveBeenCalled();
+    expect(global.performance.measure).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle the case where responseEnd equals startTime (zero-duration request)', () => {
+    mockEntries = [
+      {
+        name: 'instant-request.js',
+        startTime: 150,
+        responseEnd: 150, // Same as startTime
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).toHaveBeenCalledWith('Network entry instant-request.js', {
+      start: 150,
+      end: 150,
+    });
+    expect(result).toBe(0); // Duration: 150 - 150 = 0
+  });
+
+  it('should properly handle requests with unusual timing edge cases', () => {
+    mockEntries = [
+      {
+        name: 'request-starts-at-end.js',
+        startTime: 300, // Starts exactly at endTs
+        responseEnd: 300, // Ends exactly at endTs
+      } as PerformanceResourceTiming,
+      {
+        name: 'request-ends-at-start.js',
+        startTime: 100, // Starts exactly at startTs
+        responseEnd: 100, // Ends exactly at startTs
+      } as PerformanceResourceTiming,
+    ];
+    (global.performance.getEntriesByType as jest.Mock).mockReturnValue(mockEntries);
+
+    const result = captureNetwork(100, 300);
+
+    expect(global.performance.measure).toHaveBeenCalledTimes(2);
+    expect(result).toBe(0); // Both requests have zero duration
   });
 });

--- a/packages/scenes/src/behaviors/SceneRenderProfiler.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.ts
@@ -215,10 +215,17 @@ export function processRecordedSpans(spans: number[]) {
   return [spans[0]];
 }
 
-function captureNetwork(startTs: number, endTs: number) {
+export function captureNetwork(startTs: number, endTs: number) {
   const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
   performance.clearResourceTimings();
-  const networkEntries = entries.filter((entry) => entry.startTime >= startTs && entry.startTime <= endTs);
+  // Only include network entries that both started AND ended within the time window
+  const networkEntries = entries.filter(
+    (entry) =>
+      entry.startTime >= startTs &&
+      entry.startTime <= endTs &&
+      entry.responseEnd >= startTs &&
+      entry.responseEnd <= endTs
+  );
   for (const entry of networkEntries) {
     performance.measure('Network entry ' + entry.name, {
       start: entry.startTime,

--- a/packages/scenes/utils/setupTests.ts
+++ b/packages/scenes/utils/setupTests.ts
@@ -25,3 +25,18 @@ global.IntersectionObserver = jest.fn(() => ({
   rootMargin: '',
   thresholds: [],
 }));
+
+// Mock Performance API methods that don't exist in Jest/jsdom environment
+if (!global.performance) {
+  global.performance = {} as Performance;
+}
+
+// Add the missing Performance Resource Timing API methods
+Object.assign(global.performance, {
+  getEntriesByType: jest.fn(() => []),
+  clearResourceTimings: jest.fn(),
+  measure: jest.fn(),
+  // Keep existing methods like now() that might already exist
+  now: global.performance.now || jest.fn(() => Date.now()),
+  mark: global.performance.mark || jest.fn(),
+});


### PR DESCRIPTION
# Fix network timing capture to only include requests within measurement window

## Problem
By observing data that we currently capture I've noticed the `captureNetwork` function incorrectly captured network requests that started within the profiling time window but ended after `endTs`. This led to inaccurate network timing measurements in performance profiles. This is caused because not all network requests are considered influential for the rendering time, for example see the screenshot below:


<img width="1300" height="179" alt="image" src="https://github.com/user-attachments/assets/38188fe4-ef3f-49ce-8dea-c36a479de293" />


The last request captured is fired by faro collector and influences the `networkDuration` captured, while it should not. This results in `networkDuration > duration`.

## Solution
Updated the filtering logic in `captureNetwork` to ensure only network requests that both **start AND end** within the specified time window are captured.

### Before:
```typescript
// Only checked start time
entry.startTime >= startTs && entry.startTime <= endTs
```

### After:
```typescript
// Checks both start AND end times
entry.startTime >= startTs && 
entry.startTime <= endTs && 
entry.responseEnd >= startTs && 
entry.responseEnd <= endTs
```

## Changes
- Fixed timing filter logic in `captureNetwork` function
- Added test coverage
- Added Performance API mocking to Jest test environment setup
- Exported `captureNetwork` function for testability

## Test Coverage
Added tests for:
- Valid requests within time window
- Requests starting within but ending after window (excluded)
- Requests starting before but ending within window (excluded)
- Requests completely outside window (excluded)
- Multiple overlapping requests
- Boundary conditions
- Zero-duration requests
- Empty scenarios
