### PR TITLE
Add new operators to AdHocFiltersVariable

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -2787,7 +2787,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         '=~Matches regex',
         '!~Does not match regex',
         '<Less than',
+        '<=Less than or equal to',
         '>Greater than',
+        '>=Greater than or equal to',
       ]);
     });
 
@@ -2809,7 +2811,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         '=~Matches regex',
         '!~Does not match regex',
         '<Less than',
+        '<=Less than or equal to',
         '>Greater than',
+        '>=Greater than or equal to',
       ]);
     });
 
@@ -2825,7 +2829,14 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
       const options = screen.getAllByRole('option').map((option) => option.textContent?.trim());
 
-      expect(options).toEqual(['=Equals', '!=Not equal', '<Less than', '>Greater than']);
+      expect(options).toEqual([
+        '=Equals',
+        '!=Not equal',
+        '<Less than',
+        '<=Less than or equal to',
+        '>Greater than',
+        '>=Greater than or equal to',
+      ]);
     });
   });
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -204,8 +204,16 @@ export const OPERATORS: OperatorDefinition[] = [
     description: 'Less than',
   },
   {
+    value: '<=',
+    description: 'Less than or equal to',
+  },
+  {
     value: '>',
     description: 'Greater than',
+  },
+  {
+    value: '>=',
+    description: 'Greater than or equal to',
   },
 ];
 


### PR DESCRIPTION
Adds new operators to the AdHocFiltersVariable.

This is the result of an internal Slack chat where it was discussed that having `>=` and `<=` would be useful for example when searching for HTTP status codes.

<img width="429" height="46" alt="Screenshot 2025-08-07 at 08 36 49" src="https://github.com/user-attachments/assets/95a8aa71-e436-433d-be09-aab69b0dfb06" />
