### PR TITLE
Fix profiler query controller registration on scene re-activation

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -28,6 +28,8 @@ export class SceneQueryController
 
     // Clear running state on deactivate
     this.addActivationHandler(() => {
+      // In cases of re-activation, we need to set the query controller again as it might have been set by other scene
+      this.profiler?.setQueryController(this);
       return () => this.#running.clear();
     });
   }


### PR DESCRIPTION
## Fix profiler query controller registration on scene re-activation

### Problem

When scenes are re-activated, the profiler's query controller reference could be overridden by other scenes, causing the profiler to lose track of the correct query controller for performance monitoring.

### Solution

Added explicit query controller registration in the activation handler of `SceneQueryController` to ensure that during re-activation, the profiler maintains the correct reference to the query controller. This prevents performance tracking issues when scenes are activated multiple times or when multiple scenes interact.