### PR TITLE
AdHocFilters: Fix hidden filters in new combobox layout

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -38,15 +38,17 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
         ) : null
       )}
 
-      {filters.map((filter, index) => (
-        <AdHocFilterPill
-          key={`${index}-${filter.key}`}
-          filter={filter}
-          model={model}
-          readOnly={readOnly || filter.readOnly}
-          focusOnWipInputRef={focusOnWipInputRef.current}
-        />
-      ))}
+      {filters
+        .filter((filter) => !filter.hidden)
+        .map((filter, index) => (
+          <AdHocFilterPill
+            key={`${index}-${filter.key}`}
+            filter={filter}
+            model={model}
+            readOnly={readOnly || filter.readOnly}
+            focusOnWipInputRef={focusOnWipInputRef.current}
+          />
+        ))}
 
       {!readOnly ? <AdHocFiltersAlwaysWipCombobox model={model} ref={focusOnWipInputRef} /> : null}
     </div>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -2571,9 +2571,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('does not display hidden filters', async () => {
-      act(() => {
-        const { filtersVar } = setup();
+      const { filtersVar } = setup();
 
+      act(() => {
         filtersVar.setState({
           filters: [
             ...filtersVar.state.filters,
@@ -2583,10 +2583,10 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         });
       });
 
-      expect(await screen.findByText('key1 = valLabel1')).toBeInTheDocument();
-      expect(await screen.findByText('key2 = valLabel2')).toBeInTheDocument();
+      expect(await screen.findByText('key1 = val1')).toBeInTheDocument();
+      expect(await screen.findByText('key2 = val2')).toBeInTheDocument();
       expect(screen.queryAllByText('hidden_key = hidden_val')).toEqual([]);
-      expect(screen.queryAllByText('visible_key = visible_val')).toEqual([]);
+      expect(screen.queryAllByText('visible_key = visible_val')).not.toEqual([]);
     });
 
     it('focusing the input opens the key dropdown', async () => {


### PR DESCRIPTION
Adds the `hidden` filter functionality to the new adhoc combobox layout as well.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.29.8--canary.1216.17039188390.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.29.8--canary.1216.17039188390.0
  npm install @grafana/scenes@6.29.8--canary.1216.17039188390.0
  # or 
  yarn add @grafana/scenes-react@6.29.8--canary.1216.17039188390.0
  yarn add @grafana/scenes@6.29.8--canary.1216.17039188390.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
