### PR TITLE
Typo: replace &#151; with dash 

### DIFF
--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -13,7 +13,7 @@ A scene is a collection of objects, called _scene objects_. These objects repres
 
 Scenes allow you to group and nest objects. Things like data, time ranges, or variables can be added to any object in the tree, making them available to that object and all descendant objects. Because of this, scenes allow you to create dashboards that have multiple time ranges, queries that can be shared and transformed, or nested variables.
 
-@grafana/scenes comes with multiple objects&#151;like `SceneQueryRunner`, `SceneFlexLayout`, `VizPanel`, and more&#151;to solve common problems. However, you can also create your own scene objects to extend functionality.
+@grafana/scenes comes with multiple objects - like `SceneQueryRunner`, `SceneFlexLayout`, `VizPanel`, and more - to solve common problems. However, you can also create your own scene objects to extend functionality.
 
 ## Scene object
 


### PR DESCRIPTION
`&#151;` seems to be em dash in Windows-1252, but it's not rendered properly 

<img width="764" height="256" alt="image" src="https://github.com/user-attachments/assets/c8e3656e-b102-4605-857c-fce9e3e4648d" />