### PR TITLE
DataLayers: Annotations can be enabled properly

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.test.ts
@@ -455,6 +455,7 @@ describe.each(['11.1.2', '11.1.1'])('AnnotationsDataLayer', (v) => {
   it('should not run query when enable is false', async () => {
     const layer = new AnnotationsDataLayer({
       name: 'Test layer',
+      isEnabled: false,
       query: { name: 'Test', enable: false, iconColor: 'red', theActualQuery: '$A' },
     });
 
@@ -470,6 +471,33 @@ describe.each(['11.1.2', '11.1.1'])('AnnotationsDataLayer', (v) => {
     await new Promise((r) => setTimeout(r, 1));
 
     expect(runRequestMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should toggle anno query enabling when anno itself is toggled', () => {
+    const layer = new AnnotationsDataLayer({
+      name: 'Test layer',
+      isEnabled: false,
+      query: { name: 'Test', enable: false, iconColor: 'red', theActualQuery: '$A' },
+    });
+
+    const scene = new TestScene({
+      $timeRange: new SceneTimeRange(),
+      $data: new SceneDataLayerSet({
+        layers: [layer],
+      }),
+    });
+
+    scene.activate();
+
+    expect(layer.state.query.enable).toBe(false);
+
+    layer.onEnable();
+
+    expect(layer.state.query.enable).toBe(true);
+
+    layer.onDisable();
+
+    expect(layer.state.query.enable).toBe(false);
   });
 });
 

--- a/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
+++ b/packages/scenes/src/querying/layers/annotations/AnnotationsDataLayer.tsx
@@ -51,6 +51,13 @@ export class AnnotationsDataLayer
 
     const timeRange = sceneGraph.getTimeRange(this);
 
+    this.setState({
+      query: {
+        ...this.state.query,
+        enable: true,
+      },
+    });
+
     this._timeRangeSub = timeRange.subscribeToState(() => {
       this.runWithTimeRange(timeRange);
     });
@@ -58,6 +65,13 @@ export class AnnotationsDataLayer
 
   public onDisable(): void {
     this.publishEvent(new RefreshEvent(), true);
+
+    this.setState({
+      query: {
+        ...this.state.query,
+        enable: false,
+      },
+    });
 
     this._timeRangeSub?.unsubscribe();
   }


### PR DESCRIPTION
This [PR](https://github.com/grafana/scenes/pull/1174) fixed an issue where annotation requests would be made even when the query was disabled, but after that PR got merged, any annotations that were disabled from the settings page would not be enabled and ran from the toggle on the dashboard (the query would remain disabled while the annotation itself would be enabled).

This causes issues as one would expect the annotation to run when toggled from the dashboard (even though it was disabled from the settings page). This fix also aligns with how annotations worked pre-scenes.