### PR TITLE
AdHocFilters: Remove merging of different filter type with same keys

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -992,43 +992,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
-  it('filters are matched to origin ones if keys match', () => {
-    const { filtersVar } = setup({
-      originFilters: [
-        {
-          key: 'dbFilterKey',
-          operator: '=',
-          value: 'dbFilterValue',
-          origin: 'dashboard',
-        },
-      ],
-    });
-
-    // this is a normal filter but the key matches the
-    // dashboard filter so we overwrite this filter
-    // with the dashboard injected one
-    const urlValues = {
-      'var-filters': ['dbFilterKey|!=|newDbFilterValue'],
-    };
-
-    act(() => {
-      locationService.partial(urlValues);
-    });
-
-    // new filter will take values from the URL normal filter
-    // but keep it as a dashboard level filter
-    expect(filtersVar.state.originFilters![0]).toEqual({
-      key: 'dbFilterKey',
-      keyLabel: 'dbFilterKey',
-      operator: '!=',
-      value: 'newDbFilterValue',
-      valueLabels: ['newDbFilterValue'],
-      origin: 'dashboard',
-      condition: '',
-      restorable: true,
-    });
-  });
-
   it('url updates origin filters properly', async () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -80,15 +80,7 @@ function updateOriginFilters(prevOriginFilters: AdHocFilterWithLabels[], filters
     const foundOriginFilterIndex = prevOriginFilters.findIndex((f) => f.key === filters[i].key);
 
     // if we find a match we update originFilters with what's in the URL.
-    // If there is a normal filter without an origin that matches keys with
-    // some dashboard lvl filter we maintain it as dashboard lvl filter in the
-    // new dashboard
-    if (foundOriginFilterIndex > -1) {
-      if (!filters[i].origin && prevOriginFilters[foundOriginFilterIndex].origin === 'dashboard') {
-        filters[i].origin = 'dashboard';
-        filters[i].restorable = true;
-      }
-
+    if (foundOriginFilterIndex > -1 && filters[i].origin === prevOriginFilters[foundOriginFilterIndex].origin) {
       if (isMatchAllFilter(filters[i])) {
         filters[i].matchAllFilter = true;
       }


### PR DESCRIPTION

https://github.com/user-attachments/assets/0a09143a-67fa-4629-a15c-a22125c4794f


*Note on video: the applicability API is not working so all filter pills are valid here*


Modifications have been brought to injected filters.

Before this PR, when switching dashboards, if there were multiple filters of different types with the same key, e.g.: a dashboard default filter and a normal user added filter, then these two filters would be merged into one -- basically the user value would be used to edit the default filter.

The same would not happen to scopes which means we have an inconsistent experience.

Due to rising complexities around merging multiple filter types together when they have the same key, a decision was made to disallow merging of different filter types into one everywhere, which is how scope filters currently work -- if there are a scope filter and another user added filter with the same key present in the bar, then both will be visible and will not be merged and the applicability API can be used to determine which will be applied in the queries.

This PR does the same to dashboard default filters. 

Value edits are still maintained though, so if an origin filters is edited then they will maintain their edits across scope dashboards