### PR TITLE
SceneRenderProfiler: Handle overlapping profiles by cancelling previous profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 !.vscode/launch.json
 .vs/
 .eslintcache
+.cursor/
 
 # Build
 compiled


### PR DESCRIPTION
## Handle overlapping profiles in SceneRenderProfiler

### Problem

Rapid user interactions mixed performance data from multiple actions into a single profile.

### Solution

When a new profile is requested while trailing frames are being recorded, cancel the current profile and start fresh. Each interaction now gets its own isolated measurement.

### How to test

1. Open a dashboard with random walk panel with no delay and set auto refresh to 5s
2. Slow down `/api/annotations` requests to for example 4s (using Requestly for example).
3. Observe console with `localStorage.setItem('grafana.debug.scenes', 'true')`. While the tail is being recorded (2s), and the refresh happens, the profile should be cancelled and a new one should be started. _Before this change, refresh event would be added as a crumb of the initial interaction profile, and the profile would never end._
4. Slow down `/api/annotations` requests to 2s (using Requestly for example).
5. Observe profile being recorded and a new one started on the dashboard refresh interval.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.30.4--canary.1225.17209599335.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.30.4--canary.1225.17209599335.0
  npm install @grafana/scenes@6.30.4--canary.1225.17209599335.0
  # or 
  yarn add @grafana/scenes-react@6.30.4--canary.1225.17209599335.0
  yarn add @grafana/scenes@6.30.4--canary.1225.17209599335.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
