### PR TITLE
SceneGridRow: Adjust row panel count to account for repeats

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -81,7 +81,7 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
   public getPanelCount(children: SceneGridItemLike[]) {
     let count = 0;
     for (const child of children) {
-      count = 1 + (child.state.repeatedPanels?.length || 0);
+      count = child.getChildCount?.() || 1;
     }
     return count;
   }

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -81,7 +81,7 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
   public getPanelCount(children: SceneGridItemLike[]) {
     let count = 0;
     for (const child of children) {
-      count = child.getChildCount?.() || 1;
+      count += child.getChildCount?.() || 1;
     }
     return count;
   }

--- a/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridRow.tsx
@@ -77,6 +77,14 @@ export class SceneGridRow extends SceneObjectBase<SceneGridRowState> {
       this.onCollapseToggle();
     }
   }
+
+  public getPanelCount(children: SceneGridItemLike[]) {
+    let count = 0;
+    for (const child of children) {
+      count = 1 + (child.state.repeatedPanels?.length || 0);
+    }
+    return count;
+  }
 }
 
 export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow>) {
@@ -86,7 +94,7 @@ export function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow
   const layoutDragClass = layout.getDragClass();
   const isDraggable = layout.isDraggable() && !isRepeatCloneOrChildOf(model);
 
-  const count = children ? children.length : 0;
+  const count = model.getPanelCount(children);
   const panels = count === 1 ? 'panel' : 'panels';
 
   return (

--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -13,7 +13,6 @@ export interface SceneGridItemPlacement {
 export interface SceneGridItemStateLike extends SceneGridItemPlacement, SceneObjectState {
   isResizable?: boolean;
   isDraggable?: boolean;
-  repeatedPanels?: VizPanel[];
 }
 
 export interface SceneGridItemLike extends SceneObject<SceneGridItemStateLike> {

--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -13,6 +13,7 @@ export interface SceneGridItemPlacement {
 export interface SceneGridItemStateLike extends SceneGridItemPlacement, SceneObjectState {
   isResizable?: boolean;
   isDraggable?: boolean;
+  repeatedPanels?: VizPanel[];
 }
 
 export interface SceneGridItemLike extends SceneObject<SceneGridItemStateLike> {

--- a/packages/scenes/src/components/layout/grid/types.ts
+++ b/packages/scenes/src/components/layout/grid/types.ts
@@ -21,6 +21,11 @@ export interface SceneGridItemLike extends SceneObject<SceneGridItemStateLike> {
    * Provide a custom CSS class name for the underlying DOM element when special styling (i.e. for mobile breakpoint) is required.
    **/
   getClassName?(): string;
+
+  /**
+   * Get the number of grid item children (eg. original panel with all repeats)
+   **/
+  getChildCount?(): number;
 }
 
 export class SceneGridLayoutDragStartEvent extends BusEventWithPayload<{ evt: PointerEvent; panel: VizPanel }> {


### PR DESCRIPTION
adjusting row panel count to account for the new `repeatedPanels` property
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.31.1--canary.1227.17262127065.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.31.1--canary.1227.17262127065.0
  npm install @grafana/scenes@6.31.1--canary.1227.17262127065.0
  # or 
  yarn add @grafana/scenes-react@6.31.1--canary.1227.17262127065.0
  yarn add @grafana/scenes@6.31.1--canary.1227.17262127065.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
