### PR TITLE
Variables: Support for multiple properties

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -747,4 +747,24 @@ describe('MultiValueVariable', () => {
       expect(variable.urlSync?.getKeys()).toEqual([]);
     });
   });
+
+  describe('multi prop / object support', () => {
+    it('Can have object values', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        value: 'A',
+        text: 'A',
+        delayMs: 0,
+        skipUrlSync: true,
+        optionsToReturn: [
+          { label: 'Test', value: 'test', properties: { id: 'test', display: 'Test', location: 'US' } },
+          { label: 'Prod', value: 'pod', properties: { id: 'prod', display: 'Prod', location: 'EU' } },
+        ],
+      });
+
+      await lastValueFrom(variable.validateAndUpdate());
+
+      expect(variable.getValue('location')).toEqual('US');
+    });
+  });
 });


### PR DESCRIPTION

I explored variables with many "value properties" first in https://github.com/grafana/scenes/pull/995 . The thing that troubled me is that the natural continuation for that is to support it for Query variables as well, and from a user perspective building a dashboard it becomes very muddy/confusing two introduce basically identical variable types with the only difference being one support values with many properties. 

In this PR I am taking the first step in supporting "object" / multi property values in MultiValueVariable. Which required a very small change. 

Next I would explore

* What small change would be have to make to QueryVariable to now take advantage of "object" / multi prop variable values 
* What small change would be have to make to CustomVariable to now take advantage of "object" / multi prop variable values, support json? 

^ I am not doing this in the next week or so, anyone who has time could start exploring the above.  

Open question
* Should we support "multi" select (ie, multiple different object values). 