### PR TITLE
[WIP] SceneTimeRangeCompare: Add alignTimeShifts option

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -96,7 +96,7 @@ export { SceneToolbarButton, SceneToolbarInput } from './components/SceneToolbar
 export { SceneTimePicker } from './components/SceneTimePicker';
 export { SceneRefreshPicker, type SceneRefreshPickerState } from './components/SceneRefreshPicker';
 export { SceneTimeRangeTransformerBase } from './core/SceneTimeRangeTransformerBase';
-export { SceneTimeRangeCompare } from './components/SceneTimeRangeCompare';
+export { SceneTimeRangeCompare, alignCompareSeriesFields } from './components/SceneTimeRangeCompare';
 export { SceneByFrameRepeater } from './components/SceneByFrameRepeater';
 export { SceneByVariableRepeater } from './components/SceneByVariableRepeater';
 export { SceneControlsSpacer } from './components/SceneControlsSpacer';


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/109947 that applies time shift by default but adds the option to disable it depending on the application.

`alignCompareSeriesFields` is exported to be used by applications that want to disable the time shift.