### PR TITLE
export escapeUrlPipeDelimiters for esc-18160 and fix in metrics drilldown.

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -11,6 +11,7 @@ import {
   escapeLabelValueInExactSelector,
   escapeLabelValueInRegexSelector,
   escapeURLDelimiters,
+  escapeUrlPipeDelimiters,
   renderPrometheusLabelFilters,
 } from './variables/utils';
 import {
@@ -153,6 +154,7 @@ export const sceneUtils = {
   escapeLabelValueInRegexSelector,
   escapeLabelValueInExactSelector,
   escapeURLDelimiters,
+  escapeUrlPipeDelimiters,
 
   // Variable guards
   isAdHocVariable,
@@ -171,3 +173,4 @@ export { SafeSerializableSceneObject } from './utils/SafeSerializableSceneObject
 export { getExploreURL } from './utils/explore';
 export { loadResources } from './utils/loadResources';
 export { PATH_ID_SEPARATOR } from './utils/pathId';
+export { escapeUrlPipeDelimiters } from './variables/utils';


### PR DESCRIPTION
From this [escalation](https://github.com/grafana/support-escalations/issues/18160) metrics drilldown needed to escape pipe delimiters for Prometheus label values in the extension point link from dashboard to drilldown app. The `|` in a label value conflicts with the `|` delimiter between label, operator and value in the filters variable URL.

Importing `scenesUtils` to get access to `escapeUrlPipeDelimiters`  blew up our bundle entry point size by over 500kB.

For now, we are [copying this function](https://github.com/grafana/metrics-drilldown/pull/662) but for long term, we would like to import this function directly as this is a scenes conventions.

Thank you!