### PR TITLE
SceneGraph: Filter out dashboard controls from `getVariables()`

### DIFF
--- a/packages/scenes/src/core/sceneGraph/index.ts
+++ b/packages/scenes/src/core/sceneGraph/index.ts
@@ -15,10 +15,12 @@ import {
   getAncestor,
   findDescendents,
   getScopes,
+  getDashboardControls,
 } from './sceneGraph';
 
 export const sceneGraph = {
   getVariables,
+  getDashboardControls,
   getData,
   getTimeRange,
   getLayout,

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { of } from 'rxjs';
 
 import { sceneGraph } from '.';
-import { hasVariableDependencyInLoadingState } from './sceneGraph';
+import { getDashboardControls, getVariables, hasVariableDependencyInLoadingState } from './sceneGraph';
 import { EmbeddedScene } from '../../components/EmbeddedScene';
 import { SceneFlexItem, SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { SceneCanvasText } from '../../components/SceneCanvasText';
@@ -406,6 +406,40 @@ describe('sceneGraph', () => {
 
       expect(hasVariableDependencyInLoadingState(loadingVariable)).toBe(false);
       expect(logSpy).toHaveBeenCalledWith('Query variable is referencing itself');
+    });
+  });
+
+  describe('getVariables()', () => {
+    it('only returns the closest variables that are not meant to be rendered under a dashboard controls menu', () => {
+      const variable1 = new TestVariable({ name: 'A', value: '1', showInControlsMenu: false });
+      const variable2 = new TestVariable({ name: 'B', value: '1', showInControlsMenu: true });
+
+      const scene = new SceneFlexLayout({
+        $variables: new SceneVariableSet({ variables: [variable1, variable2] }),
+        children: [],
+      });
+
+      const variables = getVariables(scene);
+
+      expect(variables.state.variables.length).toBe(1);
+      expect(variables.state.variables[0].state.name).toBe('A');
+    });
+  });
+
+  describe('getDashboardControls()', () => {
+    it('only returns the closest variables that are not meant to be rendered under a dashboard controls menu', () => {
+      const variable1 = new TestVariable({ name: 'A', value: '1', showInControlsMenu: false });
+      const variable2 = new TestVariable({ name: 'B', value: '1', showInControlsMenu: true });
+
+      const scene = new SceneFlexLayout({
+        $variables: new SceneVariableSet({ variables: [variable1, variable2] }),
+        children: [],
+      });
+
+      const variables = getDashboardControls(scene);
+
+      expect(variables.state.variables.length).toBe(1);
+      expect(variables.state.variables[0].state.name).toBe('B');
     });
   });
 });

--- a/packages/scenes/src/core/sceneGraph/sceneGraph.ts
+++ b/packages/scenes/src/core/sceneGraph/sceneGraph.ts
@@ -2,7 +2,7 @@ import { Scope, ScopedVars } from '@grafana/data';
 import { EmptyDataNode, EmptyVariableSet } from '../../variables/interpolation/defaults';
 
 import { sceneInterpolator } from '../../variables/interpolation/sceneInterpolator';
-import { VariableCustomFormatterFn, SceneVariables } from '../../variables/types';
+import { VariableCustomFormatterFn, SceneVariables, SceneVariable } from '../../variables/types';
 
 import { isDataLayer, SceneDataLayerProvider, SceneDataProvider, SceneLayout, SceneObject } from '../types';
 import { lookupVariable } from '../../variables/lookupVariable';
@@ -17,9 +17,25 @@ import { SCOPES_VARIABLE_NAME } from '../../variables/constants';
  * Get the closest node with variables
  */
 export function getVariables(sceneObject: SceneObject): SceneVariables {
-  return getClosest(sceneObject, (s) => s.state.$variables) ?? EmptyVariableSet;
+  const variables = getClosest(sceneObject, (s) => s.state.$variables) ?? EmptyVariableSet;
+
+  return filterVariables(variables, (v) => v.state.showInControlsMenu !== true);
 }
 
+/**
+ * Get the closest node with controls
+ */
+export function getDashboardControls(sceneObject: SceneObject): SceneVariables {
+  const variables = getClosest(sceneObject, (s) => s.state.$variables) ?? EmptyVariableSet;
+
+  return filterVariables(variables, (v) => v.state.showInControlsMenu === true);
+}
+
+function filterVariables(sceneObject: SceneVariables, filter: (v: SceneVariable) => boolean) {
+  sceneObject.setState({ variables: sceneObject.state.variables.filter(filter) });
+
+  return sceneObject;
+}
 /**
  * Will walk up the scene object graph to the closest $data scene object
  */


### PR DESCRIPTION
**Related PR:** https://github.com/grafana/grafana/pull/109225

### What changed?
As discussed in https://github.com/grafana/grafana/pull/109225#discussion_r2306953250 we wanted to move the functionality of filtering out variables that are meant to be rendered under a dashboard-controls dropdown menu to scenes. This PR also adds another function for getting the "dashboard control" variables. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.32.1--canary.1231.17376394106.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.32.1--canary.1231.17376394106.0
  npm install @grafana/scenes@6.32.1--canary.1231.17376394106.0
  # or 
  yarn add @grafana/scenes-react@6.32.1--canary.1231.17376394106.0
  yarn add @grafana/scenes@6.32.1--canary.1231.17376394106.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
