### PR TITLE
SceneTimeRangeCompare: Add needsAlignment to meta

### DIFF
--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -199,6 +199,8 @@ const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary
       timeCompare: {
         diffMs: diff,
         isTimeShiftQuery: true,
+        // @ts-ignore Remove when https://github.com/grafana/grafana/pull/109947 is released
+        needsAlignment: true,
       },
     };
     series.fields.forEach((field) => {


### PR DESCRIPTION
Adds a `needsAlignment` flag to series meta. grafana/data `timeCompare` type will be updated in https://github.com/grafana/grafana/pull/109947