### PR TITLE
GroupByVariable: Do not show default value in url

### DIFF
--- a/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
+++ b/packages/scenes/src/variables/groupby/GroupByVariable.test.tsx
@@ -206,7 +206,7 @@ describe.each(['11.1.2', '11.1.1'])('GroupByVariable', (v) => {
       });
 
       expect(variable.state.value).toEqual(['defaultVal1']);
-      expect(locationService.getLocation().search).toBe('?var-test=defaultVal1&restorable-var-test=false');
+      expect(locationService.getLocation().search).toBe('?var-test=&restorable-var-test=false');
     });
 
     it('should use default value if nothing arrives from the url', async () => {
@@ -219,7 +219,7 @@ describe.each(['11.1.2', '11.1.1'])('GroupByVariable', (v) => {
 
       await act(async () => {
         await lastValueFrom(variable.validateAndUpdate());
-        expect(locationService.getLocation().search).toBe('?var-test=defaultVal1&restorable-var-test=false');
+        expect(locationService.getLocation().search).toBe('?var-test=&restorable-var-test=false');
         expect(variable.state.value).toEqual(['defaultVal1']);
         expect(variable.state.text).toEqual(['defaultVal1']);
       });
@@ -236,7 +236,7 @@ describe.each(['11.1.2', '11.1.1'])('GroupByVariable', (v) => {
 
       await act(async () => {
         await lastValueFrom(variable.validateAndUpdate());
-        expect(locationService.getLocation().search).toBe('?var-test=defaultVal1&restorable-var-test=false');
+        expect(locationService.getLocation().search).toBe('?var-test=&restorable-var-test=false');
         expect(variable.state.value).toEqual(['defaultVal1']);
         expect(variable.state.text).toEqual(['defaultVal1']);
       });

--- a/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/groupby/GroupByVariableUrlSyncHandler.ts
@@ -30,7 +30,10 @@ export class GroupByVariableUrlSyncHandler implements SceneObjectUrlSyncHandler 
     }
 
     return {
-      [this.getKey()]: toUrlValues(this._sceneObject.state.value, this._sceneObject.state.text),
+      [this.getKey()]:
+        this._sceneObject.state.defaultValue && !this._sceneObject.state.restorable
+          ? ['']
+          : toUrlValues(this._sceneObject.state.value, this._sceneObject.state.text),
       [this.getRestorableKey()]: this._sceneObject.state.defaultValue
         ? this._sceneObject.state.restorable
           ? 'true'


### PR DESCRIPTION
This brings consistency with how the adhoc filters var does it.

Basically, default values do not get synced in the URL (as they are pulled for other sources e.g.: scopes or dashboards). As soon as there is user input that modifies the variable from its default value we begin syncing with the URL so we can carry this new value across dashboards. 