### PR TITLE
SceneGridLayout: Adjust item y position for all children after a breakpoint

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -67,6 +67,21 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
     };
   }
 
+  public adjustYPositions(after: number, amount: number) {
+    for (const child of this.state.children) {
+      if (child.state.y! > after) {
+        child.setState({ y: child.state.y! + amount });
+      }
+      if (child instanceof SceneGridRow) {
+        for (const rowChild of child.state.children) {
+          if (rowChild.state.y! > after) {
+            rowChild.setState({ y: rowChild.state.y! + amount });
+          }
+        }
+      }
+    }
+  }
+
   public toggleRow(row: SceneGridRow) {
     const isCollapsed = row.state.isCollapsed;
 


### PR DESCRIPTION
This adds functionality to handle item positions when other items in the layout grows or shrinks. It turns out relying completely on react grid for this functionality did not work out when dealing with repeating panel inside rows.

https://github.com/grafana/grafana/issues/110273
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.34.1--canary.1243.17576735400.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.34.1--canary.1243.17576735400.0
  npm install @grafana/scenes@6.34.1--canary.1243.17576735400.0
  # or 
  yarn add @grafana/scenes-react@6.34.1--canary.1243.17576735400.0
  yarn add @grafana/scenes@6.34.1--canary.1243.17576735400.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
