### PR TITLE
SceneAppPage: Page background option

### DIFF
--- a/packages/scenes-app/src/pages/DemoListPage.tsx
+++ b/packages/scenes-app/src/pages/DemoListPage.tsx
@@ -29,6 +29,7 @@ function getDemoSceneApp() {
       updateUrlOnInit: true,
       createBrowserHistorySteps: true,
     },
+    defaultPageBackground: 'canvas',
     pages: [
       new SceneAppPage({
         title: 'Demos',
@@ -110,7 +111,7 @@ export class DemoList extends SceneObjectBase<DemoListState> {
       children.push(
         new SceneReactObject({
           reactNode: (
-            <Card key={demo.title} href={demoUrl(slugify(demo.title))}>
+            <Card key={demo.title} href={demoUrl(slugify(demo.title))} isOnCanvas={true}>
               <Card.Heading>{demo.title}</Card.Heading>
             </Card>
           ),

--- a/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
+++ b/packages/scenes/src/components/SceneApp/SceneAppPageView.tsx
@@ -81,6 +81,8 @@ export function SceneAppPageView({ page }: Props) {
     pageActions.push(<SceneDebugger scene={containerPage} key={'scene-debugger'} />);
   }
 
+  const background = page.state.background ?? appContext?.state.defaultPageBackground ?? 'primary';
+
   return (
     <PluginPage
       layout={layout}
@@ -88,6 +90,7 @@ export function SceneAppPageView({ page }: Props) {
       actions={pageActions}
       renderTitle={containerState.renderTitle}
       subTitle={containerState.subTitle}
+      background={background}
     >
       <scene.Component model={scene} />
     </PluginPage>

--- a/packages/scenes/src/components/SceneApp/types.ts
+++ b/packages/scenes/src/components/SceneApp/types.ts
@@ -15,6 +15,7 @@ export interface SceneAppState extends SceneObjectState {
   pages: SceneAppPageLike[];
   name?: string;
   urlSyncOptions?: SceneUrlSyncOptions;
+  defaultPageBackground?: 'primary' | 'canvas';
 }
 
 export interface SceneAppRoute {
@@ -71,6 +72,7 @@ export interface SceneAppPageState extends SceneObjectState {
   getFallbackPage?: () => SceneAppPageLike;
 
   layout?: PageLayoutType;
+  background?: 'primary' | 'canvas';
 }
 
 export interface SceneAppPageLike extends SceneObject<SceneAppPageState>, DataRequestEnricher {


### PR DESCRIPTION

Problem)

There has been a long-standing inconsistency in page designs / main background. Between pages that use the `canvas` background (Dashboard, Explore, Drilldown) and all other pages that use the `primary` background. 

Most or all of the scene apps on cloud (o11y, frontend o11y, kubernetes app, and others) use `primary` background but look very much like dashboards (but with tabs).  For more on this specific problem, [there is this doc I wrote a long time ago](https://docs.google.com/document/d/13CafKOo4y3icTmocU4H2-72Kl7ACm-pLeNtNjQ5l5hY/edit?tab=t.0#heading=h.hout21b7w2bg) 

I have tried many many times to solve this inconcisteny over past 3 years. 
* Switching to canvas as the default background for all pages (Works great in dark theme, but a gray surface does not look ideal in light theme).
* Switching to primary as the dashboard background (ie only borders as a separator around panels)
* Any many permutations of the above. 

But none of my attempts to solve it have looked great. Before summer I stumbled on this solution of embracing this inconsistency rather than trying to get rid of it. So this it was this PR proposes. 

This adds a new background option to SceneAppPage and SceneApp (can set a default for the whole app). OSS PR: 

<img width="1915" height="1515" alt="Screenshot 2025-09-16 at 13 13 28" src="https://github.com/user-attachments/assets/df61ac7b-7b56-41df-a20f-633d52d31bca" />
<img width="1914" height="1516" alt="Screenshot 2025-09-16 at 13 13 10" src="https://github.com/user-attachments/assets/23f7438d-46bc-494d-bd78-6bbb13efc790" />
<img width="1911" height="1514" alt="Screenshot 2025-09-16 at 13 14 04" src="https://github.com/user-attachments/assets/df2558a3-3a25-4967-8b91-d218b6d58bdf" />
<img width="1914" height="1511" alt="Screenshot 2025-09-16 at 13 13 47" src="https://github.com/user-attachments/assets/fc263119-029a-4758-8a66-6702cc7e4274" />

