### PR TITLE
SceneTimePicker: Pass move duration tooltip

### DIFF
--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import { useLocalStorage } from 'react-use';
 import { uniqBy } from 'lodash';
 
-import { TimeOption, TimeRange, isDateTime, rangeUtil, toUtc } from '@grafana/data';
+import {
+  TimeOption,
+  TimeRange,
+  intervalToAbbreviatedDurationString,
+  isDateTime,
+  rangeUtil,
+  toUtc,
+} from '@grafana/data';
 import { TimeRangePicker } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
@@ -73,6 +80,10 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
   }
 
   const rangesToUse = quickRanges || defaultQuickRanges;
+  const moveDuration = intervalToAbbreviatedDurationString({
+    start: timeRangeState.value.from.toDate(),
+    end: timeRangeState.value.to.toDate(),
+  });
 
   return (
     <TimeRangePicker
@@ -89,6 +100,7 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
       fiscalYearStartMonth={timeRangeState.fiscalYearStartMonth}
       onMoveBackward={model.onMoveBackward}
       onMoveForward={model.onMoveForward}
+      moveDuration={moveDuration}
       onZoom={model.onZoom}
       onChangeTimeZone={timeRange.onTimeZoneChange}
       onChangeFiscalYearStartMonth={model.onChangeFiscalYearStartMonth}

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -100,6 +100,7 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
       fiscalYearStartMonth={timeRangeState.fiscalYearStartMonth}
       onMoveBackward={model.onMoveBackward}
       onMoveForward={model.onMoveForward}
+      // @ts-expect-error (temporary till we update grafana/ui)
       moveDuration={moveDuration}
       onZoom={model.onZoom}
       onChangeTimeZone={timeRange.onTimeZoneChange}

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -117,7 +117,6 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
             })
           : undefined
       }
-      // @ts-expect-error (temporary till we update grafana/ui)
       moveBackwardTooltip={t(
         'grafana-scenes.components.time-picker.move-backward-tooltip',
         'Move {{moveBackwardDuration}} backward',

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -15,6 +15,7 @@ import { TimeRangePicker } from '@grafana/ui';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
 import { SceneComponentProps, SceneObjectState } from '../core/types';
+import { t } from '@grafana/i18n';
 
 export interface SceneTimePickerState extends SceneObjectState {
   hidePicker?: boolean;
@@ -109,9 +110,19 @@ function SceneTimePickerRenderer({ model }: SceneComponentProps<SceneTimePicker>
       onMoveBackward={model.onMoveBackward}
       onMoveForward={model.onMoveForward}
       // @ts-expect-error (temporary till we update grafana/ui)
-      moveForwardDuration={moveForwardDuration}
+      moveForwardTooltip={
+        moveForwardDuration
+          ? t('grafana-scenes.components.time-picker.move-forward-tooltip', 'Move {{moveForwardDuration}} forward', {
+              moveForwardDuration,
+            })
+          : undefined
+      }
       // @ts-expect-error (temporary till we update grafana/ui)
-      moveBackwardDuration={moveBackwardDuration}
+      moveBackwardTooltip={t(
+        'grafana-scenes.components.time-picker.move-backward-tooltip',
+        'Move {{moveBackwardDuration}} backward',
+        { moveBackwardDuration }
+      )}
       onZoom={model.onZoom}
       onChangeTimeZone={timeRange.onTimeZoneChange}
       onChangeFiscalYearStartMonth={model.onChangeFiscalYearStartMonth}

--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -40,6 +40,10 @@
       "splitter": {
         "aria-label-pane-resize-widget": "Pane resize widget"
       },
+      "time-picker": {
+        "move-backward-tooltip": "Move {{moveBackwardDuration}} backward",
+        "move-forward-tooltip": "Move {{moveForwardDuration}} forward"
+      },
       "viz-panel": {
         "title": {
           "title": "Title"


### PR DESCRIPTION
This PR extends the TimePicker and passes the move duration tooltip, so the component shows the panning interval.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.36.0--canary.1248.17797615374.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.36.0--canary.1248.17797615374.0
  npm install @grafana/scenes@6.36.0--canary.1248.17797615374.0
  # or 
  yarn add @grafana/scenes-react@6.36.0--canary.1248.17797615374.0
  yarn add @grafana/scenes@6.36.0--canary.1248.17797615374.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
