### PR TITLE
Variables: Remove the `showInControlsMenu?` prop

### DIFF
--- a/packages/scenes/src/variables/types.ts
+++ b/packages/scenes/src/variables/types.ts
@@ -14,7 +14,6 @@ export interface SceneVariableState extends SceneObjectState {
   loading?: boolean;
   error?: any | null;
   description?: string | null;
-  showInControlsMenu?: boolean;
 }
 
 export interface SceneVariable<TState extends SceneVariableState = SceneVariableState> extends SceneObject<TState> {


### PR DESCRIPTION
### What changed?
We have decided to use the `hide` property on variables for displaying them under the dashboard controls drop-down instead of the freshly introduced `showInControlsMenu?` property, mostly to make the UI for users simpler in the future. 
This PR is updating the `SceneVariableState` by removing the `showInControlsMenu` prop from the model.

Here is a relevant PR in core Grafana: https://github.com/grafana/grafana/pull/111245
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.36.0--canary.1249.17799138899.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.36.0--canary.1249.17799138899.0
  npm install @grafana/scenes@6.36.0--canary.1249.17799138899.0
  # or 
  yarn add @grafana/scenes-react@6.36.0--canary.1249.17799138899.0
  yarn add @grafana/scenes@6.36.0--canary.1249.17799138899.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
