### PR TITLE
VizPanel: Allow clearing default values

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -360,7 +360,7 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
     // onPanelTypeChanged is mainly used by plugins to migrate from Angular to React.
     // For example, this will migrate options from 'graph' to 'timeseries' if the previous and new plugin ID matches.
-    let updatedOptions = this._plugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
+    const updatedOptions = this._plugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
 
     if (updatedOptions && !isEmpty(updatedOptions)) {
       const { options } = getPanelOptionsWithDefaults({


### PR DESCRIPTION
https://github.com/grafana/grafana/issues/91600 

This PR allows clearing default values in panel options. Currently trying to remove a default value would result in no actual change.

A little explanation about the code:
- the logic to allow clearing out values was already there but it was overwritten by the merge with the `getPanelOptionsWithDefaults` function
- previously `onOptionsChange` was accepting `isAfterPluginChange` as a parameter
   - this parameter was not doing anything given that, in `getPanelOptionsWithDefaults` where it was used, it was not affecting `options` but `fieldConfig`. This was removed
   - the logic for this was moved to the actual plugin change logic
   - `getPanelOptionsWithDefaults` call was removed completely from `onOptionsChange`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.40.0--canary.1255.18001595104.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes-react@6.40.0--canary.1255.18001595104.0
  npm install @grafana/scenes@6.40.0--canary.1255.18001595104.0
  # or 
  yarn add @grafana/scenes-react@6.40.0--canary.1255.18001595104.0
  yarn add @grafana/scenes@6.40.0--canary.1255.18001595104.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
