### PR TITLE
Variables: Introduce a new type called "switch"

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -22,6 +22,7 @@ import {
   isConstantVariable,
   isIntervalVariable,
   isGroupByVariable,
+  isSwitchVariable,
 } from './variables/variants/guards';
 
 export * from './core/types';
@@ -165,6 +166,7 @@ export const sceneUtils = {
   isQueryVariable,
   isTextBoxVariable,
   isGroupByVariable,
+  isSwitchVariable,
   isRepeatCloneOrChildOf,
   buildPathIdFor,
 };

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -64,6 +64,7 @@ export { VariableValueControl } from './variables/components/VariableValueContro
 export { SceneVariableSet } from './variables/sets/SceneVariableSet';
 export { ConstantVariable } from './variables/variants/ConstantVariable';
 export { CustomVariable } from './variables/variants/CustomVariable';
+export { SwitchVariable } from './variables/variants/SwitchVariable';
 export { DataSourceVariable } from './variables/variants/DataSourceVariable';
 export { QueryVariable } from './variables/variants/query/QueryVariable';
 export { TestVariable } from './variables/variants/TestVariable';

--- a/packages/scenes/src/variables/variants/SwitchVariable.test.ts
+++ b/packages/scenes/src/variables/variants/SwitchVariable.test.ts
@@ -1,0 +1,213 @@
+import { lastValueFrom } from 'rxjs';
+
+import { SceneVariableValueChangedEvent } from '../types';
+import { SwitchVariable } from './SwitchVariable';
+
+describe('SwitchVariable', () => {
+  it('Should initialize with default values', () => {
+    const variable = new SwitchVariable({
+      name: 'test',
+    });
+
+    expect(variable.state.name).toBe('test');
+    expect(variable.state.type).toBe('switch');
+    expect(variable.state.value).toBe(false);
+  });
+
+  it('Should initialize with provided value', () => {
+    const variable = new SwitchVariable({
+      name: 'test',
+      value: true,
+    });
+
+    expect(variable.state.value).toBe(true);
+  });
+
+  it('Should initialize with other state properties', () => {
+    const variable = new SwitchVariable({
+      name: 'test',
+      value: true,
+      label: 'Test Switch',
+      description: 'A test switch variable',
+    });
+
+    expect(variable.state.name).toBe('test');
+    expect(variable.state.value).toBe(true);
+    expect(variable.state.label).toBe('Test Switch');
+    expect(variable.state.description).toBe('A test switch variable');
+  });
+
+  describe('getValue()', () => {
+    it('Should return boolean value when value is true', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: true,
+      });
+
+      expect(variable.getValue()).toBe(true);
+    });
+
+    it('Should return boolean value when value is false', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: false,
+      });
+
+      expect(variable.getValue()).toBe(false);
+    });
+
+    it('Should coerce truthy values to true', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        // @ts-expect-error - value is string
+        value: 'truthy',
+      });
+
+      expect(variable.getValue()).toBe(true);
+    });
+
+    it('Should coerce falsy values to false', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        // @ts-expect-error - value is string
+        value: '',
+      });
+
+      expect(variable.getValue()).toBe(false);
+    });
+  });
+
+  describe('setValue()', () => {
+    it('Should update value and publish change event', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: false,
+      });
+
+      let changeEvent: SceneVariableValueChangedEvent | undefined;
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, (evt) => (changeEvent = evt));
+
+      variable.setValue(true);
+
+      expect(variable.state.value).toBe(true);
+      expect(changeEvent).toBeDefined();
+      expect(changeEvent!.payload).toBe(variable);
+    });
+
+    it('Should not publish change event when value is the same', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: true,
+      });
+
+      let changeEvent: SceneVariableValueChangedEvent | undefined;
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, (evt) => (changeEvent = evt));
+
+      variable.setValue(true);
+
+      expect(variable.state.value).toBe(true);
+      expect(changeEvent).toBeUndefined();
+    });
+
+    it('Should coerce non-boolean values to boolean', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: false,
+      });
+
+      // @ts-expect-error - value is string
+      variable.setValue('truthy');
+      expect(variable.state.value).toBe(true);
+
+      // @ts-expect-error - value is number
+      variable.setValue(0);
+      expect(variable.state.value).toBe(false);
+
+      // @ts-expect-error - value is number
+      variable.setValue(1);
+      expect(variable.state.value).toBe(true);
+
+      // @ts-expect-error - value is null
+      variable.setValue(null);
+      expect(variable.state.value).toBe(false);
+
+      // @ts-expect-error - value is undefined
+      variable.setValue(undefined);
+      expect(variable.state.value).toBe(false);
+    });
+  });
+
+  describe('validateAndUpdate', () => {
+    it('Should publish change event when value has changed since last validation', async () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: false,
+      });
+
+      let changeEvent: SceneVariableValueChangedEvent | undefined;
+      variable.subscribeToEvent(SceneVariableValueChangedEvent, (evt) => (changeEvent = evt));
+
+      // First validation should trigger event
+      await lastValueFrom(variable.validateAndUpdate());
+      expect(changeEvent).toBeDefined();
+
+      // Reset event
+      changeEvent = undefined;
+
+      // Second validation without value change should not trigger event
+      await lastValueFrom(variable.validateAndUpdate());
+      expect(changeEvent).toBeUndefined();
+
+      // Change value and validate again should trigger event
+      variable.setState({ value: true });
+      await lastValueFrom(variable.validateAndUpdate());
+      expect(changeEvent).toBeDefined();
+    });
+
+    it('Should return empty result object', async () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: false,
+      });
+
+      const result = await lastValueFrom(variable.validateAndUpdate());
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('URL syncing', () => {
+    it('Should not have URL syncing capabilities by default', () => {
+      const variable = new SwitchVariable({
+        name: 'testSwitch',
+        value: true,
+      });
+
+      // SwitchVariable doesn't implement URL syncing like TextBoxVariable does
+      expect(variable.urlSync).toBeUndefined();
+      expect((variable as any).getUrlState).toBeUndefined();
+      expect((variable as any).updateFromUrl).toBeUndefined();
+    });
+  });
+
+  describe('Event publishing behavior', () => {
+    it('Should publish events with bubbling enabled', () => {
+      const variable = new SwitchVariable({
+        name: 'test',
+        value: false,
+      });
+
+      let eventBubbled = false;
+      const mockPublishEvent = jest.spyOn(variable, 'publishEvent').mockImplementation((event, bubble) => {
+        eventBubbled = bubble || false;
+        return variable;
+      });
+
+      variable.setValue(true);
+
+      expect(mockPublishEvent).toHaveBeenCalledWith(expect.any(SceneVariableValueChangedEvent), true);
+      expect(eventBubbled).toBe(true);
+
+      mockPublishEvent.mockRestore();
+    });
+  });
+});

--- a/packages/scenes/src/variables/variants/SwitchVariable.test.ts
+++ b/packages/scenes/src/variables/variants/SwitchVariable.test.ts
@@ -176,16 +176,68 @@ describe('SwitchVariable', () => {
   });
 
   describe('URL syncing', () => {
-    it('Should not have URL syncing capabilities by default', () => {
+    it('Should have URL syncing capabilities', () => {
       const variable = new SwitchVariable({
         name: 'testSwitch',
         value: true,
       });
 
-      // SwitchVariable doesn't implement URL syncing like TextBoxVariable does
-      expect(variable.urlSync).toBeUndefined();
-      expect((variable as any).getUrlState).toBeUndefined();
-      expect((variable as any).updateFromUrl).toBeUndefined();
+      // SwitchVariable now implements URL syncing
+      expect(variable.urlSync).toBeDefined();
+      expect(variable.getUrlState).toBeDefined();
+      expect(variable.updateFromUrl).toBeDefined();
+      expect(variable.getKeys).toBeDefined();
+    });
+
+    it('Should return correct URL state', () => {
+      const variable = new SwitchVariable({
+        name: 'testSwitch',
+        value: true,
+      });
+
+      const urlState = variable.getUrlState();
+      expect(urlState).toEqual({ 'var-testSwitch': 'true' });
+
+      variable.setValue(false);
+      const urlStateFalse = variable.getUrlState();
+      expect(urlStateFalse).toEqual({ 'var-testSwitch': 'false' });
+    });
+
+    it('Should update from URL state', () => {
+      const variable = new SwitchVariable({
+        name: 'testSwitch',
+        value: false,
+      });
+
+      variable.updateFromUrl({ 'var-testSwitch': 'true' });
+      expect(variable.getValue()).toBe(true);
+
+      variable.updateFromUrl({ 'var-testSwitch': 'false' });
+      expect(variable.getValue()).toBe(false);
+
+      // Any string other than 'true' should be false
+      variable.updateFromUrl({ 'var-testSwitch': 'anything' });
+      expect(variable.getValue()).toBe(false);
+    });
+
+    it('Should return correct keys for URL sync', () => {
+      const variable = new SwitchVariable({
+        name: 'testSwitch',
+        value: true,
+      });
+
+      expect(variable.getKeys()).toEqual(['var-testSwitch']);
+    });
+
+    it('Should skip URL sync when skipUrlSync is true', () => {
+      const variable = new SwitchVariable({
+        name: 'testSwitch',
+        value: true,
+        skipUrlSync: true,
+      });
+
+      expect(variable.getKeys()).toEqual([]);
+      expect(variable.getUrlState()).toEqual({});
     });
   });
 

--- a/packages/scenes/src/variables/variants/SwitchVariable.tsx
+++ b/packages/scenes/src/variables/variants/SwitchVariable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Observable, of } from 'rxjs';
-import { Switch } from '@grafana/ui';
+import { Switch, useTheme2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import {
@@ -65,14 +66,27 @@ export class SwitchVariable extends SceneObjectBase<SwitchVariableState> impleme
 
 function SwitchVariableRenderer({ model }: SceneComponentProps<SwitchVariable>) {
   const state = model.useState();
+  const theme = useTheme2();
+
+  const containerStyle = css({
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0, 1),
+    height: theme.spacing(theme.components.height.md),
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.components.input.borderColor}`,
+    background: theme.colors.background.primary,
+  });
 
   return (
-    <Switch
-      disabled={false}
-      value={state.value}
-      onChange={(event) => {
-        model.setValue(event!.currentTarget.checked);
-      }}
-    />
+    <div className={containerStyle}>
+      <Switch
+        disabled={false}
+        value={state.value}
+        onChange={(event) => {
+          model.setValue(event!.currentTarget.checked);
+        }}
+      />
+    </div>
   );
 }

--- a/packages/scenes/src/variables/variants/SwitchVariable.tsx
+++ b/packages/scenes/src/variables/variants/SwitchVariable.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Observable, of } from 'rxjs';
+import { Switch } from '@grafana/ui';
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { VariableDependencyConfig } from '../VariableDependencyConfig';
+import {
+  SceneVariable,
+  SceneVariableState,
+  SceneVariableValueChangedEvent,
+  ValidateAndUpdateResult,
+  VariableValue,
+} from '../types';
+import { SceneComponentProps } from '../../core/types';
+
+export interface SwitchVariableState extends SceneVariableState {
+  value: boolean;
+}
+
+export class SwitchVariable extends SceneObjectBase<SwitchVariableState> implements SceneVariable<SwitchVariableState> {
+  public static Component = SwitchVariableRenderer;
+
+  protected _variableDependency = new VariableDependencyConfig(this, {
+    statePaths: ['value'],
+  });
+
+  private _prevValue: VariableValue = '';
+
+  public constructor(initialState: Partial<SwitchVariableState>) {
+    super({
+      type: 'switch',
+      value: false,
+      name: '',
+      ...initialState,
+    });
+  }
+
+  /**
+   * This function is called on when SceneVariableSet is activated or when a dependency changes.
+   */
+  public validateAndUpdate(): Observable<ValidateAndUpdateResult> {
+    const newValue = this.getValue();
+
+    if (this._prevValue !== newValue) {
+      this._prevValue = newValue;
+      this.publishEvent(new SceneVariableValueChangedEvent(this), true);
+    }
+
+    return of({});
+  }
+
+  public setValue(newValue: boolean): void {
+    // Ignore if there's no change
+    if (this.getValue() === newValue) {
+      return;
+    }
+
+    this.setState({ value: Boolean(newValue) });
+    this.publishEvent(new SceneVariableValueChangedEvent(this), true);
+  }
+
+  public getValue(): VariableValue {
+    return Boolean(this.state.value);
+  }
+}
+
+function SwitchVariableRenderer({ model }: SceneComponentProps<SwitchVariable>) {
+  const state = model.useState();
+
+  return (
+    <Switch
+      disabled={false}
+      value={state.value}
+      onChange={(event) => {
+        model.setValue(event!.currentTarget.checked);
+      }}
+    />
+  );
+}

--- a/packages/scenes/src/variables/variants/guards.ts
+++ b/packages/scenes/src/variables/variants/guards.ts
@@ -7,6 +7,7 @@ import { IntervalVariable } from './IntervalVariable';
 import { TextBoxVariable } from './TextBoxVariable';
 import { QueryVariable } from './query/QueryVariable';
 import { GroupByVariable } from '../groupby/GroupByVariable';
+import { SwitchVariable } from './SwitchVariable';
 
 export function isAdHocVariable(variable: SceneVariable): variable is AdHocFiltersVariable {
   return variable.state.type === 'adhoc';
@@ -38,4 +39,8 @@ export function isTextBoxVariable(variable: SceneVariable): variable is TextBoxV
 
 export function isGroupByVariable(variable: SceneVariable): variable is GroupByVariable {
   return variable.state.type === 'groupby';
+}
+
+export function isSwitchVariable(variable: SceneVariable): variable is SwitchVariable {
+  return variable.state.type === 'switch';
 }


### PR DESCRIPTION
### What changed?
This PR is the scenes counterpart of the https://github.com/grafana/grafana/pull/111366 core Grafana PR, that introduces a new variable for boolean values, and renders them a switch.


https://github.com/user-attachments/assets/f5251ffe-927b-4b5b-b27a-4890789c8d85

