### PR TITLE
AdHocFilters: Maintain saved hidden property on url sync update

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -623,6 +623,20 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(locationService.getLocation().search).toBe('?var-filters=key2%7C%3D%7Cval2');
   });
 
+  it('properly hides filter on url sync', async () => {
+    // filter is hidden on dashboard
+    const { filtersVar } = setup({
+      filters: [{ key: 'key1', keyLabel: 'key1', operator: '=', value: 'val1', hidden: true }],
+    });
+
+    // and should be maintained on url sync
+    act(() => {
+      locationService.partial({ 'var-filters': ['key1|=|valUrl'] });
+    });
+
+    expect(filtersVar.state.filters.length).toEqual(1);
+  });
+
   it('overrides state when url has empty key', () => {
     const { filtersVar } = setup();
 


### PR DESCRIPTION
Setting a filter as hidden and then navigating to that dashboard through a URL that contains a filter with the same key would overwrite the dashboard hidden setting and show again this filter. Not having it at all in the URL work properly.
This feels a bit confusing and this PR would fix that, but at the same time I am not sure as the URL works as the source of truth afaik, so having the filter in the URL should overwrite the hidden setting