### PR TITLE
Added timezone support to the FormatVariable interface and Date formatter

### DIFF
--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -1,7 +1,8 @@
 import { t } from '@grafana/i18n';
 import { isArray, map, replace } from 'lodash';
 
-import { dateTime, Registry, RegistryItem, textUtil, escapeRegex, urlUtil } from '@grafana/data';
+import { dateTime, dateTimeForTimeZone, Registry, RegistryItem, textUtil, escapeRegex, urlUtil } from '@grafana/data';
+import { TimeZone } from '@grafana/schema';
 import { VariableType, VariableFormatID } from '@grafana/schema';
 
 import { VariableValue, VariableValueSingle } from '../types';
@@ -27,6 +28,7 @@ export interface FormatVariable {
 
   getValue(fieldPath?: string): VariableValue | undefined | null;
   getValueText?(fieldPath?: string): string;
+  getTimeZone?(): TimeZone;
   urlSync?: SceneObjectUrlSyncHandler;
 }
 
@@ -267,7 +269,7 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
         'grafana-scenes.variables.format-registry.formats.description.format-date-in-different-ways',
         'Format date in different ways'
       ),
-      formatter: (value, args) => {
+      formatter: (value, args, variable) => {
         let nrValue = NaN;
 
         if (typeof value === 'number') {
@@ -281,18 +283,21 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
         }
 
         const arg = args[0] ?? 'iso';
+        const timeZone = variable.getTimeZone?.();
+
         switch (arg) {
           case 'ms':
             return String(value);
           case 'seconds':
             return `${Math.round(nrValue! / 1000)}`;
           case 'iso':
-            return dateTime(nrValue).toISOString();
+            return timeZone ? dateTimeForTimeZone(timeZone, nrValue).toISOString() : dateTime(nrValue).toISOString();
           default:
+            const dateTimeObj = timeZone ? dateTimeForTimeZone(timeZone, nrValue) : dateTime(nrValue);
             if ((args || []).length > 1) {
-              return dateTime(nrValue).format(args.join(':'));
+              return dateTimeObj.format(args.join(':'));
             }
-            return dateTime(nrValue).format(arg);
+            return dateTimeObj.format(arg);
         }
       },
     },

--- a/packages/scenes/src/variables/macros/timeMacros.ts
+++ b/packages/scenes/src/variables/macros/timeMacros.ts
@@ -60,6 +60,11 @@ export class TimeFromAndToMacro implements FormatVariable {
       return dateTimeFormat(timeRange.state.value.to, { timeZone: timeRange.getTimeZone() });
     }
   }
+
+  public getTimeZone() {
+    const timeRange = getTimeRange(this._sceneObject);
+    return timeRange.getTimeZone();
+  }
 }
 
 /**


### PR DESCRIPTION
**The Problem**

https://github.com/grafana/grafana/issues/106452

When using `${__to:date:M}` or similar date formatting on __from/__to, the value was evaluated in the client's local timezone instead of respecting the dashboard's configured timezone (e.g., UTC). This breaks Prometheus queries like `month() == bool vector(${__to:date:M})` across different timezones.

**The Fix**
Made changes to 3 files:

1. formatRegistry.ts - Added timezone support to the interface and formatter
* Added getTimeZone?(): TimeZone method to the FormatVariable interface
* Imported dateTimeForTimeZone from @grafana/data
* Updated the Date formatter to use dateTimeForTimeZone(timeZone, nrValue) when a timezone is available
* Falls back to the old behavior (dateTime(nrValue)) when no timezone is provided

2. timeMacros.ts - Implemented timezone retrieval for time macros
* Added getTimeZone() method to TimeFromAndToMacro class
* This method retrieves the timezone from the scene's time range using getTimeRange(this._sceneObject).getTimeZone()

3. timeMacros.test.ts - Added tests
* Test 1: Verifies UTC timezone is respected
* Test 2: Verifies custom timezones (America/New_York) are respected
* Test 3: Verifies the specific bug case - cross-timezone month boundaries (March 31st 23:00 UTC appears as April 1st in Stockholm UTC+2)
