### PR TITLE
CustomVariable: Expose query parsing mechanism

### DIFF
--- a/packages/scenes/src/variables/variants/CustomVariable.test.ts
+++ b/packages/scenes/src/variables/variants/CustomVariable.test.ts
@@ -299,7 +299,7 @@ label-3 : value-3,`,
       const scene = new TestScene({ $variables: new SceneVariableSet({ variables: [A, B] }) });
       scene.activate();
 
-      expect(B.transformQueryToOptions()).toEqual([
+      expect(B.transformCsvStringToOptions(B.state.query)).toEqual([
         { label: '1', value: '1' },
         { label: '2', value: '2' },
         { label: 'value1', value: 'value1' },
@@ -325,7 +325,7 @@ label-3 : value-3,`,
       const scene = new TestScene({ $variables: new SceneVariableSet({ variables: [A, B] }) });
       scene.activate();
 
-      expect(B.transformQueryToOptions(false)).toEqual([
+      expect(B.transformCsvStringToOptions(B.state.query, false)).toEqual([
         { label: '1', value: '1' },
         { label: '2', value: '2' },
         { label: '$A', value: '$A' },

--- a/packages/scenes/src/variables/variants/CustomVariable.tsx
+++ b/packages/scenes/src/variables/variants/CustomVariable.tsx
@@ -32,9 +32,9 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
 
   // We expose this publicly as we also need it outside the variable
   // The interpolate flag is needed since we don't always want to get the interpolated options
-  public transformQueryToOptions(interpolate = true): VariableValueOption[] {
-    const query = interpolate ? sceneGraph.interpolate(this, this.state.query) : this.state.query;
-    const match = query.match(/(?:\\,|[^,])+/g) ?? [];
+  public transformCsvStringToOptions(str: string, interpolate = true): VariableValueOption[] {
+    str = interpolate ? sceneGraph.interpolate(this, str) : str;
+    const match = str.match(/(?:\\,|[^,])+/g) ?? [];
 
     return match.map((text) => {
       text = text.replace(/\\,/g, ',');
@@ -49,7 +49,7 @@ export class CustomVariable extends MultiValueVariable<CustomVariableState> {
   }
 
   public getValueOptions(args: VariableGetOptionsArgs): Observable<VariableValueOption[]> {
-    const options = this.transformQueryToOptions();
+    const options = this.transformCsvStringToOptions(this.state.query);
 
     if (!options.length) {
       this.skipNextValidation = true;


### PR DESCRIPTION
Expose the method that parses the query in Custom Variable. This is needed to be prevent code duplication in https://github.com/grafana/grafana/pull/110831
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.39.4--canary.1269.18370736450.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.39.4--canary.1269.18370736450.0
  npm install @grafana/scenes-react@6.39.4--canary.1269.18370736450.0
  # or 
  yarn add @grafana/scenes@6.39.4--canary.1269.18370736450.0
  yarn add @grafana/scenes-react@6.39.4--canary.1269.18370736450.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
