### PR TITLE
Fix rounding on old-style adhoc filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFilterBuilder.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterBuilder.tsx
@@ -41,5 +41,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
       borderBottomLeftRadius: 0,
       borderTopLeftRadius: 0,
     },
-  })
-})
+  }),
+});

--- a/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFilterRenderer.tsx
@@ -297,7 +297,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
       '> :first-child': {
         borderBottomLeftRadius: 0,
         borderTopLeftRadius: 0,
-      }
+      },
     },
     '> *': {
       '&:not(:first-child)': {


### PR DESCRIPTION
some slack context here: https://raintank-corp.slack.com/archives/C025WTVRBSN/p1760024648955739

| before | after |
| --- | --- |
| <img width="515" height="55" alt="image" src="https://github.com/user-attachments/assets/89a39e64-e344-4433-b868-8ebb6cdb201f" /> | <img width="515" height="61" alt="image" src="https://github.com/user-attachments/assets/efb8b026-199d-4bfb-951c-d0afbe74ac7c" /> |
| <img width="100" height="59" alt="image" src="https://github.com/user-attachments/assets/18937e05-5d9b-4d8c-8533-387dc53a31bc" /> | <img width="101" height="56" alt="image" src="https://github.com/user-attachments/assets/5126aeb2-977b-45de-9ffe-9f4324795940" /> |
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.39.4--canary.1271.18383171846.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.39.4--canary.1271.18383171846.0
  npm install @grafana/scenes-react@6.39.4--canary.1271.18383171846.0
  # or 
  yarn add @grafana/scenes@6.39.4--canary.1271.18383171846.0
  yarn add @grafana/scenes-react@6.39.4--canary.1271.18383171846.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
