### PR TITLE
SceneGridLayout: Preserve float gridPos values

### DIFF
--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.test.tsx
@@ -6,6 +6,7 @@ import { SceneComponentProps, SceneObjectState } from '../../../core/types';
 import { EmbeddedScene } from '../../EmbeddedScene';
 import { SceneGridItem } from './SceneGridItem';
 
+import { DEFAULT_PANEL_SPAN } from './constants';
 import { SceneGridLayout } from './SceneGridLayout';
 import { SceneGridRow } from './SceneGridRow';
 import * as utils from './utils';
@@ -1111,8 +1112,8 @@ describe('SceneGridLayout', () => {
         children: [
           new SceneGridItem({
             key: 'invalid',
-            x: undefined,
-            y: undefined,
+            x: NaN,
+            y: Infinity,
             width: NaN,
             height: Infinity,
             isDraggable: false,
@@ -1127,8 +1128,8 @@ describe('SceneGridLayout', () => {
 
       expect(gridLayout[0].x).toBe(0);
       expect(gridLayout[0].y).toBe(0);
-      expect(gridLayout[0].w).toBe(4); // DEFAULT_PANEL_SPAN
-      expect(gridLayout[0].h).toBe(4); // DEFAULT_PANEL_SPAN
+      expect(gridLayout[0].w).toBe(DEFAULT_PANEL_SPAN);
+      expect(gridLayout[0].h).toBe(DEFAULT_PANEL_SPAN);
     });
   });
 });

--- a/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
+++ b/packages/scenes/src/components/layout/grid/SceneGridLayout.tsx
@@ -368,8 +368,8 @@ export class SceneGridLayout extends SceneObjectBase<SceneGridLayoutState> imple
   private toGridCell(child: SceneGridItemLike): ReactGridLayout.Layout {
     const size = child.state;
 
-    let x = size.x ?? 0;
-    let y = size.y ?? 0;
+    let x = Number.isFinite(Number(size.x)) ? Number(size.x) : 0;
+    let y = Number.isFinite(Number(size.y)) ? Number(size.y) : 0;
     const w = Number.isFinite(Number(size.width)) ? Number(size.width) : DEFAULT_PANEL_SPAN;
     const h = Number.isFinite(Number(size.height)) ? Number(size.height) : DEFAULT_PANEL_SPAN;
 


### PR DESCRIPTION
## What this PR does

Fixes handling of float `gridPos` values in SceneGridLayout to support legacy dashboards.

### Changes:
- Changed `toGridCell` to preserve float values for `x`, `y`, `width`, and `height`
- Only defaults to `DEFAULT_PANEL_SPAN` when values are non-finite (NaN, Infinity)
- Added tests to prevent regression

### Why:
Some legacy dashboards have float `gridPos` values (e.g., from panel repeats: `24 / 5 = 4.8`). Previously, non-integer values were replaced with `DEFAULT_PANEL_SPAN` (4), breaking panel layouts. Now floats are preserved and handled by react-grid-layout, matching the old architecture's behavior.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.39.7--canary.1275.18536941655.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.39.7--canary.1275.18536941655.0
  npm install @grafana/scenes-react@6.39.7--canary.1275.18536941655.0
  # or 
  yarn add @grafana/scenes@6.39.7--canary.1275.18536941655.0
  yarn add @grafana/scenes-react@6.39.7--canary.1275.18536941655.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
