### PR TITLE
SeneRenderProfiler: Remove tab inactive frame detection backup mechanism

### DIFF
--- a/packages/scenes/src/behaviors/SceneRenderProfiler.test.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.test.ts
@@ -393,22 +393,6 @@ describe('SceneRenderProfiler integration tests', () => {
       // The first profile should not complete because it was cancelled
       expect(onProfileComplete).not.toHaveBeenCalled();
     });
-
-    it('should handle tab inactive detection during tail recording', () => {
-      setupProfileTest('tab-inactive-test');
-
-      // Execute first frame, then simulate tab inactive
-      mockTime += 16;
-      const firstCallback = Object.values(frameCallbacks).filter(Boolean)[0];
-      frameCallbacks = [];
-      firstCallback(mockTime);
-      expect(profiler.isTailRecording()).toBe(true);
-
-      mockTime += 1500; // > TAB_INACTIVE_THRESHOLD
-      const secondCallback = Object.values(frameCallbacks).filter(Boolean)[0];
-      secondCallback(mockTime);
-      expect(profiler.isTailRecording()).toBe(false);
-    });
   });
 
   describe('Slow frame recording integration', () => {

--- a/packages/scenes/src/behaviors/SceneRenderProfiler.ts
+++ b/packages/scenes/src/behaviors/SceneRenderProfiler.ts
@@ -4,7 +4,6 @@ import { LongFrameDetector } from './LongFrameDetector';
 
 const POST_STORM_WINDOW = 2000; // Time after last query to observe slow frames
 const DEFAULT_LONG_FRAME_THRESHOLD = 30; // Threshold for tail recording slow frames
-const TAB_INACTIVE_THRESHOLD = 1000; // Tab inactive threshold in ms
 
 /**
  * SceneRenderProfiler tracks dashboard interaction performance including:
@@ -236,14 +235,6 @@ export class SceneRenderProfiler {
   private measureTrailingFrames = (measurementStartTs: number, lastFrameTime: number, profileStartTs: number) => {
     const currentFrameTime = performance.now();
     const frameLength = currentFrameTime - lastFrameTime;
-
-    // Fallback: Detect if tab was inactive (frame longer than reasonable threshold)
-    // This serves as backup to Page Visibility API in case the event wasn't triggered
-    if (frameLength > TAB_INACTIVE_THRESHOLD) {
-      writeSceneLog('SceneRenderProfiler', 'Tab was inactive, cancelling profile measurement');
-      this.cancelProfile();
-      return;
-    }
 
     this.#recordedTrailingSpans.push(frameLength);
 


### PR DESCRIPTION
## Remove unreliable tab inactive detection backup

### Problem

The 1-second TAB_INACTIVE_THRESHOLD backup mechanism in SceneRenderProfiler could cause false profile cancellations when legitimate frames take longer than 1 second to process.

### Solution

Removed the backup mechanism entirely, relying solely on the Page Visibility API for tab inactivity detection. This eliminates false positives while maintaining proper cancellation for actual tab switches.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.39.7--canary.1276.18534228532.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.39.7--canary.1276.18534228532.0
  npm install @grafana/scenes-react@6.39.7--canary.1276.18534228532.0
  # or 
  yarn add @grafana/scenes@6.39.7--canary.1276.18534228532.0
  yarn add @grafana/scenes-react@6.39.7--canary.1276.18534228532.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
