### PR TITLE
Switch Variable: Add an id for the input

### DIFF
--- a/packages/scenes/src/variables/variants/SwitchVariable.tsx
+++ b/packages/scenes/src/variables/variants/SwitchVariable.tsx
@@ -117,6 +117,7 @@ function SwitchVariableRenderer({ model }: SceneComponentProps<SwitchVariable>) 
   return (
     <div className={styles.container}>
       <Switch
+        id={`var-${state.key}`}
         value={state.value === state.enabledValue}
         onChange={(event) => {
           model.setValue(event!.currentTarget.checked ? state.enabledValue : state.disabledValue);


### PR DESCRIPTION
### What changed?

Added an `id` for the Switch input to make it possible to link it with the label on the callsite (e.g. in core Grafana).

https://github.com/user-attachments/assets/87731e6e-57c6-4ca9-9909-1b8fd39a088f


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.42.3--canary.1295.19058579723.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.42.3--canary.1295.19058579723.0
  npm install @grafana/scenes-react@6.42.3--canary.1295.19058579723.0
  # or 
  yarn add @grafana/scenes@6.42.3--canary.1295.19058579723.0
  yarn add @grafana/scenes-react@6.42.3--canary.1295.19058579723.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
