### PR TITLE
Demos: Update panel with header actions demo

### DIFF
--- a/packages/scenes-app/src/demos/panelHeaderActions.tsx
+++ b/packages/scenes-app/src/demos/panelHeaderActions.tsx
@@ -3,9 +3,9 @@ import {
   PanelBuilders,
   SceneAppPage,
   SceneAppPageState,
-  SceneCSSGridItem,
   SceneCSSGridLayout,
   VizPanelExploreButton,
+  VizPanelMenu,
 } from '@grafana/scenes';
 import { getEmbeddedSceneDefaults, getQueryRunnerWithRandomWalkQuery } from './utils';
 import { Button, Select } from '@grafana/ui';
@@ -22,44 +22,38 @@ export function getPanelHeaderActions(defaults: SceneAppPageState) {
           templateColumns: 'repeat(auto-fit, minmax(400px, 1fr))',
           autoRows: '320px',
           children: [
-            new SceneCSSGridItem({
-              body: PanelBuilders.timeseries()
-                .setTitle('Panel with sm button')
-                .setData(getQueryRunnerWithRandomWalkQuery())
-                .setHeaderActions(
-                  <Button size="sm" variant="secondary">
-                    Does nothing
-                  </Button>
-                )
-                .build(),
-            }),
-            new SceneCSSGridItem({
-              body: PanelBuilders.timeseries()
-                .setTitle('Panel with md button')
-                .setData(getQueryRunnerWithRandomWalkQuery())
-                .setHeaderActions(
-                  <Button size="md" variant="secondary">
-                    Does nothing
-                  </Button>
-                )
-                .build(),
-            }),
-            new SceneCSSGridItem({
-              body: PanelBuilders.timeseries()
-                .setTitle('Panel with select')
-                .setData(getQueryRunnerWithRandomWalkQuery())
-                .setHeaderActions(
-                  <Select options={[{ label: 'Option 1', value: '1' }]} onChange={() => {}} value="1" />
-                )
-                .build(),
-            }),
-            new SceneCSSGridItem({
-              body: PanelBuilders.timeseries()
-                .setTitle('Panel with explore button')
-                .setData(getQueryRunnerWithRandomWalkQuery())
-                .setHeaderActions(new VizPanelExploreButton())
-                .build(),
-            }),
+            PanelBuilders.timeseries()
+              .setTitle('Panel with explore button')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHeaderActions(new VizPanelExploreButton())
+              .build(),
+            PanelBuilders.timeseries()
+              .setTitle('Panel sm button and menu')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHeaderActions(new VizPanelExploreButton())
+              .setMenu(new VizPanelMenu({ items: [{ text: 'Option 1' }] }))
+              .build(),
+            PanelBuilders.timeseries()
+              .setTitle('Panel sm button and menu always show menu')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHeaderActions(new VizPanelExploreButton())
+              .setMenu(new VizPanelMenu({ items: [{ text: 'Option 1' }] }))
+              .setShowMenuAlways(true)
+              .build(),
+            PanelBuilders.timeseries()
+              .setTitle('Panel with md button')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHeaderActions(
+                <Button size="md" variant="secondary">
+                  Does nothing
+                </Button>
+              )
+              .build(),
+            PanelBuilders.timeseries()
+              .setTitle('Panel with select')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHeaderActions(<Select options={[{ label: 'Option 1', value: '1' }]} onChange={() => {}} value="1" />)
+              .build(),
           ],
         }),
       });


### PR DESCRIPTION
Updates the demo with panel header actions to also include options with button + menu 


<img width="1258" height="1255" alt="Screenshot 2025-11-12 at 08 50 29" src="https://github.com/user-attachments/assets/0c32e3dd-59a4-45c6-987c-c2b2f3356cdb" />
