### PR TITLE
MultiValueVariable: Fixes urlSync issues that caused wrong interpolation in queries

### DIFF
--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -578,6 +578,18 @@ describe('MultiValueVariable', () => {
       expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: ['A'] });
     });
 
+    it('getUrlState should not return array if var is not multi and value is single element array', async () => {
+      const variable = new TestVariable({
+        name: 'test',
+        options: [],
+        value: ['A'],
+        optionsToReturn: [],
+        delayMs: 0,
+      });
+
+      expect(variable.urlSync?.getUrlState()).toEqual({ ['var-test']: 'A' });
+    });
+
     it('updateFromUrl should update value for single value', async () => {
       const variable = new TestVariable({
         name: 'test',

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -433,7 +433,7 @@ export class MultiValueUrlSyncHandler<TState extends MultiValueVariableState = M
     let urlValue: string | string[] | null = null;
     let value = this._sceneObject.state.value;
 
-    if (Array.isArray(value)) {
+    if (Array.isArray(value) && value.length > 1) {
       urlValue = value.map(String);
     } else if ((this, this._sceneObject.state.isMulti)) {
       // If we are inMulti mode we must return an array here as otherwise UrlSyncManager will not pass all values (in an array) in updateFromUrl


### PR DESCRIPTION
Fixes an issue that requires a chain of events for it to happen. Some datasources do different interpolation between vars that are single or multi value -- e.g.: sql datasources will interpolate a single value as just `value` while a multi value gets interpolated as `'value1,value2'` or, if it's a multi var with a single value, still `'value'`.

This causes an issue in dashboards where if you have some multi value variable, and save that dashboard, then it saves it as an array, let's also assume we have just one value selection in the multi-value variable, so the json model will contain a value of `['some_value']`.

Then, if we change that variable to be a single value variable then everything looks all right in the UI, but if we don't save the dashboard and update the default values we will continue having an array value even though the variable is no longer `isMulti`.

This will work fine as long as we do not overwrite the variable value using the urlSync. Scenes will know to pick the correct string value and try to use that in the variable.

But only in the scenario where we overwrite the url value, due to `skipNextValidation` flag being set true from the urlSync, in `interceptStateUpdateAfterValidation` the value will be set back to an array, which will then cause problems.

This PR fixes the issue from the url sync, so that the single value variable with array value stored in the JSON model can continue working in all scenarios.

https://github.com/user-attachments/assets/e147ba94-7e65-420c-8b9f-b5625bffcc5a



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.46.1--canary.1300.19300363353.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.46.1--canary.1300.19300363353.0
  npm install @grafana/scenes-react@6.46.1--canary.1300.19300363353.0
  # or 
  yarn add @grafana/scenes@6.46.1--canary.1300.19300363353.0
  yarn add @grafana/scenes-react@6.46.1--canary.1300.19300363353.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
