### PR TITLE
VizPanel: Do not pass empty array to titleItems

### DIFF
--- a/packages/scenes-app/src/demos/panelHeaderActions.tsx
+++ b/packages/scenes-app/src/demos/panelHeaderActions.tsx
@@ -54,6 +54,18 @@ export function getPanelHeaderActions(defaults: SceneAppPageState) {
               .setData(getQueryRunnerWithRandomWalkQuery())
               .setHeaderActions(<Select options={[{ label: 'Option 1', value: '1' }]} onChange={() => {}} value="1" />)
               .build(),
+            PanelBuilders.timeseries()
+              .setTitle('Hover header')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHeaderActions(new VizPanelExploreButton())
+              .setMenu(new VizPanelMenu({ items: [{ text: 'Option 1' }] }))
+              .setHoverHeader(true)
+              .build(),
+            PanelBuilders.timeseries()
+              .setTitle('')
+              .setData(getQueryRunnerWithRandomWalkQuery())
+              .setHoverHeader(true)
+              .build(),
           ],
         }),
       });

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -244,7 +244,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             height={height}
             selectionId={model.state.key}
             displayMode={displayMode}
-            titleItems={titleItemsElement}
+            titleItems={titleItemsElement.length > 0 ? titleItemsElement : undefined}
             dragClass={dragClass}
             actions={actionsElement}
             dragClassCancel={dragClassCancel}


### PR DESCRIPTION
Trying to fix an issue with VizPanel and no title and hoverHeader (it was showing a 1-2 pixel empty hover header). 

There is an OSS PR as well that will need this change 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.47.0--canary.1302.19359467581.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@6.47.0--canary.1302.19359467581.0
  npm install @grafana/scenes-react@6.47.0--canary.1302.19359467581.0
  # or 
  yarn add @grafana/scenes@6.47.0--canary.1302.19359467581.0
  yarn add @grafana/scenes-react@6.47.0--canary.1302.19359467581.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
