### PR TITLE
fix: remove hardcoded values in sortVariableValues

### DIFF
--- a/packages/scenes/src/variables/variants/query/utils.ts
+++ b/packages/scenes/src/variables/variants/query/utils.ts
@@ -104,11 +104,11 @@ export const sortVariableValues = (options: VariableValueOption[], sortOrder: Va
       });
       options = options.reverse();
       break;
-    case VariableSort.naturalAsc || 7:
+    case VariableSort.naturalAsc:
       // Sort by natural sort
       options = sortByNaturalSort(options);
       break;
-    case VariableSort.naturalDesc || 8:
+    case VariableSort.naturalDesc:
       options = sortByNaturalSort(options);
       options = options.reverse();
       break;


### PR DESCRIPTION
The minimum required grafana/data version now includes these enum values.
Safe to delete the defaults 

