### PR TITLE
SceneQueryController: Do not mark query as complete on PartialResult state

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.test.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.test.ts
@@ -59,6 +59,41 @@ describe('SceneQueryController', () => {
     expect((window as any).__grafanaRunningQueryCount).toBe(0);
   });
 
+  it('should NOT mark query as complete on PartialResult, only on Done', async () => {
+    const { query, streamFuncs } = registerQuery(scene);
+    let next = jest.fn();
+
+    query.subscribe({ next });
+
+    expect((window as any).__grafanaRunningQueryCount).toBe(1);
+    expect(controller.state.isRunning).toBe(true);
+
+    // PartialResult emissions should not complete the query
+    streamFuncs.next({ state: LoadingState.PartialResult });
+    expect((window as any).__grafanaRunningQueryCount).toBe(1);
+    expect(controller.state.isRunning).toBe(true);
+
+    streamFuncs.next({ state: LoadingState.PartialResult });
+    expect((window as any).__grafanaRunningQueryCount).toBe(1);
+    expect(controller.state.isRunning).toBe(true);
+
+    // Final Done should complete it
+    streamFuncs.next({ state: LoadingState.Done });
+    expect((window as any).__grafanaRunningQueryCount).toBe(0);
+    expect(controller.state.isRunning).toBe(false);
+  });
+
+  it('should still mark query as complete on Streaming state', async () => {
+    const { query, streamFuncs } = registerQuery(scene);
+
+    query.subscribe(() => {});
+
+    expect(controller.state.isRunning).toBe(true);
+
+    streamFuncs.next({ state: LoadingState.Streaming });
+    expect(controller.state.isRunning).toBe(false);
+  });
+
   it('Last unsubscribe should set running to false', async () => {
     const { query: query1 } = registerQuery(scene);
 

--- a/packages/scenes/src/querying/registerQueryWithController.ts
+++ b/packages/scenes/src/querying/registerQueryWithController.ts
@@ -69,7 +69,7 @@ export function registerQueryWithController<T extends QueryResultWithState>(
 
       const sub = queryStream.subscribe({
         next: (v) => {
-          if (!markedAsCompleted && v.state !== LoadingState.Loading) {
+          if (!markedAsCompleted && v.state !== LoadingState.Loading && v.state !== LoadingState.PartialResult) {
             markedAsCompleted = true;
             queryControler.queryCompleted(entry);
             endQueryCallback?.(performance.now()); // Success case - no error


### PR DESCRIPTION
## Summary

- `registerQueryWithController` now skips `queryCompleted()` when the emitted state is `LoadingState.PartialResult`, so `SceneRenderProfiler` only fires "All queries completed" after the final `Done` arrives
- `Streaming` behaviour is unchanged — live tail queries still complete immediately on the first emission
- Adds two new tests: one asserting that `PartialResult` does _not_ complete the query, one asserting that `Streaming` still does

## Context

`LoadingState.PartialResult` is introduced in [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466). Loki split queries adopt it in [grafana/grafana#128482](https://github.com/grafana/grafana/pull/128482) (with `Streaming` fallback on older Grafana).

Unlike `Streaming` (live tail), `PartialResult` always terminates with `Done`. Before this fix, `registerQueryWithController` marked queries complete on the first non-`Loading` packet, so reporting fired too early for split queries.

## Merge order

1. [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466)
2. **This PR**
3. [grafana/grafana#128482](https://github.com/grafana/grafana/pull/128482)

The `PartialResult` check no-ops safely until #128466 is released.

## Future follow-ups

Optional hardening (not required to merge; must not block data after `Done`):

- **Protocol violation (dev-only):** warn when `Done` is followed by `PartialResult` on the same requestId/subscription (may coordinate with Grafana core — see [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466) follow-ups).
- **Late `PartialResult` UX:** optionally re-open `SceneQueryController` running state when a `PartialResult` arrives after completion was recorded — refresh spinner and image-renderer timing only; do not tie to data forwarding.

Broader pipeline follow-ups (stale requestId filtering, `SceneQueryRunner` dedup) live in [grafana/grafana#128466](https://github.com/grafana/grafana/pull/128466).

## Test plan

- [ ] `yarn test:scenes -- --testPathPatterns=SceneQueryController --watchAll=false` passes
- [ ] Manual: Loki dashboard with 7-day range + scene profiling — confirm completion only after final `Done`