### PR TITLE
Refresh button width adaptation

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -227,14 +227,9 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
   const refreshText = withText
     ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
     : undefined;
-  const cancelText = withText
-    ? t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel')
-    : undefined;
+  const cancelText = withText ? t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel') : undefined;
 
-  let text =
-    refresh === RefreshPicker.autoOption?.value
-      ? autoValue
-      : refreshText;
+  let text = refresh === RefreshPicker.autoOption?.value ? autoValue : refreshText;
   let tooltip: string | undefined;
 
   if (isRunning) {
@@ -271,7 +266,9 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
   }
 
   const alternateText = isRunning
-    ? (refresh === RefreshPicker.autoOption?.value ? autoValue : refreshText)
+    ? refresh === RefreshPicker.autoOption?.value
+      ? autoValue
+      : refreshText
     : cancelText;
 
   return (
@@ -285,9 +282,7 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
           isLoading={!isRunning}
         />
       </div>
-      <div>
-        {picker}
-      </div>
+      <div>{picker}</div>
     </div>
   );
 }

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Unsubscribable } from 'rxjs';
+import { css } from '@emotion/css';
 import { rangeUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
@@ -208,47 +209,86 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   };
 }
 
+const stableWidthContainerStyles = css({
+  display: 'inline-grid',
+  '> *': {
+    gridColumn: 1,
+    gridRow: 1,
+  },
+  '.refresh-picker > button:first-child': {
+    flex: 1,
+  },
+});
+
 export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneRefreshPicker>) {
   const { refresh, intervals, autoEnabled, autoValue, isOnCanvas, primary, withText } = model.useState();
   const isRunning = useQueryControllerState(model);
 
+  const refreshText = withText
+    ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
+    : undefined;
+  const cancelText = withText
+    ? t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel')
+    : undefined;
+
   let text =
     refresh === RefreshPicker.autoOption?.value
       ? autoValue
-      : withText
-      ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
-      : undefined;
+      : refreshText;
   let tooltip: string | undefined;
-  let width: string | undefined;
 
   if (isRunning) {
     tooltip = t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries');
 
     if (withText) {
-      text = t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel');
+      text = cancelText;
     }
   }
 
-  if (withText) {
-    width = '96px';
-  }
+  const pickerProps = {
+    showAutoInterval: autoEnabled,
+    value: refresh,
+    intervals: intervals,
+    primary: primary,
+    isOnCanvas: isOnCanvas ?? true,
+  };
 
-  return (
+  const picker = (
     <RefreshPicker
-      showAutoInterval={autoEnabled}
-      value={refresh}
-      intervals={intervals}
+      {...pickerProps}
       tooltip={tooltip}
-      width={width}
       text={text}
       onRefresh={() => {
         model.onRefresh();
       }}
-      primary={primary}
       onIntervalChanged={model.onIntervalChanged}
       isLoading={isRunning}
-      isOnCanvas={isOnCanvas ?? true}
     />
+  );
+
+  if (!withText) {
+    return picker;
+  }
+
+  const alternateText = isRunning
+    ? (refresh === RefreshPicker.autoOption?.value ? autoValue : refreshText)
+    : cancelText;
+
+  return (
+    <div className={stableWidthContainerStyles}>
+      <div style={{ visibility: 'hidden', pointerEvents: 'none' }} aria-hidden="true">
+        <RefreshPicker
+          {...pickerProps}
+          text={alternateText}
+          onRefresh={() => {}}
+          onIntervalChanged={() => {}}
+          isLoading={!isRunning}
+        />
+      </div>
+      <div>
+        {picker}
+      </div>
+    </div>
   );
 }
 

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -212,27 +212,18 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
   const { refresh, intervals, autoEnabled, autoValue, isOnCanvas, primary, withText } = model.useState();
   const isRunning = useQueryControllerState(model);
 
-  const refreshText = withText
-    ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
-    : undefined;
-  const cancelText = withText ? t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel') : undefined;
+  const refreshLabel = t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh');
+  const cancelLabel = t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel');
 
-  let text: string | ReactNode = refresh === RefreshPicker.autoOption?.value ? autoValue : refreshText;
-  let tooltip: string | undefined;
+  let text: string | ReactNode | undefined;
 
-  if (isRunning) {
-    tooltip = t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries');
-
-    if (withText) {
-      text = cancelText;
-    }
-  }
-
-  if (withText && refreshText && cancelText) {
+  if (refresh === RefreshPicker.autoOption?.value) {
+    text = isRunning && withText ? cancelLabel : autoValue;
+  } else if (withText) {
     text = (
       <span style={{ display: 'inline-grid' }}>
-        <span style={{ gridColumn: 1, gridRow: 1, visibility: isRunning ? 'hidden' : 'visible' }}>{refreshText}</span>
-        <span style={{ gridColumn: 1, gridRow: 1, visibility: isRunning ? 'visible' : 'hidden' }}>{cancelText}</span>
+        <span style={{ gridArea: '1/1', visibility: isRunning ? 'hidden' : 'visible' }}>{refreshLabel}</span>
+        <span style={{ gridArea: '1/1', visibility: isRunning ? 'visible' : 'hidden' }}>{cancelLabel}</span>
       </span>
     );
   }
@@ -242,11 +233,12 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       showAutoInterval={autoEnabled}
       value={refresh}
       intervals={intervals}
-      tooltip={tooltip}
-      text={text as string}
-      onRefresh={() => {
-        model.onRefresh();
-      }}
+      tooltip={
+        isRunning ? t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries') : undefined
+      }
+      // @ts-expect-error RefreshPicker types text as string but accepts ReactNode at runtime
+      text={text}
+      onRefresh={() => model.onRefresh()}
       primary={primary}
       onIntervalChanged={model.onIntervalChanged}
       isLoading={isRunning}

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Unsubscribable } from 'rxjs';
 import { rangeUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -212,20 +212,29 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
   const { refresh, intervals, autoEnabled, autoValue, isOnCanvas, primary, withText } = model.useState();
   const isRunning = useQueryControllerState(model);
 
-  let text =
-    refresh === RefreshPicker.autoOption?.value
-      ? autoValue
-      : withText
-      ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
-      : undefined;
+  const refreshText = withText
+    ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
+    : undefined;
+  const cancelText = withText ? t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel') : undefined;
+
+  let text: string | ReactNode = refresh === RefreshPicker.autoOption?.value ? autoValue : refreshText;
   let tooltip: string | undefined;
 
   if (isRunning) {
     tooltip = t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries');
 
     if (withText) {
-      text = t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel');
+      text = cancelText;
     }
+  }
+
+  if (withText && refreshText && cancelText) {
+    text = (
+      <span style={{ display: 'inline-grid' }}>
+        <span style={{ gridColumn: 1, gridRow: 1, visibility: isRunning ? 'hidden' : 'visible' }}>{refreshText}</span>
+        <span style={{ gridColumn: 1, gridRow: 1, visibility: isRunning ? 'visible' : 'hidden' }}>{cancelText}</span>
+      </span>
+    );
   }
 
   return (
@@ -234,7 +243,7 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       value={refresh}
       intervals={intervals}
       tooltip={tooltip}
-      text={text}
+      text={text as string}
       onRefresh={() => {
         model.onRefresh();
       }}

--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Unsubscribable } from 'rxjs';
-import { css } from '@emotion/css';
 import { rangeUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
@@ -209,81 +208,41 @@ export class SceneRefreshPicker extends SceneObjectBase<SceneRefreshPickerState>
   };
 }
 
-const stableWidthContainerStyles = css({
-  display: 'inline-grid',
-  '> *': {
-    gridColumn: 1,
-    gridRow: 1,
-  },
-  '.refresh-picker > button:first-child': {
-    flex: 1,
-  },
-});
-
 export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneRefreshPicker>) {
   const { refresh, intervals, autoEnabled, autoValue, isOnCanvas, primary, withText } = model.useState();
   const isRunning = useQueryControllerState(model);
 
-  const refreshText = withText
-    ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
-    : undefined;
-  const cancelText = withText ? t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel') : undefined;
-
-  let text = refresh === RefreshPicker.autoOption?.value ? autoValue : refreshText;
+  let text =
+    refresh === RefreshPicker.autoOption?.value
+      ? autoValue
+      : withText
+      ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
+      : undefined;
   let tooltip: string | undefined;
 
   if (isRunning) {
     tooltip = t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries');
 
     if (withText) {
-      text = cancelText;
+      text = t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel');
     }
   }
 
-  const pickerProps = {
-    showAutoInterval: autoEnabled,
-    value: refresh,
-    intervals: intervals,
-    primary: primary,
-    isOnCanvas: isOnCanvas ?? true,
-  };
-
-  const picker = (
+  return (
     <RefreshPicker
-      {...pickerProps}
+      showAutoInterval={autoEnabled}
+      value={refresh}
+      intervals={intervals}
       tooltip={tooltip}
       text={text}
       onRefresh={() => {
         model.onRefresh();
       }}
+      primary={primary}
       onIntervalChanged={model.onIntervalChanged}
       isLoading={isRunning}
+      isOnCanvas={isOnCanvas ?? true}
     />
-  );
-
-  if (!withText) {
-    return picker;
-  }
-
-  const alternateText = isRunning
-    ? refresh === RefreshPicker.autoOption?.value
-      ? autoValue
-      : refreshText
-    : cancelText;
-
-  return (
-    <div className={stableWidthContainerStyles}>
-      <div style={{ visibility: 'hidden', pointerEvents: 'none' }} aria-hidden="true">
-        <RefreshPicker
-          {...pickerProps}
-          text={alternateText}
-          onRefresh={() => {}}
-          onIntervalChanged={() => {}}
-          isLoading={!isRunning}
-        />
-      </div>
-      <div>{picker}</div>
-    </div>
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the fixed width of the SceneRefreshPicker button with a dynamic width solution to support multi-language labels and prevent layout shifts when toggling between refresh and cancel states.

The original issue (https://github.com/grafana/grafana/issues/119789) reported that the fixed `96px` width caused text truncation for longer labels (e.g., German) and layout shifts. This PR introduces a CSS `inline-grid` container where both the visible `RefreshPicker` and a hidden `RefreshPicker` (displaying the alternate text) occupy the same grid cell. This ensures the button's width always accommodates the longest possible label, preventing truncation and layout shifts. The hidden instance uses `visibility: hidden` and `pointer-events: none` to be inert.

---
<p><a href="https://cursor.com/agents/bc-36bf5598-72a7-4b1d-a3a4-96c53a265196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36bf5598-72a7-4b1d-a3a4-96c53a265196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->