### PR TITLE
Filters: Show/hide internal label based on variable label

### DIFF
--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -112,6 +112,7 @@
         "collapse": "Collapse",
         "collapse-filters": "Collapse filters",
         "expand-filters": "Expand filters",
+        "filters-label": "Filters:",
         "group-by-label": "Group by:",
         "show-more-filters_one": "Show {{count}} more filters",
         "show-more-filters_other": "Show {{count}} more filters",

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -91,7 +91,7 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
     >
       {!readOnly && valueRecommendations && <valueRecommendations.Component model={valueRecommendations} />}
 
-      {hideLabel && (
+      {enableGroupBy && hideLabel && (
         <span className={styles.filtersLabel}>
           {t('grafana-scenes.variables.adhoc-filters-combobox-renderer.filters-label', 'Filters:')}
         </span>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -28,6 +28,7 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
     valueRecommendations,
     enableGroupBy,
     hideLabel,
+    variableLabel,
     groupByRestorable,
   } = controller.useState();
   const styles = useStyles2(getStyles);
@@ -102,8 +103,10 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
       {!readOnly && valueRecommendations && <valueRecommendations.Component model={valueRecommendations} />}
 
       {enableGroupBy && hideLabel && (
-        <span className={styles.filtersLabel}>
-          {t('grafana-scenes.variables.adhoc-filters-combobox-renderer.filters-label', 'Filters:')}
+        <span id={`${variableControlId}-label`} className={styles.filtersLabel}>
+          {variableLabel
+            ? `${variableLabel}:`
+            : t('grafana-scenes.variables.adhoc-filters-combobox-renderer.filters-label', 'Filters:')}
         </span>
       )}
 
@@ -112,7 +115,7 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
         // that the input is announced before focussing on the pills
         <span
           tabIndex={0}
-          aria-labelledby={variableControlId}
+          aria-labelledby={hideLabel ? `${variableControlId}-label` : variableControlId}
           className={styles.screenReaderOnlyLabel}
           data-testid="AdHocFilter-label-announcer"
         />

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -19,7 +19,8 @@ interface Props {
 }
 
 export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRenderer({ controller }: Props) {
-  const { originFilters, filters, readOnly, collapsible, valueRecommendations, enableGroupBy } = controller.useState();
+  const { originFilters, filters, readOnly, collapsible, valueRecommendations, enableGroupBy, hideLabel } =
+    controller.useState();
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
   const [collapsed, setCollapsed] = useState(true);
@@ -89,6 +90,12 @@ export const AdHocFiltersComboboxRenderer = memo(function AdHocFiltersComboboxRe
       })}
     >
       {!readOnly && valueRecommendations && <valueRecommendations.Component model={valueRecommendations} />}
+
+      {hideLabel && (
+        <span className={styles.filtersLabel}>
+          {t('grafana-scenes.variables.adhoc-filters-combobox-renderer.filters-label', 'Filters:')}
+        </span>
+      )}
 
       {adhocFiltersToRender.map((filter, index) => (
         <AdHocFilterPill
@@ -289,6 +296,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignSelf: 'stretch',
     backgroundColor: theme.colors.border.weak,
     flexShrink: 0,
+  }),
+  filtersLabel: css({
+    ...theme.typography.bodySmall,
+    fontWeight: theme.typography.fontWeightBold,
+    color: theme.colors.text.primary,
+    whiteSpace: 'nowrap',
   }),
   groupByLabel: css({
     ...theme.typography.bodySmall,

--- a/packages/scenes/src/variables/adhoc/controller/AdHocFiltersController.ts
+++ b/packages/scenes/src/variables/adhoc/controller/AdHocFiltersController.ts
@@ -23,6 +23,7 @@ export interface AdHocFiltersControllerState {
   drilldownRecommendationsEnabled?: boolean;
   enableGroupBy?: boolean;
   hideLabel?: boolean;
+  variableLabel?: string;
   groupByRestorable?: boolean;
 }
 

--- a/packages/scenes/src/variables/adhoc/controller/AdHocFiltersController.ts
+++ b/packages/scenes/src/variables/adhoc/controller/AdHocFiltersController.ts
@@ -22,6 +22,7 @@ export interface AdHocFiltersControllerState {
   valueRecommendations?: AdHocFiltersRecommendations;
   drilldownRecommendationsEnabled?: boolean;
   enableGroupBy?: boolean;
+  hideLabel?: boolean;
 }
 
 /**

--- a/packages/scenes/src/variables/adhoc/controller/AdHocFiltersVariableController.ts
+++ b/packages/scenes/src/variables/adhoc/controller/AdHocFiltersVariableController.ts
@@ -30,6 +30,7 @@ export class AdHocFiltersVariableController implements AdHocFiltersController {
       drilldownRecommendationsEnabled: state.drilldownRecommendationsEnabled,
       enableGroupBy: state.enableGroupBy,
       hideLabel: state.hide === VariableHide.hideLabel,
+      variableLabel: state.label,
       groupByRestorable: this.model.isGroupByRestorable(),
     };
   }

--- a/packages/scenes/src/variables/adhoc/controller/AdHocFiltersVariableController.ts
+++ b/packages/scenes/src/variables/adhoc/controller/AdHocFiltersVariableController.ts
@@ -1,4 +1,4 @@
-import { SelectableValue } from '@grafana/data';
+import { SelectableValue, VariableHide } from '@grafana/data';
 import { AdHocFilterWithLabels, AdHocFiltersVariable } from '../AdHocFiltersVariable';
 import { AdHocFiltersController, AdHocFiltersControllerState } from './AdHocFiltersController';
 import { getQueryController } from '../../../core/sceneGraph/getQueryController';
@@ -28,6 +28,7 @@ export class AdHocFiltersVariableController implements AdHocFiltersController {
       valueRecommendations: this.model.getRecommendations(),
       drilldownRecommendationsEnabled: state.drilldownRecommendationsEnabled,
       enableGroupBy: state.enableGroupBy,
+      hideLabel: state.hide === VariableHide.hideLabel,
     };
   }
 


### PR DESCRIPTION
Shows/hides a `Filters:` label inside the filters bar if the variable one is hidden.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.3.6--canary.1412.23904058991.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@7.3.6--canary.1412.23904058991.0
  npm install @grafana/scenes-react@7.3.6--canary.1412.23904058991.0
  # or 
  yarn add @grafana/scenes@7.3.6--canary.1412.23904058991.0
  yarn add @grafana/scenes-react@7.3.6--canary.1412.23904058991.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
