### PR TITLE
fix(SceneRefreshPicker): remove hardcoded width to fix i18n button overlap

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -219,7 +219,6 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
       : undefined;
   let tooltip: string | undefined;
-  let width: string | undefined;
 
   if (isRunning) {
     tooltip = t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries');
@@ -229,9 +228,6 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
     }
   }
 
-  if (withText) {
-    width = '96px';
-  }
 
   return (
     <RefreshPicker
@@ -239,7 +235,6 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       value={refresh}
       intervals={intervals}
       tooltip={tooltip}
-      width={width}
       text={text}
       onRefresh={() => {
         model.onRefresh();


### PR DESCRIPTION
## Summary

- Remove the hardcoded `96px` width from `SceneRefreshPicker` when `withText` is enabled
- The fixed width caused the German translation "Aktualisieren" (and potentially other long translations) to overflow and overlap with adjacent buttons in the dashboard toolbar
- The button now sizes naturally to its content, accommodating all locales

## Context

Fixes grafana/grafana#119789

The `SceneRefreshPicker` component sets a fixed `width: '96px'` when `withText` is `true`. This width is sufficient for the English "Refresh" (7 chars) but causes overflow with longer translations like the German "Aktualisieren" (14 chars). Removing the fixed width allows the button to adapt to its content.

**Before (German locale):** "Aktualisieren" overflows and overlaps with the auto-refresh interval dropdown

**After:** Button sizes to fit the translated text without overlap

## Test plan

- [ ] Verify refresh button displays correctly in English
- [ ] Verify refresh button displays correctly in German (no overlap with dropdown)
- [ ] Verify Cancel state still renders properly when queries are running
- [ ] Verify auto-refresh interval text displays correctly