### PR TITLE
chore: replace standardTransformers import with registry access

### DIFF
--- a/packages/scenes/src/querying/layers/annotations/standardAnnotationsSupport.ts
+++ b/packages/scenes/src/querying/layers/annotations/standardAnnotationsSupport.ts
@@ -15,7 +15,7 @@ import {
   FieldType,
   getFieldDisplayName,
   KeyValue,
-  standardTransformers,
+  standardTransformersRegistry,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
@@ -72,7 +72,7 @@ export function singleFrameFromPanelData(): OperatorFunction<DataFrame[], DataFr
         };
 
         return of(data).pipe(
-          standardTransformers.mergeTransformer.operator({}, ctx),
+          standardTransformersRegistry.get('merge').transformation.operator({}, ctx),
           map((d) => d[0])
         );
       })


### PR DESCRIPTION
## Summary
- Replace `standardTransformers.mergeTransformer` import with `standardTransformersRegistry.get('merge')` in `standardAnnotationsSupport.ts`
- Decouples Scenes from the `standardTransformers` namespace export, enabling Grafana to remove it from `@grafana/data`'s public API for bundle size improvements

## Test plan
- [x] Verify annotations still work in dashboards with Scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.3.13--canary.1425.24205906579.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@7.3.13--canary.1425.24205906579.0
  npm install @grafana/scenes-react@7.3.13--canary.1425.24205906579.0
  # or 
  yarn add @grafana/scenes@7.3.13--canary.1425.24205906579.0
  yarn add @grafana/scenes-react@7.3.13--canary.1425.24205906579.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
