### PR TITLE
SceneTimePicker: Add time range validation on zoom, backwards and forwards move

### DIFF
--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -30,7 +30,9 @@ export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
   public onZoom = () => {
     const timeRange = sceneGraph.getTimeRange(this);
     const zoomedTimeRange = getZoomedTimeRange(timeRange.state.value, 2);
-    timeRange.onTimeRangeChange(zoomedTimeRange);
+    if (isValidTimeRange(zoomedTimeRange)) {
+      timeRange.onTimeRangeChange(zoomedTimeRange);
+    }
   };
 
   public onChangeFiscalYearStartMonth = (month: number) => {
@@ -52,7 +54,11 @@ export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
       state: { value: range },
     } = timeRange;
 
-    timeRange.onTimeRangeChange(getShiftedTimeRange(TimeRangeDirection.Backward, range));
+    const newTimeRange = getShiftedTimeRange(TimeRangeDirection.Backward, range);
+
+    if (isValidTimeRange(newTimeRange)) {
+      timeRange.onTimeRangeChange(newTimeRange);
+    }
   };
 
   public onMoveForward = () => {
@@ -61,7 +67,11 @@ export class SceneTimePicker extends SceneObjectBase<SceneTimePickerState> {
       state: { value: range },
     } = timeRange;
 
-    timeRange.onTimeRangeChange(getShiftedTimeRange(TimeRangeDirection.Forward, range, Date.now()));
+    const newTimeRange = getShiftedTimeRange(TimeRangeDirection.Forward, range);
+
+    if (isValidTimeRange(newTimeRange)) {
+      timeRange.onTimeRangeChange(newTimeRange);
+    }
   };
 }
 
@@ -209,4 +219,11 @@ function limit(value: TimePickerHistoryItem[]): TimePickerHistoryItem[] {
 
 function isAbsolute(value: TimeRange): boolean {
   return isDateTime(value.raw.from) || isDateTime(value.raw.to);
+}
+
+function isValidTimeRange(timeRange: TimeRange) {
+  if (timeRange.to.isValid() && timeRange.from.isValid()) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
You can zoom out until you reach invalid date that will crash UI. Adding date validity check to prevent this.

This fixes:
- crash on zoom out until invalid date
- crash on forwards move into invalid date
- crash on backwards move into invalid date
- move forward fix (was capped at Date.now() for some reason)

Fixes https://github.com/grafana/grafana/issues/113117
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.3.14--canary.1427.24507393312.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@7.3.14--canary.1427.24507393312.0
  npm install @grafana/scenes-react@7.3.14--canary.1427.24507393312.0
  # or 
  yarn add @grafana/scenes@7.3.14--canary.1427.24507393312.0
  yarn add @grafana/scenes-react@7.3.14--canary.1427.24507393312.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
