### PR TITLE
AdHocFilterVariable: Default to combobox layout in filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -69,7 +69,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('renders filters', async () => {
-    setup();
+    setup({ layout: 'horizontal' });
     expect(screen.getByText('key1')).toBeInTheDocument();
     expect(screen.getByText('val1')).toBeInTheDocument();
     expect(screen.getByText('key2')).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('adds filter', async () => {
-    const { filtersVar } = setup();
+    const { filtersVar } = setup({ layout: 'horizontal' });
 
     // Select key
     await userEvent.click(screen.getByTestId('AdHocFilter-add'));
@@ -92,7 +92,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('removes filter', async () => {
-    const { filtersVar } = setup();
+    const { filtersVar } = setup({ layout: 'horizontal' });
 
     await userEvent.click(screen.getByTestId('AdHocFilter-remove-key1'));
 
@@ -100,7 +100,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('changes filter', async () => {
-    const { filtersVar, runRequest } = setup();
+    const { filtersVar, runRequest } = setup({ layout: 'horizontal' });
 
     await new Promise((r) => setTimeout(r, 1));
 
@@ -118,7 +118,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('clears the value of a filter if the key is changed', async () => {
-    const { filtersVar } = setup();
+    const { filtersVar } = setup({ layout: 'horizontal' });
 
     const wrapper = screen.getByTestId('AdHocFilter-key1');
     const selects = getAllByRole(wrapper, 'combobox');
@@ -129,7 +129,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('can set a custom value', async () => {
-    const { filtersVar, runRequest } = setup();
+    const { filtersVar, runRequest } = setup({ layout: 'horizontal' });
 
     await new Promise((r) => setTimeout(r, 1));
 
@@ -148,6 +148,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('shows key groups and orders according to first occurrence of a group item', async () => {
     const { runRequest } = setup({
+      layout: 'horizontal',
       getTagKeysProvider: async () => ({
         replace: true,
         values: [
@@ -210,6 +211,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('shows value groups and orders according to first occurrence of a group item', async () => {
     const { runRequest } = setup({
+      layout: 'horizontal',
       getTagValuesProvider: async () => ({
         replace: true,
         values: [
@@ -272,6 +274,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('Exact match operators show custom value last', async () => {
     const { filtersVar, runRequest } = setup({
+      layout: 'horizontal',
       filters: [
         { key: 'key1', operator: '=', value: 'val1' },
         { key: 'key2', operator: '=', value: 'val2' },
@@ -339,6 +342,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('Regex operators show custom value first', async () => {
     const { filtersVar, runRequest } = setup({
+      layout: 'horizontal',
       filters: [
         { key: 'key1', operator: '=~', value: 'val1' },
         { key: 'key2', operator: '=~', value: 'val2' },
@@ -405,7 +409,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('can set the same custom value again', async () => {
-    const { filtersVar, runRequest } = setup();
+    const { filtersVar, runRequest } = setup({ layout: 'horizontal' });
 
     await new Promise((r) => setTimeout(r, 1));
 
@@ -439,6 +443,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     const delayingPromise = new Promise<string>((resolve) => (resolveCallback = resolve));
 
     const { filtersVar, runRequest } = setup({
+      layout: 'horizontal',
       getTagValuesProvider: async () => {
         await delayingPromise;
         return {
@@ -472,7 +477,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   describe('By default, Without altering `useQueriesAsFilterForOptions`', () => {
     it('Should not collect and pass respective data source queries to getTagKeys call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ filters: [] });
+      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [] });
 
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
@@ -487,7 +492,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should not collect and pass respective data source queries to getTagValues call', async () => {
-      const { getTagValuesSpy, timeRange } = setup({ filters: [] });
+      const { getTagValuesSpy, timeRange } = setup({ layout: 'horizontal', filters: [] });
 
       // Select key
       const key = 'Key 3';
@@ -508,7 +513,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   describe('When `useQueriesAsFilterForOptions` is set to `true`', () => {
     it('Should collect and pass respective data source queries to getTagKeys call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
+      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true });
 
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
@@ -528,7 +533,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should apply the filters request enricher to getTagKeys call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true }, () => ({
+      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true }, () => ({
         key: 'overwrittenKey',
       }));
 
@@ -549,7 +554,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should collect and pass respective data source queries to getTagValues call', async () => {
-      const { getTagValuesSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true });
+      const { getTagValuesSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true });
 
       // Select key
       const key = 'Key 3';
@@ -573,7 +578,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should apply the filters request enricher to getTagValues call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ filters: [], useQueriesAsFilterForOptions: true }, () => ({
+      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true }, () => ({
         key: 'overwrittenKey',
       }));
 
@@ -651,7 +656,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('reflects emtpy state in url', async () => {
-    const { filtersVar } = setup();
+    const { filtersVar } = setup({ layout: 'horizontal' });
 
     await userEvent.click(screen.getByTestId('AdHocFilter-remove-key1'));
     await userEvent.click(screen.getByTestId('AdHocFilter-remove-key2'));
@@ -1946,6 +1951,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('Can encode a custom value', async () => {
     const { filtersVar, runRequest } = setup({
+      layout: 'horizontal',
       allowCustomValue: true,
       filters: [
         {
@@ -2037,6 +2043,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('Selecting a key correctly shows the label', async () => {
     const { filtersVar } = setup({
+      layout: 'horizontal',
       defaultKeys: [
         {
           text: 'some',
@@ -2061,6 +2068,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   it('Selecting a default key correctly shows the label', async () => {
     const { filtersVar } = setup({
+      layout: 'horizontal',
       defaultKeys: [
         {
           text: 'some',
@@ -2935,7 +2943,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('does not display hidden filters', async () => {
-      const { filtersVar } = setup();
+      const { filtersVar } = setup({ layout: 'horizontal' });
 
       act(() => {
         filtersVar.setState({
@@ -3159,7 +3167,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   describe('operators', () => {
     it('shows the regex operators when allowCustomValue is undefined', async () => {
-      setup();
+      setup({ layout: 'horizontal' });
 
       const middleKeySelect = screen.getAllByRole('combobox')[1];
       await userEvent.click(middleKeySelect);
@@ -3182,6 +3190,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     it('shows the regex operators when allowCustomValue is set true', async () => {
       setup({
+        layout: 'horizontal',
         allowCustomValue: true,
       });
 
@@ -3206,6 +3215,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
     it('does not show the regex operators when allowCustomValue is set false', async () => {
       setup({
+        layout: 'horizontal',
         allowCustomValue: false,
       });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -513,7 +513,11 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
   describe('When `useQueriesAsFilterForOptions` is set to `true`', () => {
     it('Should collect and pass respective data source queries to getTagKeys call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true });
+      const { getTagKeysSpy, timeRange } = setup({
+        layout: 'horizontal',
+        filters: [],
+        useQueriesAsFilterForOptions: true,
+      });
 
       // Select key
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
@@ -533,9 +537,12 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should apply the filters request enricher to getTagKeys call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true }, () => ({
-        key: 'overwrittenKey',
-      }));
+      const { getTagKeysSpy, timeRange } = setup(
+        { layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true },
+        () => ({
+          key: 'overwrittenKey',
+        })
+      );
 
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));
       const keyCombobox = getKeyComboboxElement();
@@ -554,7 +561,11 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should collect and pass respective data source queries to getTagValues call', async () => {
-      const { getTagValuesSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true });
+      const { getTagValuesSpy, timeRange } = setup({
+        layout: 'horizontal',
+        filters: [],
+        useQueriesAsFilterForOptions: true,
+      });
 
       // Select key
       const key = 'Key 3';
@@ -578,9 +589,12 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
 
     it('Should apply the filters request enricher to getTagValues call', async () => {
-      const { getTagKeysSpy, timeRange } = setup({ layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true }, () => ({
-        key: 'overwrittenKey',
-      }));
+      const { getTagKeysSpy, timeRange } = setup(
+        { layout: 'horizontal', filters: [], useQueriesAsFilterForOptions: true },
+        () => ({
+          key: 'overwrittenKey',
+        })
+      );
 
       const key = 'Key 3';
       await userEvent.click(screen.getByTestId('AdHocFilter-add'));

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -90,6 +90,9 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   /**
    * @experimental
    * Controls the layout and design of the label.
+   * @deprecated The `layout` property is deprecated and scheduled for removal before grafana v14.
+   * The `'horizontal'` and `'vertical'` options are no longer supported.
+   * Use `'combobox'` instead or remove this property entirely.
    */
   layout?: AdHocControlsLayout;
   /**
@@ -299,6 +302,7 @@ export class AdHocFiltersVariable
   private _recommendations: AdHocFiltersRecommendations | undefined;
 
   public constructor(state: Partial<AdHocFiltersVariableState>) {
+    const { collapsible, defaultKeys, drilldownRecommendationsEnabled, ...restState } = state;
     const behaviors = state.$behaviors ?? [];
     const recommendations = state.drilldownRecommendationsEnabled ? new AdHocFiltersRecommendations() : undefined;
 
@@ -315,8 +319,12 @@ export class AdHocFiltersVariable
       filterExpression:
         state.filterExpression ??
         renderExpression(state.expressionBuilder, [...(state.originFilters ?? []), ...(state.filters ?? [])]),
-      ...state,
-      $behaviors: behaviors.length > 0 ? behaviors : undefined,
+      ...restState,
+      ...(behaviors.length > 0 && { $behaviors: behaviors }),
+      ...(collapsible !== undefined && { collapsible }),
+      ...(drilldownRecommendationsEnabled !== undefined && { drilldownRecommendationsEnabled }),
+      ...(defaultKeys && { defaultKeys }),
+      layout: state.layout || 'combobox',
     });
 
     this._recommendations = recommendations;


### PR DESCRIPTION
Its about time we defaulted to using `combobox` layout in filters variable. 

Thinking if minor/patch release is enough or this is big enough to go into major?


Additional changes:
- cleaned up state to avoid undefined values like [here](https://github.com/grafana/grafana/pull/118599/changes#diff-9c18d3f6ab194173badc7c6c78dc5ccb3e336a01aec3ae5809d6c5fbf5a3c8eeR464-R468)
- Adjusted 52 out of 268 tests  that relied on `horizontal` layout to pass.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.4.0--canary.1428.24514808405.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@7.4.0--canary.1428.24514808405.0
  npm install @grafana/scenes-react@7.4.0--canary.1428.24514808405.0
  # or 
  yarn add @grafana/scenes@7.4.0--canary.1428.24514808405.0
  yarn add @grafana/scenes-react@7.4.0--canary.1428.24514808405.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
