### PR TITLE
fix(adhoc): skip manual-mode AdHocFiltersVariable in drilldown filter discovery

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -572,6 +572,36 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(runRequestCall2[1].filters).toEqual(filtersVar.state.filters);
     });
 
+    it('should not pass adhoc filters via request object when applyMode is manual', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const filtersVar = new AdHocFiltersVariable({
+        datasource: { uid: 'test-uid' },
+        applyMode: 'manual',
+        filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+      });
+
+      const scene = new EmbeddedScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [filtersVar] }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      const deactivate = activateFullSceneTree(scene);
+      deactivationHandlers.push(deactivate);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[0];
+
+      // Manual-mode filters should NOT be passed via request.filters
+      // since they are applied via expressionBuilder and variable interpolation
+      expect(runRequestCall[1].filters).toBeUndefined();
+    });
+
     it('should pass adhoc origin filter via request object if they have a source defined', async () => {
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'test-uid' },

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -57,7 +57,7 @@ exports[`SceneQueryRunner when running query should build DataQueryRequest objec
     "from": "now-6h",
     "to": "now",
   },
-  "requestId": "SQR194",
+  "requestId": "SQR195",
   "scopes": undefined,
   "startTime": 1689063488000,
   "targets": [

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.test.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.test.ts
@@ -1,0 +1,121 @@
+import { AdHocFiltersVariable } from './AdHocFiltersVariable';
+import { findClosestAdHocFilterInHierarchy, findGlobalAdHocFilterVariableByUid, allActiveFilterSets } from './patchGetAdhocFilters';
+import { SceneVariableSet } from '../sets/SceneVariableSet';
+import { SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
+import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
+import { EmbeddedScene } from '../../components/EmbeddedScene';
+import { SceneCanvasText } from '../../components/SceneCanvasText';
+import { SceneDeactivationHandler } from '../../core/types';
+
+describe('findClosestAdHocFilterInHierarchy', () => {
+  it('should find auto-mode AdHocFiltersVariable matching datasource uid', () => {
+    const filtersVar = new AdHocFiltersVariable({
+      datasource: { uid: 'test-uid' },
+      applyMode: 'auto',
+      filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+    });
+
+    const scene = new EmbeddedScene({
+      $variables: new SceneVariableSet({ variables: [filtersVar] }),
+      body: new SceneCanvasText({ text: 'hello' }),
+    });
+
+    const deactivate = activateFullSceneTree(scene);
+
+    const body = scene.state.body as SceneCanvasText;
+    const result = findClosestAdHocFilterInHierarchy('test-uid', body);
+
+    expect(result).toBe(filtersVar);
+
+    deactivate();
+  });
+
+  it('should skip manual-mode AdHocFiltersVariable even when datasource uid matches', () => {
+    const filtersVar = new AdHocFiltersVariable({
+      datasource: { uid: 'test-uid' },
+      applyMode: 'manual',
+      filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+    });
+
+    const scene = new EmbeddedScene({
+      $variables: new SceneVariableSet({ variables: [filtersVar] }),
+      body: new SceneCanvasText({ text: 'hello' }),
+    });
+
+    const deactivate = activateFullSceneTree(scene);
+
+    const body = scene.state.body as SceneCanvasText;
+    const result = findClosestAdHocFilterInHierarchy('test-uid', body);
+
+    expect(result).toBeUndefined();
+
+    deactivate();
+  });
+
+  it('should find auto-mode variable when both manual and auto exist in hierarchy', () => {
+    const manualVar = new AdHocFiltersVariable({
+      name: 'manual',
+      datasource: { uid: 'test-uid' },
+      applyMode: 'manual',
+      filters: [{ key: 'manual', operator: '=', value: '1', condition: '' }],
+    });
+
+    const autoVar = new AdHocFiltersVariable({
+      name: 'auto',
+      datasource: { uid: 'test-uid' },
+      applyMode: 'auto',
+      filters: [{ key: 'auto', operator: '=', value: '1', condition: '' }],
+    });
+
+    const scene = new EmbeddedScene({
+      $variables: new SceneVariableSet({ variables: [manualVar, autoVar] }),
+      body: new SceneCanvasText({ text: 'hello' }),
+    });
+
+    const deactivate = activateFullSceneTree(scene);
+
+    const body = scene.state.body as SceneCanvasText;
+    const result = findClosestAdHocFilterInHierarchy('test-uid', body);
+
+    expect(result).toBe(autoVar);
+
+    deactivate();
+  });
+});
+
+describe('findGlobalAdHocFilterVariableByUid', () => {
+  const deactivationHandlers: SceneDeactivationHandler[] = [];
+
+  afterEach(() => {
+    allActiveFilterSets.clear();
+    deactivationHandlers.forEach((d) => d());
+    deactivationHandlers.length = 0;
+  });
+
+  it('should find auto-mode variable in global set', () => {
+    const filtersVar = new AdHocFiltersVariable({
+      datasource: { uid: 'test-uid' },
+      applyMode: 'auto',
+      filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+    });
+
+    // patchGetAdhocFilters adds to allActiveFilterSets on activation for auto mode
+    allActiveFilterSets.add(filtersVar);
+
+    const result = findGlobalAdHocFilterVariableByUid('test-uid');
+    expect(result).toBe(filtersVar);
+  });
+
+  it('should skip manual-mode variable in global set', () => {
+    const filtersVar = new AdHocFiltersVariable({
+      datasource: { uid: 'test-uid' },
+      applyMode: 'manual',
+      filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+    });
+
+    allActiveFilterSets.add(filtersVar);
+
+    const result = findGlobalAdHocFilterVariableByUid('test-uid');
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.test.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.test.ts
@@ -5,7 +5,6 @@ import {
   allActiveFilterSets,
 } from './patchGetAdhocFilters';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
-import { SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 import { EmbeddedScene } from '../../components/EmbeddedScene';
 import { SceneCanvasText } from '../../components/SceneCanvasText';

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.test.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.test.ts
@@ -1,5 +1,9 @@
 import { AdHocFiltersVariable } from './AdHocFiltersVariable';
-import { findClosestAdHocFilterInHierarchy, findGlobalAdHocFilterVariableByUid, allActiveFilterSets } from './patchGetAdhocFilters';
+import {
+  findClosestAdHocFilterInHierarchy,
+  findGlobalAdHocFilterVariableByUid,
+  allActiveFilterSets,
+} from './patchGetAdhocFilters';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
 import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
@@ -58,7 +58,11 @@ export function findClosestAdHocFilterInHierarchy(
   while (current) {
     const variables = current.state.$variables?.state.variables ?? [];
     for (const variable of variables) {
-      if (variable instanceof AdHocFiltersVariable && interpolate(variable, variable.state.datasource?.uid) === dsUid) {
+      if (
+        variable instanceof AdHocFiltersVariable &&
+        variable.state.applyMode !== 'manual' &&
+        interpolate(variable, variable.state.datasource?.uid) === dsUid
+      ) {
         return variable;
       }
     }
@@ -74,7 +78,7 @@ export function findClosestAdHocFilterInHierarchy(
  */
 export function findGlobalAdHocFilterVariableByUid(dsUid: string | undefined): AdHocFiltersVariable | undefined {
   for (const filter of allActiveFilterSets.values()) {
-    if (interpolate(filter, filter.state.datasource?.uid) === dsUid) {
+    if (filter.state.applyMode !== 'manual' && interpolate(filter, filter.state.datasource?.uid) === dsUid) {
       return filter;
     }
   }


### PR DESCRIPTION
Found encountered this bug in fe o11y, where adding ad hoc filter would concatenate query with itself causing it to fail

## Summary
- `findClosestAdHocFilterInHierarchy` and `findGlobalAdHocFilterVariableByUid` matched any `AdHocFiltersVariable` by datasource UID, ignoring `applyMode`. This caused `DrilldownDependenciesManager` to put manual-mode filters into `request.filters`, which the datasource then auto-applied on top of the `expressionBuilder` interpolation — resulting in double filter application and query concatenation
- Fix: skip variables with `applyMode: 'manual'` in both finder functions, since they handle filter application themselves via `expressionBuilder` and `${VarName}` interpolation


🤖 Generated with [Claude Code](https://claude.com/claude-code)