### PR TITLE
SceneQueryRunner: Clear incomplete data on deactivation to prevent stuck panels

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -2930,6 +2930,33 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(queryRunner.state.data?.series).not.toBe(firstSeries);
     });
   });
+
+  describe('when deactivated with incomplete data', () => {
+    it('should clear incomplete data and re-run queries on reactivation', async () => {
+      const tick = () => new Promise((r) => setTimeout(r, 1));
+      const subject = new Subject<DataQueryResponse>();
+      runRequestMock.mockImplementationOnce(() =>
+        subject.pipe(map(() => ({ state: LoadingState.Loading, series: [], timeRange: {} as any })))
+      );
+
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }], $timeRange: new SceneTimeRange() });
+      const deactivate = queryRunner.activate();
+      await tick();
+
+      subject.next({ data: [] });
+      await tick();
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Loading);
+
+      deactivate();
+      expect(queryRunner.state.data).toBeUndefined();
+
+      runRequestMock.mockClear();
+      queryRunner.activate();
+      await tick();
+
+      expect(runRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 class CustomDataSource extends RuntimeDataSource {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -428,6 +428,12 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     this._timeSub = undefined;
     this._timeSubRange = undefined;
 
+    // Reset data to its initial state unless it reached a terminal state (Done or Error).
+    // Incomplete data is discarded so reactivation starts with a clean slate.
+    if (this.state.data && ![LoadingState.Done, LoadingState.Error].includes(this.state.data.state)) {
+      this.setState({ data: undefined });
+    }
+
     this._drilldownDependenciesManager.cleanup();
   }
 

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -429,7 +429,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
     this._timeSubRange = undefined;
 
     // Reset data to its initial state unless it reached a terminal state (Done or Error).
-    // Incomplete data is discarded so reactivation starts with a clean slate.
+    // Incomplete data is discarded so reactivation starts with a clean state.
     if (this.state.data && ![LoadingState.Done, LoadingState.Error].includes(this.state.data.state)) {
       this.setState({ data: undefined });
     }

--- a/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
+++ b/packages/scenes/src/querying/__snapshots__/SceneQueryRunner.test.ts.snap
@@ -57,7 +57,7 @@ exports[`SceneQueryRunner when running query should build DataQueryRequest objec
     "from": "now-6h",
     "to": "now",
   },
-  "requestId": "SQR194",
+  "requestId": "SQR196",
   "scopes": undefined,
   "startTime": 1689063488000,
   "targets": [


### PR DESCRIPTION
**What is this feature?**

when a panel is deactivated while its query is still in flight (e.g. another panel temporarily activated it via the `dashboard` datasource and then released it), the panel's data state remains "Loading" with no active subscription to resolve it.

on reactivation, the panel sees existing data and assumes it doesn't need to re-query and leaving it permanently ostuck in a loading state.

on deactivation, we should discard any data that hasn't reached a terminal state (Done or Error). This ensures that when the panel reactivates, it recognizes there's no usable data and issues a fresh query.

data that already completed successfully is preserved, so panels scrolling in and out of view don't unnecessarily re-fetch.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.4.1--canary.1430.24681505648.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@7.4.1--canary.1430.24681505648.0
  npm install @grafana/scenes-react@7.4.1--canary.1430.24681505648.0
  # or 
  yarn add @grafana/scenes@7.4.1--canary.1430.24681505648.0
  yarn add @grafana/scenes-react@7.4.1--canary.1430.24681505648.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
