### PR TITLE
AdHocFilters: Support free-form filter expression input in combobox

### DIFF
--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -130,6 +130,9 @@
         "tooltip": "Applied by default in this dashboard. If edited, it carries over to other dashboards.",
         "tooltip-restore-groupby-set-by-this-dashboard": "Restore groupby set by this dashboard."
       },
+      "expression-hint-placeholder": {
+        "press-enter-to-apply": "Press Enter to apply"
+      },
       "format-registry": {
         "formats": {
           "description": {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -527,7 +527,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
             handleResetWip();
             setTimeout(() => refs.domReference.current?.focus());
           } else {
-            handleChangeViewMode?.();
+            handleChangeViewMode?.(undefined, false);
             focusOnWipInputRef?.();
           }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -508,15 +508,12 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
             setActiveIndex(null);
             return;
           }
-          
+
           controller.startProfile?.(FILTER_CHANGED_INTERACTION);
-          
+
           const isMultiValueCommit = Boolean(parsed.operator && isMultiValueOperator(parsed.operator));
           if (!isMultiValueCommit) {
-            const custom = onAddCustomValue?.(
-              { label: parsed.value, value: parsed.value, isCustom: true },
-              filter
-            );
+            const custom = onAddCustomValue?.({ label: parsed.value, value: parsed.value, isCustom: true }, filter);
             parsed.value = custom?.value ?? parsed.value;
             parsed.valueLabels = custom?.valueLabels ?? parsed.valueLabels;
           }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -112,7 +112,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const optionsSearcher = useMemo(() => getAdhocOptionSearcher(options), [options]);
 
-  const { isExpressionInput, parseExpression, buildExpressionUpdate } = useFreeFormExpression({
+  const { canCommitExpression, parsedExpression, parseExpression, commitExpressionUpdate } = useFreeFormExpression({
     controller,
     filter,
     inputValue,
@@ -296,7 +296,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   }, []);
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
-  if (allowCustomValue && filterInputType !== 'operator' && inputValue && !isExpressionInput) {
+  if (allowCustomValue && filterInputType !== 'operator' && inputValue && !parsedExpression) {
     const operatorDefinition = OPERATORS.find((op) => filter?.operator === op.value);
     const customOptionValue: SelectableValue<string> = {
       value: inputValue.trim(),
@@ -494,8 +494,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleEnterInput = useCallback(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
-      if (event.key === 'Enter' && isExpressionInput && filter) {
-        const parsed = buildExpressionUpdate();
+      if (event.key === 'Enter' && canCommitExpression && filter) {
+        const parsed = commitExpressionUpdate();
 
         if (parsed) {
           event.preventDefault();
@@ -605,8 +605,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       controller,
       filter,
       filterInputType,
-      isExpressionInput,
-      buildExpressionUpdate,
+      canCommitExpression,
+      commitExpressionUpdate,
       populateInputOnEdit,
       handleChangeViewMode,
       refs.domReference,
@@ -839,7 +839,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                     <LoadingOptionsPlaceholder />
                   ) : optionsError ? (
                     <OptionsErrorPlaceholder handleFetchOptions={() => handleFetchOptions(filterInputType)} />
-                  ) : !filteredDropDownItems.length && isExpressionInput ? (
+                  ) : !filteredDropDownItems.length && canCommitExpression ? (
                     <ExpressionHintPlaceholder />
                   ) : !filteredDropDownItems.length &&
                     (!allowCustomValue || filterInputType === 'operator' || !inputValue) ? (

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -119,6 +119,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     filterInputType,
     allowCustomValue,
     isGroupBy,
+    populateInputOnEdit,
   });
 
   const isLastFilter = useMemo(() => {
@@ -500,32 +501,38 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
         if (parsed) {
           event.preventDefault();
 
-          if (parsed.value) {
-            controller.startProfile?.(FILTER_CHANGED_INTERACTION);
-
-            if (parsed.operator && !isMultiValueOperator(parsed.operator)) {
-              const custom = onAddCustomValue?.(
-                { label: parsed.value, value: parsed.value } as SelectableValue<string>,
-                filter
-              );
-              parsed.value = custom?.value ?? parsed.value;
-              parsed.valueLabels = custom?.valueLabels ?? parsed.valueLabels;
-            }
+          if (!parsed.value) {
+            controller.updateFilter(filter, parsed);
+            switchInputType('value', setInputType, undefined, refs.domReference.current);
+            setInputValue('');
+            setActiveIndex(null);
+            return;
+          }
+          
+          controller.startProfile?.(FILTER_CHANGED_INTERACTION);
+          
+          const isMultiValueCommit = Boolean(parsed.operator && isMultiValueOperator(parsed.operator));
+          if (!isMultiValueCommit) {
+            const custom = onAddCustomValue?.(
+              { label: parsed.value, value: parsed.value, isCustom: true },
+              filter
+            );
+            parsed.value = custom?.value ?? parsed.value;
+            parsed.valueLabels = custom?.valueLabels ?? parsed.valueLabels;
           }
 
           controller.updateFilter(filter, parsed);
 
-          if (parsed.value) {
-            if (isAlwaysWip) {
-              handleResetWip();
-              setTimeout(() => refs.domReference.current?.focus());
-            } else {
-              handleChangeViewMode?.();
-              focusOnWipInputRef?.();
-            }
+          if (isAlwaysWip) {
+            handleResetWip();
+            setTimeout(() => refs.domReference.current?.focus());
           } else {
-            switchInputType('value', setInputType, undefined, refs.domReference.current);
-            setInputValue('');
+            handleChangeViewMode?.();
+            focusOnWipInputRef?.();
+          }
+
+          if (isMultiValueCommit) {
+            setOpen(false);
           }
 
           setActiveIndex(null);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -511,12 +511,25 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                   .split(',')
                   .map((v) => v.trim())
                   .filter(Boolean);
-                update.value = values[0] ?? '';
+
+                if (!values.length) {
+                  controller.updateFilter(filter, { key, keyLabel, operator: parsed.operator });
+                  switchInputType('value', setInputType, undefined, refs.domReference.current);
+                  setInputValue('');
+                  setActiveIndex(null);
+                  return;
+                }
+
+                update.value = values[0];
                 update.values = values;
                 update.valueLabels = values;
               } else {
-                update.value = parsed.value;
-                update.valueLabels = [parsed.value];
+                const customValue = onAddCustomValue?.(
+                  { label: parsed.value, value: parsed.value } as SelectableValue<string>,
+                  filter
+                );
+                update.value = customValue?.value ?? parsed.value;
+                update.valueLabels = customValue?.valueLabels ?? [parsed.value];
                 update.values = undefined;
               }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -512,10 +512,10 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           controller.startProfile?.(FILTER_CHANGED_INTERACTION);
 
           const isMultiValueCommit = Boolean(parsed.operator && isMultiValueOperator(parsed.operator));
-          if (!isMultiValueCommit) {
-            const custom = onAddCustomValue?.({ label: parsed.value, value: parsed.value, isCustom: true }, filter);
-            parsed.value = custom?.value ?? parsed.value;
-            parsed.valueLabels = custom?.valueLabels ?? parsed.valueLabels;
+          if (!isMultiValueCommit && onAddCustomValue) {
+            const custom = onAddCustomValue({ label: parsed.value, value: parsed.value, isCustom: true }, filter);
+            parsed.value = custom.value;
+            parsed.valueLabels = custom.valueLabels;
           }
 
           controller.updateFilter(filter, parsed);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -112,17 +112,16 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const optionsSearcher = useMemo(() => getAdhocOptionSearcher(options), [options]);
 
+  const operatorValues = useMemo(() => controller.getOperators().map((o) => o.value!), [controller]);
+
   const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
 
   const parsedExpression = useMemo(() => {
     if (!inputValue || !expressionInputEnabled) {
       return null;
     }
-    return parseFilterExpression(
-      inputValue,
-      controller.getOperators().map((o) => o.value!)
-    );
-  }, [inputValue, expressionInputEnabled, controller]);
+    return parseFilterExpression(inputValue, operatorValues);
+  }, [inputValue, expressionInputEnabled, operatorValues]);
 
   const isExpressionInput = parsedExpression !== null;
 
@@ -267,9 +266,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     setInputValue(value);
 
     const nextIsExpressionInput =
-      !!value &&
-      expressionInputEnabled &&
-      parseFilterExpression(value, controller.getOperators().map((o) => o.value!)) !== null;
+      !!value && expressionInputEnabled && parseFilterExpression(value, operatorValues) !== null;
     const nextFilteredItems = flattenOptionGroups(handleOptionGroups(optionsSearcher(value)));
 
     if (nextIsExpressionInput) {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -513,8 +513,10 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
               controller.updateFilter(filter, update);
               if (isAlwaysWip) {
                 handleResetWip();
+                setTimeout(() => refs.domReference.current?.focus());
               } else {
                 handleChangeViewMode?.();
+                focusOnWipInputRef?.();
               }
             } else {
               controller.updateFilter(filter, { key, keyLabel, operator: parsed.operator });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -30,7 +30,6 @@ import {
   flattenOptionGroups,
   generateFilterUpdatePayload,
   generatePlaceholder,
-  parseFilterExpression,
   populateInputValueOnInputTypeSwitch,
   setupDropdownAccessibility,
   switchInputType,
@@ -41,6 +40,7 @@ import {
 } from './utils';
 import { handleOptionGroups } from '../../utils';
 import { useFloatingInteractions, MAX_MENU_HEIGHT } from './useFloatingInteractions';
+import { useFreeFormExpression } from './useFreeFormExpression';
 import { MultiValuePill } from './MultiValuePill';
 import { getAdhocOptionSearcher } from '../getAdhocOptionSearcher';
 import {
@@ -112,18 +112,14 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const optionsSearcher = useMemo(() => getAdhocOptionSearcher(options), [options]);
 
-  const operatorValues = useMemo(() => controller.getOperators().map((o) => o.value!), [controller]);
-
-  const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
-
-  const parsedExpression = useMemo(() => {
-    if (!inputValue || !expressionInputEnabled) {
-      return null;
-    }
-    return parseFilterExpression(inputValue, operatorValues);
-  }, [inputValue, expressionInputEnabled, operatorValues]);
-
-  const isExpressionInput = parsedExpression !== null;
+  const { isExpressionInput, parseExpression, buildExpressionUpdate } = useFreeFormExpression({
+    controller,
+    filter,
+    inputValue,
+    filterInputType,
+    allowCustomValue,
+    isGroupBy,
+  });
 
   const isLastFilter = useMemo(() => {
     if (isAlwaysWip) {
@@ -265,8 +261,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     const value = event.target.value;
     setInputValue(value);
 
-    const nextIsExpressionInput =
-      !!value && expressionInputEnabled && parseFilterExpression(value, operatorValues) !== null;
+    const nextIsExpressionInput = parseExpression(value) !== null;
     const nextFilteredItems = flattenOptionGroups(handleOptionGroups(optionsSearcher(value)));
 
     if (nextIsExpressionInput) {
@@ -499,50 +494,28 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleEnterInput = useCallback(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
-      if (event.key === 'Enter' && isExpressionInput && parsedExpression && filter) {
-        const key = filterInputType === 'operator' ? filter.key : parsedExpression.key;
-        const keyLabel = filterInputType === 'operator' ? filter.keyLabel ?? filter.key : parsedExpression.key;
+      if (event.key === 'Enter' && isExpressionInput && filter) {
+        const parsed = buildExpressionUpdate();
 
-        if (key) {
+        if (parsed) {
           event.preventDefault();
 
-          if (parsedExpression.value) {
+          if (parsed.value) {
             controller.startProfile?.(FILTER_CHANGED_INTERACTION);
 
-            const update: Partial<AdHocFilterWithLabels> = {
-              key,
-              keyLabel,
-              operator: parsedExpression.operator,
-            };
-
-            if (isMultiValueOperator(parsedExpression.operator)) {
-              const values = parsedExpression.value
-                .split(',')
-                .map((v) => v.trim())
-                .filter(Boolean);
-
-              if (!values.length) {
-                controller.updateFilter(filter, { key, keyLabel, operator: parsedExpression.operator });
-                switchInputType('value', setInputType, undefined, refs.domReference.current);
-                setInputValue('');
-                setActiveIndex(null);
-                return;
-              }
-
-              update.value = values[0];
-              update.values = values;
-              update.valueLabels = values;
-            } else {
-              const customValue = onAddCustomValue?.(
-                { label: parsedExpression.value, value: parsedExpression.value } as SelectableValue<string>,
+            if (parsed.operator && !isMultiValueOperator(parsed.operator)) {
+              const custom = onAddCustomValue?.(
+                { label: parsed.value, value: parsed.value } as SelectableValue<string>,
                 filter
               );
-              update.value = customValue?.value ?? parsedExpression.value;
-              update.valueLabels = customValue?.valueLabels ?? [parsedExpression.value];
-              update.values = undefined;
+              parsed.value = custom?.value ?? parsed.value;
+              parsed.valueLabels = custom?.valueLabels ?? parsed.valueLabels;
             }
+          }
 
-            controller.updateFilter(filter, update);
+          controller.updateFilter(filter, parsed);
+
+          if (parsed.value) {
             if (isAlwaysWip) {
               handleResetWip();
               setTimeout(() => refs.domReference.current?.focus());
@@ -551,7 +524,6 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
               focusOnWipInputRef?.();
             }
           } else {
-            controller.updateFilter(filter, { key, keyLabel, operator: parsedExpression.operator });
             switchInputType('value', setInputType, undefined, refs.domReference.current);
             setInputValue('');
           }
@@ -633,8 +605,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       controller,
       filter,
       filterInputType,
-      parsedExpression,
       isExpressionInput,
+      buildExpressionUpdate,
       populateInputOnEdit,
       handleChangeViewMode,
       refs.domReference,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -29,6 +29,7 @@ import {
   flattenOptionGroups,
   generateFilterUpdatePayload,
   generatePlaceholder,
+  parseFilterExpression,
   populateInputValueOnInputTypeSwitch,
   setupDropdownAccessibility,
   switchInputType,
@@ -478,6 +479,55 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleEnterInput = useCallback(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
+      if (event.key === 'Enter' && allowCustomValue && !isGroupBy && inputValue && filter && ['key', 'operator'].includes(filterInputType)) {
+        const operators = controller.getOperators().map((o) => o.value!);
+        const parsed = parseFilterExpression(inputValue, operators);
+
+        if (parsed) {
+          const key = filterInputType === 'operator' ? filter.key : parsed.key;
+          const keyLabel = filterInputType === 'operator' ? filter.keyLabel ?? filter.key : parsed.key;
+
+          if (key) {
+            event.preventDefault();
+
+            if (parsed.value) {
+              controller.startProfile?.(FILTER_CHANGED_INTERACTION);
+
+              const update: Partial<AdHocFilterWithLabels> = {
+                key,
+                keyLabel,
+                operator: parsed.operator,
+              };
+
+              if (isMultiValueOperator(parsed.operator)) {
+                const values = parsed.value.split(',').map((v) => v.trim()).filter(Boolean);
+                update.value = values[0] ?? '';
+                update.values = values;
+                update.valueLabels = values;
+              } else {
+                update.value = parsed.value;
+                update.valueLabels = [parsed.value];
+                update.values = undefined;
+              }
+
+              controller.updateFilter(filter, update);
+              if (isAlwaysWip) {
+                handleResetWip();
+              } else {
+                handleChangeViewMode?.();
+              }
+            } else {
+              controller.updateFilter(filter, { key, keyLabel, operator: parsed.operator });
+              switchInputType('value', setInputType, undefined, refs.domReference.current);
+              setInputValue('');
+            }
+
+            setActiveIndex(null);
+            return;
+          }
+        }
+      }
+
       if (event.key === 'Enter' && activeIndex != null) {
         // safeguard for non existing items
         // note: custom item is added to filteredDropDownItems if allowed
@@ -545,11 +595,13 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     },
     [
       activeIndex,
+      allowCustomValue,
       filteredDropDownItems,
       handleLocalMultiValueChange,
       controller,
       filter,
       filterInputType,
+      inputValue,
       populateInputOnEdit,
       handleChangeViewMode,
       refs.domReference,
@@ -559,6 +611,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       isGroupBy,
       isAlwaysWip,
       handleResetWip,
+      setInputType,
     ]
   );
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -19,6 +19,7 @@ import { AdHocFiltersController } from '../controller/AdHocFiltersController';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   DropdownItem,
+  ExpressionHintPlaceholder,
   LoadingOptionsPlaceholder,
   MultiValueApplyButton,
   NoOptionsPlaceholder,
@@ -110,6 +111,20 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   const filterInputTypeRef = useRef<AdHocInputType>(initialInputType);
 
   const optionsSearcher = useMemo(() => getAdhocOptionSearcher(options), [options]);
+
+  const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
+
+  const parsedExpression = useMemo(() => {
+    if (!inputValue || !expressionInputEnabled) {
+      return null;
+    }
+    return parseFilterExpression(
+      inputValue,
+      controller.getOperators().map((o) => o.value!)
+    );
+  }, [inputValue, expressionInputEnabled, controller]);
+
+  const isExpressionInput = parsedExpression !== null;
 
   const isLastFilter = useMemo(() => {
     if (isAlwaysWip) {
@@ -250,8 +265,16 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   function onChange(event: React.ChangeEvent<HTMLInputElement>) {
     const value = event.target.value;
     setInputValue(value);
+
+    const nextIsExpressionInput =
+      !!value &&
+      expressionInputEnabled &&
+      parseFilterExpression(value, controller.getOperators().map((o) => o.value!)) !== null;
     const nextFilteredItems = flattenOptionGroups(handleOptionGroups(optionsSearcher(value)));
-    if (!nextFilteredItems.length && allowCustomValue) {
+
+    if (nextIsExpressionInput) {
+      setActiveIndex(null);
+    } else if (!nextFilteredItems.length && allowCustomValue) {
       setActiveIndex(0);
     } else {
       setActiveIndex(getFirstSelectableIndex(nextFilteredItems));
@@ -281,7 +304,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   }, []);
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
-  if (allowCustomValue && filterInputType !== 'operator' && inputValue) {
+  if (allowCustomValue && filterInputType !== 'operator' && inputValue && !isExpressionInput) {
     const operatorDefinition = OPERATORS.find((op) => filter?.operator === op.value);
     const customOptionValue: SelectableValue<string> = {
       value: inputValue.trim(),
@@ -479,77 +502,65 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleEnterInput = useCallback(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
-      if (
-        event.key === 'Enter' &&
-        allowCustomValue &&
-        !isGroupBy &&
-        inputValue &&
-        filter &&
-        (filterInputType === 'key' || filterInputType === 'operator')
-      ) {
-        const operators = controller.getOperators().map((o) => o.value!);
-        const parsed = parseFilterExpression(inputValue, operators);
+      if (event.key === 'Enter' && isExpressionInput && parsedExpression && filter) {
+        const key = filterInputType === 'operator' ? filter.key : parsedExpression.key;
+        const keyLabel = filterInputType === 'operator' ? filter.keyLabel ?? filter.key : parsedExpression.key;
 
-        if (parsed) {
-          const key = filterInputType === 'operator' ? filter.key : parsed.key;
-          const keyLabel = filterInputType === 'operator' ? filter.keyLabel ?? filter.key : parsed.key;
+        if (key) {
+          event.preventDefault();
 
-          if (key) {
-            event.preventDefault();
+          if (parsedExpression.value) {
+            controller.startProfile?.(FILTER_CHANGED_INTERACTION);
 
-            if (parsed.value) {
-              controller.startProfile?.(FILTER_CHANGED_INTERACTION);
+            const update: Partial<AdHocFilterWithLabels> = {
+              key,
+              keyLabel,
+              operator: parsedExpression.operator,
+            };
 
-              const update: Partial<AdHocFilterWithLabels> = {
-                key,
-                keyLabel,
-                operator: parsed.operator,
-              };
+            if (isMultiValueOperator(parsedExpression.operator)) {
+              const values = parsedExpression.value
+                .split(',')
+                .map((v) => v.trim())
+                .filter(Boolean);
 
-              if (isMultiValueOperator(parsed.operator)) {
-                const values = parsed.value
-                  .split(',')
-                  .map((v) => v.trim())
-                  .filter(Boolean);
-
-                if (!values.length) {
-                  controller.updateFilter(filter, { key, keyLabel, operator: parsed.operator });
-                  switchInputType('value', setInputType, undefined, refs.domReference.current);
-                  setInputValue('');
-                  setActiveIndex(null);
-                  return;
-                }
-
-                update.value = values[0];
-                update.values = values;
-                update.valueLabels = values;
-              } else {
-                const customValue = onAddCustomValue?.(
-                  { label: parsed.value, value: parsed.value } as SelectableValue<string>,
-                  filter
-                );
-                update.value = customValue?.value ?? parsed.value;
-                update.valueLabels = customValue?.valueLabels ?? [parsed.value];
-                update.values = undefined;
+              if (!values.length) {
+                controller.updateFilter(filter, { key, keyLabel, operator: parsedExpression.operator });
+                switchInputType('value', setInputType, undefined, refs.domReference.current);
+                setInputValue('');
+                setActiveIndex(null);
+                return;
               }
 
-              controller.updateFilter(filter, update);
-              if (isAlwaysWip) {
-                handleResetWip();
-                setTimeout(() => refs.domReference.current?.focus());
-              } else {
-                handleChangeViewMode?.();
-                focusOnWipInputRef?.();
-              }
+              update.value = values[0];
+              update.values = values;
+              update.valueLabels = values;
             } else {
-              controller.updateFilter(filter, { key, keyLabel, operator: parsed.operator });
-              switchInputType('value', setInputType, undefined, refs.domReference.current);
-              setInputValue('');
+              const customValue = onAddCustomValue?.(
+                { label: parsedExpression.value, value: parsedExpression.value } as SelectableValue<string>,
+                filter
+              );
+              update.value = customValue?.value ?? parsedExpression.value;
+              update.valueLabels = customValue?.valueLabels ?? [parsedExpression.value];
+              update.values = undefined;
             }
 
-            setActiveIndex(null);
-            return;
+            controller.updateFilter(filter, update);
+            if (isAlwaysWip) {
+              handleResetWip();
+              setTimeout(() => refs.domReference.current?.focus());
+            } else {
+              handleChangeViewMode?.();
+              focusOnWipInputRef?.();
+            }
+          } else {
+            controller.updateFilter(filter, { key, keyLabel, operator: parsedExpression.operator });
+            switchInputType('value', setInputType, undefined, refs.domReference.current);
+            setInputValue('');
           }
+
+          setActiveIndex(null);
+          return;
         }
       }
 
@@ -620,13 +631,13 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     },
     [
       activeIndex,
-      allowCustomValue,
       filteredDropDownItems,
       handleLocalMultiValueChange,
       controller,
       filter,
       filterInputType,
-      inputValue,
+      parsedExpression,
+      isExpressionInput,
       populateInputOnEdit,
       handleChangeViewMode,
       refs.domReference,
@@ -859,6 +870,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                     <LoadingOptionsPlaceholder />
                   ) : optionsError ? (
                     <OptionsErrorPlaceholder handleFetchOptions={() => handleFetchOptions(filterInputType)} />
+                  ) : !filteredDropDownItems.length && isExpressionInput ? (
+                    <ExpressionHintPlaceholder />
                   ) : !filteredDropDownItems.length &&
                     (!allowCustomValue || filterInputType === 'operator' || !inputValue) ? (
                     <NoOptionsPlaceholder />

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -112,7 +112,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const optionsSearcher = useMemo(() => getAdhocOptionSearcher(options), [options]);
 
-  const { canCommitExpression, parsedExpression, parseExpression, commitExpressionUpdate } = useFreeFormExpression({
+  const { canCommitExpressionUpdate, parseExpression, commitExpressionUpdate } = useFreeFormExpression({
     controller,
     filter,
     inputValue,
@@ -296,7 +296,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   }, []);
 
   // adding custom option this way so that virtualiser is aware of it and can scroll to
-  if (allowCustomValue && filterInputType !== 'operator' && inputValue && !parsedExpression) {
+  if (allowCustomValue && filterInputType !== 'operator' && inputValue && !canCommitExpressionUpdate) {
     const operatorDefinition = OPERATORS.find((op) => filter?.operator === op.value);
     const customOptionValue: SelectableValue<string> = {
       value: inputValue.trim(),
@@ -494,7 +494,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleEnterInput = useCallback(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
-      if (event.key === 'Enter' && canCommitExpression && filter) {
+      if (event.key === 'Enter' && canCommitExpressionUpdate && filter) {
         const parsed = commitExpressionUpdate();
 
         if (parsed) {
@@ -605,7 +605,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       controller,
       filter,
       filterInputType,
-      canCommitExpression,
+      canCommitExpressionUpdate,
       commitExpressionUpdate,
       populateInputOnEdit,
       handleChangeViewMode,
@@ -839,7 +839,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
                     <LoadingOptionsPlaceholder />
                   ) : optionsError ? (
                     <OptionsErrorPlaceholder handleFetchOptions={() => handleFetchOptions(filterInputType)} />
-                  ) : !filteredDropDownItems.length && canCommitExpression ? (
+                  ) : !filteredDropDownItems.length && canCommitExpressionUpdate ? (
                     <ExpressionHintPlaceholder />
                   ) : !filteredDropDownItems.length &&
                     (!allowCustomValue || filterInputType === 'operator' || !inputValue) ? (

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -479,7 +479,14 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleEnterInput = useCallback(
     (event: React.KeyboardEvent, multiValueEdit?: boolean) => {
-      if (event.key === 'Enter' && allowCustomValue && !isGroupBy && inputValue && filter && ['key', 'operator'].includes(filterInputType)) {
+      if (
+        event.key === 'Enter' &&
+        allowCustomValue &&
+        !isGroupBy &&
+        inputValue &&
+        filter &&
+        (filterInputType === 'key' || filterInputType === 'operator')
+      ) {
         const operators = controller.getOperators().map((o) => o.value!);
         const parsed = parseFilterExpression(inputValue, operators);
 
@@ -500,7 +507,10 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
               };
 
               if (isMultiValueOperator(parsed.operator)) {
-                const values = parsed.value.split(',').map((v) => v.trim()).filter(Boolean);
+                const values = parsed.value
+                  .split(',')
+                  .map((v) => v.trim())
+                  .filter(Boolean);
                 update.value = values[0] ?? '';
                 update.values = values;
                 update.valueLabels = values;

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
@@ -108,6 +108,16 @@ export const NoOptionsPlaceholder = () => {
   );
 };
 
+export const ExpressionHintPlaceholder = () => {
+  return (
+    <DropdownItem onClick={(e) => e.stopPropagation()}>
+      <Trans i18nKey="grafana-scenes.variables.expression-hint-placeholder.press-enter-to-apply">
+        Press Enter to apply
+      </Trans>
+    </DropdownItem>
+  );
+};
+
 export const OptionsErrorPlaceholder = ({ handleFetchOptions }: { handleFetchOptions: () => void }) => {
   return (
     <DropdownItem onClick={handleFetchOptions}>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
@@ -10,19 +10,30 @@ interface DropdownItemProps {
   addGroupBottomBorder?: boolean;
   isMultiValueEdit?: boolean;
   checked?: boolean;
+  nonInteractive?: boolean;
 }
 
 export const DropdownItem = forwardRef<HTMLDivElement, DropdownItemProps & React.HTMLProps<HTMLDivElement>>(
-  function DropdownItem({ children, active, addGroupBottomBorder, isMultiValueEdit, checked, ...rest }, ref) {
+  function DropdownItem(
+    { children, active, addGroupBottomBorder, isMultiValueEdit, checked, nonInteractive, ...rest },
+    ref
+  ) {
     const styles = useStyles2(getStyles);
     const id = useId();
+
+    const ariaProps = nonInteractive ? {} : { role: 'option', 'aria-selected': active };
+
     return (
       <div
         ref={ref}
-        role="option"
         id={id}
-        aria-selected={active}
-        className={cx(styles.option, active && styles.optionFocused, addGroupBottomBorder && styles.groupBottomBorder)}
+        {...ariaProps}
+        className={cx(
+          styles.option,
+          active && styles.optionFocused,
+          addGroupBottomBorder && styles.groupBottomBorder,
+          nonInteractive && styles.optionNonInteractive
+        )}
         {...rest}
       >
         <div className={styles.optionBody} data-testid={`data-testid ad hoc filter option value ${children}`}>
@@ -64,6 +75,16 @@ const getStyles = (theme: GrafanaTheme2) => ({
       border: `1px solid ${theme.colors.primary.border}`,
     },
   }),
+  optionNonInteractive: css({
+    label: 'grafana-select-option-non-interactive',
+    cursor: 'default',
+    '&:hover': {
+      background: 'transparent',
+      '@media (forced-colors: active), (prefers-contrast: more)': {
+        border: 'none',
+      },
+    },
+  }),
   optionBody: css({
     label: 'grafana-select-option-body',
     display: 'flex',
@@ -94,7 +115,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 export const LoadingOptionsPlaceholder = () => {
   return (
-    <DropdownItem onClick={(e) => e.stopPropagation()}>
+    <DropdownItem nonInteractive onClick={(e) => e.stopPropagation()}>
       <Trans i18nKey="grafana-scenes.variables.loading-options-placeholder.loading-options">Loading options...</Trans>
     </DropdownItem>
   );
@@ -102,7 +123,7 @@ export const LoadingOptionsPlaceholder = () => {
 
 export const NoOptionsPlaceholder = () => {
   return (
-    <DropdownItem onClick={(e) => e.stopPropagation()}>
+    <DropdownItem nonInteractive onClick={(e) => e.stopPropagation()}>
       <Trans i18nKey="grafana-scenes.variables.no-options-placeholder.no-options-found">No options found</Trans>
     </DropdownItem>
   );
@@ -110,7 +131,7 @@ export const NoOptionsPlaceholder = () => {
 
 export const ExpressionHintPlaceholder = () => {
   return (
-    <DropdownItem onClick={(e) => e.stopPropagation()}>
+    <DropdownItem nonInteractive onClick={(e) => e.stopPropagation()}>
       <Trans i18nKey="grafana-scenes.variables.expression-hint-placeholder.press-enter-to-apply">
         Press Enter to apply
       </Trans>

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
@@ -1,0 +1,244 @@
+import { renderHook } from '@testing-library/react';
+
+import { useFreeFormExpression, UseFreeFormExpressionProps } from './useFreeFormExpression';
+import { OPERATORS } from '../AdHocFiltersVariable';
+import { AdHocFiltersController } from '../controller/AdHocFiltersController';
+
+const DEFAULT_OPERATORS = OPERATORS.map(({ value }) => ({ value }));
+
+function createController(overrides?: Partial<AdHocFiltersController>): AdHocFiltersController {
+  return {
+    useState: () => ({ filters: [] }),
+    getKeys: jest.fn().mockResolvedValue([]),
+    getValuesFor: jest.fn().mockResolvedValue([]),
+    getOperators: jest.fn().mockReturnValue(DEFAULT_OPERATORS),
+    updateFilter: jest.fn(),
+    updateToMatchAll: jest.fn(),
+    removeFilter: jest.fn(),
+    removeLastFilter: jest.fn(),
+    handleComboboxBackspace: jest.fn(),
+    addWip: jest.fn(),
+    restoreOriginalFilter: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderFreeForm(props: Partial<UseFreeFormExpressionProps> = {}) {
+  const defaults: UseFreeFormExpressionProps = {
+    controller: createController(),
+    filter: { key: 'instance', keyLabel: 'Instance', operator: '=', value: '' },
+    inputValue: '',
+    filterInputType: 'key',
+    allowCustomValue: true,
+    isGroupBy: false,
+  };
+  return renderHook((p: UseFreeFormExpressionProps) => useFreeFormExpression(p), {
+    initialProps: { ...defaults, ...props },
+  });
+}
+
+describe('useFreeFormExpression', () => {
+  describe('parseExpression / parsedExpression gating', () => {
+    it('returns null when allowCustomValue is false', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo', allowCustomValue: false });
+      expect(result.current.parsedExpression).toBeNull();
+      expect(result.current.isExpressionInput).toBe(false);
+      expect(result.current.parseExpression('foo = bar')).toBeNull();
+    });
+
+    it('returns null when isGroupBy is true', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo', isGroupBy: true });
+      expect(result.current.parsedExpression).toBeNull();
+      expect(result.current.parseExpression('foo = bar')).toBeNull();
+    });
+
+    it('returns null when filterInputType is "value"', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo', filterInputType: 'value' });
+      expect(result.current.parsedExpression).toBeNull();
+      expect(result.current.parseExpression('foo = bar')).toBeNull();
+    });
+
+    it('returns null for empty / whitespace input', () => {
+      const empty = renderFreeForm({ inputValue: '' });
+      expect(empty.result.current.parsedExpression).toBeNull();
+
+      const whitespace = renderFreeForm({ inputValue: '   ' });
+      expect(whitespace.result.current.parsedExpression).toBeNull();
+    });
+
+    it('returns null for input without a recognised operator', () => {
+      const { result } = renderFreeForm({ inputValue: 'just a key' });
+      expect(result.current.parsedExpression).toBeNull();
+      expect(result.current.isExpressionInput).toBe(false);
+    });
+  });
+
+  describe('parseExpression / parsedExpression success', () => {
+    it('parses a full expression (key + operator + value)', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo' });
+      expect(result.current.parsedExpression).toEqual({ key: 'instance', operator: '=', value: 'tempo' });
+      expect(result.current.isExpressionInput).toBe(true);
+    });
+
+    it('parses a partial expression (operator + value, no key)', () => {
+      const { result } = renderFreeForm({ inputValue: '= tempo' });
+      expect(result.current.parsedExpression).toEqual({ key: undefined, operator: '=', value: 'tempo' });
+    });
+
+    it('parses operator-only input (operator, no value)', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance =' });
+      expect(result.current.parsedExpression).toEqual({ key: 'instance', operator: '=', value: '' });
+    });
+
+    it('parseExpression(inputValue) matches the memoised parsedExpression', () => {
+      const { result } = renderFreeForm({ inputValue: 'region =| us-east, us-west' });
+      expect(result.current.parseExpression('region =| us-east, us-west')).toEqual(result.current.parsedExpression);
+    });
+  });
+
+  describe('buildExpressionUpdate — guards', () => {
+    it('returns null when filter is undefined', () => {
+      const { result } = renderFreeForm({ filter: undefined, inputValue: 'instance = tempo' });
+      expect(result.current.buildExpressionUpdate()).toBeNull();
+    });
+
+    it('returns null when there is no parseable expression', () => {
+      const { result } = renderFreeForm({ inputValue: 'just a key' });
+      expect(result.current.buildExpressionUpdate()).toBeNull();
+    });
+
+    it('returns null when parsing yields no key and we are not in operator input mode', () => {
+      // filterInputType='key' + partial expression ("= tempo") has no key to stage against
+      const { result } = renderFreeForm({
+        filterInputType: 'key',
+        filter: { key: '', operator: '', value: '' },
+        inputValue: '= tempo',
+      });
+      expect(result.current.buildExpressionUpdate()).toBeNull();
+    });
+  });
+
+  describe('buildExpressionUpdate — full commits (filterInputType="key")', () => {
+    it('builds an update for a full single-value expression', () => {
+      const { result } = renderFreeForm({
+        filter: { key: '', operator: '', value: '' },
+        inputValue: 'instance = tempo',
+      });
+
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'instance',
+        keyLabel: 'instance',
+        operator: '=',
+        value: 'tempo',
+        valueLabels: ['tempo'],
+        values: undefined,
+      });
+    });
+
+    it('explicitly clears `values` on single-value commits to unwind a previous multi-value state', () => {
+      const { result } = renderFreeForm({
+        filter: { key: '', operator: '=|', value: 'a', values: ['a', 'b'], valueLabels: ['a', 'b'] },
+        inputValue: 'instance = tempo',
+      });
+      expect(result.current.buildExpressionUpdate()).toMatchObject({ values: undefined });
+    });
+
+    it('builds an update for a multi-value expression (splits commas, trims, filters blanks)', () => {
+      const { result } = renderFreeForm({
+        filter: { key: '', operator: '', value: '' },
+        inputValue: 'region =| us-east,  us-west , eu-north',
+      });
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'region',
+        keyLabel: 'region',
+        operator: '=|',
+        value: 'us-east',
+        values: ['us-east', 'us-west', 'eu-north'],
+        valueLabels: ['us-east', 'us-west', 'eu-north'],
+      });
+    });
+
+    it('stages operator-only (no value) when the user has not typed a value yet', () => {
+      const { result } = renderFreeForm({
+        filter: { key: '', operator: '', value: '' },
+        inputValue: 'instance =',
+      });
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'instance',
+        keyLabel: 'instance',
+        operator: '=',
+      });
+    });
+
+    it('falls back to operator-only staging for multi-value operator with comma-only input', () => {
+      const { result } = renderFreeForm({
+        filter: { key: '', operator: '', value: '' },
+        inputValue: 'region =| ,,  , ',
+      });
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'region',
+        keyLabel: 'region',
+        operator: '=|',
+      });
+    });
+  });
+
+  describe('buildExpressionUpdate — partial commits (filterInputType="operator")', () => {
+    it('uses the staged filter.key when parsing has no key', () => {
+      const { result } = renderFreeForm({
+        filter: { key: 'instance', keyLabel: 'Instance', operator: '', value: '' },
+        filterInputType: 'operator',
+        inputValue: '= tempo',
+      });
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'instance',
+        keyLabel: 'Instance',
+        operator: '=',
+        value: 'tempo',
+        valueLabels: ['tempo'],
+        values: undefined,
+      });
+    });
+
+    it('falls back to filter.key when filter.keyLabel is undefined', () => {
+      const { result } = renderFreeForm({
+        filter: { key: 'instance', operator: '', value: '' },
+        filterInputType: 'operator',
+        inputValue: '= tempo',
+      });
+      expect(result.current.buildExpressionUpdate()).toMatchObject({
+        key: 'instance',
+        keyLabel: 'instance',
+      });
+    });
+
+    it('supports multi-value operators with a staged key', () => {
+      const { result } = renderFreeForm({
+        filter: { key: 'region', keyLabel: 'Region', operator: '', value: '' },
+        filterInputType: 'operator',
+        inputValue: '=| a, b',
+      });
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'region',
+        keyLabel: 'Region',
+        operator: '=|',
+        value: 'a',
+        values: ['a', 'b'],
+        valueLabels: ['a', 'b'],
+      });
+    });
+
+    it('stages operator-only when value is missing', () => {
+      const { result } = renderFreeForm({
+        filter: { key: 'instance', keyLabel: 'Instance', operator: '', value: '' },
+        filterInputType: 'operator',
+        inputValue: '=',
+      });
+      expect(result.current.buildExpressionUpdate()).toEqual({
+        key: 'instance',
+        keyLabel: 'Instance',
+        operator: '=',
+      });
+    });
+  });
+});

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
@@ -31,6 +31,7 @@ function renderFreeForm(props: Partial<UseFreeFormExpressionProps> = {}) {
     filterInputType: 'key',
     allowCustomValue: true,
     isGroupBy: false,
+    populateInputOnEdit: false,
   };
   return renderHook((p: UseFreeFormExpressionProps) => useFreeFormExpression(p), {
     initialProps: { ...defaults, ...props },
@@ -51,6 +52,15 @@ describe('useFreeFormExpression', () => {
 
     it('is false when the input type is "value" (user is picking a value, not typing an expression)', () => {
       const { result } = renderFreeForm({ inputValue: 'instance = tempo', filterInputType: 'value' });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
+    });
+
+    it('is false when editing a specific pill (populateInputOnEdit = true), so pill edits stay scoped to the clicked token', () => {
+      const { result } = renderFreeForm({
+        inputValue: 'instance = tempo',
+        filterInputType: 'operator',
+        populateInputOnEdit: true,
+      });
       expect(result.current.canCommitExpressionUpdate).toBe(false);
     });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
@@ -55,7 +55,11 @@ describe('useFreeFormExpression', () => {
 
   describe('parseExpression / parsedExpression success', () => {
     it.each<[string, string, { key: string | undefined; operator: string; value: string }]>([
-      ['full expression (key + operator + value)', 'instance = tempo', { key: 'instance', operator: '=', value: 'tempo' }],
+      [
+        'full expression (key + operator + value)',
+        'instance = tempo',
+        { key: 'instance', operator: '=', value: 'tempo' },
+      ],
       ['partial expression (operator + value, no key)', '= tempo', { key: undefined, operator: '=', value: 'tempo' }],
       ['operator-only input (operator, no value)', 'instance =', { key: 'instance', operator: '=', value: '' }],
     ])('parses %s', (_label, inputValue, expected) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
@@ -38,71 +38,88 @@ function renderFreeForm(props: Partial<UseFreeFormExpressionProps> = {}) {
 }
 
 describe('useFreeFormExpression', () => {
-  describe('parseExpression / parsedExpression gating', () => {
-    it.each<[string, Partial<UseFreeFormExpressionProps>]>([
-      ['allowCustomValue is false', { inputValue: 'instance = tempo', allowCustomValue: false }],
-      ['isGroupBy is true', { inputValue: 'instance = tempo', isGroupBy: true }],
-      ['filterInputType is "value"', { inputValue: 'instance = tempo', filterInputType: 'value' }],
-      ['input is empty', { inputValue: '' }],
-      ['input is whitespace only', { inputValue: '   ' }],
-      ['input has no recognised operator', { inputValue: 'just a key' }],
-    ])('returns null when %s', (_label, props) => {
-      const { result } = renderFreeForm(props);
-      expect(result.current.parsedExpression).toBeNull();
-      expect(result.current.canCommitExpression).toBe(false);
+  describe('canCommitExpressionUpdate — hook-level gates', () => {
+    it('is false when allowCustomValue is disabled', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo', allowCustomValue: false });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
+    });
+
+    it('is false in groupBy mode', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo', isGroupBy: true });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
+    });
+
+    it('is false when the input type is "value" (user is picking a value, not typing an expression)', () => {
+      const { result } = renderFreeForm({ inputValue: 'instance = tempo', filterInputType: 'value' });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
+    });
+
+    it('is false when input is empty', () => {
+      const { result } = renderFreeForm({ inputValue: '' });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
+    });
+
+    it('is false when input is whitespace only', () => {
+      const { result } = renderFreeForm({ inputValue: '   ' });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
+    });
+
+    it('is false when the input contains no recognised operator', () => {
+      const { result } = renderFreeForm({ inputValue: 'just a key' });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
     });
   });
 
-  describe('parseExpression / parsedExpression success', () => {
-    it.each<[string, string, { key: string | undefined; operator: string; value: string }]>([
-      [
-        'full expression (key + operator + value)',
-        'instance = tempo',
-        { key: 'instance', operator: '=', value: 'tempo' },
-      ],
-      ['partial expression (operator + value, no key)', '= tempo', { key: undefined, operator: '=', value: 'tempo' }],
-      ['operator-only input (operator, no value)', 'instance =', { key: 'instance', operator: '=', value: '' }],
-    ])('parses %s', (_label, inputValue, expected) => {
-      const { result } = renderFreeForm({ inputValue });
-      expect(result.current.parsedExpression).toEqual(expected);
+  describe('canCommitExpressionUpdate — mode-aware committability', () => {
+    it('is false in key mode when the expression has no key (e.g. "= tempo")', () => {
+      const { result } = renderFreeForm({ filterInputType: 'key', inputValue: '= tempo' });
+      expect(result.current.canCommitExpressionUpdate).toBe(false);
     });
 
-    it('parseExpression(inputValue) matches the memoised parsedExpression', () => {
+    it('is true in key mode for a full expression', () => {
+      const { result } = renderFreeForm({ filterInputType: 'key', inputValue: 'instance = tempo' });
+      expect(result.current.canCommitExpressionUpdate).toBe(true);
+    });
+
+    it('is true in key mode for operator-only input with a key (e.g. "instance =")', () => {
+      const { result } = renderFreeForm({ filterInputType: 'key', inputValue: 'instance =' });
+      expect(result.current.canCommitExpressionUpdate).toBe(true);
+    });
+
+    it('is true in operator mode for a partial expression (filter.key fills in the missing key)', () => {
+      const { result } = renderFreeForm({
+        filterInputType: 'operator',
+        filter: { key: 'instance', keyLabel: 'Instance', operator: '', value: '' },
+        inputValue: '= tempo',
+      });
+      expect(result.current.canCommitExpressionUpdate).toBe(true);
+    });
+
+    it('parseExpression(input) agrees with canCommitExpressionUpdate for the same input', () => {
       const { result } = renderFreeForm({ inputValue: 'region =| us-east, us-west' });
-      expect(result.current.parseExpression('region =| us-east, us-west')).toEqual(result.current.parsedExpression);
-    });
-  });
-
-  describe('canCommitExpression — mode-aware commitability', () => {
-    it.each<[string, Partial<UseFreeFormExpressionProps>, boolean]>([
-      ['key mode + full expression', { filterInputType: 'key', inputValue: 'instance = tempo' }, true],
-      ['key mode + operator-only input with key', { filterInputType: 'key', inputValue: 'instance =' }, true],
-      ['key mode + partial expression (no key)', { filterInputType: 'key', inputValue: '= tempo' }, false],
-      [
-        'operator mode + partial expression (filter.key fills in)',
-        {
-          filterInputType: 'operator',
-          filter: { key: 'instance', keyLabel: 'Instance', operator: '', value: '' },
-          inputValue: '= tempo',
-        },
-        true,
-      ],
-    ])('%s → canCommitExpression=%s', (_label, props, expected) => {
-      const { result } = renderFreeForm(props);
-      expect(result.current.canCommitExpression).toBe(expected);
+      expect(result.current.parseExpression('region =| us-east, us-west') !== null).toBe(
+        result.current.canCommitExpressionUpdate
+      );
     });
   });
 
   describe('commitExpressionUpdate — guards', () => {
-    it.each<[string, Partial<UseFreeFormExpressionProps>]>([
-      ['filter is undefined', { filter: undefined, inputValue: 'instance = tempo' }],
-      ['there is no parseable expression', { inputValue: 'just a key' }],
-      [
-        'parsing yields no key and we are not in operator input mode',
-        { filterInputType: 'key', filter: { key: '', operator: '', value: '' }, inputValue: '= tempo' },
-      ],
-    ])('returns null when %s', (_label, props) => {
-      const { result } = renderFreeForm(props);
+    it('returns null when filter is undefined', () => {
+      const { result } = renderFreeForm({ filter: undefined, inputValue: 'instance = tempo' });
+      expect(result.current.commitExpressionUpdate()).toBeNull();
+    });
+
+    it('returns null when there is no parseable expression', () => {
+      const { result } = renderFreeForm({ inputValue: 'just a key' });
+      expect(result.current.commitExpressionUpdate()).toBeNull();
+    });
+
+    it('returns null when parsing yields no key and we are not in operator input mode', () => {
+      const { result } = renderFreeForm({
+        filterInputType: 'key',
+        filter: { key: '', operator: '', value: '' },
+        inputValue: '= tempo',
+      });
       expect(result.current.commitExpressionUpdate()).toBeNull();
     });
   });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.test.ts
@@ -39,55 +39,28 @@ function renderFreeForm(props: Partial<UseFreeFormExpressionProps> = {}) {
 
 describe('useFreeFormExpression', () => {
   describe('parseExpression / parsedExpression gating', () => {
-    it('returns null when allowCustomValue is false', () => {
-      const { result } = renderFreeForm({ inputValue: 'instance = tempo', allowCustomValue: false });
+    it.each<[string, Partial<UseFreeFormExpressionProps>]>([
+      ['allowCustomValue is false', { inputValue: 'instance = tempo', allowCustomValue: false }],
+      ['isGroupBy is true', { inputValue: 'instance = tempo', isGroupBy: true }],
+      ['filterInputType is "value"', { inputValue: 'instance = tempo', filterInputType: 'value' }],
+      ['input is empty', { inputValue: '' }],
+      ['input is whitespace only', { inputValue: '   ' }],
+      ['input has no recognised operator', { inputValue: 'just a key' }],
+    ])('returns null when %s', (_label, props) => {
+      const { result } = renderFreeForm(props);
       expect(result.current.parsedExpression).toBeNull();
-      expect(result.current.isExpressionInput).toBe(false);
-      expect(result.current.parseExpression('foo = bar')).toBeNull();
-    });
-
-    it('returns null when isGroupBy is true', () => {
-      const { result } = renderFreeForm({ inputValue: 'instance = tempo', isGroupBy: true });
-      expect(result.current.parsedExpression).toBeNull();
-      expect(result.current.parseExpression('foo = bar')).toBeNull();
-    });
-
-    it('returns null when filterInputType is "value"', () => {
-      const { result } = renderFreeForm({ inputValue: 'instance = tempo', filterInputType: 'value' });
-      expect(result.current.parsedExpression).toBeNull();
-      expect(result.current.parseExpression('foo = bar')).toBeNull();
-    });
-
-    it('returns null for empty / whitespace input', () => {
-      const empty = renderFreeForm({ inputValue: '' });
-      expect(empty.result.current.parsedExpression).toBeNull();
-
-      const whitespace = renderFreeForm({ inputValue: '   ' });
-      expect(whitespace.result.current.parsedExpression).toBeNull();
-    });
-
-    it('returns null for input without a recognised operator', () => {
-      const { result } = renderFreeForm({ inputValue: 'just a key' });
-      expect(result.current.parsedExpression).toBeNull();
-      expect(result.current.isExpressionInput).toBe(false);
+      expect(result.current.canCommitExpression).toBe(false);
     });
   });
 
   describe('parseExpression / parsedExpression success', () => {
-    it('parses a full expression (key + operator + value)', () => {
-      const { result } = renderFreeForm({ inputValue: 'instance = tempo' });
-      expect(result.current.parsedExpression).toEqual({ key: 'instance', operator: '=', value: 'tempo' });
-      expect(result.current.isExpressionInput).toBe(true);
-    });
-
-    it('parses a partial expression (operator + value, no key)', () => {
-      const { result } = renderFreeForm({ inputValue: '= tempo' });
-      expect(result.current.parsedExpression).toEqual({ key: undefined, operator: '=', value: 'tempo' });
-    });
-
-    it('parses operator-only input (operator, no value)', () => {
-      const { result } = renderFreeForm({ inputValue: 'instance =' });
-      expect(result.current.parsedExpression).toEqual({ key: 'instance', operator: '=', value: '' });
+    it.each<[string, string, { key: string | undefined; operator: string; value: string }]>([
+      ['full expression (key + operator + value)', 'instance = tempo', { key: 'instance', operator: '=', value: 'tempo' }],
+      ['partial expression (operator + value, no key)', '= tempo', { key: undefined, operator: '=', value: 'tempo' }],
+      ['operator-only input (operator, no value)', 'instance =', { key: 'instance', operator: '=', value: '' }],
+    ])('parses %s', (_label, inputValue, expected) => {
+      const { result } = renderFreeForm({ inputValue });
+      expect(result.current.parsedExpression).toEqual(expected);
     });
 
     it('parseExpression(inputValue) matches the memoised parsedExpression', () => {
@@ -96,36 +69,48 @@ describe('useFreeFormExpression', () => {
     });
   });
 
-  describe('buildExpressionUpdate — guards', () => {
-    it('returns null when filter is undefined', () => {
-      const { result } = renderFreeForm({ filter: undefined, inputValue: 'instance = tempo' });
-      expect(result.current.buildExpressionUpdate()).toBeNull();
-    });
-
-    it('returns null when there is no parseable expression', () => {
-      const { result } = renderFreeForm({ inputValue: 'just a key' });
-      expect(result.current.buildExpressionUpdate()).toBeNull();
-    });
-
-    it('returns null when parsing yields no key and we are not in operator input mode', () => {
-      // filterInputType='key' + partial expression ("= tempo") has no key to stage against
-      const { result } = renderFreeForm({
-        filterInputType: 'key',
-        filter: { key: '', operator: '', value: '' },
-        inputValue: '= tempo',
-      });
-      expect(result.current.buildExpressionUpdate()).toBeNull();
+  describe('canCommitExpression — mode-aware commitability', () => {
+    it.each<[string, Partial<UseFreeFormExpressionProps>, boolean]>([
+      ['key mode + full expression', { filterInputType: 'key', inputValue: 'instance = tempo' }, true],
+      ['key mode + operator-only input with key', { filterInputType: 'key', inputValue: 'instance =' }, true],
+      ['key mode + partial expression (no key)', { filterInputType: 'key', inputValue: '= tempo' }, false],
+      [
+        'operator mode + partial expression (filter.key fills in)',
+        {
+          filterInputType: 'operator',
+          filter: { key: 'instance', keyLabel: 'Instance', operator: '', value: '' },
+          inputValue: '= tempo',
+        },
+        true,
+      ],
+    ])('%s → canCommitExpression=%s', (_label, props, expected) => {
+      const { result } = renderFreeForm(props);
+      expect(result.current.canCommitExpression).toBe(expected);
     });
   });
 
-  describe('buildExpressionUpdate — full commits (filterInputType="key")', () => {
+  describe('commitExpressionUpdate — guards', () => {
+    it.each<[string, Partial<UseFreeFormExpressionProps>]>([
+      ['filter is undefined', { filter: undefined, inputValue: 'instance = tempo' }],
+      ['there is no parseable expression', { inputValue: 'just a key' }],
+      [
+        'parsing yields no key and we are not in operator input mode',
+        { filterInputType: 'key', filter: { key: '', operator: '', value: '' }, inputValue: '= tempo' },
+      ],
+    ])('returns null when %s', (_label, props) => {
+      const { result } = renderFreeForm(props);
+      expect(result.current.commitExpressionUpdate()).toBeNull();
+    });
+  });
+
+  describe('commitExpressionUpdate — full commits (filterInputType="key")', () => {
     it('builds an update for a full single-value expression', () => {
       const { result } = renderFreeForm({
         filter: { key: '', operator: '', value: '' },
         inputValue: 'instance = tempo',
       });
 
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'instance',
         keyLabel: 'instance',
         operator: '=',
@@ -140,7 +125,7 @@ describe('useFreeFormExpression', () => {
         filter: { key: '', operator: '=|', value: 'a', values: ['a', 'b'], valueLabels: ['a', 'b'] },
         inputValue: 'instance = tempo',
       });
-      expect(result.current.buildExpressionUpdate()).toMatchObject({ values: undefined });
+      expect(result.current.commitExpressionUpdate()).toMatchObject({ values: undefined });
     });
 
     it('builds an update for a multi-value expression (splits commas, trims, filters blanks)', () => {
@@ -148,7 +133,7 @@ describe('useFreeFormExpression', () => {
         filter: { key: '', operator: '', value: '' },
         inputValue: 'region =| us-east,  us-west , eu-north',
       });
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'region',
         keyLabel: 'region',
         operator: '=|',
@@ -163,7 +148,7 @@ describe('useFreeFormExpression', () => {
         filter: { key: '', operator: '', value: '' },
         inputValue: 'instance =',
       });
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'instance',
         keyLabel: 'instance',
         operator: '=',
@@ -175,7 +160,7 @@ describe('useFreeFormExpression', () => {
         filter: { key: '', operator: '', value: '' },
         inputValue: 'region =| ,,  , ',
       });
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'region',
         keyLabel: 'region',
         operator: '=|',
@@ -183,14 +168,14 @@ describe('useFreeFormExpression', () => {
     });
   });
 
-  describe('buildExpressionUpdate — partial commits (filterInputType="operator")', () => {
+  describe('commitExpressionUpdate — partial commits (filterInputType="operator")', () => {
     it('uses the staged filter.key when parsing has no key', () => {
       const { result } = renderFreeForm({
         filter: { key: 'instance', keyLabel: 'Instance', operator: '', value: '' },
         filterInputType: 'operator',
         inputValue: '= tempo',
       });
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'instance',
         keyLabel: 'Instance',
         operator: '=',
@@ -206,7 +191,7 @@ describe('useFreeFormExpression', () => {
         filterInputType: 'operator',
         inputValue: '= tempo',
       });
-      expect(result.current.buildExpressionUpdate()).toMatchObject({
+      expect(result.current.commitExpressionUpdate()).toMatchObject({
         key: 'instance',
         keyLabel: 'instance',
       });
@@ -218,7 +203,7 @@ describe('useFreeFormExpression', () => {
         filterInputType: 'operator',
         inputValue: '=| a, b',
       });
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'region',
         keyLabel: 'Region',
         operator: '=|',
@@ -234,7 +219,7 @@ describe('useFreeFormExpression', () => {
         filterInputType: 'operator',
         inputValue: '=',
       });
-      expect(result.current.buildExpressionUpdate()).toEqual({
+      expect(result.current.commitExpressionUpdate()).toEqual({
         key: 'instance',
         keyLabel: 'Instance',
         operator: '=',

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -29,8 +29,7 @@ export function useFreeFormExpression({
     .map((o) => o.value)
     .filter((value): value is string => Boolean(value));
 
-  const expressionInputEnabled =
-    allowCustomValue && !isGroupBy && filterInputType !== 'value' && !populateInputOnEdit;
+  const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value' && !populateInputOnEdit;
 
   const parseExpression = useCallback(
     (input: string) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -12,6 +12,7 @@ export interface UseFreeFormExpressionProps {
   filterInputType: AdHocInputType;
   allowCustomValue: boolean;
   isGroupBy: boolean | undefined;
+  populateInputOnEdit: boolean | undefined;
 }
 
 export function useFreeFormExpression({
@@ -21,13 +22,15 @@ export function useFreeFormExpression({
   filterInputType,
   allowCustomValue,
   isGroupBy,
+  populateInputOnEdit,
 }: UseFreeFormExpressionProps) {
   const operatorValues = controller
     .getOperators()
     .map((o) => o.value)
     .filter((value): value is string => Boolean(value));
 
-  const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
+  const expressionInputEnabled =
+    allowCustomValue && !isGroupBy && filterInputType !== 'value' && !populateInputOnEdit;
 
   const parseExpression = useCallback(
     (input: string) => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -22,7 +22,9 @@ export function useFreeFormExpression({
   allowCustomValue,
   isGroupBy,
 }: UseFreeFormExpressionProps) {
-  const operatorValues = useMemo(() => controller.getOperators().map((o) => o.value!), [controller]);
+  const operatorValues = controller.getOperators()
+    .map((o) => o.value)
+    .filter((value): value is string => Boolean(value))
 
   const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
 
@@ -37,9 +39,10 @@ export function useFreeFormExpression({
   );
 
   const parsedExpression = useMemo(() => parseExpression(inputValue), [parseExpression, inputValue]);
-  const isExpressionInput = parsedExpression !== null;
+  const canCommitExpression =
+    parsedExpression !== null && (filterInputType === 'operator' || Boolean(parsedExpression.key));
 
-  const buildExpressionUpdate = useCallback((): Partial<AdHocFilterWithLabels> | null => {
+  const commitExpressionUpdate = useCallback((): Partial<AdHocFilterWithLabels> | null => {
     if (!parsedExpression || !filter) {
       return null;
     }
@@ -79,8 +82,8 @@ export function useFreeFormExpression({
 
   return {
     parsedExpression,
-    isExpressionInput,
     parseExpression,
-    buildExpressionUpdate,
+    canCommitExpression,
+    commitExpressionUpdate,
   };
 }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -1,0 +1,86 @@
+import { useCallback, useMemo } from 'react';
+
+import { AdHocFilterWithLabels, isMultiValueOperator } from '../AdHocFiltersVariable';
+import { AdHocFiltersController } from '../controller/AdHocFiltersController';
+import { parseFilterExpression } from './utils';
+import { AdHocInputType } from './AdHocFiltersCombobox';
+
+export interface UseFreeFormExpressionProps {
+  controller: AdHocFiltersController;
+  filter: AdHocFilterWithLabels | undefined;
+  inputValue: string;
+  filterInputType: AdHocInputType;
+  allowCustomValue: boolean;
+  isGroupBy: boolean | undefined;
+}
+
+export function useFreeFormExpression({
+  controller,
+  filter,
+  inputValue,
+  filterInputType,
+  allowCustomValue,
+  isGroupBy,
+}: UseFreeFormExpressionProps) {
+  const operatorValues = useMemo(() => controller.getOperators().map((o) => o.value!), [controller]);
+
+  const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
+
+  const parseExpression = useCallback(
+    (input: string) => {
+      if (!input || !expressionInputEnabled) {
+        return null;
+      }
+      return parseFilterExpression(input, operatorValues);
+    },
+    [expressionInputEnabled, operatorValues]
+  );
+
+  const parsedExpression = useMemo(() => parseExpression(inputValue), [parseExpression, inputValue]);
+  const isExpressionInput = parsedExpression !== null;
+
+  const buildExpressionUpdate = useCallback((): Partial<AdHocFilterWithLabels> | null => {
+    if (!parsedExpression || !filter) {
+      return null;
+    }
+
+    const key = filterInputType === 'operator' ? filter.key : parsedExpression.key;
+    const keyLabel = filterInputType === 'operator' ? filter.keyLabel ?? filter.key : parsedExpression.key;
+    if (!key) {
+      return null;
+    }
+
+    const staged: Partial<AdHocFilterWithLabels> = { key, keyLabel, operator: parsedExpression.operator };
+
+    if (!parsedExpression.value) {
+      return staged;
+    }
+
+    if (isMultiValueOperator(parsedExpression.operator)) {
+      const values = parsedExpression.value
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+
+      if (!values.length) {
+        return staged;
+      }
+
+      return { ...staged, value: values[0], values, valueLabels: values };
+    }
+
+    return {
+      ...staged,
+      value: parsedExpression.value,
+      valueLabels: [parsedExpression.value],
+      values: undefined,
+    };
+  }, [filter, filterInputType, parsedExpression]);
+
+  return {
+    parsedExpression,
+    isExpressionInput,
+    parseExpression,
+    buildExpressionUpdate,
+  };
+}

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -24,10 +24,10 @@ export function useFreeFormExpression({
   isGroupBy,
   populateInputOnEdit,
 }: UseFreeFormExpressionProps) {
-  const operatorValues = controller
-    .getOperators()
-    .map((o) => o.value)
-    .filter((value): value is string => Boolean(value));
+  const operatorValues = useMemo(
+    () => controller.getOperators().map((o) => o.value).filter((v): v is string => Boolean(v)),
+    [controller]
+  );
 
   const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value' && !populateInputOnEdit;
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -25,7 +25,11 @@ export function useFreeFormExpression({
   populateInputOnEdit,
 }: UseFreeFormExpressionProps) {
   const operatorValues = useMemo(
-    () => controller.getOperators().map((o) => o.value).filter((v): v is string => Boolean(v)),
+    () =>
+      controller
+        .getOperators()
+        .map((o) => o.value)
+        .filter((v): v is string => Boolean(v)),
     [controller]
   );
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -34,14 +34,20 @@ export function useFreeFormExpression({
       if (!input || !expressionInputEnabled) {
         return null;
       }
-      return parseFilterExpression(input, operatorValues);
+      const parsed = parseFilterExpression(input, operatorValues);
+      if (!parsed) {
+        return null;
+      }
+      if (filterInputType !== 'operator' && !parsed.key) {
+        return null;
+      }
+      return parsed;
     },
-    [expressionInputEnabled, operatorValues]
+    [expressionInputEnabled, operatorValues, filterInputType]
   );
 
   const parsedExpression = useMemo(() => parseExpression(inputValue), [parseExpression, inputValue]);
-  const canCommitExpression =
-    parsedExpression !== null && (filterInputType === 'operator' || Boolean(parsedExpression.key));
+  const canCommitExpressionUpdate = parsedExpression !== null;
 
   const commitExpressionUpdate = useCallback((): Partial<AdHocFilterWithLabels> | null => {
     if (!parsedExpression || !filter) {
@@ -82,9 +88,8 @@ export function useFreeFormExpression({
   }, [filter, filterInputType, parsedExpression]);
 
   return {
-    parsedExpression,
     parseExpression,
-    canCommitExpression,
+    canCommitExpressionUpdate,
     commitExpressionUpdate,
   };
 }

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -22,9 +22,10 @@ export function useFreeFormExpression({
   allowCustomValue,
   isGroupBy,
 }: UseFreeFormExpressionProps) {
-  const operatorValues = controller.getOperators()
+  const operatorValues = controller
+    .getOperators()
     .map((o) => o.value)
-    .filter((value): value is string => Boolean(value))
+    .filter((value): value is string => Boolean(value));
 
   const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value';
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.test.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.test.ts
@@ -1,4 +1,9 @@
-import { generatePlaceholder, INPUT_PLACEHOLDER_DEFAULT, GROUP_BY_PLACEHOLDER_DEFAULT } from './utils';
+import {
+  generatePlaceholder,
+  INPUT_PLACEHOLDER_DEFAULT,
+  GROUP_BY_PLACEHOLDER_DEFAULT,
+  parseFilterExpression,
+} from './utils';
 import { AdHocFilterWithLabels } from '../AdHocFiltersVariable';
 
 describe('generatePlaceholder', () => {
@@ -153,5 +158,44 @@ describe('generatePlaceholder', () => {
         expect(result).toBe(GROUP_BY_PLACEHOLDER_DEFAULT);
       });
     });
+  });
+});
+
+describe('parseFilterExpression', () => {
+  const operators = ['=', '!=', '=|', '!=|', '=~', '!~', '<', '<=', '>', '>='];
+
+  it.each<[string, { key: string | undefined; operator: string; value: string }]>([
+    ['instance = tempo', { key: 'instance', operator: '=', value: 'tempo' }],
+    ['instance!=tempo-distributor', { key: 'instance', operator: '!=', value: 'tempo-distributor' }],
+    ['error_rate >= 0.5', { key: 'error_rate', operator: '>=', value: '0.5' }],
+    ['method =~ GET|POST', { key: 'method', operator: '=~', value: 'GET|POST' }],
+    ['region =| us-east', { key: 'region', operator: '=|', value: 'us-east' }],
+    ['region !=| us-east', { key: 'region', operator: '!=|', value: 'us-east' }],
+    ['method !~ DELETE', { key: 'method', operator: '!~', value: 'DELETE' }],
+    ['latency < 100', { key: 'latency', operator: '<', value: '100' }],
+    ['latency <= 100', { key: 'latency', operator: '<=', value: '100' }],
+    ['latency > 100', { key: 'latency', operator: '>', value: '100' }],
+    ['latency >= 100', { key: 'latency', operator: '>=', value: '100' }],
+    ['instance=', { key: 'instance', operator: '=', value: '' }],
+    ['instance = ', { key: 'instance', operator: '=', value: '' }],
+    ['my.label-name = foo', { key: 'my.label-name', operator: '=', value: 'foo' }],
+    ['key!=|val', { key: 'key', operator: '!=|', value: 'val' }],
+    ['  instance = tempo  ', { key: 'instance', operator: '=', value: 'tempo' }],
+    ['= tempo', { key: undefined, operator: '=', value: 'tempo' }],
+    ['!=tempo', { key: undefined, operator: '!=', value: 'tempo' }],
+    ['=~ GET|POST', { key: undefined, operator: '=~', value: 'GET|POST' }],
+    ['!=| us-east', { key: undefined, operator: '!=|', value: 'us-east' }],
+    ['>= 0.5', { key: undefined, operator: '>=', value: '0.5' }],
+    ['=', { key: undefined, operator: '=', value: '' }],
+    ['!= ', { key: undefined, operator: '!=', value: '' }],
+    ['key = value=with=equals', { key: 'key', operator: '=', value: 'value=with=equals' }],
+    ['region =| us-east, us-west, eu-north', { key: 'region', operator: '=|', value: 'us-east, us-west, eu-north' }],
+    ['region !=| us-east,us-west', { key: 'region', operator: '!=|', value: 'us-east,us-west' }],
+  ])('should parse "%s"', (input, expected) => {
+    expect(parseFilterExpression(input, operators)).toEqual(expected);
+  });
+
+  it.each<string>(['just-a-key', 'plain text', '', '   '])('should return null for "%s"', (input) => {
+    expect(parseFilterExpression(input, operators)).toBeNull();
   });
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -220,3 +220,50 @@ export const populateInputValueOnInputTypeSwitch = ({
     setInputValue('');
   }
 };
+
+/**
+ * Parse a free-form filter string into its parts.
+ * Handles both full expressions ("instance = tempo") and partial ones ("= tempo", "!=").
+ * Returns null if no recognised operator is found.
+ *
+ * Finds the earliest operator occurrence in the string. When multiple operators
+ * match at the same position, the longest one wins (e.g. "!=" over "=").
+ *
+ * @param operatorValues - The operator strings to recognise, sourced from controller.getOperators().
+ */
+export function parseFilterExpression(
+  input: string,
+  operatorValues: string[]
+): { key: string | undefined; operator: string; value: string } | null {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let matchIndex = -1;
+  let matchedOperator = '';
+
+  for (const op of operatorValues) {
+    const idx = trimmed.indexOf(op);
+    if (idx === -1) {
+      continue;
+    }
+
+    if (matchIndex === -1 || idx < matchIndex || (idx === matchIndex && op.length > matchedOperator.length)) {
+      matchIndex = idx;
+      matchedOperator = op;
+    }
+  }
+
+  if (matchIndex === -1) {
+    return null;
+  }
+
+  const key = matchIndex > 0 ? trimmed.slice(0, matchIndex).trim() : undefined;
+  if (matchIndex > 0 && !key) {
+    return null;
+  }
+
+  const value = trimmed.slice(matchIndex + matchedOperator.length).trim();
+  return { key, operator: matchedOperator, value };
+}


### PR DESCRIPTION
**What is this feature?**

Allows users to type a complete filter expression (e.g. instance = tempo) into the ad-hoc filter combobox and commit it with Enter, instead of selecting key, operator, and value one by one



https://github.com/user-attachments/assets/21b38149-16dc-4c30-b191-c948f041b79c



Fixes: https://github.com/grafana/grafana/issues/121024
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.0--canary.1431.25064603103.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.1.0--canary.1431.25064603103.0
  npm install @grafana/scenes-react@8.1.0--canary.1431.25064603103.0
  # or 
  yarn add @grafana/scenes@8.1.0--canary.1431.25064603103.0
  yarn add @grafana/scenes-react@8.1.0--canary.1431.25064603103.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
