### PR TITLE
Variables: Fix options search to be case-insensitive

### DIFF
--- a/packages/scenes/src/variables/filter.test.ts
+++ b/packages/scenes/src/variables/filter.test.ts
@@ -155,7 +155,7 @@ describe('filter', () => {
     });
 
     it('should do case-insensitive substring match when needle contains special characters', () => {
-      const stringOptions = ['test-variable-value', 'another-test-variable-value', 'other-subscription'];
+      const stringOptions = ['test-variable-value', 'other-subscription'];
       const options = stringOptions.map((value) => ({ value }));
 
       const matches = fuzzyFind(options, stringOptions, 'TEST-Variable-value');

--- a/packages/scenes/src/variables/filter.test.ts
+++ b/packages/scenes/src/variables/filter.test.ts
@@ -57,6 +57,15 @@ describe('filter', () => {
 
       expect(matches.map((m) => m.value)).toEqual(['台南市', '南投縣']);
     });
+
+    it('should do case-insensitive substring match when needle contains non-ascii characters', () => {
+      const stringOptions = ['Über'];
+      const options = stringOptions.map((value) => ({ value }));
+
+      const matches = fuzzyFind(options, stringOptions, 'ü');
+
+      expect(matches.map((m) => m.value)).toEqual(['Über']);
+    });
   });
 
   describe('operators', () => {
@@ -143,6 +152,15 @@ describe('filter', () => {
 
       // Should only match exact substring
       expect(matches.map((m) => m.value)).toEqual(['user@example.com']);
+    });
+
+    it('should do case-insensitive substring match when needle contains special characters', () => {
+      const stringOptions = ['test-variable-value', 'another-test-variable-value', 'other-subscription'];
+      const options = stringOptions.map((value) => ({ value }));
+
+      const matches = fuzzyFind(options, stringOptions, 'TEST-Variable-value');
+
+      expect(matches.map((m) => m.value)).toEqual(['test-variable-value']);
     });
 
     it('should fall back to substring match when needle contains backslash', () => {

--- a/packages/scenes/src/variables/filter.ts
+++ b/packages/scenes/src/variables/filter.ts
@@ -1,4 +1,4 @@
-import { SelectableValue } from '@grafana/data';
+import { escapeRegex, SelectableValue } from '@grafana/data';
 import uFuzzy from '@leeoniya/ufuzzy';
 import { VariableValueOption } from './types';
 
@@ -48,10 +48,12 @@ export function fuzzyFind<T extends SelectableValue | VariableValueOption>(
     // if these differ then special chars exist in the input
     keptChars !== inputChars
   ) {
+    const needleRegex = new RegExp(escapeRegex(needle), 'i');
+
     for (let i = 0; i < haystack.length; i++) {
       let item = haystack[i];
 
-      if (item.includes(needle)) {
+      if (needleRegex.test(item)) {
         matches.push(options[i]);
       }
     }


### PR DESCRIPTION
This PR turns variable option search to also be case insensitive when searching with special chars. Case insensitivity was already there so for a var option `test` and a search `TEST` it would correctly match, but this did not work well if a char like `-` appeared, so an option `test-value` would not be matched by a search string `TEST-`. This PR fixes that
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.4.2--canary.1433.24826259640.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@7.4.2--canary.1433.24826259640.0
  npm install @grafana/scenes-react@7.4.2--canary.1433.24826259640.0
  # or 
  yarn add @grafana/scenes@7.4.2--canary.1433.24826259640.0
  yarn add @grafana/scenes-react@7.4.2--canary.1433.24826259640.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
