### PR TITLE
AdHocFilters: Don't store incomplete filters in recents

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersRecommendations.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersRecommendations.test.tsx
@@ -223,6 +223,28 @@ describe('AdHocFiltersRecommendations', () => {
         expect(recommendations!.state.recentFilters!.length).toBeLessThanOrEqual(MAX_RECENT_DRILLDOWNS);
       });
     });
+
+    it('should not store incomplete filters', async () => {
+      const { filtersVar } = setup({
+        drilldownRecommendationsEnabled: true,
+        filters: [{ key: 'cluster', value: '1', operator: '=' }],
+      });
+
+      let recommendations: AdHocFiltersRecommendations | undefined;
+      await waitFor(() => {
+        recommendations = filtersVar.getRecommendations();
+        expect(recommendations).toBeDefined();
+      });
+
+      act(() => {
+        recommendations!.storeRecentFilter({ key: '', operator: '', value: '' });
+        recommendations!.storeRecentFilter({ key: 'cluster', operator: '', value: '' });
+        recommendations!.storeRecentFilter({ key: 'cluster', operator: '=', value: '' });
+        recommendations!.storeRecentFilter({ key: '', operator: '=', value: 'us-east' });
+      });
+
+      expect(localStorage.getItem(RECENT_FILTERS_KEY)).toBeNull();
+    });
   });
 
   describe('addFilterToParent', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersRecommendations.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersRecommendations.tsx
@@ -12,8 +12,8 @@ import { getDataSource } from '../../utils/getDataSource';
 import { DrilldownRecommendations, DrilldownPill } from '../components/DrilldownRecommendations';
 import { ScopesVariable } from '../variants/ScopesVariable';
 import { SCOPES_VARIABLE_NAME } from '../constants';
-import { AdHocFilterWithLabels, AdHocFiltersVariable, isGroupByFilter } from './AdHocFiltersVariable';
 import { getAdHocFilterInteractionHandler } from '../../core/sceneGraph/getReportInteractionHandler';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, isFilterComplete, isGroupByFilter } from './AdHocFiltersVariable';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneComponentProps, SceneObjectState } from '../../core/types';
 import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSerializableSceneObject';
@@ -293,8 +293,13 @@ export class AdHocFiltersRecommendations extends SceneObjectBase<AdHocFiltersRec
 
   /**
    * Stores a recent filter in localStorage and updates state.
+   * No-op for filters that are not yet complete (key/operator/value all set)
    */
   public storeRecentFilter(filter: AdHocFilterWithLabels) {
+    if (!isFilterComplete(filter)) {
+      return;
+    }
+
     const key = this._getFiltersStorageKey();
     const storedFilters = store.get(key);
     const allRecentFilters = storedFilters ? JSON.parse(storedFilters) : [];
@@ -311,10 +316,10 @@ export class AdHocFiltersRecommendations extends SceneObjectBase<AdHocFiltersRec
 
   /**
    * Stores a recent grouping key in localStorage and updates state.
-   * No-op when enableGroupBy is false.
+   * No-op when enableGroupBy is false or when the key is empty.
    */
   public storeRecentGrouping(groupByKey: string) {
-    if (!this._isGroupByEnabled) {
+    if (!this._isGroupByEnabled || !groupByKey) {
       return;
     }
 


### PR DESCRIPTION
**What is this change?**
Guards `storeRecentFilter` / `storeRecentGrouping` so they only persist filters that are actually complete (key + operator + value)

This is currently possible when adding a filter -> deleting it using backspace 

before:

https://github.com/user-attachments/assets/873206d6-a6ff-42b7-9c14-ae1165032d13


after:

https://github.com/user-attachments/assets/0e64652a-ff3e-4e2d-811d-02f002d61633



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.2--canary.1437.25167055427.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.1.2--canary.1437.25167055427.0
  npm install @grafana/scenes-react@8.1.2--canary.1437.25167055427.0
  # or 
  yarn add @grafana/scenes@8.1.2--canary.1437.25167055427.0
  yarn add @grafana/scenes-react@8.1.2--canary.1437.25167055427.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
