### PR TITLE
SceneRefreshPicker: use new loadingText prop on RefreshPicker

### DIFF
--- a/packages/scenes/src/components/SceneRefreshPicker.tsx
+++ b/packages/scenes/src/components/SceneRefreshPicker.tsx
@@ -219,18 +219,13 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       ? t('grafana-scenes.components.scene-refresh-picker.text-refresh', 'Refresh')
       : undefined;
   let tooltip: string | undefined;
-  let width: string | undefined;
+  let loadingText: string | undefined;
+  if (withText) {
+    loadingText = t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel');
+  }
 
   if (isRunning) {
     tooltip = t('grafana-scenes.components.scene-refresh-picker.tooltip-cancel', 'Cancel all queries');
-
-    if (withText) {
-      text = t('grafana-scenes.components.scene-refresh-picker.text-cancel', 'Cancel');
-    }
-  }
-
-  if (withText) {
-    width = '96px';
   }
 
   return (
@@ -239,8 +234,9 @@ export function SceneRefreshPickerRenderer({ model }: SceneComponentProps<SceneR
       value={refresh}
       intervals={intervals}
       tooltip={tooltip}
-      width={width}
       text={text}
+      // @ts-expect-error - this prop is only available in grafana>13.1.0-25211456722
+      loadingText={loadingText}
       onRefresh={() => {
         model.onRefresh();
       }}


### PR DESCRIPTION
- uses new `loadingText` prop available on `RefreshPicker`
  - this removes the need for a hardcoded width! 🥳 
  - not sure the best way to set this property without getting a type error - seems scenes pulls in grafana/ui@11.6.0? 😕 
- follow up to https://github.com/grafana/grafana/pull/123894

Fixes https://github.com/grafana/grafana/issues/123801
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.3--canary.1438.25211572201.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.1.3--canary.1438.25211572201.0
  npm install @grafana/scenes-react@8.1.3--canary.1438.25211572201.0
  # or 
  yarn add @grafana/scenes@8.1.3--canary.1438.25211572201.0
  yarn add @grafana/scenes-react@8.1.3--canary.1438.25211572201.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
