### PR TITLE
VIzPanel: add data-viz-panel-id attribute

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -238,7 +238,12 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   return (
     <div className={relativeWrapper}>
-      <div ref={ref as RefCallback<HTMLDivElement>} className={absoluteWrapper} data-viz-panel-key={model.state.key}>
+      <div
+        ref={ref as RefCallback<HTMLDivElement>}
+        className={absoluteWrapper}
+        data-viz-panel-key={model.state.key}
+        data-viz-panel-id={model.getPathId()}
+      >
         <PanelChrome
           title={titleInterpolated}
           description={description?.trim() ? model.getDescription : undefined}


### PR DESCRIPTION
Adds `data-viz-panel-id={model.getPathId()}` on VizPanel's wrapping element. `data-viz-panel-key` (= `state.key`) is shared across repeated panel instances; `getPathId()` disambiguates. Additive - existing attribute kept.

Unblocks [grafana/grafana#124045](https://github.com/grafana/grafana/pull/124045).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.3--canary.1439.25364282343.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.1.3--canary.1439.25364282343.0
  npm install @grafana/scenes-react@8.1.3--canary.1439.25364282343.0
  # or 
  yarn add @grafana/scenes@8.1.3--canary.1439.25364282343.0
  yarn add @grafana/scenes-react@8.1.3--canary.1439.25364282343.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
