### PR TITLE
AdHocFilters: Fix stale operator list in free-form expression input

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -24,14 +24,9 @@ export function useFreeFormExpression({
   isGroupBy,
   populateInputOnEdit,
 }: UseFreeFormExpressionProps) {
-  const operatorValues = useMemo(
-    () =>
-      controller
-        .getOperators()
-        .map((o) => o.value)
-        .filter((v): v is string => Boolean(v)),
-    [controller]
-  );
+  const operatorValues = controller.getOperators()
+    .map((o) => o.value)
+    .filter((v): v is string => Boolean(v))
 
   const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value' && !populateInputOnEdit;
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/useFreeFormExpression.ts
@@ -24,9 +24,10 @@ export function useFreeFormExpression({
   isGroupBy,
   populateInputOnEdit,
 }: UseFreeFormExpressionProps) {
-  const operatorValues = controller.getOperators()
+  const operatorValues = controller
+    .getOperators()
     .map((o) => o.value)
-    .filter((v): v is string => Boolean(v))
+    .filter((v): v is string => Boolean(v));
 
   const expressionInputEnabled = allowCustomValue && !isGroupBy && filterInputType !== 'value' && !populateInputOnEdit;
 


### PR DESCRIPTION
The `controller` reference is stable across renders, drop the memo and derive operators directly

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.3--canary.1440.25382986387.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.1.3--canary.1440.25382986387.0
  npm install @grafana/scenes-react@8.1.3--canary.1440.25382986387.0
  # or 
  yarn add @grafana/scenes@8.1.3--canary.1440.25382986387.0
  yarn add @grafana/scenes-react@8.1.3--canary.1440.25382986387.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
