### PR TITLE
Filters: Validate `originFilters` better on set

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1433,32 +1433,39 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(filtersVar.state.originFilters![0].restorable).toBe(false);
   });
 
-  it('does not crash when restoring an origin filter that was seeded without a value', () => {
-    // Repro: an origin filter is supplied with neither `value` nor `values` (e.g. dashboard
-    // JSON whose origin filter lost its value through a previous round-trip). Before the fix,
-    // _setOriginalValue stored [undefined], and a later restoreOriginalFilter (e.g. on
-    // dashboard navigation deactivation) propagated value: undefined into renderFilter, which
-    // then crashed on undefined.replace(...).
+  it('still stores groupBy origin filters in _originalValues even without a value field', () => {
+    // groupBy origin filters carry their meaning in the key, not the value. They must
+    // round-trip through _originalValues so getOriginalFilters() reflects them when the
+    // dashboard is saved. Don't drop them via the no-value guard meant for regular filters.
     const { filtersVar } = setup({
-      originFilters: [
-        {
-          key: 'dbFilter1',
-          operator: '=~',
-          // value and values intentionally omitted
-          origin: 'dashboard',
-        } as AdHocFilterWithLabels,
-      ],
+      originFilters: [{ key: 'cluster', operator: 'groupBy', origin: 'dashboard' } as AdHocFilterWithLabels],
     });
 
-    // Nothing legitimate to restore to, so no original should be stored.
+    expect(
+      filtersVar['_originalValues'].has(`cluster${VALUE_KEY_DELIMITER}dashboard${VALUE_KEY_DELIMITER}groupBy`)
+    ).toBe(true);
+    expect(filtersVar.getOriginalFilters().some((f) => f.key === 'cluster' && f.operator === 'groupBy')).toBe(true);
+  });
+
+  it('does not crash when restoring an origin filter whose stored original lacks a value', () => {
+    // Repro: at some point an origin filter without a usable value is fed to the variable
+    // (e.g. dashboard JSON whose origin filter lost its value through a previous round-trip,
+    // or an external setOriginalFilters call). Before the fix, _setOriginalValue stored
+    // [undefined] for it, and a later restoreOriginalFilter (e.g. on dashboard navigation
+    // deactivation) propagated value: undefined into renderFilter, which crashed on
+    // undefined.replace(...).
+    const { filtersVar } = setup({
+      originFilters: [{ key: 'dbFilter1', operator: '=~', value: 'currentVal', origin: 'dashboard' }],
+    });
+
+    // Pollute _originalValues with the buggy shape via the public API. The fix is to drop
+    // such filters at the seam instead of storing [undefined].
+    filtersVar.setOriginalFilters([{ key: 'dbFilter1', operator: '=~', origin: 'dashboard' } as AdHocFilterWithLabels]);
     expect(filtersVar['_originalValues'].has(`dbFilter1${VALUE_KEY_DELIMITER}dashboard`)).toBe(false);
 
     act(() => {
-      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
-        value: 'edited',
-      });
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], { value: 'edited' });
     });
-
     expect(filtersVar.state.originFilters![0].restorable).toBe(true);
 
     expect(() => {
@@ -1468,34 +1475,8 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     }).not.toThrow();
 
     // With no original to restore to, restore is a no-op and the user's edit is preserved
-    // rather than being silently rewritten to an empty string.
+    // rather than being silently rewritten to an empty string or undefined.
     expect(filtersVar.state.originFilters![0].value).toBe('edited');
-  });
-
-  it('does not include filters without a renderable value in the rendered expression', () => {
-    // Safety net: even if a filter sneaks through with value === undefined (e.g. external
-    // mutation), renderExpression must skip it instead of crashing on .replace().
-    const { filtersVar } = setup({
-      originFilters: [
-        {
-          key: 'dbFilter1',
-          operator: '=',
-          value: 'dbValue1',
-          origin: 'dashboard',
-        },
-      ],
-    });
-
-    act(() => {
-      filtersVar.setState({
-        originFilters: [
-          ...(filtersVar.state.originFilters ?? []),
-          { key: 'broken', operator: '=~', origin: 'dashboard' } as AdHocFilterWithLabels,
-        ],
-      });
-    });
-
-    expect(filtersVar.state.filterExpression).toBe('dbFilter1="dbValue1",key1="val1",key2="val2"');
   });
 
   it('will save the original value and set filter as restorable if it has an origin', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1434,10 +1434,11 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('does not crash when restoring an origin filter that was seeded without a value', () => {
-    // Repro: an origin filter is supplied with neither `value` nor `values`. Before the fix,
+    // Repro: an origin filter is supplied with neither `value` nor `values` (e.g. dashboard
+    // JSON whose origin filter lost its value through a previous round-trip). Before the fix,
     // _setOriginalValue stored [undefined], and a later restoreOriginalFilter (e.g. on
-    // dashboard navigation) propagated value: undefined into renderFilter, which then crashed
-    // on undefined.replace(...).
+    // dashboard navigation deactivation) propagated value: undefined into renderFilter, which
+    // then crashed on undefined.replace(...).
     const { filtersVar } = setup({
       originFilters: [
         {
@@ -1448,6 +1449,9 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         } as AdHocFilterWithLabels,
       ],
     });
+
+    // Nothing legitimate to restore to, so no original should be stored.
+    expect(filtersVar['_originalValues'].has(`dbFilter1${VALUE_KEY_DELIMITER}dashboard`)).toBe(false);
 
     act(() => {
       filtersVar._updateFilter(filtersVar.state.originFilters![0], {
@@ -1463,7 +1467,35 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       });
     }).not.toThrow();
 
-    expect(filtersVar.state.originFilters![0].value).toBe('');
+    // With no original to restore to, restore is a no-op and the user's edit is preserved
+    // rather than being silently rewritten to an empty string.
+    expect(filtersVar.state.originFilters![0].value).toBe('edited');
+  });
+
+  it('does not include filters without a renderable value in the rendered expression', () => {
+    // Safety net: even if a filter sneaks through with value === undefined (e.g. external
+    // mutation), renderExpression must skip it instead of crashing on .replace().
+    const { filtersVar } = setup({
+      originFilters: [
+        {
+          key: 'dbFilter1',
+          operator: '=',
+          value: 'dbValue1',
+          origin: 'dashboard',
+        },
+      ],
+    });
+
+    act(() => {
+      filtersVar.setState({
+        originFilters: [
+          ...(filtersVar.state.originFilters ?? []),
+          { key: 'broken', operator: '=~', origin: 'dashboard' } as AdHocFilterWithLabels,
+        ],
+      });
+    });
+
+    expect(filtersVar.state.filterExpression).toBe('dbFilter1="dbValue1",key1="val1",key2="val2"');
   });
 
   it('will save the original value and set filter as restorable if it has an origin', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1434,9 +1434,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('still stores groupBy origin filters in _originalValues even without a value field', () => {
-    // groupBy origin filters carry their meaning in the key, not the value. They must
-    // round-trip through _originalValues so getOriginalFilters() reflects them when the
-    // dashboard is saved. Don't drop them via the no-value guard meant for regular filters.
     const { filtersVar } = setup({
       originFilters: [{ key: 'cluster', operator: 'groupBy', origin: 'dashboard' } as AdHocFilterWithLabels],
     });
@@ -1448,12 +1445,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('does not crash when restoring an origin filter whose stored original lacks a value', () => {
-    // Repro: at some point an origin filter without a usable value is fed to the variable
-    // (e.g. dashboard JSON whose origin filter lost its value through a previous round-trip,
-    // or an external setOriginalFilters call). Before the fix, _setOriginalValue stored
-    // [undefined] for it, and a later restoreOriginalFilter (e.g. on dashboard navigation
-    // deactivation) propagated value: undefined into renderFilter, which crashed on
-    // undefined.replace(...).
     const { filtersVar } = setup({
       originFilters: [{ key: 'dbFilter1', operator: '=~', value: 'currentVal', origin: 'dashboard' }],
     });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1433,6 +1433,39 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(filtersVar.state.originFilters![0].restorable).toBe(false);
   });
 
+  it('does not crash when restoring an origin filter that was seeded without a value', () => {
+    // Repro: an origin filter is supplied with neither `value` nor `values`. Before the fix,
+    // _setOriginalValue stored [undefined], and a later restoreOriginalFilter (e.g. on
+    // dashboard navigation) propagated value: undefined into renderFilter, which then crashed
+    // on undefined.replace(...).
+    const { filtersVar } = setup({
+      originFilters: [
+        {
+          key: 'dbFilter1',
+          operator: '=~',
+          // value and values intentionally omitted
+          origin: 'dashboard',
+        } as AdHocFilterWithLabels,
+      ],
+    });
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
+        value: 'edited',
+      });
+    });
+
+    expect(filtersVar.state.originFilters![0].restorable).toBe(true);
+
+    expect(() => {
+      act(() => {
+        filtersVar.restoreOriginalFilter(filtersVar.state.originFilters![0]);
+      });
+    }).not.toThrow();
+
+    expect(filtersVar.state.originFilters![0].value).toBe('');
+  });
+
   it('will save the original value and set filter as restorable if it has an origin', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -601,10 +601,7 @@ export class AdHocFiltersVariable
     const rawValues = filter.values ?? [filter.value];
     const value = rawValues.filter((v): v is string => v !== undefined && v !== null);
 
-    // A filter with no usable value isn't actually restorable to anything. Storing [undefined]
-    // here would later flow back through restoreOriginalFilter -> renderFilter and crash on
-    // String.prototype.replace, so skip rather than seed a fake original.
-    if (value.length === 0) {
+    if (!isGroupByFilter(filter) && value.length === 0) {
       return;
     }
 
@@ -1241,15 +1238,8 @@ function renderExpression(
   filters: AdHocFilterWithLabels[] | undefined
 ) {
   return (builder ?? renderPrometheusLabelFilters)(
-    filters?.filter((f) => isFilterApplicable(f) && !isGroupByFilter(f) && hasRenderableValue(f)) ?? []
+    filters?.filter((f) => isFilterApplicable(f) && !isGroupByFilter(f)) ?? []
   );
-}
-
-function hasRenderableValue(filter: AdHocFilterWithLabels): boolean {
-  if (isMultiValueOperator(filter.operator)) {
-    return Array.isArray(filter.values) && filter.values.length > 0 && filter.values.every((v) => v != null);
-  }
-  return filter.value != null;
 }
 
 function getGroupByKeys(filters: AdHocFilterWithLabels[]): string[] {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -599,10 +599,14 @@ export class AdHocFiltersVariable
    */
   private _setOriginalValue(filter: AdHocFilterWithLabels): void {
     const rawValues = filter.values ?? [filter.value];
-    // Filter out undefined entries and ensure at least an empty-string seed so
-    // a later restoreOriginalFilter cannot resurrect `value: undefined` and crash renderFilter.
-    const sanitized = rawValues.filter((v): v is string => v !== undefined && v !== null);
-    const value = sanitized.length > 0 ? sanitized : [''];
+    const value = rawValues.filter((v): v is string => v !== undefined && v !== null);
+
+    // A filter with no usable value isn't actually restorable to anything. Storing [undefined]
+    // here would later flow back through restoreOriginalFilter -> renderFilter and crash on
+    // String.prototype.replace, so skip rather than seed a fake original.
+    if (value.length === 0) {
+      return;
+    }
 
     this._originalValues.set(originalValueKey(filter), {
       value,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -598,6 +598,10 @@ export class AdHocFiltersVariable
    * Store a snapshot of the filter's current value and operator so it can be restored later.
    */
   private _setOriginalValue(filter: AdHocFilterWithLabels): void {
+    if (!isFilterComplete(filter)) {
+      return;
+    }
+
     const rawValues = filter.values ?? [filter.value];
     const value = rawValues.filter((v): v is string => v !== undefined && v !== null);
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -598,8 +598,14 @@ export class AdHocFiltersVariable
    * Store a snapshot of the filter's current value and operator so it can be restored later.
    */
   private _setOriginalValue(filter: AdHocFilterWithLabels): void {
+    const rawValues = filter.values ?? [filter.value];
+    // Filter out undefined entries and ensure at least an empty-string seed so
+    // a later restoreOriginalFilter cannot resurrect `value: undefined` and crash renderFilter.
+    const sanitized = rawValues.filter((v): v is string => v !== undefined && v !== null);
+    const value = sanitized.length > 0 ? sanitized : [''];
+
     this._originalValues.set(originalValueKey(filter), {
-      value: filter.values ?? [filter.value],
+      value,
       operator: filter.operator,
       ...(filter.valueLabels && { valueLabels: filter.valueLabels }),
       ...(filter.keyLabel && { keyLabel: filter.keyLabel }),
@@ -1231,8 +1237,15 @@ function renderExpression(
   filters: AdHocFilterWithLabels[] | undefined
 ) {
   return (builder ?? renderPrometheusLabelFilters)(
-    filters?.filter((f) => isFilterApplicable(f) && !isGroupByFilter(f)) ?? []
+    filters?.filter((f) => isFilterApplicable(f) && !isGroupByFilter(f) && hasRenderableValue(f)) ?? []
   );
+}
+
+function hasRenderableValue(filter: AdHocFilterWithLabels): boolean {
+  if (isMultiValueOperator(filter.operator)) {
+    return Array.isArray(filter.values) && filter.values.length > 0 && filter.values.every((v) => v != null);
+  }
+  return filter.value != null;
 }
 
 function getGroupByKeys(filters: AdHocFilterWithLabels[]): string[] {


### PR DESCRIPTION
Validates the `originFilters` have a valid filter passed to them when set. Potentially, in some scenarios, the filter might not be complete, for example coming from scopes, which will cause a crash downstream when trying to build the expression