### PR TITLE
Fix: Skip legacy `CircularDataFrame` frames in `useClearPreviousData()`

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -335,6 +335,11 @@ function useClearPreviousData(data?: DataFrame[]) {
     currVals.current.clear();
 
     for (let i = 0; i < currFrames.length; i++) {
+      // skip legacy CircularDataFrame streaming frames
+      if ('appendRow' in currFrames[i]) {
+        continue;
+      }
+
       let fields = currFrames[i].fields;
 
       for (let j = 0; j < fields.length; j++) {


### PR DESCRIPTION
https://github.com/grafana/support-escalations/issues/22223

the legacy `CircularDataFrame` class (that extends the deprecated `MutableDataFrame`) which the [unmaintained] Redis plugin uses for streaming uses proxy objects for various frame properties, and these do not support mutation. so we skip them here via a cheap prop check.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.4--canary.1443.25574082078.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.2.4--canary.1443.25574082078.0
  npm install @grafana/scenes-react@8.2.4--canary.1443.25574082078.0
  # or 
  yarn add @grafana/scenes@8.2.4--canary.1443.25574082078.0
  yarn add @grafana/scenes-react@8.2.4--canary.1443.25574082078.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
