### PR TITLE
docs: document SceneQueryRunner for custom views and loading states

### DIFF
--- a/docusaurus/docs/advanced-data.md
+++ b/docusaurus/docs/advanced-data.md
@@ -61,6 +61,79 @@ class CustomObject extends SceneObjectBase<CustomObjectState> {
 The subscription returned from `sourceData.subscribeToState` is added to `this._subs`. Because of this, you don't need to do any cleanup when the custom object is destroyed, as the library will take care of unsubscribing.
 :::
 
+## Custom HTML or non-VizPanel views
+
+`SceneQueryRunner` is a **`SceneDataProvider`**: it is not tied to Grafana’s chart panels (`VizPanel`). To build tables, KPIs, or plain HTML/CSS from query results:
+
+1. Place a `SceneQueryRunner` on an ancestor (`$data` on `EmbeddedScene` or a layout item), or attach `$data` to the same branch as your custom object.
+2. In your renderer, call **`sceneGraph.getData(model).useState()`** (or `subscribeToState` / [`getResultsStream()`](#subscribe-outside-react-with-getresultsstream) for non-hook code).
+3. Read **`panelData`** from `@grafana/data`’s **`PanelData`** shape: **`series`** (data frames), **`annotations`**, **`state`** (`LoadingState` from **`@grafana/data`**), **`errors`**.
+
+### Loading state and incremental updates
+
+The runner uses Grafana’s **`runRequest`**. That API pushes **updates over time**, not only one final object. Expect:
+
+- **`LoadingState.Loading`**—including while variables are still resolving—and sometimes **multiple** emissions before **`LoadingState.Done`**.
+- **`LoadingState.Done`** when the datasource finished successfully.
+- **`LoadingState.Error`** (or **`errors`** on the payload) on failure.
+
+Your UI should treat **`panelData` as reactive stream state**: show spinners/skeletons on **`Loading`**, render frames on **`Done`**, surface **`errors`** on failure.
+
+Example pattern:
+
+```tsx
+import { LoadingState } from '@grafana/data';
+
+function TableFromQueryRenderer({ model }: SceneComponentProps<CustomObject>) {
+  const providerState = sceneGraph.getData(model).useState();
+  const panelData = providerState.data;
+
+  if (!panelData || panelData.state === LoadingState.Loading) {
+    return <div>Loading…</div>;
+  }
+
+  if (panelData.state === LoadingState.Error && panelData.errors?.length) {
+    return (
+      <div role="alert">
+        {panelData.errors.map((e, i) => (
+          <p key={i}>{e.message}</p>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <table className="my-html-table">
+      <tbody>
+        {panelData.series.map((frame, idx) => (
+          <tr key={idx}>
+            <td>{frame.name ?? frame.refId}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+```
+
+Adapt row/cell extraction to your datasource (inspect `frame.fields` or use **`DataFrameView`** when you need typed rows).
+
+## `SceneQueryRunner` options relevant to custom views
+
+These `SceneQueryRunner` state fields affect **when** and **how** queries run—affecting what your HTML panel observes:
+
+| Option | Purpose |
+| ------ | ------- |
+| **`runQueriesMode`** | **`'auto'`** (default) runs on activate, time range changes, and when variable dependencies settle. **`'manual'`** skips that—call **`runQueries()`** yourself (tests or special workflows). |
+| **`maxDataPointsFromWidth`** | When **`true`**, Grafana picks **`maxDataPoints`** from the panel container width—you must **`setContainerWidth(px)`** on the runner when your layout settles (typically from the render path measuring the wrapper). Without width, queries may defer until known. |
+| **`isInViewChanged` / `bypassIsInViewChanged`** | Used with lazy rendering: runners can **defer** executing until visible; call **`isInViewChanged(true)`** when scrolled into view. |
+
+For variable loading and cascading dependencies (why queries briefly stay in **`Loading`** without issuing a datasource call), see [Waiting for variables](./advanced-variables#waiting-for-variables).
+
+## Subscribe outside React with `getResultsStream`
+
+For logic outside React (or imperative subscribers), **`SceneDataProvider.getResultsStream()`** returns an RxJS-compatible stream that replays **`{ origin, data }`** payloads (same **`PanelData`** as **`useState`**). Prefer **`sceneGraph.getData`** + **`subscribeToState`** for most scenes; **`getResultsStream`** is optional when integrating non-React code.
+
 ## Use time range
 
 Similarly to data, you can use the closest time range in a custom scene object using `sceneGraph.getTimeRange(model)`. This method can be used both in the custom object class and the renderer, as described previously in the [Use data](#use-data) section.

--- a/docusaurus/docs/core-concepts.md
+++ b/docusaurus/docs/core-concepts.md
@@ -191,6 +191,10 @@ const scene = new EmbeddedScene({
 
 Each scene object has a `$data` and `$timeRange` property that can be configured. Because a scene is an object tree, the data and time range configured through `SceneQueryRunner` and `SceneTimeRange` respectively are available to the objects they're added to _and_ all descendant objects.
 
+:::tip
+**Custom HTML or non-`VizPanel` views:** you can drive any markup from `SceneQueryRunner` by using `sceneGraph.getData()` and reading **`PanelData`** (`series`, `state`, errors). Grafana’s query pipeline typically emits **`Loading` several times**, then **`Done`**—same as dashboard panels—not a single snapshot. See [Data and time range in custom scene objects](./advanced-data).
+:::
+
 In the following example, each `VizPanel` uses different data. "Panel A" uses data defined on the `EmbeddedScene`, while "Panel B" has its own data and time range configured:
 
 ```tsx


### PR DESCRIPTION
**Motivation**
I use SceneQueryRunner behind my own HTML/React components rather than Grafana’s built-in viz. It was hard to discover that query results are delivered as a stream of PanelData updates (same as dashboard panels / runRequest), not a single payload. In production I assumed a stable first response and mishandled cases where Loading and Done did not behave like “first message = loading, last = done” in the simple mental model—I sometimes saw Done sooner than expected in the sequence of updates.

I also did not know **runQueriesMode**: 'manual' existed and used a much worse workaround (e.g. clearing queries to stop execution). Recording runQueriesMode, getResultsStream, and PanelData/loading semantics in the docs should help the next developer avoid the same integration mistakes.

**What changed**
core-concepts.md: tip under Data and time range linking custom views + streaming loading behavior to advanced-data.
advanced-data.md: sections on custom HTML, LoadingState/incremental updates, SceneQueryRunner options (runQueriesMode, maxDataPointsFromWidth, lazy/in-view), and getResultsStream.

**Notes**
Documentation only; no SDK behavior changes.

