### PR TITLE
Filters: Extra guard on filters coming from scopes

### DIFF
--- a/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
+++ b/packages/scenes/src/variables/adhoc/getAdHocFiltersFromScopes.ts
@@ -45,7 +45,7 @@ function processFilter(
   duplicatedFilters: AdHocFilterWithLabels[],
   filter: ScopeSpecFilter
 ) {
-  if (!filter) {
+  if (!filter || !filter.key || !filter.operator || !filter.value) {
     return;
   }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.5--canary.1445.25657793781.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.2.5--canary.1445.25657793781.0
  npm install @grafana/scenes-react@8.2.5--canary.1445.25657793781.0
  # or 
  yarn add @grafana/scenes@8.2.5--canary.1445.25657793781.0
  yarn add @grafana/scenes-react@8.2.5--canary.1445.25657793781.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
