### PR TITLE
Filters: Fix setting wrong original filter value

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -599,7 +599,7 @@ export class AdHocFiltersVariable
    */
   private _setOriginalValue(filter: AdHocFilterWithLabels): void {
     this._originalValues.set(originalValueKey(filter), {
-      value: filter.values ?? [filter.value],
+      value: filter.values && filter.values.length ? filter.values : [filter.value],
       operator: filter.operator,
       ...(filter.valueLabels && { valueLabels: filter.valueLabels }),
       ...(filter.keyLabel && { keyLabel: filter.keyLabel }),


### PR DESCRIPTION
Fixes a bug where the `values` prop might exist but be an empty array `[]`, in that case it would set that as the value instead of defaulting to the `[filter.value]`, which would lose the original and cause issues on restore.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.5--canary.1446.25665636763.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.2.5--canary.1446.25665636763.0
  npm install @grafana/scenes-react@8.2.5--canary.1446.25665636763.0
  # or 
  yarn add @grafana/scenes@8.2.5--canary.1446.25665636763.0
  yarn add @grafana/scenes-react@8.2.5--canary.1446.25665636763.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
