### PR TITLE
fix(ScopedVars): Fix getValue

### DIFF
--- a/packages/scenes/src/variables/interpolation/ScopedVarsVariable.test.ts
+++ b/packages/scenes/src/variables/interpolation/ScopedVarsVariable.test.ts
@@ -1,0 +1,55 @@
+import { ScopedVar } from '@grafana/data';
+
+import { ScopedVarsVariable } from './ScopedVarsVariable';
+
+function makeScopedVar(value: unknown, text?: string): ScopedVar {
+  return { value, text };
+}
+
+describe('ScopedVarsVariable', () => {
+  describe('getValue', () => {
+    it('returns a string value as-is', () => {
+      const wrapper = new ScopedVarsVariable('server', makeScopedVar('server1'));
+
+      expect(wrapper.getValue('')).toBe('server1');
+    });
+
+    it('returns a number value as-is', () => {
+      const wrapper = new ScopedVarsVariable('count', makeScopedVar(42));
+
+      expect(wrapper.getValue('')).toBe(42);
+    });
+
+    it('returns a boolean value as-is', () => {
+      const wrapper = new ScopedVarsVariable('enabled', makeScopedVar(true));
+
+      expect(wrapper.getValue('')).toBe(true);
+    });
+
+    it('returns an array value as-is', () => {
+      const value = ['server1', 'server2'];
+      const wrapper = new ScopedVarsVariable('servers', makeScopedVar(value));
+
+      expect(wrapper.getValue('')).toEqual(['server1', 'server2']);
+      expect(Array.isArray(wrapper.getValue(''))).toBe(true);
+    });
+
+    it('returns a nested field when fieldPath is provided', () => {
+      const wrapper = new ScopedVarsVariable('host', makeScopedVar({ name: 'server1', port: 3000 }));
+
+      expect(wrapper.getValue('name')).toBe('server1');
+    });
+
+    it('returns a deeply nested field via dot-path', () => {
+      const wrapper = new ScopedVarsVariable('config', makeScopedVar({ host: { name: 'srv' } }));
+
+      expect(wrapper.getValue('host.name')).toBe('srv');
+    });
+
+    it('returns undefined for a non-existent fieldPath', () => {
+      const wrapper = new ScopedVarsVariable('host', makeScopedVar({ a: 1 }));
+
+      expect(wrapper.getValue('b')).toBeUndefined();
+    });
+  });
+});

--- a/packages/scenes/src/variables/interpolation/ScopedVarsVariable.ts
+++ b/packages/scenes/src/variables/interpolation/ScopedVarsVariable.ts
@@ -13,20 +13,8 @@ export class ScopedVarsVariable implements FormatVariable {
   }
 
   public getValue(fieldPath: string): VariableValue {
-    let { value } = this.state;
-    let realValue = value.value;
-
-    if (fieldPath) {
-      realValue = getFieldAccessor(fieldPath)(value.value);
-    } else {
-      realValue = value.value;
-    }
-
-    if (realValue === 'string' || realValue === 'number' || realValue === 'boolean') {
-      return realValue;
-    }
-
-    return String(realValue);
+    const { value } = this.state;
+    return fieldPath ? getFieldAccessor(fieldPath)(value.value) : value.value;
   }
 
   public getValueText(): string {


### PR DESCRIPTION
The same bug exists in Grafana and is tackled by https://github.com/grafana/grafana/pull/123285 

### Problem
The guard condition in `ScopedVarsVariable.getValue()` incorrectly compared the runtime value against the string literals 'string', 'number', and 'boolean' instead of using `typeof`.

For multi-value scoped variables where the value is an array, this coerced ['a', 'b'] into 'a,b'. The method also had no test coverage.