### PR TITLE
style: fix prettier error

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -235,7 +235,11 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   const context = model.getPanelContext();
   const panelId = model.getLegacyPanelId();
-  const outdatedPluginError = t('grafana-scenes.components.viz-panel-renderer.outdated-plugin-error', 'An unexpected error occurred. Updating the "{{pluginName}}" plugin to the latest version may fix the problem.', { pluginName: plugin.meta.name });
+  const outdatedPluginError = t(
+    'grafana-scenes.components.viz-panel-renderer.outdated-plugin-error',
+    'An unexpected error occurred. Updating the "{{pluginName}}" plugin to the latest version may fix the problem.',
+    { pluginName: plugin.meta.name }
+  );
 
   return (
     <div className={relativeWrapper}>
@@ -285,7 +289,10 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
             }
 
             return (
-              <ErrorBoundaryAlert title={plugin.meta.hasUpdate ? outdatedPluginError : undefined} dependencies={[plugin, data]}>
+              <ErrorBoundaryAlert
+                title={plugin.meta.hasUpdate ? outdatedPluginError : undefined}
+                dependencies={[plugin, data]}
+              >
                 <PluginContextProvider meta={plugin.meta}>
                   <PanelContextProvider value={context}>
                     {isReadyToRender && (


### PR DESCRIPTION
Looks like the suggestions in https://github.com/grafana/scenes/pull/1449 caused prettier errors which are failing CI (which was disabled for the last 3 days due to an incident so went unnoticed).
