### PR TITLE
LiveNowTimer: make refresh rate configurable

### DIFF
--- a/packages/scenes/src/behaviors/LiveNowTimer.test.ts
+++ b/packages/scenes/src/behaviors/LiveNowTimer.test.ts
@@ -44,6 +44,37 @@ describe('LiveNowTimer', () => {
 
     expect(VizPanel.prototype.forceRender).toHaveBeenCalledTimes(2);
   });
+
+  it('should restart the interval with the new rate when enabled', () => {
+    const { timer } = setup({ enabled: false });
+    timer.enable();
+
+    expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), LiveNowTimer.DEFAULT_REFRESH_RATE);
+
+    timer.setRefreshRate(500);
+
+    expect(clearInterval).toHaveBeenCalledTimes(2);
+    expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 500);
+    expect(timer.isEnabled).toBe(true);
+  });
+
+  it('should not enable a disabled timer when setRefreshRate is called', () => {
+    const { timer } = setup({ enabled: false });
+
+    timer.setRefreshRate(500);
+
+    expect(setInterval).not.toHaveBeenCalled();
+    expect(timer.isEnabled).toBe(false);
+  });
+
+  it('should use the updated refresh rate the next time enable is called', () => {
+    const { timer } = setup({ enabled: false });
+
+    timer.setRefreshRate(500);
+    timer.enable();
+
+    expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 500);
+  });
 });
 
 function setup({ enabled = true } = {}) {

--- a/packages/scenes/src/behaviors/LiveNowTimer.ts
+++ b/packages/scenes/src/behaviors/LiveNowTimer.ts
@@ -46,6 +46,13 @@ export class LiveNowTimer extends SceneObjectBase<LiveNowTimerState> {
     this.setState({ enabled: false });
   }
 
+  public setRefreshRate(refreshRate: number) {
+    this.setState({ refreshRate });
+    if (this.state.enabled) {
+      this.enable();
+    }
+  }
+
   public get isEnabled() {
     return this.state.enabled;
   }

--- a/packages/scenes/src/behaviors/LiveNowTimer.ts
+++ b/packages/scenes/src/behaviors/LiveNowTimer.ts
@@ -5,14 +5,15 @@ import { SceneObjectState } from '../core/types';
 
 interface LiveNowTimerState extends SceneObjectState {
   enabled: boolean;
+  refreshRate?: number;
 }
 
 export class LiveNowTimer extends SceneObjectBase<LiveNowTimerState> {
   private timerId: number | undefined = undefined;
-  private static REFRESH_RATE = 100; // ms
+  public static DEFAULT_REFRESH_RATE = 100; // ms
 
-  public constructor({ enabled = false }) {
-    super({ enabled });
+  public constructor({ enabled = false, refreshRate }: { enabled?: boolean; refreshRate?: number } = {}) {
+    super({ enabled, refreshRate });
     this.addActivationHandler(this._activationHandler);
   }
 
@@ -35,7 +36,7 @@ export class LiveNowTimer extends SceneObjectBase<LiveNowTimerState> {
       for (const panel of panels) {
         panel.forceRender();
       }
-    }, LiveNowTimer.REFRESH_RATE);
+    }, this.state.refreshRate ?? LiveNowTimer.DEFAULT_REFRESH_RATE);
     this.setState({ enabled: true });
   }
 


### PR DESCRIPTION
Adds an optional refreshRate option (defaulting to the existing 100ms) so consumers can tune how often live panels re-render when using LiveNowTimer.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.6--canary.1455.25923549101.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.2.6--canary.1455.25923549101.0
  npm install @grafana/scenes-react@8.2.6--canary.1455.25923549101.0
  # or 
  yarn add @grafana/scenes@8.2.6--canary.1455.25923549101.0
  yarn add @grafana/scenes-react@8.2.6--canary.1455.25923549101.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
