### PR TITLE
Filters: Key fetching waits for other vars to load first

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -50,6 +50,8 @@ import { TestContextProvider } from '../../../utils/test/TestContextProvider';
 import { FiltersRequestEnricher } from '../../core/types';
 import { generateFilterUpdatePayload } from './AdHocFiltersCombobox/utils';
 import { ScopesVariable } from '../variants/ScopesVariable';
+import { TestVariable } from '../variants/TestVariable';
+import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 
 function setTemplateSrvWithFilters(filters: AdHocVariableFilter[]): AdHocVariableFilter[] {
   setTemplateSrv({
@@ -2148,6 +2150,67 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         timeRange: timeRange.state.value,
       })
     );
+  });
+
+  describe('Defers data source calls until in-scope template variables finish loading', () => {
+    function setupWithSlowVariable() {
+      setTemplateSrvWithFilters([]);
+      const getTagKeysSpy = jest.fn().mockReturnValue([{ text: 'k1', value: 'k1' }]);
+      setDataSourceSrv({
+        get: () =>
+          ({
+            getTagKeys: getTagKeysSpy,
+            getRef: () => ({ uid: 'my-ds-uid' }),
+          } as unknown),
+        getInstanceSettings: () => ({ uid: 'my-ds-uid' }),
+      } as unknown as DataSourceSrv);
+
+      // No delayMs → stays loading until `signalUpdateCompleted` is called.
+      const slowVariable = new TestVariable({ name: 'base64', query: 'query' });
+      const filtersVar = new AdHocFiltersVariable({
+        datasource: { uid: 'my-ds-uid' },
+        name: 'filters',
+        filters: [],
+      });
+
+      const scene = new EmbeddedScene({
+        $timeRange: new SceneTimeRange(),
+        $variables: new SceneVariableSet({ variables: [slowVariable, filtersVar] }),
+        body: new SceneFlexLayout({ children: [] }),
+      });
+
+      activateFullSceneTree(scene);
+
+      return { slowVariable, filtersVar, getTagKeysSpy };
+    }
+
+    it('_getKeys does not call getTagKeys while a sibling variable is still loading', async () => {
+      const { slowVariable, filtersVar, getTagKeysSpy } = setupWithSlowVariable();
+
+      const keysPromise = filtersVar._getKeys(null);
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(getTagKeysSpy).not.toHaveBeenCalled();
+
+      // Resolve the variable; the awaiting `_getKeys` should now proceed.
+      slowVariable.signalUpdateCompleted();
+      await keysPromise;
+      expect(getTagKeysSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('drains multiple concurrent waiters when the variable settles', async () => {
+      const { slowVariable, filtersVar, getTagKeysSpy } = setupWithSlowVariable();
+
+      const first = filtersVar._getKeys(null);
+      const second = filtersVar._getKeys(null);
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(getTagKeysSpy).not.toHaveBeenCalled();
+
+      slowVariable.signalUpdateCompleted();
+      await Promise.all([first, second]);
+      expect(getTagKeysSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('variable expression / value', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -294,7 +294,11 @@ export class AdHocFiltersVariable
   protected _variableDependency = new VariableDependencyConfig(this, {
     dependsOnScopes: true,
     onReferencedVariableValueChanged: () => this._updateScopesFilters(),
+    onAnyVariableChanged: () => this._drainPendingVariableWaits(),
   });
+
+  /** Resolvers waiting for in-scope variables to finish loading before a data source call. */
+  private _pendingVariableWaits: Array<() => void> = [];
 
   protected _urlSync = new AdHocFiltersVariableUrlSyncHandler(this);
 
@@ -1025,6 +1029,35 @@ export class AdHocFiltersVariable
   }
 
   /**
+   * Wait until template variables in scope have finished loading.
+   *  Prevents data source calls like getTagKeys
+   * from running with unresolved `$var` references in the panel queries we forward.
+   */
+  private _waitForVariables(): Promise<void> {
+    if (!this._isAnyInScopeVariableLoading()) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      this._pendingVariableWaits.push(resolve);
+    });
+  }
+
+  private _isAnyInScopeVariableLoading(): boolean {
+    const variableSet = sceneGraph.getVariables(this);
+    return variableSet.state.variables.some((v) => variableSet.isVariableLoadingOrWaitingToUpdate(v));
+  }
+
+  private _drainPendingVariableWaits() {
+    if (this._pendingVariableWaits.length === 0 || this._isAnyInScopeVariableLoading()) {
+      return;
+    }
+    const waiters = this._pendingVariableWaits;
+    this._pendingVariableWaits = [];
+    waiters.forEach((resolve) => resolve());
+  }
+
+  /**
    * Get possible keys given current filters. Do not call from plugins directly
    */
   public async _getKeys(currentKey: string | null): Promise<Array<SelectableValue<string>>> {
@@ -1042,6 +1075,8 @@ export class AdHocFiltersVariable
     if (!ds || !ds.getTagKeys) {
       return [];
     }
+
+    await this._waitForVariables();
 
     const applicableOriginFilters =
       this.state.originFilters?.filter((f) => !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f)) ?? [];
@@ -1102,6 +1137,8 @@ export class AdHocFiltersVariable
       return override ? dataFromResponse(override.values).map(toSelectableValue) : [];
     }
 
+    await this._waitForVariables();
+
     const applicableOriginFilters =
       this.state.originFilters?.filter((f) => !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f)) ?? [];
     const otherFilters = this.state.filters
@@ -1153,6 +1190,8 @@ export class AdHocFiltersVariable
     if (!ds || !ds.getTagValues) {
       return [];
     }
+
+    await this._waitForVariables();
 
     const originFilters =
       this.state.originFilters?.filter((f) => f.key !== filter.key && !isGroupByFilter(f) && !isMatchAllFilter(f)) ??


### PR DESCRIPTION
Since we are sending queries to the key/value retrieval calls for filters and groupBys, we need to make sure that other variables are already updated beforehand otherwise we risk to passing the queries with uninterpolated vars in the payload.

To test:
- Have a dashboard with a slow query var and a filter (I used a devenv mysql ds and set the query var to `Select Sleep(10)`)
- Clicking on the filter will trigger a key retrieval call that will wait for the query var to finish first before getting corect key values.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.6--canary.1460.26393386258.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.2.6--canary.1460.26393386258.0
  npm install @grafana/scenes-react@8.2.6--canary.1460.26393386258.0
  # or 
  yarn add @grafana/scenes@8.2.6--canary.1460.26393386258.0
  yarn add @grafana/scenes-react@8.2.6--canary.1460.26393386258.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
