### PR TITLE
Filters: Better origin filter validation

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -3776,6 +3776,43 @@ describe('group-by', () => {
       expect(isFilterComplete({ key: '', operator: 'groupBy', value: '', condition: '' })).toBe(false);
       expect(isFilterComplete({ key: 'k', operator: '', value: '', condition: '' })).toBe(false);
     });
+
+    it('returns false for regular filter with undefined or null value', () => {
+      expect(
+        isFilterComplete({ key: 'key1', operator: '=', value: undefined as unknown as string, condition: '' })
+      ).toBe(false);
+      expect(isFilterComplete({ key: 'key1', operator: '=', value: null as unknown as string, condition: '' })).toBe(
+        false
+      );
+    });
+  });
+
+  describe('constructor', () => {
+    it('drops origin filters that are missing a value', () => {
+      const variable = new AdHocFiltersVariable({
+        name: 'filters',
+        datasource: { uid: 'test' },
+        originFilters: [
+          { key: 'complete', operator: '=', value: 'foo', origin: 'dashboard' },
+          { key: 'incomplete', operator: '=', origin: 'dashboard' } as AdHocFilterWithLabels,
+          { key: 'empty', operator: '=', value: '', origin: 'dashboard' },
+          { key: 'groupBy', operator: 'groupBy', value: '', origin: 'dashboard' },
+        ],
+      });
+
+      expect(variable.state.originFilters?.map((f) => f.key)).toEqual(['complete', 'groupBy']);
+    });
+
+    it('does not crash building the expression when saved origin filters are missing a value', () => {
+      expect(
+        () =>
+          new AdHocFiltersVariable({
+            name: 'filters',
+            datasource: { uid: 'test' },
+            originFilters: [{ key: 'broken', operator: '=', origin: 'dashboard' } as AdHocFilterWithLabels],
+          })
+      ).not.toThrow();
+    });
   });
 
   describe('_addGroupByFilter', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -303,13 +303,22 @@ export class AdHocFiltersVariable
   private _recommendations: AdHocFiltersRecommendations | undefined;
 
   public constructor(state: Partial<AdHocFiltersVariableState>) {
-    const { collapsible, defaultKeys, drilldownRecommendationsEnabled, ...restState } = state;
+    const {
+      collapsible,
+      defaultKeys,
+      drilldownRecommendationsEnabled,
+      originFilters: rawOriginFilters,
+      ...restState
+    } = state;
     const behaviors = state.$behaviors ?? [];
     const recommendations = state.drilldownRecommendationsEnabled ? new AdHocFiltersRecommendations() : undefined;
 
     if (recommendations) {
       behaviors.push(recommendations);
     }
+
+    // validate origin filter completion
+    const originFilters = rawOriginFilters?.filter(isFilterComplete);
 
     super({
       type: 'adhoc',
@@ -319,8 +328,9 @@ export class AdHocFiltersVariable
       applyMode: 'auto',
       filterExpression:
         state.filterExpression ??
-        renderExpression(state.expressionBuilder, [...(state.originFilters ?? []), ...(state.filters ?? [])]),
+        renderExpression(state.expressionBuilder, [...(originFilters ?? []), ...(state.filters ?? [])]),
       ...restState,
+      originFilters,
       ...(behaviors.length > 0 && { $behaviors: behaviors }),
       ...(collapsible !== undefined && { collapsible }),
       ...(drilldownRecommendationsEnabled !== undefined && { drilldownRecommendationsEnabled }),
@@ -1324,7 +1334,11 @@ export function isGroupByFilter(filter: AdHocFilterWithLabels): boolean {
 }
 
 export function isFilterComplete(filter: AdHocFilterWithLabels): boolean {
-  return filter.key !== '' && filter.operator !== '' && (isGroupByFilter(filter) || filter.value !== '');
+  return (
+    filter.key !== '' &&
+    filter.operator !== '' &&
+    (isGroupByFilter(filter) || (filter.value != null && filter.value !== ''))
+  );
 }
 
 export function isFilterApplicable(filter: AdHocFilterWithLabels): boolean {


### PR DESCRIPTION
This PR validates origin filters to make sure they are valid on construct, otherwise drops them
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.7--canary.1461.26397304796.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.2.7--canary.1461.26397304796.0
  npm install @grafana/scenes-react@8.2.7--canary.1461.26397304796.0
  # or 
  yarn add @grafana/scenes@8.2.7--canary.1461.26397304796.0
  yarn add @grafana/scenes-react@8.2.7--canary.1461.26397304796.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
