### PR TITLE
chore: fix baseUrl prop to pass build

### DIFF
--- a/packages/scenes-app/.config/webpack/webpack.config.ts
+++ b/packages/scenes-app/.config/webpack/webpack.config.ts
@@ -79,7 +79,7 @@ const config = (env): Configuration => ({
           loader: 'swc-loader',
           options: {
             jsc: {
-              baseUrl: './src',
+              baseUrl: path.resolve(process.cwd(), 'src'),
               target: 'es2015',
               loose: false,
               parser: {


### PR DESCRIPTION
Fixes failing CI step needed for a bunch of renovate dep updates, e.g.: https://github.com/grafana/scenes/pull/1466