### PR TITLE
Variables: Fixes multi value select mobile issue

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -186,6 +186,7 @@ export function VariableValueSelectMulti({
       components={{ Option: OptionWithCheckbox }}
       isClearable={true}
       hideSelectedOptions={false}
+      blurInputOnSelect={false}
       onInputChange={onInputChange}
       onBlur={() => {
         model.changeValueTo(uncommittedValue, undefined, true);
@@ -196,6 +197,7 @@ export function VariableValueSelectMulti({
         if (action.action === 'clear' && noValueOnClear) {
           model.changeValueTo([], undefined, true);
         }
+
         setUncommittedValue(newValue.map((x) => x.value!));
       }}
     />
@@ -236,10 +238,12 @@ export const OptionWithCheckbox = ({
       ref={innerRef}
       className={cx(selectStyles.option, isFocused && selectStyles.optionFocused)}
       {...rest}
-      // TODO: use below selector once we update grafana dependencies to ^11.1.0
-      // data-testid={selectors.components.Select.option}
-      data-testid="data-testid Select option"
+      data-testid={selectors.components.Select.option}
       title={data.title}
+      // rest.onClick cannot be set here as it causes double onClick
+      onClick={undefined}
+      // Using onPointerDown here as onClick is not fired first time for mobile/touch devices
+      onPointerDown={rest.onClick}
     >
       <div className={optionStyles.checkbox}>
         <Checkbox indeterminate={indeterminate} value={isSelected} />


### PR DESCRIPTION
We have some issues with variable selection (multi value) on mobiles/touch devices

**Fixes**

* Menu is closed/ value committed when option is selected 
* Current value onBlur happen does not take into account the newly selected value but previous state 
* You have to touch twice inside menu for a selection to happen 

**Other issues found but unable to solve**

* hitting the "clear value", nothing really happens (no variable change happens), and input not focused and menu is not opened 
* Sometimes the menu is not shown but the input is focused 

To test / verify issues use the variables scene app demo: 

http://localhost:3000/a/grafana-scenes-app/demos/variables 

Then open chrome dev tools and switch to a mobile device 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.3.0--canary.1526.26872404207.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.3.0--canary.1526.26872404207.0
  npm install scenes-app@8.3.0--canary.1526.26872404207.0
  npm install @grafana/scenes-react@8.3.0--canary.1526.26872404207.0
  # or 
  yarn add @grafana/scenes@8.3.0--canary.1526.26872404207.0
  yarn add scenes-app@8.3.0--canary.1526.26872404207.0
  yarn add @grafana/scenes-react@8.3.0--canary.1526.26872404207.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
