### PR TITLE
Variables: Complete render profile when variable batch settles without a query

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -95,16 +95,37 @@ export class SceneQueryController
     }
 
     if (this.state.enableProfiling) {
-      // Delegate to next frame to check if all queries are completed
-      // This is to account for scenarios when there's "yet another" query that's started
-      if (this.#tryCompleteProfileFrameId) {
-        cancelAnimationFrame(this.#tryCompleteProfileFrameId);
-      }
-
-      this.#tryCompleteProfileFrameId = requestAnimationFrame(() => {
-        this.profiler?.tryCompletingProfile();
-      });
+      this.#scheduleProfileCompletionCheck();
     }
+  }
+
+  /**
+   * Re-evaluate whether the in-progress profile can complete, without a query
+   * count change. Used when the scene reaches an idle state through a non-query
+   * event (e.g. a variable update batch settling) so that a render that issued
+   * no panel query — because it was blocked on a variable, as happens when a
+   * template variable is missing from the URL during image rendering — still
+   * signals completion instead of hanging until the image-renderer times out.
+   * Safe against premature completion: a query starting within the profiler's
+   * trailing window cancels the tail recording and re-evaluates.
+   */
+  public attemptProfileCompletion() {
+    if (!this.state.enableProfiling) {
+      return;
+    }
+    this.#scheduleProfileCompletionCheck();
+  }
+
+  #scheduleProfileCompletionCheck() {
+    // Delegate to next frame to check if all queries are completed
+    // This is to account for scenarios when there's "yet another" query that's started
+    if (this.#tryCompleteProfileFrameId) {
+      cancelAnimationFrame(this.#tryCompleteProfileFrameId);
+    }
+
+    this.#tryCompleteProfileFrameId = requestAnimationFrame(() => {
+      this.profiler?.tryCompletingProfile();
+    });
   }
 
   public cancelAll() {

--- a/packages/scenes/src/behaviors/types.ts
+++ b/packages/scenes/src/behaviors/types.ts
@@ -45,4 +45,12 @@ export interface SceneQueryControllerLike extends SceneObject<SceneQueryStateCon
   startProfile(name: string): void;
   cancelProfile(): void;
   runningQueriesCount(): number;
+
+  /**
+   * Re-evaluate whether an in-progress render profile can complete, without a
+   * change to the running query count. Used when the scene reaches an idle
+   * state through a non-query event (e.g. a variable update batch settling) so
+   * that a render whose panel never issued a query still signals completion.
+   */
+  attemptProfileCompletion?(): void;
 }

--- a/packages/scenes/src/performance/SceneRenderProfiler.test.ts
+++ b/packages/scenes/src/performance/SceneRenderProfiler.test.ts
@@ -4,7 +4,8 @@ import {
   ADHOC_VALUES_DROPDOWN_INTERACTION,
   GROUPBY_DIMENSIONS_INTERACTION,
 } from './interactionConstants';
-import { SceneComponentInteractionEvent, SceneQueryControllerLike } from '../behaviors/types';
+import { SceneComponentInteractionEvent, SceneQueryControllerEntry, SceneQueryControllerLike } from '../behaviors/types';
+import { SceneQueryController } from '../behaviors/SceneQueryController';
 // ScenePerformanceTracker imports handled via mocking
 
 // Mock writeSceneLog to prevent console noise in tests
@@ -768,6 +769,71 @@ describe('SceneRenderProfiler integration tests', () => {
       // Verify performance APIs were consumed for network processing
       expect((global.performance.getEntriesByType as jest.Mock).mock.calls.length).toBeGreaterThan(0);
       expect((global.performance.clearResourceTimings as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Render readiness when a render is blocked on a variable', () => {
+    // Reproduces the image-renderer hang from support escalation #22639: when a solo-panel
+    // render is blocked on a template variable (e.g. the variable is missing from the URL),
+    // the panel never issues a query, so the scene can go idle without a running-query
+    // transition. Profile completion is otherwise only driven by query-count changes, so the
+    // dashboard_view interaction never completes and the image-renderer hangs until timeout.
+    const queryEntry = (origin: SceneQueryControllerLike): SceneQueryControllerEntry => ({
+      type: 'SceneQueryRunner/runQueries',
+      origin,
+      cancel: () => {},
+    });
+
+    it('does not complete the profile when the scene goes idle without a query (the bug)', () => {
+      const controller = new SceneQueryController({ enableProfiling: true }, profiler);
+      controller.startProfile('dashboard_view');
+
+      // No query ever runs (panel blocked on a variable) and nothing pokes the controller.
+      mockTracker.notifyDashboardInteractionComplete.mockClear();
+      simulateAnimationFrames(2000);
+
+      expect(mockTracker.notifyDashboardInteractionComplete).not.toHaveBeenCalled();
+    });
+
+    it('completes the profile when the variable set settles (the fix)', () => {
+      const controller = new SceneQueryController({ enableProfiling: true }, profiler);
+      controller.startProfile('dashboard_view');
+
+      // SceneVariableSet calls this when its update batch settles with nothing pending.
+      controller.attemptProfileCompletion();
+      mockTracker.notifyDashboardInteractionComplete.mockClear();
+      // A bit more than POST_STORM_WINDOW (2000ms): the tail starts one frame into the
+      // simulation because attemptProfileCompletion schedules tryCompletingProfile via rAF.
+      simulateAnimationFrames(2100);
+
+      expect(mockTracker.notifyDashboardInteractionComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ interactionType: 'dashboard_view' })
+      );
+    });
+
+    it('does not complete early if a query starts before the variable-triggered tail finishes', () => {
+      const controller = new SceneQueryController({ enableProfiling: true }, profiler);
+      controller.startProfile('dashboard_view');
+
+      // Variable set settles and starts the trailing window...
+      controller.attemptProfileCompletion();
+      simulateAnimationFrames(100);
+      expect(profiler.isTailRecording()).toBe(true);
+
+      // ...but the panel then issues its query within the window, which cancels the tail.
+      const entry = queryEntry(controller);
+      controller.queryStarted(entry);
+      expect(profiler.isTailRecording()).toBe(false);
+
+      mockTracker.notifyDashboardInteractionComplete.mockClear();
+      simulateAnimationFrames(2000);
+      // A query is still running, so the profile must not complete yet.
+      expect(mockTracker.notifyDashboardInteractionComplete).not.toHaveBeenCalled();
+
+      // Once the query completes the scene settles and the profile completes normally.
+      controller.queryCompleted(entry);
+      simulateAnimationFrames(2100);
+      expect(mockTracker.notifyDashboardInteractionComplete).toHaveBeenCalled();
     });
   });
 });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -18,6 +18,7 @@ import { TestObjectWithVariableDependency, TestScene } from '../TestScene';
 import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 import { SceneVariable, SceneVariableState, VariableValue } from '../types';
 import { ObjectVariable } from '../variants/ObjectVariable';
+import { SceneQueryController } from '../../behaviors/SceneQueryController';
 
 interface SceneTextItemState extends SceneObjectState {
   text: string;
@@ -1003,6 +1004,31 @@ describe('SceneVariableList', () => {
 
       // Change B while C is loading (They are on different levels but should behave the same as with A & B)
       expect(C.state.value).toBe('ABBA');
+    });
+  });
+
+  describe('Render profile completion', () => {
+    it('notifies the query controller when the update batch settles', () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const queryController = new SceneQueryController({ enableProfiling: true });
+      const scene = new TestScene({
+        $behaviors: [queryController],
+        $variables: new SceneVariableSet({ variables: [A] }),
+      });
+
+      const attemptSpy = jest.spyOn(queryController, 'attemptProfileCompletion');
+
+      activateFullSceneTree(scene);
+
+      // While A is still loading the batch has not settled, so we don't poke the controller.
+      expect(A.state.loading).toBe(true);
+      expect(attemptSpy).not.toHaveBeenCalled();
+
+      // Once the variable resolves the batch settles and the controller is notified, so a
+      // render whose panel never issued a query can still complete instead of hanging.
+      A.signalUpdateCompleted();
+
+      expect(attemptSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -208,6 +208,17 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
         error: (err) => this._handleVariableError(variable, err),
       });
     }
+
+    // When the batch has fully settled (nothing updating, nothing queued) let the
+    // query controller re-evaluate whether an in-progress render profile can
+    // complete. Profile completion is otherwise only driven by query count
+    // changes, so a render whose panel never issued a query because it was
+    // blocked on a variable (e.g. a template variable missing from the URL during
+    // image rendering) would never signal completion, and the image-renderer
+    // would hang until it times out.
+    if (this._updating.size === 0 && this._variablesToUpdate.size === 0) {
+      sceneGraph.getQueryController(this)?.attemptProfileCompletion?.();
+    }
   }
 
   /**


### PR DESCRIPTION
## What this PR does

Render readiness for image rendering / report capture depends on `SceneRenderProfiler` reporting the `dashboard_view` interaction complete (grafana-image-renderer waits for this signal). Today that completion is only re-evaluated from `SceneQueryController.changeRunningQueryCount` — i.e. when a query starts or finishes.

When a panel render is blocked on a variable (e.g. a single-panel `/render/d-solo` render where a template variable is missing from the URL, so the panel parks in `Loading` without issuing a query), the scene can reach its final idle state via the variable set with no running-query transition. `tryCompletingProfile` is then never invoked again, the interaction never completes, and the image renderer waits until it times out.

This adds a non-query trigger: when `SceneVariableSet` finishes an update batch with nothing updating or queued, it asks the query controller to re-evaluate completion via a new `SceneQueryController.attemptProfileCompletion()`.

Safe against premature completion: it schedules the same trailing-window check used after a query completes, and a query starting within that window cancels the tail and re-evaluates — so the happy path (variables settle, then the panel queries) is unaffected.

## Related

Follows up grafana/grafana#118215, which reduced these single-panel render hangs by loading variables on init but didn't fully resolve them.

## Tests

- `SceneVariableSet`: settling an update batch notifies the query controller.
- `SceneRenderProfiler` integration: idle-with-no-query never completes (the bug); `attemptProfileCompletion()` completes it (the fix); a query starting in the trailing window defers completion (no premature capture).
