### PR TITLE
test: move transformation variable tests from @grafana/data

### DIFF
--- a/packages/scenes/src/variables/transformations/calculateField.test.ts
+++ b/packages/scenes/src/variables/transformations/calculateField.test.ts
@@ -1,0 +1,147 @@
+import {
+  BinaryOperationID,
+  DataFrame,
+  DataFrameView,
+  DataTransformerID,
+  FieldType,
+  getDefaultTimeRange,
+  standardTransformers,
+  toDataFrame,
+} from '@grafana/data';
+import { type DataTransformerConfig, LoadingState } from '@grafana/schema';
+import { SceneFlexLayout, SceneFlexItem } from '../../components/layout/SceneFlexLayout';
+import { SceneDataNode } from '../../core/SceneDataNode';
+import { sceneGraph } from '../../core/sceneGraph';
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { SceneObject, SceneDeactivationHandler } from '../../core/types';
+import { SceneDataTransformer } from '../../querying/SceneDataTransformer';
+import { mockTransformationsRegistry } from '../../utils/mockTransformationsRegistry';
+import { SceneVariableSet } from '../sets/SceneVariableSet';
+import { SceneVariable } from '../types';
+import { TestVariable } from '../variants/TestVariable';
+
+const seriesA = toDataFrame({
+  fields: [
+    { name: 'TheTime', type: FieldType.time, values: [1000, 2000] },
+    { name: 'A', type: FieldType.number, values: [1, 100] },
+  ],
+});
+
+const seriesBC = toDataFrame({
+  fields: [
+    { name: 'TheTime', type: FieldType.time, values: [1000, 2000] },
+    { name: 'B', type: FieldType.number, values: [2, 200] },
+    { name: 'C', type: FieldType.number, values: [3, 300] },
+    { name: 'D', type: FieldType.string, values: ['first', 'second'] },
+    { name: 'E', type: FieldType.boolean, values: [true, false] },
+  ],
+});
+
+describe('calculateField transformer w/ timeseries', () => {
+  beforeAll(() => {
+    mockTransformationsRegistry([standardTransformers.calculateFieldTransformer]);
+  });
+
+  beforeEach(() => {
+    seriesA.fields.forEach((f) => {
+      delete f.state;
+    });
+    seriesBC.fields.forEach((f) => {
+      delete f.state;
+    });
+  });
+
+  it('uses template variable substituion', async () => {
+    const cfg = {
+      id: DataTransformerID.calculateField,
+      options: {
+        alias: '$var1',
+        mode: 'binary',
+        binary: {
+          left: 'A',
+          operator: BinaryOperationID.Add,
+          right: '$var2',
+        },
+        replaceFields: true,
+      },
+    };
+
+    const data = await setupTransformationScene(seriesA, cfg, [
+      new TestVariable({ name: 'var1', value: 'Test' }),
+      new TestVariable({ name: 'var2', value: 5 }),
+    ]);
+
+    const filtered = data[0];
+    const rows = new DataFrameView(filtered).toArray();
+    expect(rows).toEqual([
+      {
+        Test: 6,
+        TheTime: 1000,
+      },
+      {
+        Test: 105,
+        TheTime: 2000,
+      },
+    ]);
+  });
+});
+
+function activateFullSceneTree(scene: SceneObject): SceneDeactivationHandler {
+  const deactivationHandlers: SceneDeactivationHandler[] = [];
+
+  // Important that variables are activated before other children
+  if (scene.state.$variables) {
+    deactivationHandlers.push(activateFullSceneTree(scene.state.$variables));
+  }
+
+  scene.forEachChild((child) => {
+    // For query runners which by default use the container width for maxDataPoints calculation we are setting a width.
+    // In real life this is done by the React component when VizPanel is rendered.
+    if ('setContainerWidth' in child) {
+      // @ts-expect-error
+      child.setContainerWidth(500);
+    }
+    deactivationHandlers.push(activateFullSceneTree(child));
+  });
+
+  deactivationHandlers.push(scene.activate());
+
+  return () => {
+    for (const handler of deactivationHandlers) {
+      handler();
+    }
+  };
+}
+
+function setupTransformationScene(
+  inputData: DataFrame,
+  cfg: DataTransformerConfig,
+  variables: SceneVariable[]
+): Promise<DataFrame[]> {
+  class TestSceneObject extends SceneObjectBase<{}> {}
+  const dataNode = new SceneDataNode({
+    data: {
+      state: LoadingState.Loading,
+      timeRange: getDefaultTimeRange(),
+      series: [inputData],
+    },
+  });
+
+  const transformationNode = new SceneDataTransformer({
+    transformations: [cfg],
+  });
+
+  const consumer = new TestSceneObject({
+    $data: transformationNode,
+  });
+
+  const scene = new SceneFlexLayout({
+    $data: dataNode,
+    $variables: new SceneVariableSet({ variables }),
+    children: [new SceneFlexItem({ body: consumer })],
+  });
+
+  activateFullSceneTree(scene);
+
+  return Promise.resolve(sceneGraph.getData(consumer).state.data?.series ?? []);
+}

--- a/packages/scenes/src/variables/transformations/filterByName.test.ts
+++ b/packages/scenes/src/variables/transformations/filterByName.test.ts
@@ -1,0 +1,160 @@
+import {
+  DataFrame,
+  DataTransformerConfig,
+  DataTransformerID,
+  FieldType,
+  getDefaultTimeRange,
+  LoadingState,
+  standardTransformers,
+  toDataFrame,
+} from '@grafana/data';
+import { SceneFlexLayout, SceneFlexItem } from '../../components/layout/SceneFlexLayout';
+import { SceneDataNode } from '../../core/SceneDataNode';
+import { sceneGraph } from '../../core/sceneGraph';
+import { SceneObjectBase } from '../../core/SceneObjectBase';
+import { SceneObject, SceneDeactivationHandler } from '../../core/types';
+import { SceneDataTransformer } from '../../querying/SceneDataTransformer';
+import { mockTransformationsRegistry } from '../../utils/mockTransformationsRegistry';
+import { SceneVariableSet } from '../sets/SceneVariableSet';
+import { SceneVariable } from '../types';
+import { TestVariable } from '../variants/TestVariable';
+
+export const seriesWithNamesToMatch = toDataFrame({
+  fields: [
+    { name: 'startsWithA', type: FieldType.time, values: [1000, 2000] },
+    { name: 'B', type: FieldType.boolean, values: [true, false] },
+    { name: 'startsWithC', type: FieldType.string, values: ['a', 'b'] },
+    { name: 'D', type: FieldType.number, values: [1, 2] },
+  ],
+});
+
+describe('filterByName transformer', () => {
+  beforeAll(() => {
+    mockTransformationsRegistry([
+      standardTransformers.filterFieldsByNameTransformer,
+      standardTransformers.filterFieldsTransformer,
+    ]);
+  });
+
+  describe('respects', () => {
+    it('it can use a variable with multiple comma separated', async () => {
+      const cfg = {
+        id: DataTransformerID.filterFieldsByName,
+        options: {
+          include: {
+            variable: '$var',
+          },
+          byVariable: true,
+        },
+      };
+
+      const data = await setupTransformationScene(seriesWithNamesToMatch, cfg, [
+        new TestVariable({ name: 'var', value: 'B,D' }),
+      ]);
+      const filtered = data[0];
+      expect(filtered.fields.length).toBe(2);
+      expect(filtered.fields[0].name).toBe('B');
+      expect(filtered.fields[1].name).toBe('D');
+    });
+
+    it('it can use a variable with multiple comma separated values in {}', async () => {
+      const cfg = {
+        id: DataTransformerID.filterFieldsByName,
+        options: {
+          include: {
+            variable: '$var',
+          },
+          byVariable: true,
+        },
+      };
+
+      const data = await setupTransformationScene(seriesWithNamesToMatch, cfg, [
+        new TestVariable({ name: 'var', value: 'B,D' }),
+      ]);
+
+      const filtered = data[0];
+      expect(filtered.fields.length).toBe(2);
+      expect(filtered.fields[0].name).toBe('B');
+      expect(filtered.fields[1].name).toBe('D');
+    });
+
+    it('uses template variable substitution', async () => {
+      const cfg = {
+        id: DataTransformerID.filterFieldsByName,
+        options: {
+          include: {
+            pattern: '/^$var/',
+          },
+        },
+      };
+
+      const data = await setupTransformationScene(seriesWithNamesToMatch, cfg, [
+        new TestVariable({ name: 'var', value: 'startsWith' }),
+      ]);
+
+      const filtered = data[0];
+      expect(filtered.fields.length).toBe(2);
+      expect(filtered.fields[0].name).toBe('startsWithA');
+    });
+  });
+});
+
+function activateFullSceneTree(scene: SceneObject): SceneDeactivationHandler {
+  const deactivationHandlers: SceneDeactivationHandler[] = [];
+
+  // Important that variables are activated before other children
+  if (scene.state.$variables) {
+    deactivationHandlers.push(activateFullSceneTree(scene.state.$variables));
+  }
+
+  scene.forEachChild((child) => {
+    // For query runners which by default use the container width for maxDataPoints calculation we are setting a width.
+    // In real life this is done by the React component when VizPanel is rendered.
+    if ('setContainerWidth' in child) {
+      // @ts-expect-error
+      child.setContainerWidth(500);
+    }
+    deactivationHandlers.push(activateFullSceneTree(child));
+  });
+
+  deactivationHandlers.push(scene.activate());
+
+  return () => {
+    for (const handler of deactivationHandlers) {
+      handler();
+    }
+  };
+}
+
+function setupTransformationScene(
+  inputData: DataFrame,
+  cfg: DataTransformerConfig,
+  variables: SceneVariable[]
+): Promise<DataFrame[]> {
+  class TestSceneObject extends SceneObjectBase<{}> {}
+  const dataNode = new SceneDataNode({
+    data: {
+      state: LoadingState.Loading,
+      timeRange: getDefaultTimeRange(),
+      series: [inputData],
+    },
+  });
+
+  const transformationNode = new SceneDataTransformer({
+    transformations: [cfg],
+  });
+
+  const consumer = new TestSceneObject({
+    $data: transformationNode,
+  });
+
+  const scene = new SceneFlexLayout({
+    $data: dataNode,
+    $variables: new SceneVariableSet({ variables }),
+    children: [new SceneFlexItem({ body: consumer })],
+  });
+
+  activateFullSceneTree(scene);
+
+  return Promise.resolve(sceneGraph.getData(consumer).state.data?.series ?? []);
+}


### PR DESCRIPTION
**What is this feature?**

Moves the `grafana/scenes` dependent `calculateField` and `filterByName` test cases from `@grafana/data` into the scenes package.

- https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
- https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/filterByName.test.ts

**Why do we need this feature?**

So `@grafana/data` can drop its dev dependency on `grafana/scenes`.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.3.1--canary.1542.27400485682.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.3.1--canary.1542.27400485682.0
  npm install scenes-app@8.3.1--canary.1542.27400485682.0
  npm install @grafana/scenes-react@8.3.1--canary.1542.27400485682.0
  # or 
  yarn add @grafana/scenes@8.3.1--canary.1542.27400485682.0
  yarn add scenes-app@8.3.1--canary.1542.27400485682.0
  yarn add @grafana/scenes-react@8.3.1--canary.1542.27400485682.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
