### PR TITLE
chore: ignore changelogs in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ packages/*/dist/**
 # Added by lerna repair
 /.nx/workspace-data
 .turbo
+
+# Changelogs are autogens; leave them as is
+**/CHANGELOG.md


### PR DESCRIPTION
With latest dep bumps in prettier it now complains on changelogs. since they are autogenerated prettier should not fight the changelog generation, so we ignore them alltogether.