### PR TITLE
Dashboards: Push error and notice status items into panel header

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -12,6 +12,7 @@ import {
   PanelProps,
   PluginContextProvider,
   PluginType,
+  QueryResultMetaNotice,
   SetPanelAttentionEvent,
 } from '@grafana/data';
 
@@ -234,6 +235,11 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   const isReadyToRender = dataObject.isDataReadyToDisplay ? dataObject.isDataReadyToDisplay() : true;
 
   const context = model.getPanelContext();
+  // The host (e.g. dashboard) only provides an inspector opener when the new panel errors UI
+  // is enabled. Use its presence to decide between the new errors/notices popover and the
+  // legacy single status message.
+  // @ts-expect-error onOpenInspector is added in a newer @grafana/ui version
+  const showNewPanelErrorsUI = Boolean(context.onOpenInspector);
   const panelId = model.getLegacyPanelId();
   const outdatedPluginError = t(
     'grafana-scenes.components.viz-panel-renderer.outdated-plugin-error',
@@ -254,7 +260,14 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           description={description?.trim() ? model.getDescription : undefined}
           loadingState={data.state}
           statusMessage={getChromeStatusMessage(data, _pluginLoadError)}
-          statusMessageOnClick={model.onStatusMessageClick}
+          // @ts-expect-error remove this on next grafana/ui update
+          statusItems={showNewPanelErrorsUI ? getChromeStatusItems(data, _pluginLoadError) : undefined}
+          statusMessageOnClick={() => {
+            // Report the interaction for analytics, then let the container (e.g. dashboard) open the inspector.
+            model.onStatusMessageClick();
+            // @ts-expect-error onOpenInspector is added in a newer @grafana/ui version
+            context.onOpenInspector?.();
+          }}
           width={width === 0 ? undefined : width}
           height={height === 0 ? undefined : height}
           selectionId={model.state.key}
@@ -429,6 +442,45 @@ function getChromeStatusMessage(data: PanelData, pluginLoadingError: string | un
     message = data.errors.map((e) => e.message).join(', ');
   }
   return message;
+}
+
+type PanelStatusSeverity = QueryResultMetaNotice['severity'];
+
+interface PanelStatusItem {
+  severity: PanelStatusSeverity;
+  text: string;
+}
+
+/**
+ * Builds the combined list of query errors and result notices shown in the panel header
+ * status popover. Errors come from the query response, notices from the frame metadata.
+ */
+function getChromeStatusItems(data: PanelData, pluginLoadingError: string | undefined): PanelStatusItem[] {
+  const items: PanelStatusItem[] = [];
+
+  if (pluginLoadingError) {
+    items.push({ severity: 'error', text: pluginLoadingError });
+  }
+
+  const errors = data.errors ?? (data.error ? [data.error] : []);
+  for (const error of errors) {
+    items.push({ severity: 'error', text: error.message ?? 'Query error' });
+  }
+
+  const seen = new Set<string>();
+  for (const frame of data.series ?? []) {
+    for (const notice of frame.meta?.notices ?? []) {
+      const severity: PanelStatusSeverity = notice.severity ?? 'info';
+      const key = `${severity}:${notice.text}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      items.push({ severity, text: notice.text });
+    }
+  }
+
+  return items;
 }
 
 const relativeWrapper = css({

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -282,7 +282,6 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
           onFocus={setPanelAttention}
           onMouseEnter={setPanelAttention}
           onMouseMove={debouncedMouseMove}
-          // @ts-expect-error remove this on next grafana/ui update
           subHeaderContent={subHeaderElement.length ? subHeaderElement : undefined}
           onDragStart={(e: React.PointerEvent) => {
             dragHooks.onDragStart?.(e, model);


### PR DESCRIPTION
This PR gathers query errors and notices so they can be rendered into a single UI tooltip that links to the inspector to show a unified view of these per panel

For https://github.com/grafana/grafana/pull/126750
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.5.1--canary.1550.28094466812.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.5.1--canary.1550.28094466812.0
  npm install scenes-app@8.5.1--canary.1550.28094466812.0
  npm install @grafana/scenes-react@8.5.1--canary.1550.28094466812.0
  # or 
  yarn add @grafana/scenes@8.5.1--canary.1550.28094466812.0
  yarn add scenes-app@8.5.1--canary.1550.28094466812.0
  yarn add @grafana/scenes-react@8.5.1--canary.1550.28094466812.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
