### PR TITLE
VizPanel: Increment renderCounter on data-driven re-renders

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -15,6 +15,7 @@ import {
   PanelProps,
   toUtc,
   DataTransformerConfig,
+  DataQueryRequest,
 } from '@grafana/data';
 import * as grafanaData from '@grafana/data';
 import { getPanelPlugin } from '../../../utils/test/__mocks__/pluginMocks';
@@ -907,6 +908,41 @@ describe('VizPanel', () => {
         // Verify panel props time range comes from data time range
         expect(panelProps?.timeRange.from.toISOString()).toEqual('2022-01-01T00:00:00.000Z');
         expect(panelProps?.data.timeRange.from.toISOString()).toEqual('2022-01-01T00:00:00.000Z');
+      });
+
+      it('Should increment renderCounter only when a new data request settles', async () => {
+        const data = new SceneDataNode({
+          data: { ...getTestData(), state: LoadingState.Done, request: { requestId: 'SQR1' } as DataQueryRequest },
+        });
+
+        panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          pluginId: 'custom-plugin-id',
+          $timeRange: new SceneTimeRange(),
+          $data: data,
+        });
+
+        pluginToLoad = getTestPlugin1();
+
+        render(<panel.Component model={panel} />);
+
+        expect(await screen.findByText('My custom panel')).toBeInTheDocument();
+
+        const initialRenderCounter = panelProps?.renderCounter ?? 0;
+
+        // Same request id, only the loading state changes: no new request, renderCounter unchanged.
+        act(() => {
+          data.setState({ data: { ...data.state.data!, state: LoadingState.Streaming } });
+        });
+        expect(panelProps?.renderCounter).toBe(initialRenderCounter);
+
+        // A new data request settles (e.g. a query variable finished loading and the query re-ran).
+        // The component re-renders from the data subscription, so the plugin must receive a new
+        // renderCounter; otherwise plugins that re-apply imperative DOM changes on renderCounter
+        // change would silently lose them.
+        act(() => {
+          data.setState({ data: { ...data.state.data!, request: { requestId: 'SQR2' } as DataQueryRequest } });
+        });
+        expect(panelProps?.renderCounter).toBe(initialRenderCounter + 1);
       });
     });
 

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -1,5 +1,5 @@
 import { Trans, t } from '@grafana/i18n';
-import React, { memo, RefCallback, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { memo, RefCallback, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useMeasure, usePrevious } from 'react-use';
 
 // @ts-ignore
@@ -103,6 +103,27 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
 
   const dataWithSeriesLimit = useDataWithSeriesLimit(rawData.data, seriesLimit, seriesLimitShowAll);
   const dataWithFieldConfig = model.applyFieldConfig(dataWithSeriesLimit);
+
+  // Preserve the legacy panel render contract for data-driven re-renders.
+  // Panel plugins that imperatively mutate their own DOM after render (e.g. text/HTML
+  // panels that run a post-render script) re-apply those mutations whenever `renderCounter`
+  // changes. In the legacy architecture renderCounter was bumped on every render/refresh,
+  // but VizPanel only bumps _renderCounter on forceRender() (referenced-variable change,
+  // options change, time range for skipDataQuery panels). A data-driven re-render, e.g. a
+  // query-type variable settling and the panel's query re-running, re-renders the plugin and
+  // resets its DOM without ever changing renderCounter, so those plugins never re-apply and
+  // their DOM changes are lost. Bump the counter the plugin sees whenever a new data request
+  // settles so the contract holds without requiring any plugin changes.
+  const [dataRenderCounter, setDataRenderCounter] = useState(0);
+  const prevRequestId = useRef<string | undefined>(undefined);
+  const requestId = rawData.data?.request?.requestId;
+  useEffect(() => {
+    if (prevRequestId.current !== undefined && requestId !== prevRequestId.current) {
+      setDataRenderCounter((counter) => counter + 1);
+    }
+    prevRequestId.current = requestId;
+  }, [requestId]);
+
   const sceneTimeRange = sceneGraph.getTimeRange(model);
   const timeZone = sceneTimeRange.getTimeZone();
   const timeRange = model.getTimeRange(dataWithFieldConfig);
@@ -307,7 +328,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
                         transparent={displayMode === 'transparent'}
                         width={innerWidth}
                         height={innerHeight}
-                        renderCounter={_renderCounter}
+                        renderCounter={_renderCounter + dataRenderCounter}
                         replaceVariables={model.interpolate}
                         onOptionsChange={model.onOptionsChange}
                         onFieldConfigChange={model.onFieldConfigChange}


### PR DESCRIPTION
## What

`VizPanel` re-renders whenever its data changes (the renderer subscribes to data via `dataObject.useState()`), but it does not bump the `renderCounter` prop on those re-renders. This bumps `renderCounter` when a new data request settles.

## Why

Panel plugins that imperatively mutate their own DOM after render (e.g. text/HTML panels running a post-render script) re-apply those mutations whenever `renderCounter` changes. So when the component re-renders because its data changed, the plugin must receive a new `renderCounter`. Otherwise the re-render resets the plugin's DOM and it is never re-applied, so the scripted content disappears (for example when a query-type variable finishes loading and the panel's query re-runs).

`renderCounter` was hardcoded to `0` until https://github.com/grafana/scenes/pull/934, which introduced `_renderCounter` and bumped it only on options changes (https://github.com/grafana/scenes/pull/954 later added `forceRender` for referenced-variable and time-range changes). Data-driven re-renders were never covered, so a re-render caused purely by new data still passes an unchanged `renderCounter`.

## Fix

Track the data request id in the renderer and add a counter, bumped on each new request, to the value passed to the plugin:

```tsx
renderCounter={_renderCounter + dataRenderCounter}
```

The first request after mount is skipped (initial mount already renders once); keying on `requestId` means streaming frames within the same request do not over-trigger.

## Test

`VizPanel > panel rendering > data plugin > Should increment renderCounter only when a new data request settles`: a same-request state change leaves `renderCounter` unchanged, a new request increments it.

Placement note: this lives in the renderer so it resolves the same data object the renderer already displays and can schedule a re-render via `useState`. Happy to move it model-side (symmetric to the existing `skipDataQuery` time-range `forceRender`) if preferred.

## Affected plugins (rely on `renderCounter`)

Core panels that read the prop today, so they benefit from the contract being restored on data-driven re-renders:

- [`annolist`](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/annolist/AnnoListPanel.tsx) — re-fetches annotations in `componentDidUpdate` when `renderCounter` changes
- [`dashlist`](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/dashlist/DashList.tsx) — re-fetches dashboards via `useThrottle(props.renderCounter, 5000)`
- [`stat`](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/stat/StatPanel.tsx), [`gauge`](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/gauge/GaugePanel.tsx), [`bargauge`](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/bargauge/BarGaugePanel.tsx) — forward it to [`VizRepeater`](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx), whose `shouldComponentUpdate` re-renders on `renderCounter` change
- [`logstable`](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/logstable/LogsTable.tsx) — forwards it to the table

Note on the fetch-triggering panels: `annolist` and `dashlist` run no datasource queries, so the query runner takes the no-queries path and produces no `request`. They never receive a new `requestId`, so this change does not bump their counter and does not introduce extra fetches; only query-running panels (and third-party DOM-mutating panels) get the corrected behavior.
