### PR TITLE
feat(variables): per-key interpolation for ad hoc filter variables

### DIFF
--- a/docusaurus/docs/advanced-adhoc-fIlters.md
+++ b/docusaurus/docs/advanced-adhoc-fIlters.md
@@ -121,3 +121,46 @@ new SceneQueryRunner({
 ```
 
 Such configured query contains the variable expression `$filters`. You can change the name of the variable. By default, the `AdHocFiltersVariable` will render the filters to valid Prometheus label filter expressions separated by a comma.
+
+## Interpolating a single filter by key
+
+Use bracket-quoted key syntax to interpolate the value(s) of one filter instead of the whole expression:
+
+```ts
+// filter: env = prod
+'${filters["env"]}'; // -> prod
+```
+
+Both double-quoted (`["env"]`) and single-quoted (`['env']`) forms are supported. The key is matched exactly against the combined origin (scope/dashboard) and user filters; group-by entries are excluded. Keys containing dots or spaces are fine inside the brackets:
+
+```ts
+// filter: pod.name = api-0
+'${filters["pod.name"]}'; // -> api-0
+```
+
+A single resolved value renders as a scalar. Multiple values - a multi-value operator (`=|` / `!=|`) or several filters sharing a key - render through the standard variable formatters:
+
+```ts
+// filter: env =| prod|staging
+'${filters["env"]}'; // -> {prod,staging}  (glob default)
+'${filters["env"]:csv}'; // -> prod,staging
+'${filters["env"]:pipe}'; // -> prod|staging
+'${filters["env"]:json}'; // -> ["prod","staging"]
+'${filters["env"]:singlequote}'; // -> 'prod','staging'
+```
+
+The operator token of the (first) matching filter is available via the `.operator` accessor:
+
+```ts
+// filter: env =| prod|staging
+'${filters["env"].operator}'; // -> =|
+```
+
+### Notes and limitations
+
+- A missing key renders as an empty string (`${filters["unknown"]}` -> ``), including with a formatter.
+- An unrecognized accessor (anything other than `.operator`) renders as an empty string.
+- The dot form `${filters.env}` is **not** a per-key accessor. It falls through to the whole-expression behavior and logs a development-mode warning advising bracket syntax. Always use brackets for per-key access.
+- The output shape depends on cardinality: a single-value key returns a scalar, so `${filters["env"]:json}` yields the raw string `"prod"` rather than `["prod"]`. This matches multi-value-variable behavior.
+- A key containing a quote of the active delimiter cannot be expressed; use the other delimiter (no backslash escaping). Nested interpolation inside a key (`${filters["${other}"]}`) is not supported - the key is matched literally.
+- Per-key interpolation is a `@grafana/scenes` feature; it is independent of Grafana core's `template_srv`.

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1881,6 +1881,91 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(value).toEqual(filtersVar.state.filterExpression);
   });
 
+  describe('getValue per-key resolution', () => {
+    function makeVariable(overrides: Partial<AdHocFiltersVariableState>) {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        name: 'filters',
+        filters: [],
+        ...overrides,
+      });
+      variable.activate();
+      return variable;
+    }
+
+    it('resolves a single-value filter to a scalar', () => {
+      const variable = makeVariable({ filters: [{ key: 'env', operator: '=', value: 'prod' }] });
+      expect(variable.getValue('["env"]')).toBe('prod');
+    });
+
+    it('resolves a multi-value (=|) filter to an array of values', () => {
+      const variable = makeVariable({
+        filters: [{ key: 'env', operator: '=|', value: 'prod', values: ['prod', 'staging'] }],
+      });
+      expect(variable.getValue('["env"]')).toEqual(['prod', 'staging']);
+    });
+
+    it('flattens multiple filters sharing a key into one array', () => {
+      const variable = makeVariable({
+        filters: [
+          { key: 'env', operator: '=', value: 'prod' },
+          { key: 'env', operator: '=', value: 'staging' },
+        ],
+      });
+      expect(variable.getValue('["env"]')).toEqual(['prod', 'staging']);
+    });
+
+    it('resolves a key containing dots, spaces and special chars', () => {
+      const variable = makeVariable({ filters: [{ key: 'pod.name region', operator: '=', value: 'api-0' }] });
+      expect(variable.getValue('["pod.name region"]')).toBe('api-0');
+    });
+
+    it('returns empty string for a missing key', () => {
+      const variable = makeVariable({ filters: [{ key: 'env', operator: '=', value: 'prod' }] });
+      expect(variable.getValue('["region"]')).toBe('');
+    });
+
+    it('resolves the .operator accessor to the operator token', () => {
+      const variable = makeVariable({
+        filters: [{ key: 'env', operator: '=|', value: 'prod', values: ['prod', 'staging'] }],
+      });
+      expect(variable.getValue('["env"].operator')).toBe('=|');
+    });
+
+    it('returns empty string for an unrecognized accessor', () => {
+      const variable = makeVariable({ filters: [{ key: 'env', operator: '=', value: 'prod' }] });
+      expect(variable.getValue('["env"].foo')).toBe('');
+    });
+
+    it('returns empty string for the .operator accessor on a missing key', () => {
+      const variable = makeVariable({ filters: [{ key: 'env', operator: '=', value: 'prod' }] });
+      expect(variable.getValue('["region"].operator')).toBe('');
+    });
+
+    it('excludes groupBy filters from value resolution', () => {
+      const variable = makeVariable({
+        filters: [],
+        originFilters: [{ key: 'env', operator: GROUP_BY_OPERATOR, value: '', origin: 'scope' }],
+      });
+      expect(variable.getValue('["env"]')).toBe('');
+    });
+
+    it('resolves an origin/scope-injected filter by key', () => {
+      const variable = makeVariable({
+        filters: [],
+        originFilters: [{ key: 'env', operator: '=', value: 'prod', origin: 'scope' }],
+      });
+      expect(variable.getValue('["env"]')).toBe('prod');
+    });
+
+    it('falls through to the whole expression for a dot-form field path', () => {
+      const variable = makeVariable({ filters: [{ key: 'env', operator: '=', value: 'prod' }] });
+      // Dot form is not a per-key accessor; getValue returns the whole filter expression.
+      expect(variable.getValue('env')).toBe(variable.state.filterExpression);
+    });
+  });
+
   it('Can override and replace getTagKeys and getTagValues', async () => {
     const { filtersVar } = setup({
       getTagKeysProvider: () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -32,7 +32,7 @@ import { css } from '@emotion/css';
 import { getEnrichedFiltersRequest } from '../getEnrichedFiltersRequest';
 import { AdHocFiltersComboboxRenderer } from './AdHocFiltersCombobox/AdHocFiltersComboboxRenderer';
 import { wrapInSafeSerializableSceneObject } from '../../utils/wrapInSafeSerializableSceneObject';
-import { debounce, isEqual } from 'lodash';
+import { debounce, isEqual, toPath } from 'lodash';
 import { getAdHocFiltersFromScopes } from './getAdHocFiltersFromScopes';
 import { VariableDependencyConfig } from '../VariableDependencyConfig';
 import { getQueryController } from '../../core/sceneGraph/getQueryController';
@@ -735,7 +735,65 @@ export class AdHocFiltersVariable
       ];
     }
 
+    if (fieldPath) {
+      const parsed = parseFilterFieldPath(fieldPath);
+
+      if (parsed) {
+        return this.getFilterValueByKey(parsed.key, parsed.accessor);
+      }
+
+      // A dot-only path (`${filters.env}`) is not a per-key accessor; bracket syntax is the
+      // documented contract. Warn in dev builds, then fall through to whole-expression behavior.
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `[AdHocFiltersVariable] "${fieldPath}" is not a per-key accessor. ` +
+            `Use bracket-quoted key syntax, e.g. \${${this.state.name}["${fieldPath}"]}. ` +
+            `Falling back to the whole filter expression.`
+        );
+      }
+    }
+
     return this.state.filterExpression;
+  }
+
+  /**
+   * Resolves a single filter key (and optional accessor) to its value(s). Candidate filters are
+   * the combined origin + user filters, excluding groupBy and WIP filters - the same set used to
+   * build `filterExpression`. Returns:
+   *  - value accessor (default): the flattened value(s) of all filters matching `key` - a scalar
+   *    string when exactly one value resolves, otherwise a `string[]` for the formatter to render.
+   *  - `operator` accessor: the operator token of the first matching filter.
+   *  - any other accessor, or a missing key: an empty string.
+   */
+  private getFilterValueByKey(key: string, accessor?: string): VariableValue {
+    const { originFilters, filters, _wip } = this.state;
+
+    const matches = [...(originFilters ?? []), ...filters].filter(
+      (f) => f !== _wip && !isGroupByFilter(f) && f.key === key
+    );
+
+    if (matches.length === 0) {
+      return '';
+    }
+
+    if (accessor === 'operator') {
+      return matches[0].operator;
+    }
+
+    if (accessor !== undefined) {
+      // Unrecognized accessor (e.g. `.foo`).
+      return '';
+    }
+
+    const values = matches.flatMap((f) =>
+      isMultiValueOperator(f.operator) ? f.values ?? [] : f.value != null ? [f.value] : []
+    );
+
+    if (values.length === 1) {
+      return values[0];
+    }
+
+    return values;
   }
 
   public _updateFilter(filter: AdHocFilterWithLabels, update: Partial<AdHocFilterWithLabels>) {
@@ -1397,6 +1455,29 @@ function originalValueKey({ key, origin, operator }: { key: string; origin?: str
   return operator === GROUP_BY_OPERATOR
     ? `${key}${VALUE_KEY_DELIMITER}${origin}${VALUE_KEY_DELIMITER}${GROUP_BY_OPERATOR}`
     : `${key}${VALUE_KEY_DELIMITER}${origin}`;
+}
+
+/**
+ * Parses a bracket-quoted filter field path into a filter key and optional accessor.
+ *
+ * Only paths whose first segment is bracket-quoted (`["env"]`, `['env']`, `["env"].operator`,
+ * `["a"]["b"]`) are treated as per-key accessors. A plain dot path (`env`, `a.b`) returns null so
+ * the caller falls through to legacy whole-expression behavior. The first lodash path segment is
+ * the filter key; an optional second segment is the accessor.
+ */
+export function parseFilterFieldPath(fieldPath: string): { key: string; accessor?: string } | null {
+  // Bracket syntax is the documented contract for per-key access. A dot-first path is legacy.
+  if (fieldPath.charAt(0) !== '[') {
+    return null;
+  }
+
+  const segments = toPath(fieldPath);
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  return { key: segments[0], accessor: segments[1] };
 }
 
 export function isMultiValueOperator(operatorValue: string): boolean {

--- a/packages/scenes/src/variables/constants.test.ts
+++ b/packages/scenes/src/variables/constants.test.ts
@@ -59,7 +59,7 @@ describe('VARIABLE_REGEX', () => {
     });
   });
 
-  it('matches single-quoted bracket key ${filters[\'env\']}', () => {
+  it("matches single-quoted bracket key ${filters['env']}", () => {
     expect(matchOne("${filters['env']}")).toMatchObject({
       match: "${filters['env']}",
       var3: 'filters',

--- a/packages/scenes/src/variables/constants.test.ts
+++ b/packages/scenes/src/variables/constants.test.ts
@@ -1,0 +1,129 @@
+import { VARIABLE_REGEX } from './constants';
+
+interface ParsedVariableMatch {
+  match: string;
+  var1?: string;
+  var2?: string;
+  fmt2?: string;
+  var3?: string;
+  fieldPath?: string;
+  fmt3?: string;
+}
+
+function matchOne(input: string): ParsedVariableMatch | null {
+  VARIABLE_REGEX.lastIndex = 0;
+  const result = VARIABLE_REGEX.exec(input);
+
+  if (!result) {
+    return null;
+  }
+
+  const [match, var1, var2, fmt2, var3, fieldPath, fmt3] = result;
+  return { match, var1, var2, fmt2, var3, fieldPath, fmt3 };
+}
+
+describe('VARIABLE_REGEX', () => {
+  it('matches legacy $var form', () => {
+    expect(matchOne('$var')).toMatchObject({ match: '$var', var1: 'var' });
+  });
+
+  it('matches legacy [[var]] form', () => {
+    expect(matchOne('[[var]]')).toMatchObject({ match: '[[var]]', var2: 'var' });
+  });
+
+  it('matches legacy [[var:fmt]] form', () => {
+    expect(matchOne('[[var:fmt]]')).toMatchObject({ match: '[[var:fmt]]', var2: 'var', fmt2: 'fmt' });
+  });
+
+  it('matches whole-variable ${var} form', () => {
+    expect(matchOne('${var}')).toMatchObject({ match: '${var}', var3: 'var', fieldPath: '' });
+  });
+
+  it('matches dot-path ${var.field} keeping the leading dot in the capture', () => {
+    expect(matchOne('${var.field}')).toMatchObject({ match: '${var.field}', var3: 'var', fieldPath: '.field' });
+  });
+
+  it('matches numeric dot-path ${var.1}', () => {
+    expect(matchOne('${var.1}')).toMatchObject({ match: '${var.1}', var3: 'var', fieldPath: '.1' });
+  });
+
+  it('matches chained dot-path ${var.a.b}', () => {
+    expect(matchOne('${var.a.b}')).toMatchObject({ match: '${var.a.b}', var3: 'var', fieldPath: '.a.b' });
+  });
+
+  it('matches double-quoted bracket key ${filters["env"]}', () => {
+    expect(matchOne('${filters["env"]}')).toMatchObject({
+      match: '${filters["env"]}',
+      var3: 'filters',
+      fieldPath: '["env"]',
+    });
+  });
+
+  it('matches single-quoted bracket key ${filters[\'env\']}', () => {
+    expect(matchOne("${filters['env']}")).toMatchObject({
+      match: "${filters['env']}",
+      var3: 'filters',
+      fieldPath: "['env']",
+    });
+  });
+
+  it('matches bracket key with dots and spaces ${filters["a.b c"]}', () => {
+    expect(matchOne('${filters["a.b c"]}')).toMatchObject({
+      match: '${filters["a.b c"]}',
+      var3: 'filters',
+      fieldPath: '["a.b c"]',
+    });
+  });
+
+  it('matches bracket key with operator accessor ${filters["env"].operator}', () => {
+    expect(matchOne('${filters["env"].operator}')).toMatchObject({
+      match: '${filters["env"].operator}',
+      var3: 'filters',
+      fieldPath: '["env"].operator',
+    });
+  });
+
+  it('matches bracket key with a formatter ${filters["env"]:json}', () => {
+    expect(matchOne('${filters["env"]:json}')).toMatchObject({
+      match: '${filters["env"]:json}',
+      var3: 'filters',
+      fieldPath: '["env"]',
+      fmt3: 'json',
+    });
+  });
+
+  it('matches chained bracket keys ${filters["a"]["b"]}', () => {
+    expect(matchOne('${filters["a"]["b"]}')).toMatchObject({
+      match: '${filters["a"]["b"]}',
+      var3: 'filters',
+      fieldPath: '["a"]["b"]',
+    });
+  });
+
+  it('matches legacy unquoted bracket index in a dot-path ${__data.fields[1]}', () => {
+    expect(matchOne('${__data.fields[1]}')).toMatchObject({
+      match: '${__data.fields[1]}',
+      var3: '__data',
+      fieldPath: '.fields[1]',
+    });
+  });
+
+  it('matches mixed dot, unquoted index and quoted key ${__data.fields["CoolNumber"].text}', () => {
+    expect(matchOne('${__data.fields["CoolNumber"].text}')).toMatchObject({
+      match: '${__data.fields["CoolNumber"].text}',
+      var3: '__data',
+      fieldPath: '.fields["CoolNumber"].text',
+    });
+  });
+
+  it('resolves long repeated bracket / dot field paths in bounded time (no catastrophic backtracking)', () => {
+    const longBracket = `\${filters${'["x"]'.repeat(2000)}}`;
+    const longDot = `\${filters${'.x'.repeat(2000)}}`;
+
+    const start = Date.now();
+    expect(matchOne(longBracket)).toMatchObject({ var3: 'filters' });
+    expect(matchOne(longDot)).toMatchObject({ var3: 'filters' });
+    // Bounded-time guard: linear matching completes near-instantly. 1s is a generous ceiling.
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});

--- a/packages/scenes/src/variables/constants.test.ts
+++ b/packages/scenes/src/variables/constants.test.ts
@@ -59,7 +59,7 @@ describe('VARIABLE_REGEX', () => {
     });
   });
 
-  it("matches single-quoted bracket key ${filters['env']}", () => {
+  it('matches single-quoted bracket key form', () => {
     expect(matchOne("${filters['env']}")).toMatchObject({
       match: "${filters['env']}",
       var3: 'filters',

--- a/packages/scenes/src/variables/constants.ts
+++ b/packages/scenes/src/variables/constants.ts
@@ -7,11 +7,26 @@ export const AUTO_VARIABLE_VALUE = '$__auto';
 
 // Grafana core source: https://github.com/grafana/grafana/blob/main/public/app/features/variables/utils.ts#L23
 /*
- * This regex matches 3 types of variable reference with an optional format specifier
+ * This regex matches 3 types of variable reference with an optional field path and format specifier
  * \$(\w+)                          $var1
  * \[\[(\w+?)(?::(\w+))?\]\]        [[var2]] or [[var2:fmt2]]
- * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
+ * \${(\w+)(fieldPath)?(:fmt3)?}    ${var3}, ${var3.field}, ${var3["key"]}, ${var3["key"].operator}, ${var3:fmt3}
+ *
+ * The fieldPath capture (group 5) is a `*`-repeated sequence of four mutually exclusive,
+ * first-character-anchored alternatives:
+ *   \.[^:^{}\[\]]+   a legacy dot segment (.field, .1, .a.b). Excludes { } [ ] so it can never
+ *                    swallow a bracket segment or a brace; it still includes the leading dot.
+ *   \["[^"]*"\]      a double-quoted bracket key. The body allows dots, spaces, =, |, etc.
+ *   \['[^']*'\]      the single-quoted variant.
+ *   \[[^\]"']*\]     an unquoted bracket index/key (`[0]`, `[1]`). Preserves the legacy data-macro
+ *                    forms (`${__data.fields[1]}`, `${__data.fields[0].text}`) that the old regex
+ *                    matched as part of a permissive dot segment.
+ * Because the dot alternative keeps its leading `.`, the captured fieldPath for the legacy
+ * `${var.field}` form is `.field` (not `field`); sceneInterpolator strips one leading `.` so
+ * downstream consumers (getValue / getFieldAccessor) see the same string as before. Bracket
+ * keys (`["env"]`, `["env"].operator`) are passed through untouched.
  */
-export const VARIABLE_REGEX = /\$(\w+)|\[\[(\w+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
+export const VARIABLE_REGEX =
+  /\$(\w+)|\[\[(\w+?)(?::(\w+))?\]\]|\${(\w+)((?:\.[^:^{}\[\]]+|\["[^"]*"\]|\['[^']*'\]|\[[^\]"']*\])*)(?::([^}]+))?}/g;
 export const SEARCH_FILTER_VARIABLE = '__searchFilter';
 export const SCOPES_VARIABLE_NAME = '__scopes';

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.test.ts
@@ -9,6 +9,7 @@ import { VariableInterpolation } from '@grafana/runtime';
 import { VariableFormatID } from '@grafana/schema';
 
 import { sceneInterpolator } from './sceneInterpolator';
+import { AdHocFiltersVariable } from '../adhoc/AdHocFiltersVariable';
 
 describe('sceneInterpolator', () => {
   it('Should be interpolated and use closest variable', () => {
@@ -383,5 +384,121 @@ describe('sceneInterpolator', () => {
     const scene = new TestScene({});
 
     expect(sceneInterpolator(scene, 123 as any)).toBe(123);
+  });
+
+  describe('Ad hoc filter per-key interpolation', () => {
+    function sceneWithFilters(variable: AdHocFiltersVariable) {
+      return new TestScene({
+        $variables: new SceneVariableSet({ variables: [variable] }),
+      });
+    }
+
+    it('resolves a single-value key to a scalar', () => {
+      const scene = sceneWithFilters(
+        new AdHocFiltersVariable({
+          name: 'filters',
+          applyMode: 'manual',
+          filters: [{ key: 'env', operator: '=', value: 'prod' }],
+        })
+      );
+
+      expect(sceneInterpolator(scene, '${filters["env"]}')).toBe('prod');
+    });
+
+    it('composes a multi-value key with the csv / json / pipe / singlequote formatters', () => {
+      const scene = sceneWithFilters(
+        new AdHocFiltersVariable({
+          name: 'filters',
+          applyMode: 'manual',
+          filters: [{ key: 'env', operator: '=|', value: 'prod', values: ['prod', 'staging'] }],
+        })
+      );
+
+      expect(sceneInterpolator(scene, '${filters["env"]:csv}')).toBe('prod,staging');
+      expect(sceneInterpolator(scene, '${filters["env"]:json}')).toBe('["prod","staging"]');
+      expect(sceneInterpolator(scene, '${filters["env"]:pipe}')).toBe('prod|staging');
+      expect(sceneInterpolator(scene, '${filters["env"]:singlequote}')).toBe(`'prod','staging'`);
+      // glob default renders multiple values as {a,b}
+      expect(sceneInterpolator(scene, '${filters["env"]}')).toBe('{prod,staging}');
+    });
+
+    it('resolves the .operator accessor', () => {
+      const scene = sceneWithFilters(
+        new AdHocFiltersVariable({
+          name: 'filters',
+          applyMode: 'manual',
+          filters: [{ key: 'env', operator: '=|', value: 'prod', values: ['prod', 'staging'] }],
+        })
+      );
+
+      expect(sceneInterpolator(scene, '${filters["env"].operator}')).toBe('=|');
+    });
+
+    it('falls through to the whole expression for the dot form and emits a dev warning', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const variable = new AdHocFiltersVariable({
+        name: 'filters',
+        applyMode: 'manual',
+        filters: [
+          { key: 'env', operator: '=', value: 'prod' },
+          { key: 'region', operator: '=', value: 'us' },
+        ],
+      });
+      const scene = sceneWithFilters(variable);
+
+      expect(sceneInterpolator(scene, '${filters.env}')).toBe(variable.state.filterExpression);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not a per-key accessor'));
+
+      warnSpy.mockRestore();
+    });
+
+    it('resolves the whole expression with no field path', () => {
+      const variable = new AdHocFiltersVariable({
+        name: 'filters',
+        applyMode: 'manual',
+        filters: [
+          { key: 'env', operator: '=', value: 'prod' },
+          { key: 'region', operator: '=', value: 'us' },
+        ],
+      });
+      const scene = sceneWithFilters(variable);
+
+      expect(sceneInterpolator(scene, '${filters}')).toBe(variable.state.filterExpression);
+      expect(variable.state.filterExpression).toBe('env="prod",region="us"');
+    });
+
+    it('renders empty for a missing key, with or without a formatter', () => {
+      const scene = sceneWithFilters(
+        new AdHocFiltersVariable({
+          name: 'filters',
+          applyMode: 'manual',
+          filters: [{ key: 'env', operator: '=', value: 'prod' }],
+        })
+      );
+
+      expect(sceneInterpolator(scene, '${filters["region"]}')).toBe('');
+      expect(sceneInterpolator(scene, '${filters["region"]:csv}')).toBe('');
+    });
+  });
+
+  describe('Backward compatibility', () => {
+    it('leaves legacy $var / [[var]] / ${var} / ${var.field} / ${var.1} forms unchanged', () => {
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({
+          variables: [
+            new ConstantVariable({ name: 'simple', value: 'hello' }),
+            new ObjectVariable({ type: 'custom', name: 'obj', value: { prop1: 'prop1Value' } }),
+            new TestVariable({ name: 'arr', value: ['a', 'b'] }),
+          ],
+        }),
+      });
+
+      expect(sceneInterpolator(scene, '$simple')).toBe('hello');
+      expect(sceneInterpolator(scene, '[[simple]]')).toBe('hello');
+      expect(sceneInterpolator(scene, '${simple}')).toBe('hello');
+      expect(sceneInterpolator(scene, '${obj.prop1}')).toBe('prop1Value');
+      expect(sceneInterpolator(scene, '${arr.1}')).toBe('b');
+    });
   });
 });

--- a/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
+++ b/packages/scenes/src/variables/interpolation/sceneInterpolator.ts
@@ -31,9 +31,15 @@ export function sceneInterpolator(
 
   VARIABLE_REGEX.lastIndex = 0;
 
-  return target.replace(VARIABLE_REGEX, (match, var1, var2, fmt2, var3, fieldPath, fmt3) => {
+  return target.replace(VARIABLE_REGEX, (match, var1, var2, fmt2, var3, rawFieldPath, fmt3) => {
     const variableName = var1 || var2 || var3;
     const fmt = fmt2 || fmt3 || format;
+    // The widened regex captures the leading `.` for dot-paths (`.field`), whereas the legacy
+    // regex captured `field`. Strip one leading dot so dot-path consumers (getValue/getFieldAccessor)
+    // and the VariableInterpolation instrumentation see the same string as before. Bracket paths
+    // (`["env"]`, `["env"].operator`) start with `[` and are passed through untouched.
+    const fieldPath =
+      rawFieldPath && rawFieldPath.charCodeAt(0) === 0x2e /* '.' */ ? rawFieldPath.slice(1) : rawFieldPath || undefined;
     const variable = lookupFormatVariable(variableName, match, scopedVars, sceneObject);
 
     if (!variable) {


### PR DESCRIPTION
Adds `${filters["key"]}` interpolation for ad hoc filter variables: resolve a single filter's value(s) by key, with a `.operator` accessor and full formatter support (`:csv`/`:json`/`:pipe`/...). A single value renders as a scalar, multiple values (one-of operator, or multiple filters sharing a key) as an array; origin/scope filters are included, a missing key resolves to empty, and the dot form `${filters.env}` falls through to the whole expression with a dev-mode warning advising bracket syntax. The `VARIABLE_REGEX` change is additive and backward-compatible - dot-paths, `$var`/`[[var]]`, and legacy unquoted bracket indexing (`${__data.fields[1]}`, data macros) all still match, verified by the full variables suite (932 tests green). Frontend `@grafana/scenes` only; Grafana core `template_srv` and backend interpolation are out of scope.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.5.1--canary.1553.27950667546.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.5.1--canary.1553.27950667546.0
  npm install scenes-app@8.5.1--canary.1553.27950667546.0
  npm install @grafana/scenes-react@8.5.1--canary.1553.27950667546.0
  # or 
  yarn add @grafana/scenes@8.5.1--canary.1553.27950667546.0
  yarn add scenes-app@8.5.1--canary.1553.27950667546.0
  yarn add @grafana/scenes-react@8.5.1--canary.1553.27950667546.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
