### PR TITLE
SceneQueryRunner: convert forkJoin to combineLatest 

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -39,10 +39,10 @@ import { GroupByVariable } from '../variables/groupby/GroupByVariable';
 import { emptyPanelData } from '../core/SceneDataNode';
 import { SceneQueryController } from '../behaviors/SceneQueryController';
 import { activateFullSceneTree } from '../utils/test/activateFullSceneTree';
-import { SceneDeactivationHandler, SceneObjectState } from '../core/types';
+import { SceneDataQuery, SceneDeactivationHandler, SceneObjectState } from '../core/types';
 import { LocalValueVariable } from '../variables/variants/LocalValueVariable';
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { ExtraQueryDescriptor, ExtraQueryProvider } from './ExtraQueryProvider';
+import { ExtraQueryDataProcessor, ExtraQueryDescriptor, ExtraQueryProvider } from './ExtraQueryProvider';
 import { SafeSerializableSceneObject } from '../utils/SafeSerializableSceneObject';
 import { SceneQueryStateControllerState } from '../behaviors/types';
 import { config } from '@grafana/runtime';
@@ -89,6 +89,39 @@ const getDataSourceMock = jest.fn().mockImplementation((datasource) => {
                   type: 'string',
                   values: ['bar1', 'bar2', 'bar3'],
                 },
+              ],
+            }),
+          ],
+        });
+      }
+
+      // Secondary (extra) query routing used by the secondary-query merging tests.
+      // Annotation-only secondary used to assert annotation concatenation.
+      const firstRefId = request.targets[0]?.refId;
+      if (firstRefId === 'secAnnotations') {
+        return of({
+          data: [
+            toDataFrame({
+              refId: 'secAnnotations',
+              name: 'secondary annotation',
+              meta: { dataTopic: 'annotations' },
+              fields: [
+                { name: 'time', type: FieldType.time, values: [1] },
+                { name: 'text', type: FieldType.string, values: ['secondary annotation'] },
+              ],
+            }),
+          ],
+        });
+      }
+      // Any other secondary echoes its refId so series identity/order can be asserted.
+      if (typeof firstRefId === 'string' && firstRefId.startsWith('sec')) {
+        return of({
+          data: [
+            toDataFrame({
+              refId: firstRefId,
+              datapoints: [
+                [10, 1],
+                [20, 2],
               ],
             }),
           ],
@@ -1704,6 +1737,218 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
     });
   });
 
+  // Tests for the merge step at SceneQueryRunner.ts:575-577, where the primary
+  // and all secondary streams are combined with forkJoin and piped through
+  // extraQueryProcessingOperator before being delivered to onDataReceived.
+  describe('secondary query merging', () => {
+    const tick = () => new Promise((r) => setTimeout(r, 1));
+
+    const buildScene = (providers: TestExtraQueryProvider[], queries: SceneDataQuery[] = [{ refId: 'A' }]) => {
+      const timeRange = new SceneTimeRange({
+        from: '2023-08-24T05:00:00.000Z',
+        to: '2023-08-24T07:00:00.000Z',
+      });
+      const queryRunner = new SceneQueryRunner({ queries });
+      const scene = new EmbeddedScene({
+        $timeRange: timeRange,
+        $data: queryRunner,
+        controls: providers,
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+      return { scene, queryRunner };
+    };
+
+    it('appends a passthrough secondary (no processor) after the primary series', async () => {
+      const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secA')]);
+      const { scene, queryRunner } = buildScene([provider]);
+
+      scene.activate();
+      await tick();
+
+      expect(runRequestMock).toHaveBeenCalledTimes(2);
+      expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A', 'secA']);
+    });
+
+    it('spreads the primary PanelData into the merged result', async () => {
+      const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secA')]);
+      const { scene, queryRunner } = buildScene([provider]);
+
+      scene.activate();
+      await tick();
+
+      // state, request and timeRange all originate from the primary response.
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+      expect(queryRunner.state.data?.request?.requestId).toBe(runRequestMock.mock.calls[0][1].requestId);
+      expect(queryRunner.state.data?.timeRange).toEqual(runRequestMock.mock.calls[0][1].range);
+    });
+
+    it('applies the descriptor processor to the secondary series', async () => {
+      const renameProcessor: ExtraQueryDataProcessor = (_primary, secondary) =>
+        of({
+          ...secondary,
+          series: secondary.series.map((frame) => ({
+            ...frame,
+            refId: `${frame.refId}-processed`,
+            meta: { ...frame.meta, custom: { processed: true } },
+          })),
+        });
+
+      const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secA', renameProcessor)]);
+      const { scene, queryRunner } = buildScene([provider]);
+
+      scene.activate();
+      await tick();
+
+      const series = queryRunner.state.data?.series ?? [];
+      expect(series.map((s) => s.refId)).toEqual(['A', 'secA-processed']);
+      expect(series[1].meta?.custom).toEqual({ processed: true });
+    });
+
+    it('merges multiple secondaries from a single provider in order', async () => {
+      const provider = new TestExtraQueryProvider({ foo: 1 }, false, [
+        secondaryDescriptor('secA'),
+        secondaryDescriptor('secB'),
+      ]);
+      const { scene, queryRunner } = buildScene([provider]);
+
+      scene.activate();
+      await tick();
+
+      expect(runRequestMock).toHaveBeenCalledTimes(3);
+      expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A', 'secA', 'secB']);
+    });
+
+    it('merges secondaries contributed by multiple providers', async () => {
+      const providerA = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secA')]);
+      const providerB = new SecondTestExtraQueryProvider({ foo: 2 }, false, [secondaryDescriptor('secB')]);
+      const { scene, queryRunner } = buildScene([providerA, providerB]);
+
+      scene.activate();
+      await tick();
+
+      expect(runRequestMock).toHaveBeenCalledTimes(3);
+      const refIds = queryRunner.state.data?.series.map((s) => s.refId) ?? [];
+      expect(refIds[0]).toBe('A');
+      expect(refIds.slice(1).sort()).toEqual(['secA', 'secB']);
+    });
+
+    it('concatenates annotations from a secondary onto the primary annotations', async () => {
+      const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secAnnotations')]);
+      const { scene, queryRunner } = buildScene([provider], [{ refId: 'withAnnotations' }]);
+
+      scene.activate();
+      await tick();
+
+      const annotationNames = (queryRunner.state.data?.annotations ?? []).map((frame) => frame.name);
+      expect(annotationNames).toContain('exemplar');
+      expect(annotationNames).toContain('secondary annotation');
+    });
+
+    describe('stream combination semantics', () => {
+      const panelData = (over: Partial<PanelData> = {}): PanelData => ({
+        state: LoadingState.Done,
+        series: [],
+        annotations: [],
+        timeRange: {} as any,
+        request: { requestId: 'controlled' } as any,
+        ...over,
+      });
+
+      it('does not emit until the primary and all secondaries complete', async () => {
+        const primarySubject = new Subject<PanelData>();
+        const secondarySubject = new Subject<PanelData>();
+        runRequestMock.mockImplementationOnce(() => primarySubject).mockImplementationOnce(() => secondarySubject);
+
+        const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secCtrl')]);
+        const { scene, queryRunner } = buildScene([provider]);
+
+        scene.activate();
+        await tick();
+        expect(runRequestMock).toHaveBeenCalledTimes(2);
+
+        // Only the primary has completed: forkJoin must not have emitted yet.
+        primarySubject.next(panelData({ series: [toDataFrame({ refId: 'A', datapoints: [[1, 1]] })] }));
+        primarySubject.complete();
+        await tick();
+        expect(queryRunner.state.data).toBeUndefined();
+
+        // Once the secondary completes too, the combined result is emitted.
+        secondarySubject.next(
+          panelData({
+            series: [toDataFrame({ refId: 'secCtrl', datapoints: [[2, 1]] })],
+            request: { requestId: 'sec-controlled' } as any,
+          })
+        );
+        secondarySubject.complete();
+        await tick();
+
+        expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A', 'secCtrl']);
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+      });
+
+      it('keeps the primary loading state even when a secondary reports an error', async () => {
+        const primarySubject = new Subject<PanelData>();
+        const secondarySubject = new Subject<PanelData>();
+        runRequestMock.mockImplementationOnce(() => primarySubject).mockImplementationOnce(() => secondarySubject);
+
+        const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secCtrl')]);
+        const { scene, queryRunner } = buildScene([provider]);
+
+        scene.activate();
+        await tick();
+
+        primarySubject.next(panelData({ series: [toDataFrame({ refId: 'A', datapoints: [[1, 1]] })] }));
+        primarySubject.complete();
+        secondarySubject.next(
+          panelData({
+            state: LoadingState.Error,
+            series: [toDataFrame({ refId: 'secCtrl', datapoints: [[2, 1]] })],
+            errors: [{ message: 'secondary boom' }],
+            request: { requestId: 'sec-controlled' } as any,
+          })
+        );
+        secondarySubject.complete();
+        await tick();
+
+        // The merged state is taken from the primary, so the secondary error is masked,
+        // but its series are still merged in.
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+        expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A', 'secCtrl']);
+        expect(queryRunner.state.data?.errors ?? []).not.toContainEqual({ message: 'secondary boom' });
+      });
+
+      it('tears down the combined subscription when the query is cancelled', async () => {
+        const primarySubject = new Subject<PanelData>();
+        const secondarySubject = new Subject<PanelData>();
+        runRequestMock.mockImplementationOnce(() => primarySubject).mockImplementationOnce(() => secondarySubject);
+
+        const provider = new TestExtraQueryProvider({ foo: 1 }, false, [secondaryDescriptor('secCtrl')]);
+        const { scene, queryRunner } = buildScene([provider]);
+
+        scene.activate();
+        await tick();
+        expect(runRequestMock).toHaveBeenCalledTimes(2);
+
+        queryRunner.cancelQuery();
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+
+        // Emissions after cancellation must not reach the runner.
+        primarySubject.next(panelData({ series: [toDataFrame({ refId: 'A', datapoints: [[1, 1]] })] }));
+        primarySubject.complete();
+        secondarySubject.next(
+          panelData({
+            series: [toDataFrame({ refId: 'secCtrl', datapoints: [[2, 1]] })],
+            request: { requestId: 'sec-controlled' } as any,
+          })
+        );
+        secondarySubject.complete();
+        await tick();
+
+        expect(queryRunner.state.data?.series ?? []).toHaveLength(0);
+      });
+    });
+  });
+
   describe('time frame comparison', () => {
     test('should run query with time range comparison', async () => {
       const timeRange = new SceneTimeRange({
@@ -2978,13 +3223,21 @@ interface TestExtraQueryProviderState extends SceneObjectState {
 
 class TestExtraQueryProvider extends SceneObjectBase<TestExtraQueryProviderState> implements ExtraQueryProvider<{}> {
   private _shouldRerun: boolean;
+  private _descriptors?: ExtraQueryDescriptor[];
 
-  public constructor(state: { foo: number }, shouldRerun: boolean) {
+  public constructor(state: { foo: number }, shouldRerun: boolean, descriptors?: ExtraQueryDescriptor[]) {
     super(state);
     this._shouldRerun = shouldRerun;
+    this._descriptors = descriptors;
   }
 
   public getExtraQueries(): ExtraQueryDescriptor[] {
+    // When explicit descriptors are provided, use them so tests can exercise
+    // multiple secondaries, missing processors (passthrough), etc.
+    if (this._descriptors) {
+      return this._descriptors;
+    }
+
     return [
       {
         req: {
@@ -3000,4 +3253,19 @@ class TestExtraQueryProvider extends SceneObjectBase<TestExtraQueryProviderState
   public shouldRerun(prev: {}, next: {}): boolean {
     return this._shouldRerun;
   }
+}
+
+// A distinct provider class. `getClosestExtraQueryProviders` de-duplicates
+// providers by their constructor, so testing multiple providers at once
+// requires more than one class.
+class SecondTestExtraQueryProvider extends TestExtraQueryProvider {}
+
+// Build an ExtraQueryDescriptor whose secondary request targets a single refId.
+// The shared datasource mock echoes any refId starting with `sec` (see
+// getDataSourceMock) so the merged series can be asserted by refId.
+function secondaryDescriptor(refId: string, processor?: ExtraQueryDataProcessor): ExtraQueryDescriptor {
+  return {
+    req: { targets: [{ refId }] } as DataQueryRequest,
+    processor,
+  };
 }

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -1906,6 +1906,119 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
     });
   });
 
+  describe('secondary query loading and error states', () => {
+    const tick = () => new Promise((r) => setTimeout(r, 1));
+
+    const panelDataFrom = (request: DataQueryRequest, p: Partial<PanelData>): PanelData => ({
+      series: [],
+      annotations: [],
+      state: LoadingState.Loading,
+      timeRange: request.range,
+      request,
+      ...p,
+    });
+
+    // Wire the primary runRequest to one subject and the secondary to another so each can be
+    // driven independently. The primary request is issued first, the secondary second.
+    const mockPrimaryAndSecondaryStreams = () => {
+      const primarySubject = new Subject<Partial<PanelData>>();
+      const secondarySubject = new Subject<Partial<PanelData>>();
+      runRequestMock
+        .mockImplementationOnce((_ds: DataSourceApi, request: DataQueryRequest) =>
+          primarySubject.pipe(map((p) => panelDataFrom(request, p)))
+        )
+        .mockImplementationOnce((_ds: DataSourceApi, request: DataQueryRequest) =>
+          secondarySubject.pipe(map((p) => panelDataFrom(request, p)))
+        );
+      return { primarySubject: primarySubject, secondarySubject: secondarySubject };
+    };
+
+    it('emits Loading while the secondary query is still in flight', async () => {
+      const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
+
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+      const provider = new TestExtraQueryProvider({ foo: 1 }, true);
+      const scene = new EmbeddedScene({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        controls: [provider],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      scene.activate();
+      await tick();
+
+      // Primary completes but the secondary is still loading -> overall state is Loading.
+      primarySubject.next({ state: LoadingState.Done });
+      secondarySubject.next({ state: LoadingState.Loading });
+      await tick();
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Loading);
+
+      // Secondary completes -> overall state transitions to Done.
+      secondarySubject.next({ state: LoadingState.Done });
+      await tick();
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+    });
+
+    it('emits errors when the secondary query fails', async () => {
+      const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
+
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+      const provider = new TestExtraQueryProvider({ foo: 1 }, true);
+      const scene = new EmbeddedScene({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        controls: [provider],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      scene.activate();
+      await tick();
+
+      primarySubject.next({ state: LoadingState.Done });
+      secondarySubject.next({ state: LoadingState.Error, errors: [{ message: 'secondary failed' }] });
+      await tick();
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Error);
+      expect(queryRunner.state.data?.errors).toEqual([{ message: 'secondary failed' }]);
+    });
+
+    it('applies requestId suffix when the primary re-emits', async () => {
+      const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
+
+      const timeRange = new SceneTimeRange({
+        from: '2023-08-24T05:00:00.000Z',
+        to: '2023-08-24T07:00:00.000Z',
+      });
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+      const comparer = new SceneTimeRangeCompare({ compareWith: '1h' });
+      const scene = new EmbeddedScene({
+        $timeRange: timeRange,
+        $data: queryRunner,
+        controls: [comparer],
+        body: new SceneFlexLayout({
+          children: [new SceneFlexItem({ body: new SceneCanvasText({ text: 'A' }) })],
+        }),
+      });
+
+      scene.activate();
+      comparer.activate();
+      await tick();
+
+      // A single secondary response object is processed...
+      secondarySubject.next({ state: LoadingState.Done, series: [toDataFrame({ refId: 'A', fields: [] })] });
+      // ...then the primary re-emits twice, each re-triggering combineLatest against the same secondary.
+      // extraQueryProcessingOperator should prevent the processor from re-running and double-suffixing the refId.
+      primarySubject.next({ state: LoadingState.Streaming, series: [toDataFrame({ refId: 'A', fields: [] })] });
+      primarySubject.next({ state: LoadingState.Done, series: [toDataFrame({ refId: 'A', fields: [] })] });
+      await tick();
+
+      const refIds = queryRunner.state.data?.series.map((s) => s.refId) ?? [];
+      expect(refIds.filter((refId) => refId === 'A-compare')).toHaveLength(1);
+      expect(refIds).not.toContain('A-compare-compare');
+    });
+  });
+
   test('enriching query request', async () => {
     const queryRunner = new SceneQueryRunner({
       queries: [{ refId: 'A' }],

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual } from 'lodash';
-import { forkJoin, ReplaySubject, Unsubscribable } from 'rxjs';
+import { combineLatest, ReplaySubject, Unsubscribable } from 'rxjs';
 
 import { DataQuery, DataSourceRef, LoadingState } from '@grafana/schema';
 
@@ -18,7 +18,7 @@ import {
 
 // TODO: Remove this ignore annotation when the grafana runtime dependency has been updated
 // @ts-ignore
-import { getRunRequest, toDataQueryError, isExpressionReference, config } from '@grafana/runtime';
+import { config, getRunRequest, isExpressionReference, toDataQueryError } from '@grafana/runtime';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { sceneGraph } from '../core/sceneGraph';
@@ -36,11 +36,11 @@ import { writeSceneLog } from '../utils/writeSceneLog';
 import { VariableValueRecorder } from '../variables/VariableValueRecorder';
 import { emptyPanelData } from '../core/SceneDataNode';
 import { getClosest } from '../core/sceneGraph/utils';
-import { isExtraQueryProvider, ExtraQueryDataProcessor, ExtraQueryProvider } from './ExtraQueryProvider';
-import { passthroughProcessor, extraQueryProcessingOperator } from './extraQueryProcessingOperator';
+import { ExtraQueryDataProcessor, ExtraQueryProvider, isExtraQueryProvider } from './ExtraQueryProvider';
+import { extraQueryProcessingOperator, passthroughProcessor } from './extraQueryProcessingOperator';
 import { filterAnnotations } from './layers/annotations/filterAnnotations';
 import { getEnrichedDataRequest } from './getEnrichedDataRequest';
-import { registerQueryWithController, QueryProfilerLike } from './registerQueryWithController';
+import { QueryProfilerLike, registerQueryWithController } from './registerQueryWithController';
 import { findPanelProfiler } from '../utils/findPanelProfiler';
 import { AdHocFiltersVariable } from '../variables/adhoc/AdHocFiltersVariable';
 import { GroupByVariable } from '../variables/groupby/GroupByVariable';
@@ -574,7 +574,9 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
         // extra request providers.
         const op = extraQueryProcessingOperator(processors);
         // Combine the primary and secondary streams into a single stream, and apply the operator.
-        stream = forkJoin([stream, ...secondaryStreams]).pipe(op);
+        // Use combineLatest so intermediate loading/error states from the primary and secondary requests are emitted as
+        // they arrive, instead of only a single combined emission once every request has completed.
+        stream = combineLatest([stream, ...secondaryStreams]).pipe(op);
       }
 
       const panelProfiler: QueryProfilerLike | undefined = findPanelProfiler(this);

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
@@ -1,0 +1,90 @@
+import { lastValueFrom, of } from 'rxjs';
+
+import { FieldType, LoadingState, PanelData, toDataFrame } from '@grafana/data';
+
+import { extraQueryProcessingOperator, passthroughProcessor } from './extraQueryProcessingOperator';
+import { ExtraQueryDataProcessor } from './ExtraQueryProvider';
+
+function makeData(refId: string, over: Partial<PanelData> = {}): PanelData {
+  return {
+    state: LoadingState.Done,
+    series: [toDataFrame({ refId, datapoints: [[1, 1]] })],
+    annotations: [],
+    timeRange: {} as any,
+    // The operator looks up processors by the secondary's request.requestId.
+    request: { requestId: refId } as any,
+    ...over,
+  };
+}
+
+describe('passthroughProcessor', () => {
+  it('returns the secondary data unchanged', async () => {
+    const primary = makeData('A');
+    const secondary = makeData('sec1');
+
+    const result = await lastValueFrom(passthroughProcessor(primary, secondary));
+
+    expect(result).toBe(secondary);
+  });
+});
+
+describe('extraQueryProcessingOperator', () => {
+  it('applies the processor matched by the secondary request id', async () => {
+    const processor: ExtraQueryDataProcessor = (_primary, secondary) =>
+      of({
+        ...secondary,
+        series: secondary.series.map((frame) => ({ ...frame, refId: `${frame.refId}-processed` })),
+      });
+    const processors = new Map([['sec1', processor]]);
+
+    const result = await lastValueFrom(
+      of([makeData('A'), makeData('sec1')] as [PanelData, ...PanelData[]]).pipe(
+        extraQueryProcessingOperator(processors)
+      )
+    );
+
+    expect(result.series.map((s) => s.refId)).toEqual(['A', 'sec1-processed']);
+  });
+
+  it('falls back to passthrough when no processor is registered for the secondary', async () => {
+    const result = await lastValueFrom(
+      of([makeData('A'), makeData('sec1')] as [PanelData, ...PanelData[]]).pipe(extraQueryProcessingOperator(new Map()))
+    );
+
+    expect(result.series.map((s) => s.refId)).toEqual(['A', 'sec1']);
+  });
+
+  it('keeps the primary series first and preserves secondary order', async () => {
+    const result = await lastValueFrom(
+      of([makeData('A'), makeData('sec1'), makeData('sec2')] as [PanelData, ...PanelData[]]).pipe(
+        extraQueryProcessingOperator(new Map())
+      )
+    );
+
+    expect(result.series.map((s) => s.refId)).toEqual(['A', 'sec1', 'sec2']);
+  });
+
+  it('concatenates annotations primary-first', async () => {
+    const annotationFrame = (refId: string) =>
+      toDataFrame({ refId, fields: [{ name: 'time', type: FieldType.time, values: [1] }] });
+    const primary = makeData('A', { annotations: [annotationFrame('pa')] });
+    const secondary = makeData('sec1', { annotations: [annotationFrame('sa')] });
+
+    const result = await lastValueFrom(
+      of([primary, secondary] as [PanelData, ...PanelData[]]).pipe(extraQueryProcessingOperator(new Map()))
+    );
+
+    expect(result.annotations?.map((a) => a.refId)).toEqual(['pa', 'sa']);
+  });
+
+  it('spreads the primary data so its state wins over a secondary state', async () => {
+    const primary = makeData('A', { state: LoadingState.Done });
+    const secondary = makeData('sec1', { state: LoadingState.Error });
+
+    const result = await lastValueFrom(
+      of([primary, secondary] as [PanelData, ...PanelData[]]).pipe(extraQueryProcessingOperator(new Map()))
+    );
+
+    expect(result.state).toBe(LoadingState.Done);
+  });
+});

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
@@ -1,0 +1,203 @@
+import { DataFrame, DataQueryError, LoadingState, PanelData, toDataFrame } from '@grafana/data';
+import { combineLatest, Observable, of, Subject } from 'rxjs';
+
+import { ExtraQueryDataProcessor } from './ExtraQueryProvider';
+import {
+  combineLoadingStates,
+  extraQueryProcessingOperator,
+  passthroughProcessor,
+} from './extraQueryProcessingOperator';
+
+function makePanelData(
+  state: LoadingState,
+  options: {
+    requestId?: string;
+    series?: DataFrame[];
+    annotations?: DataFrame[];
+    errors?: DataQueryError[];
+  } = {}
+): PanelData {
+  return {
+    state,
+    series: options.series ?? [],
+    annotations: options.annotations,
+    errors: options.errors,
+    request: { requestId: options.requestId ?? 'A' } as PanelData['request'],
+    timeRange: {} as PanelData['timeRange'],
+  };
+}
+
+// Synchronously collect all emissions from a source observable. Safe because all of the
+// observables exercised in these tests emit synchronously.
+function collect(source: Observable<PanelData>): { emissions: PanelData[]; unsubscribe: () => void } {
+  const emissions: PanelData[] = [];
+  const sub = source.subscribe((v) => emissions.push(v));
+  return { emissions, unsubscribe: () => sub.unsubscribe() };
+}
+
+describe('combineLoadingStates', () => {
+  it('returns Error when any response is in the Error state', () => {
+    expect(combineLoadingStates([LoadingState.Loading, LoadingState.Error])).toBe(LoadingState.Error);
+    expect(combineLoadingStates([LoadingState.Error, LoadingState.Streaming])).toBe(LoadingState.Error);
+  });
+
+  it('returns Loading when any response is loading (and none errored)', () => {
+    expect(combineLoadingStates([LoadingState.Done, LoadingState.Loading])).toBe(LoadingState.Loading);
+    expect(combineLoadingStates([LoadingState.Loading, LoadingState.Streaming])).toBe(LoadingState.Loading);
+  });
+
+  it('returns Streaming when any response is streaming (and none errored or loading)', () => {
+    expect(combineLoadingStates([LoadingState.Done, LoadingState.Streaming])).toBe(LoadingState.Streaming);
+  });
+
+  it('returns the primary state (and nothing is errored, loading, or streaming)', () => {
+    expect(combineLoadingStates([LoadingState.Done, LoadingState.Done])).toBe(LoadingState.Done);
+    expect(combineLoadingStates([LoadingState.NotStarted, LoadingState.Done])).toBe(LoadingState.NotStarted);
+  });
+
+  it('falls back to Done for an empty array', () => {
+    expect(combineLoadingStates([])).toBe(LoadingState.Done);
+  });
+});
+
+describe('extraQueryProcessingOperator', () => {
+  it('emits intermediate states as sources arrive', () => {
+    const primarySubject = new Subject<PanelData>();
+    const secondarySubject = new Subject<PanelData>();
+    const processors = new Map<string, ExtraQueryDataProcessor>([['B', passthroughProcessor]]);
+
+    const { emissions } = collect(
+      combineLatest([primarySubject, secondarySubject]).pipe(extraQueryProcessingOperator(processors))
+    );
+
+    // combineLatest waits for every source before emitting anything.
+    primarySubject.next(makePanelData(LoadingState.Done, { requestId: 'A' }));
+    expect(emissions).toHaveLength(0);
+
+    // Once the secondary primes its Loading state, the combined output should reflect Loading.
+    secondarySubject.next(makePanelData(LoadingState.Loading, { requestId: 'B' }));
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Loading);
+
+    // When the secondary completes, the combined output transitions to Done.
+    secondarySubject.next(makePanelData(LoadingState.Done, { requestId: 'B' }));
+    expect(emissions).toHaveLength(2);
+    expect(emissions[1].state).toBe(LoadingState.Done);
+  });
+
+  it('emits and aggregates errors', () => {
+    const primaryError: DataQueryError = { message: 'primary boom', refId: 'A' };
+    const secondaryError: DataQueryError = { message: 'secondary boom', refId: 'B' };
+
+    const { emissions } = collect(
+      of([
+        makePanelData(LoadingState.Error, { requestId: 'A', errors: [primaryError] }),
+        makePanelData(LoadingState.Error, { requestId: 'B', errors: [secondaryError] }),
+      ] as [PanelData, PanelData]).pipe(extraQueryProcessingOperator(new Map([['B', passthroughProcessor]])))
+    );
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Error);
+    expect(emissions[0].errors).toEqual([primaryError, secondaryError]);
+    expect(emissions[0].error).toEqual(primaryError);
+  });
+
+  it('does not emit errors when no response has errors', () => {
+    const { emissions } = collect(
+      of([
+        makePanelData(LoadingState.Done, { requestId: 'A' }),
+        makePanelData(LoadingState.Done, { requestId: 'B' }),
+      ] as [PanelData, PanelData]).pipe(extraQueryProcessingOperator(new Map([['B', passthroughProcessor]])))
+    );
+
+    expect(emissions[0].errors).toBeUndefined();
+    expect(emissions[0].error).toBeUndefined();
+  });
+
+  it('merges primary and secondary series and annotations without mutating the primary', () => {
+    const primary = makePanelData(LoadingState.Done, {
+      requestId: 'A',
+      series: [toDataFrame({ refId: 'A', fields: [] })],
+      annotations: [toDataFrame({ refId: 'primary-annotation', fields: [] })],
+    });
+    const secondary = makePanelData(LoadingState.Done, {
+      requestId: 'B',
+      series: [toDataFrame({ refId: 'B', fields: [] })],
+      annotations: [toDataFrame({ refId: 'secondary-annotation', fields: [] })],
+    });
+
+    const { emissions } = collect(
+      of([primary, secondary] as [PanelData, PanelData]).pipe(
+        extraQueryProcessingOperator(new Map([['B', passthroughProcessor]]))
+      )
+    );
+
+    expect(emissions[0].series.map((s) => s.refId)).toEqual(['A', 'B']);
+    expect(emissions[0].annotations?.map((a) => a.refId)).toEqual(['primary-annotation', 'secondary-annotation']);
+
+    // The primary PanelData should not be mutated by the operator.
+    expect(primary.series).toHaveLength(1);
+    expect(primary.annotations).toHaveLength(1);
+  });
+
+  it('falls back to passing the secondary through unchanged when no processor matches its requestId', () => {
+    const secondary = makePanelData(LoadingState.Done, {
+      requestId: 'no-processor',
+      series: [toDataFrame({ refId: 'B', fields: [] })],
+    });
+
+    const { emissions } = collect(
+      of([makePanelData(LoadingState.Done, { requestId: 'A' }), secondary] as [PanelData, PanelData]).pipe(
+        extraQueryProcessingOperator(new Map())
+      )
+    );
+
+    expect(emissions[0].series.map((s) => s.refId)).toEqual(['B']);
+  });
+
+  it('runs each processor once per secondary response', () => {
+    const primarySubject = new Subject<PanelData>();
+    const secondarySubject = new Subject<PanelData>();
+
+    let processorCalls = 0;
+    // Mirror the non-idempotent timeShiftAlignmentProcessor, which mutates series.refId in place.
+    const suffixProcessor: ExtraQueryDataProcessor = (_, secondary) => {
+      processorCalls++;
+      secondary.series.forEach((s) => {
+        s.refId = `${s.refId}-compare`;
+      });
+      return of(secondary);
+    };
+
+    const { emissions } = collect(
+      combineLatest([primarySubject, secondarySubject]).pipe(
+        extraQueryProcessingOperator(new Map([['B', suffixProcessor]]))
+      )
+    );
+
+    const secondary = makePanelData(LoadingState.Done, {
+      requestId: 'B',
+      series: [toDataFrame({ refId: 'A', fields: [] })],
+    });
+
+    primarySubject.next(makePanelData(LoadingState.Loading, { requestId: 'A' }));
+    secondarySubject.next(secondary);
+
+    // Re-emit a new primary while the SAME secondary object stays the latest value.
+    // combineLatest re-emits the secondary, but the processor must not run again.
+    primarySubject.next(makePanelData(LoadingState.Done, { requestId: 'A' }));
+
+    expect(processorCalls).toBe(1);
+    expect(emissions[emissions.length - 1].series.map((s) => s.refId)).toEqual(['A-compare']);
+  });
+});
+
+describe('passthroughProcessor', () => {
+  it('emits the secondary unchanged', (done) => {
+    const secondary = makePanelData(LoadingState.Done, { requestId: 'B' });
+    passthroughProcessor(makePanelData(LoadingState.Done, { requestId: 'A' }), secondary).subscribe((out) => {
+      expect(out).toBe(secondary);
+      done();
+    });
+  });
+});

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.ts
@@ -13,7 +13,7 @@ export const passthroughProcessor: ExtraQueryDataProcessor = (_, secondary) => o
  * otherwise return the first/primary response state
  * @param responseState
  */
-function combineLoadingStates(responseState: LoadingState[]): LoadingState {
+export function combineLoadingStates(responseState: LoadingState[]): LoadingState {
   if (responseState.some((s) => s === LoadingState.Error)) {
     return LoadingState.Error;
   }

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.ts
@@ -1,32 +1,72 @@
-import { PanelData } from '@grafana/data';
-import { forkJoin, of, map, mergeMap, Observable } from 'rxjs';
+import { LoadingState, PanelData } from '@grafana/data';
+import { combineLatest, map, mergeMap, Observable, of, tap } from 'rxjs';
 import { ExtraQueryDataProcessor } from './ExtraQueryProvider';
 
 // Passthrough processor for use with ExtraQuerys.
 export const passthroughProcessor: ExtraQueryDataProcessor = (_, secondary) => of(secondary);
 
-// Factory function which takes a map from request ID to processor functions and
-// returns an rxjs operator which operates on an array of panel data responses.
-//
-// Each secondary response is transformed according to the processor function
-// identified by it's request ID. The processor function is passed the primary
-// response and the secondary response to be processed.
-//
-// The output is a single frame with the primary series and all processed
-// secondary series combined.
+/**
+ * Combines loading responseState across multiple responses
+ * If any response contains an error => Error
+ * Otherwise, if any response is loading => Loading
+ * Otherwise, if any response is streaming => Streaming
+ * otherwise return the first/primary response state
+ * @param responseState
+ */
+function combineLoadingStates(responseState: LoadingState[]): LoadingState {
+  if (responseState.some((s) => s === LoadingState.Error)) {
+    return LoadingState.Error;
+  }
+  if (responseState.some((s) => s === LoadingState.Loading)) {
+    return LoadingState.Loading;
+  }
+  if (responseState.some((s) => s === LoadingState.Streaming)) {
+    return LoadingState.Streaming;
+  }
+  // If nothing is Error, Loading, or Streaming, return the LoadingState of the primary (zero index) response.
+  return responseState[0] ?? LoadingState.Done;
+}
+
+/**
+ * extraQueryProcessingOperator maps requests by requestId to processor functions and returns an rxjs operator which operates on an array of panel data responses.
+ *
+ * Each secondary response is transformed according to the processor function identified by its request ID.
+ * The processor function is passed both the primary and the secondary responses.
+ * The output PanelData combines the primary and secondary series, and loading state & errors are aggregated across all
+ * responses so that intermediate states are reflected while requests are in flight.
+ * @param panelDataProcessors
+ */
+type RequestId = string;
 export const extraQueryProcessingOperator =
-  (processors: Map<string, ExtraQueryDataProcessor>) => (data: Observable<[PanelData, ...PanelData[]]>) => {
+  (panelDataProcessors: Map<RequestId, ExtraQueryDataProcessor>) => (data: Observable<[PanelData, ...PanelData[]]>) => {
+    // combineLatest re-emits whenever any source updates, so the same secondary response object can be seen multiple times.
+    // Processors may mutate their input and are not guaranteed to be idempotent, so we cache the processed output by source identity and only run each processor once per secondary response.
+    const processedCache = new WeakMap<PanelData, PanelData>();
     return data.pipe(
-      mergeMap(([primary, ...secondaries]) => {
-        const processedSecondaries = secondaries.flatMap((s) => {
-          return processors.get(s.request!.requestId)?.(primary, s) ?? of(s);
+      mergeMap(([primaryResponse, ...secondaryResponses]) => {
+        const processedSecondaries = secondaryResponses.map((s) => {
+          const cached = processedCache.get(s);
+          if (cached) {
+            return of(cached);
+          }
+          const processedPanelData = panelDataProcessors.get(s.request!.requestId)?.(primaryResponse, s) ?? of(s);
+          return processedPanelData.pipe(tap((out) => processedCache.set(s, out)));
         });
-        return forkJoin([of(primary), ...processedSecondaries]);
+        return combineLatest([of(primaryResponse), ...processedSecondaries]);
       }),
-      map(([primary, ...processedSecondaries]) => ({
-        ...primary,
-        series: [...primary.series, ...processedSecondaries.flatMap((s) => s.series)],
-        annotations: [...(primary.annotations ?? []), ...processedSecondaries.flatMap((s) => s.annotations ?? [])],
-      }))
+      map(([processedPrimary, ...processedSecondaries]) => {
+        const allResponses = [processedPrimary, ...processedSecondaries];
+        const allResponseErrors = allResponses.flatMap((d) => d.errors ?? []);
+        return {
+          ...processedPrimary,
+          state: combineLoadingStates(allResponses.map((d) => d.state)),
+          series: [...processedPrimary.series, ...processedSecondaries.flatMap((s) => s.series)],
+          annotations: [
+            ...(processedPrimary.annotations ?? []),
+            ...processedSecondaries.flatMap((s) => s.annotations ?? []),
+          ],
+          ...(allResponseErrors.length > 0 ? { errors: allResponseErrors, error: allResponseErrors[0] } : {}),
+        };
+      })
     );
   };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/126804

### Problem
Requests with secondary queries do not currently emit loading events. 
Requests with secondary queries that return errors do not show error states in the panel.

### Details
The problem exists as a result of how [forkJoin](https://rxjs.dev/api/index/function/forkJoin) operates. forkJoin takes many observables and only emits when all subscribed observables complete, in Grafana this means that besides first load after the browser loads a panel, there is no loading feedback for any query run in a panel (i.e. on time range or query change), and secondary queries that error out do not display any error state in the panel.

The secondary query functionality was introduced in https://github.com/grafana/scenes/pull/587 as a somewhat general interface, but developed primarily to support query time comparison functionality. 

### Solution
[combineLatest](https://rxjs.dev/api/index/function/combineLatest) takes many observables and returns an observable that emits values from the latest value received in any of the observables, this gives us the ability to merge states across multiple requests which is required in order to utilize loading states and to display errors in secondary queries.

### Concerns
Grafana's `runWithTimeRange` usage of secondary queries are not well documented, and explicit test coverage is thin for `extraQueryProcessingOperator` so there is some regression risk, although it looks as though time range comparison is the only consumer of this functionality in core Grafana so regression risk should be limited to that feature.

#### References:
Comparison of [forkJoin and combineLatest](https://shuji-bonji.github.io/RxJS-with-TypeScript/en/guide/creation-functions/combination/forkJoin-vs-combineLatest)

[rxjs forkJoin doc](https://rxjs.dev/api/index/function/forkJoin)
[rxjs combineLatest doc](https://rxjs.dev/api/index/function/combineLatest)

#### Related PRs:
Original PR that introduced secondary queries for time range comparisons: https://github.com/grafana/scenes/pull/587

#### To test:
Grab the scenes canary info below and update your local grafana package.json and run `yarn install && yarn start`.
You can use the "Flaky query" test data source scenario to verify loading state and errors on the primary or secondary query are displayed in the UI.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.5.1--canary.1554.27979683361.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.5.1--canary.1554.27979683361.0
  npm install scenes-app@8.5.1--canary.1554.27979683361.0
  npm install @grafana/scenes-react@8.5.1--canary.1554.27979683361.0
  # or 
  yarn add @grafana/scenes@8.5.1--canary.1554.27979683361.0
  yarn add scenes-app@8.5.1--canary.1554.27979683361.0
  yarn add @grafana/scenes-react@8.5.1--canary.1554.27979683361.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
