### PR TITLE
feat: add data-testid to viz panel renderer

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -263,6 +263,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
         className={absoluteWrapper}
         data-viz-panel-key={model.state.key}
         data-viz-panel-id={model.getPathId()}
+        data-testid={`${plugin.meta.id}-${model.state.key}`}
       >
         <PanelChrome
           title={titleInterpolated}


### PR DESCRIPTION
We'd like to scope data-testids to plugin rendering roots. This requires adding one to the VizPanelRenderer
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.13.1--canary.1557.29409871663.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.13.1--canary.1557.29409871663.0
  npm install scenes-app@8.13.1--canary.1557.29409871663.0
  npm install @grafana/scenes-react@8.13.1--canary.1557.29409871663.0
  # or 
  yarn add @grafana/scenes@8.13.1--canary.1557.29409871663.0
  yarn add scenes-app@8.13.1--canary.1557.29409871663.0
  yarn add @grafana/scenes-react@8.13.1--canary.1557.29409871663.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
