### PR TITLE
Fix: Scope var `queryparam` name mismatch

### DIFF
--- a/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
@@ -54,7 +54,7 @@ describe('ScopesVariable', () => {
     const { scene } = renderTestScene({ initialScopes: ['scope1', 'scope2'] });
 
     // Interpolate using sceneInterpolator and the variable set as context
-    expect(sceneInterpolator(scene, '${__scopes:queryparam}')).toEqual('scope=scope1&scope=scope2');
+    expect(sceneInterpolator(scene, '${__scopes:queryparam}')).toEqual('scopes=scope1&scopes=scope2');
     expect(sceneInterpolator(scene, '${__scopes}')).toEqual('scope1, scope2');
   });
 

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -141,7 +141,7 @@ export class ScopesVariableFormatter implements CustomVariableValue {
 
   public formatter(formatNameOrFn?: string): string {
     if (formatNameOrFn === VariableFormatID.QueryParam) {
-      return this._value.map((scope) => `scope=${encodeURIComponent(scope)}`).join('&');
+      return this._value.map((scope) => `scopes=${encodeURIComponent(scope)}`).join('&');
     }
 
     return this._value.join(', ');


### PR DESCRIPTION
Fixes a bug where links in the dashboard created using `${__scopes:queryparam}` would not function properly because the name of the query param was `scope` (singular)., while the scopes URL system expects plural. Because of this, clicking on a link generated this way would open the new link but not apply scopes.

Test steps:
- Setup grafana with grafana enterprise as well to enable scopes
- Create a dashboard with a link to another dashboard and `?${__scopes:queryparam}`
- Set a scope on the current dashboard
- go to that new dashboard through the link
- See that scopes are continued to be applied and the url says `scopes=...`
- Without this fix it will show `scope=...` and not apply the scopes in the linked dashboard

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.9.1--canary.1559.28431439128.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.9.1--canary.1559.28431439128.0
  npm install scenes-app@8.9.1--canary.1559.28431439128.0
  npm install @grafana/scenes-react@8.9.1--canary.1559.28431439128.0
  # or 
  yarn add @grafana/scenes@8.9.1--canary.1559.28431439128.0
  yarn add scenes-app@8.9.1--canary.1559.28431439128.0
  yarn add @grafana/scenes-react@8.9.1--canary.1559.28431439128.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
