### PR TITLE
Filters: Do not pass non-applicable origin filters

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1872,6 +1872,31 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(value).toEqual(['scopeOriginFilter|=|val#scope']);
   });
 
+  it('Excludes non-applicable origin filters from getValue() when fieldPath is passed', () => {
+    const { filtersVar } = setup({
+      originFilters: [
+        {
+          key: 'applicableFilter',
+          operator: '=',
+          value: 'val',
+          values: ['val'],
+          origin: 'scope',
+        },
+        {
+          key: 'nonApplicableFilter',
+          operator: '=',
+          value: 'val2',
+          values: ['val2'],
+          origin: 'scope',
+          nonApplicable: true,
+        },
+      ],
+    });
+
+    const value = filtersVar.getValue('originFilters');
+    expect(value).toEqual(['applicableFilter|=|val#scope']);
+  });
+
   it('Returns filters expression through getValue()', () => {
     const { filtersVar } = setup({
       filters: [{ key: 'key1', operator: '=', value: 'val1' }],

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -729,9 +729,9 @@ export class AdHocFiltersVariable
       }
 
       return [
-        ...originFilters.map((filter) =>
-          toArray(filter).map(escapeOriginFilterUrlDelimiters).join('|').concat(`#${filter.origin}`)
-        ),
+        ...originFilters
+          .filter((filter) => !filter.nonApplicable)
+          .map((filter) => toArray(filter).map(escapeOriginFilterUrlDelimiters).join('|').concat(`#${filter.origin}`)),
       ];
     }
 


### PR DESCRIPTION
This PR does not pass non applicable origin filters on `getValue` (for a link, for example). 

We do not need to pass non applicable origin filters across grafana dashboards, as they are regenerated on dashboard initialization, but showing only applicable ones is useful for external links, for example.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.9.2--canary.1560.28437617600.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.9.2--canary.1560.28437617600.0
  npm install scenes-app@8.9.2--canary.1560.28437617600.0
  npm install @grafana/scenes-react@8.9.2--canary.1560.28437617600.0
  # or 
  yarn add @grafana/scenes@8.9.2--canary.1560.28437617600.0
  yarn add scenes-app@8.9.2--canary.1560.28437617600.0
  yarn add @grafana/scenes-react@8.9.2--canary.1560.28437617600.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
