### PR TITLE
Deps: Unpin production dependencies in `@grafana/scenes` + `@grafana/scenes-react`

### DIFF
--- a/packages/scenes-react/package.json
+++ b/packages/scenes-react/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/grafana/scenes/issues"
   },
   "dependencies": {
-    "@emotion/css": "11.13.5",
+    "@emotion/css": "^11.13.5",
     "@emotion/react": "11.14.0",
     "@grafana/scenes": "workspace:*",
     "lodash": "^4.17.21",

--- a/packages/scenes-react/package.json
+++ b/packages/scenes-react/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.5",
-    "@emotion/react": "11.14.0",
+    "@emotion/react": "^11.14.0",
     "@grafana/scenes": "workspace:*",
     "lodash": "^4.17.21",
     "lru-cache": "^10.2.2",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.5",
-    "@emotion/react": "11.14.0",
+    "@emotion/react": "^11.14.0",
     "@floating-ui/react": "^0.27.0",
     "@leeoniya/ufuzzy": "^1.0.16",
     "@tanstack/react-virtual": "^3.9.0",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/grafana/scenes/issues"
   },
   "dependencies": {
-    "@emotion/css": "11.13.5",
+    "@emotion/css": "^11.13.5",
     "@emotion/react": "11.14.0",
     "@floating-ui/react": "^0.27.0",
     "@leeoniya/ufuzzy": "^1.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3575,7 +3575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/css@npm:11.13.5, @emotion/css@npm:^11.1.3":
+"@emotion/css@npm:11.13.5, @emotion/css@npm:^11.1.3, @emotion/css@npm:^11.13.5":
   version: 11.13.5
   resolution: "@emotion/css@npm:11.13.5"
   dependencies:
@@ -4531,7 +4531,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/scenes-react@workspace:packages/scenes-react"
   dependencies:
-    "@emotion/css": "npm:11.13.5"
+    "@emotion/css": "npm:^11.13.5"
     "@emotion/react": "npm:11.14.0"
     "@grafana/scenes": "workspace:*"
     "@rollup/plugin-eslint": "npm:^9.2.0"
@@ -4569,7 +4569,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/scenes@workspace:packages/scenes"
   dependencies:
-    "@emotion/css": "npm:11.13.5"
+    "@emotion/css": "npm:^11.13.5"
     "@emotion/react": "npm:11.14.0"
     "@floating-ui/react": "npm:^0.27.0"
     "@grafana/i18n": "npm:12.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,7 +3602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/react@npm:11.14.0, @emotion/react@npm:^11.8.1":
+"@emotion/react@npm:11.14.0, @emotion/react@npm:^11.14.0, @emotion/react@npm:^11.8.1":
   version: 11.14.0
   resolution: "@emotion/react@npm:11.14.0"
   dependencies:
@@ -4532,7 +4532,7 @@ __metadata:
   resolution: "@grafana/scenes-react@workspace:packages/scenes-react"
   dependencies:
     "@emotion/css": "npm:^11.13.5"
-    "@emotion/react": "npm:11.14.0"
+    "@emotion/react": "npm:^11.14.0"
     "@grafana/scenes": "workspace:*"
     "@rollup/plugin-eslint": "npm:^9.2.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.1"
@@ -4570,7 +4570,7 @@ __metadata:
   resolution: "@grafana/scenes@workspace:packages/scenes"
   dependencies:
     "@emotion/css": "npm:^11.13.5"
-    "@emotion/react": "npm:11.14.0"
+    "@emotion/react": "npm:^11.14.0"
     "@floating-ui/react": "npm:^0.27.0"
     "@grafana/i18n": "npm:12.4.3"
     "@leeoniya/ufuzzy": "npm:^1.0.16"


### PR DESCRIPTION
**What is this feature?**

Unpins all production dependencies in the `@grafana/scenes` + `@grafana/scenes-react` package, using the `^` semver operator to allow consumers to bump minor + patch versions as needed (e.g., to resolve dependency vulnerabilities). Open to feedback on where specific dependencies should use `~` or remain pinned, if folks have specific context/knowledge around dependencies not respecting semver correctly.

Each commit was generated by manually updating the version specifier in `package.json`, then running `yarn && yarn dedupe && yarn typecheck`, before manually verifying the lockfile diff to ensure no actual version changes occurred (some doctoring was required to revert this when it happened).

**Why do we need this feature?**

Updated [internal policy](https://docs.google.com/document/d/19rr_cEdeIQmC34BO69SWl3ELJxpSBOwdVSJ1T7SERcY/edit?usp=sharing) (🔐) that specifies that published packages should NOT pin their dependencies, to prevent downstream consumers from being stuck with vulnerable transitive dependencies.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/127460