### PR TITLE
Filters: Allow keys used in filters to be reused in groupBy

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -4002,6 +4002,44 @@ describe('group-by', () => {
         { label: 'dim2', value: 'dim2' },
       ]);
     });
+
+    it('keys used in filters can be reused in groupBy', async () => {
+      // A key that is already used as a (multi-value) filter should still be
+      // offered as a groupBy option. We achieve this by not passing the current
+      // filters to getGroupByKeys, so the datasource never excludes those keys.
+      const getGroupByKeysSpy = jest.fn().mockResolvedValue([
+        { text: 'cell', value: 'cell' },
+        { text: 'namespace', value: 'namespace' },
+      ]);
+      setDataSourceSrv({
+        get() {
+          return {
+            getGroupByKeys: getGroupByKeysSpy,
+            getRef() {
+              return { uid: 'test' };
+            },
+          };
+        },
+        getInstanceSettings() {
+          return { uid: 'test' };
+        },
+      } as unknown as DataSourceSrv);
+
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'test' },
+        applyMode: 'manual',
+        enableGroupBy: true,
+        filters: setTemplateSrvWithFilters([{ key: 'cell', operator: '=|', value: 'jg', values: ['jg', 'wr'] }]),
+      });
+      variable.activate();
+
+      const keys = await variable._getGroupByKeys(null);
+
+      // `cell` is still listed as a groupBy option even though it is filtered
+      expect(keys).toContainEqual({ label: 'cell', value: 'cell' });
+      // no filters are forwarded to the datasource, so it cannot exclude filtered keys
+      expect(getGroupByKeysSpy).toHaveBeenCalledWith(expect.objectContaining({ filters: [] }));
+    });
   });
 
   describe('isGroupByFilter', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -1149,19 +1149,13 @@ export class AdHocFiltersVariable
 
     await this._waitForVariables();
 
-    const applicableOriginFilters =
-      this.state.originFilters?.filter((f) => !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f)) ?? [];
-    const otherFilters = this.state.filters
-      .filter((f) => f.key !== currentKey && !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f))
-      .concat(this.state.baseFilters ?? [])
-      .concat(applicableOriginFilters);
     const timeRange = sceneGraph.getTimeRange(this).state.value;
     const queriesForKeys =
       queries ?? (this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined);
 
     // @ts-expect-error (TODO: remove after upgrading with https://github.com/grafana/grafana/pull/118270)
     const response = await ds.getGroupByKeys({
-      filters: otherFilters,
+      filters: [],
       queries: queriesForKeys,
       timeRange,
       scopes: sceneGraph.getScopes(this),


### PR DESCRIPTION
There are some scenarios in which we want to reuse a filter key inside a groupBy -- e.g.: if I filter with multivalue by some 'pod=|1,2,3', then I may want to also have that grouped on the same `pod` key. This PR addresses that by not passing the existing filters inside the groupBy key retriever so it knows it needs to brings those back too.

Test steps:
- add a filter with group by
- add some filter
- then try to group by the same key as in the filter -- that key should appear in the groupBy dropdown
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.9.4--canary.1562.28578412203.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.9.4--canary.1562.28578412203.0
  npm install scenes-app@8.9.4--canary.1562.28578412203.0
  npm install @grafana/scenes-react@8.9.4--canary.1562.28578412203.0
  # or 
  yarn add @grafana/scenes@8.9.4--canary.1562.28578412203.0
  yarn add scenes-app@8.9.4--canary.1562.28578412203.0
  yarn add @grafana/scenes-react@8.9.4--canary.1562.28578412203.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
