### PR TITLE
ScopesVariable: don't clobber enabled state from a stale cleanup

### DIFF
--- a/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
@@ -188,7 +188,7 @@ export class FakeScopesContext {
   };
 
   changeScopes = (scopeNames: string[]) => {
-    const value = scopeNames.map((name) => ({ spec: { title: name }, metadata: { name } }) as Scope);
+    const value = scopeNames.map((name) => ({ spec: { title: name }, metadata: { name } } as Scope));
     this.state = { ...this.state, value, loading: true };
     this.stateObservable.next(this.state);
 

--- a/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.test.tsx
@@ -74,6 +74,66 @@ describe('ScopesVariable', () => {
     const { valueChangedCount } = renderTestScene({ initialScopes: [] });
     expect(valueChangedCount.value).toEqual(1);
   });
+
+  // Two ScopesVariables can be alive at the same moment during e.g. a dashboard-to-dashboard
+  // redirect. Without the ownership guard in setContext, the second cleanup can resurrect
+  // enabled=true by restoring its stale oldState snapshot, leaving the scope UI stuck on
+  // pages that no longer have any ScopesVariable mounted.
+  describe('overlapping ScopesVariables', () => {
+    it('Should leave enabled=false after both cleanups when cleanup order is A then B', () => {
+      const context = new FakeScopesContext();
+      const varA = new ScopesVariable({ enable: true });
+      const varB = new ScopesVariable({ enable: true });
+
+      const cleanupA = varA.setContext(context);
+      expect(context.state.enabled).toBe(true);
+
+      const cleanupB = varB.setContext(context);
+      expect(context.state.enabled).toBe(true);
+
+      cleanupA?.();
+      cleanupB?.();
+
+      expect(context.state.enabled).toBe(false);
+    });
+
+    it('Should leave enabled=false after both cleanups when cleanup order is B then A', () => {
+      const context = new FakeScopesContext();
+      const varA = new ScopesVariable({ enable: true });
+      const varB = new ScopesVariable({ enable: true });
+
+      const cleanupA = varA.setContext(context);
+      const cleanupB = varB.setContext(context);
+      expect(context.state.enabled).toBe(true);
+
+      cleanupB?.();
+      cleanupA?.();
+
+      expect(context.state.enabled).toBe(false);
+    });
+
+    it('Should not resurrect enabled=true from a stale oldState snapshot', () => {
+      const context = new FakeScopesContext();
+      // Simulate a state where another ScopesVariable had already enabled scopes before
+      // this one mounts (the overlap scenario, condensed into a single instance).
+      context.setEnabled(true);
+
+      const variable = new ScopesVariable({ enable: true });
+      const cleanup = variable.setContext(context);
+      // At this point oldState.enabled was captured as true.
+
+      // Something else (another cleanup, an external caller) legitimately disables scopes.
+      context.setEnabled(false);
+      expect(context.state.enabled).toBe(false);
+
+      cleanup?.();
+
+      // Without the guard, cleanup would call setEnabled(oldState.enabled=true) and
+      // resurrect the flag. With the guard, cleanup sees enabled has drifted away
+      // from this.state.enable and skips.
+      expect(context.state.enabled).toBe(false);
+    });
+  });
 });
 
 interface SetupOptions {
@@ -128,7 +188,7 @@ export class FakeScopesContext {
   };
 
   changeScopes = (scopeNames: string[]) => {
-    const value = scopeNames.map((name) => ({ spec: { title: name }, metadata: { name } } as Scope));
+    const value = scopeNames.map((name) => ({ spec: { title: name }, metadata: { name } }) as Scope);
     this.state = { ...this.state, value, loading: true };
     this.stateObservable.next(this.state);
 

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -99,7 +99,8 @@ export class ScopesVariable extends SceneObjectBase<ScopesVariableState> impleme
     return () => {
       sub.unsubscribe();
 
-      if (this.state.enable != null) {
+      // If some other ScopesVariable changed the enabled state, we don't want to override it
+      if (this.state.enable != null && context.state.enabled === oldState.enabled) {
         context.setEnabled(oldState.enabled);
       }
     };

--- a/packages/scenes/src/variables/variants/ScopesVariable.tsx
+++ b/packages/scenes/src/variables/variants/ScopesVariable.tsx
@@ -99,8 +99,11 @@ export class ScopesVariable extends SceneObjectBase<ScopesVariableState> impleme
     return () => {
       sub.unsubscribe();
 
-      // If some other ScopesVariable changed the enabled state, we don't want to override it
-      if (this.state.enable != null && context.state.enabled === oldState.enabled) {
+      // Only restore the previous enabled state if this variable is still the current authority —
+      // i.e. the live enabled flag still matches what we set on mount. If it has drifted, another
+      // ScopesVariable's cleanup (or an external setEnabled call) has taken over ownership and we
+      // must not clobber their value.
+      if (this.state.enable != null && context.state.enabled === this.state.enable) {
         context.setEnabled(oldState.enabled);
       }
     };


### PR DESCRIPTION
ScopesVariable.setContext captures oldState.enabled at mount and restores it on cleanup. When two ScopesVariables coexist briefly (e.g. during a dashboard-to-dashboard redirect), each captures its own snapshot, and their cleanups can restore conflicting values — the last cleanup wins, which can raise enabled back to true on a page that no longer has any ScopesVariable mounted. The scope selector then sticks around on non-scope pages (Explore, Playlists, etc.).

Guard the restore on whether the live state still matches what this instance set:

```js
if (this.state.enable != null && context.state.enabled === this.state.enable) {
  context.setEnabled(oldState.enabled);
}
````

If the state has drifted since mount, another consumer owns it now — don't clobber. Order-independent, no behavior change for the single-instance case.

Longer-term fix (deriving enabled from React presence, removing this logic entirely from ScopesVariable) tracked in grafana/hyperion-planning#677.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.9.4--canary.1563.28578642174.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.9.4--canary.1563.28578642174.0
  npm install scenes-app@8.9.4--canary.1563.28578642174.0
  npm install @grafana/scenes-react@8.9.4--canary.1563.28578642174.0
  # or 
  yarn add @grafana/scenes@8.9.4--canary.1563.28578642174.0
  yarn add scenes-app@8.9.4--canary.1563.28578642174.0
  yarn add @grafana/scenes-react@8.9.4--canary.1563.28578642174.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
