### PR TITLE
VizPanel: Add support for new subtitle prop

### DIFF
--- a/packages/scenes-app/src/react-demo/Home.tsx
+++ b/packages/scenes-app/src/react-demo/Home.tsx
@@ -53,7 +53,7 @@ function HomePage() {
     <PageWrapper title="Home" subTitle="Welcome to the React first demos">
       <Stack direction={'column'} gap={2}>
         <DemoVizLayout>
-          <PlainGraphWithRandomWalk title="Welcome" maxDataPoints={50} />
+          <PlainGraphWithRandomWalk title="Welcome" subtitle="This is panel with a subtitle" maxDataPoints={50} />
         </DemoVizLayout>
         <h2>Examples</h2>
         <TextLink href={`${urlBase}/repeat-by-variable`}>Repeat by variable</TextLink>

--- a/packages/scenes-app/src/react-demo/PlainGraphWithRandomWalk.tsx
+++ b/packages/scenes-app/src/react-demo/PlainGraphWithRandomWalk.tsx
@@ -5,7 +5,7 @@ import { plainGraph } from './visualizations';
 interface Props {
   maxDataPoints?: number;
   title: string;
-  subtitle: string;
+  subtitle?: string;
   queryAlias?: string;
 }
 

--- a/packages/scenes-app/src/react-demo/PlainGraphWithRandomWalk.tsx
+++ b/packages/scenes-app/src/react-demo/PlainGraphWithRandomWalk.tsx
@@ -5,10 +5,11 @@ import { plainGraph } from './visualizations';
 interface Props {
   maxDataPoints?: number;
   title: string;
+  subtitle: string;
   queryAlias?: string;
 }
 
-export function PlainGraphWithRandomWalk({ maxDataPoints = 20, title, queryAlias }: Props) {
+export function PlainGraphWithRandomWalk({ maxDataPoints = 20, title, subtitle, queryAlias }: Props) {
   const queries = [{ uid: 'gdev-testdata', refId: 'A', scenarioId: 'random_walk', alias: queryAlias ?? 'env = $env' }];
 
   const dataProvider = useQueryRunner({
@@ -17,5 +18,5 @@ export function PlainGraphWithRandomWalk({ maxDataPoints = 20, title, queryAlias
     cacheKey: [queries, maxDataPoints],
   });
 
-  return <VizPanel title={title} viz={plainGraph} dataProvider={dataProvider} />;
+  return <VizPanel title={title} subtitle={subtitle} viz={plainGraph} dataProvider={dataProvider} />;
 }

--- a/packages/scenes-react/src/components/VizPanel.tsx
+++ b/packages/scenes-react/src/components/VizPanel.tsx
@@ -18,6 +18,7 @@ import { useAddToScene } from '../contexts/SceneContextObject';
 export interface VizPanelProps {
   title: string;
   description?: string;
+  subtitle?: string;
   dataProvider?: SceneDataProvider;
   viz: VizConfig;
   displayMode?: 'default' | 'transparent';
@@ -42,6 +43,7 @@ export function VizPanel(props: VizPanelProps) {
     displayMode,
     hoverHeader,
     hoverHeaderOffset,
+    subtitle,
     headerActions,
     menu,
     titleItems,
@@ -63,6 +65,7 @@ export function VizPanel(props: VizPanelProps) {
       key: key,
       pluginId: viz.pluginId,
       title: title,
+      subtitle: subtitle,
       titleItems: titleItems,
       description: description,
       options: viz.options,
@@ -98,6 +101,10 @@ export function VizPanel(props: VizPanelProps) {
 
     if (description !== prevProps.description) {
       stateUpdate.description = description;
+    }
+
+    if (subtitle !== prevProps.subtitle) {
+      stateUpdate.subtitle = subtitle;
     }
 
     if (displayMode !== prevProps.displayMode) {
@@ -183,6 +190,7 @@ export function VizPanel(props: VizPanelProps) {
     collapsible,
     collapsed,
     prevProps,
+    subtitle,
   ]);
 
   return <panel.Component model={panel} />;

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -50,7 +50,10 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
    */
   pluginId: string;
   title: string;
-  description?: string;
+  /** Shown in info icon tooltip next to the title, supports markdown */
+  description?: string | (() => string);
+  /** Shown as text below the title, supports markdown */
+  subtitle?: string;
   options: DeepPartial<TOptions>;
   fieldConfig: FieldConfigSource<DeepPartial<TFieldConfig>>;
   pluginVersion?: string;

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -51,7 +51,7 @@ export interface VizPanelState<TOptions = {}, TFieldConfig = {}> extends SceneOb
   pluginId: string;
   title: string;
   /** Shown in info icon tooltip next to the title, supports markdown */
-  description?: string | (() => string);
+  description?: string;
   /** Shown as text below the title, supports markdown */
   subtitle?: string;
   options: DeepPartial<TOptions>;

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -13,6 +13,7 @@ import {
   PluginContextProvider,
   PluginType,
   QueryResultMetaNotice,
+  renderMarkdown,
   SetPanelAttentionEvent,
 } from '@grafana/data';
 
@@ -41,6 +42,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
     menu,
     headerActions,
     subHeader,
+    subtitle,
     titleItems,
     seriesLimit,
     seriesLimitShowAll,
@@ -78,6 +80,13 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
       endRenderCallbackRef.current = callback || null;
     }
   });
+
+  const subtitleContent = useMemo(() => {
+    if (subtitle) {
+      return renderMarkdown(model.interpolate(subtitle, undefined, 'text'));
+    }
+    return undefined;
+  }, [subtitle, model]);
 
   // Use useEffect (after DOM updates) to measure complete render cycle timing
   useEffect(() => {
@@ -258,9 +267,10 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
         <PanelChrome
           title={titleInterpolated}
           description={description?.trim() ? model.getDescription : undefined}
+          // @ts-expect-error remove this on next grafana/ui update
+          subtitle={subtitleContent}
           loadingState={data.state}
           statusMessage={getChromeStatusMessage(data, _pluginLoadError)}
-          // @ts-expect-error remove this on next grafana/ui update
           statusItems={showNewPanelErrorsUI ? getChromeStatusItems(data, _pluginLoadError) : undefined}
           statusMessageOnClick={() => {
             // Report the interaction for analytics, then let the container (e.g. dashboard) open the inspector.


### PR DESCRIPTION
This requires latest Grafana (13.2) 

<img width="2236" height="1324" alt="image" src="https://github.com/user-attachments/assets/27e8a323-cb80-4a22-aa1d-38124a239bde" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.10.0--canary.1565.28859521678.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.10.0--canary.1565.28859521678.0
  npm install scenes-app@8.10.0--canary.1565.28859521678.0
  npm install @grafana/scenes-react@8.10.0--canary.1565.28859521678.0
  # or 
  yarn add @grafana/scenes@8.10.0--canary.1565.28859521678.0
  yarn add scenes-app@8.10.0--canary.1565.28859521678.0
  yarn add @grafana/scenes-react@8.10.0--canary.1565.28859521678.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
