### PR TITLE
Scenes: Add dashboards core as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The Dashboards squad maintains grafana/scenes.
+# The catch-all requests review from the squad on every PR.
+* @grafana/grafana-dashboards-core


### PR DESCRIPTION
Adding dashboards-core squad as code owners to avoid missing PRs that dont have assignees/reviewers assigned