### PR TITLE
Chore: Fix tag creation

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -210,7 +210,7 @@ jobs:
         # consistent, and this step is skipped on a re-run if the tag already
         # points at the right commit.
         run: |
-          EXISTING="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null || true)"
+          EXISTING="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || EXISTING=""
           if [ -z "$EXISTING" ]; then
             gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/tags/v${VERSION}" -f "sha=${VERSION_COMMIT}"
           elif [ "$EXISTING" = "$VERSION_COMMIT" ]; then

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,5 @@
   "useNx": false,
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "8.10.1",
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }


### PR DESCRIPTION
Builds on top of https://github.com/grafana/scenes/pull/1567.

Commits are signed properly now, but tagging step failed.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.10.2--canary.1570.28881723924.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.10.2--canary.1570.28881723924.0
  npm install scenes-app@8.10.2--canary.1570.28881723924.0
  npm install @grafana/scenes-react@8.10.2--canary.1570.28881723924.0
  # or 
  yarn add @grafana/scenes@8.10.2--canary.1570.28881723924.0
  yarn add scenes-app@8.10.2--canary.1570.28881723924.0
  yarn add @grafana/scenes-react@8.10.2--canary.1570.28881723924.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
