### PR TITLE
SceneQueryRunner: fan out multi-value datasource variable feeding an expression

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,5 @@
   "useNx": false,
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "8.10.2",
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -48,6 +48,7 @@ import { SceneQueryStateControllerState } from '../behaviors/types';
 import { config } from '@grafana/runtime';
 import { ScopesVariable } from '../variables/variants/ScopesVariable';
 import { ConstantVariable } from '../variables/variants/ConstantVariable';
+import { CustomVariable } from '../variables/variants/CustomVariable';
 
 const getDataSourceMock = jest.fn().mockImplementation((datasource) => {
   const isMixed = datasource?.uid === '-- Mixed --';
@@ -568,6 +569,47 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
 
       expect((getDataSourceCall[1].__sceneObject.value as SafeSerializableSceneObject).valueOf()).toBe(queryRunner);
       expect(getDataSourceCall[1].__sceneObject.text).toBe('__sceneObject');
+    });
+
+    it('should fan out a query + dependent expression across a multi-value datasource variable', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: '-- Mixed --' },
+        queries: [
+          { refId: 'A', datasource: { uid: '$ds' }, hide: true },
+          { refId: 'B', datasource: { type: '__expr__', uid: '__expr__' }, type: 'math', expression: '$A' },
+        ],
+      });
+
+      const dsVar = new CustomVariable({
+        name: 'ds',
+        query: 'ds1,ds2',
+        isMulti: true,
+        value: ['ds1', 'ds2'],
+        text: ['ds1', 'ds2'],
+      });
+
+      const scene = new EmbeddedScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [dsVar] }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      const deactivate = activateFullSceneTree(scene);
+      deactivationHandlers.push(deactivate);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const targets = runRequestMock.mock.calls[0][1].targets;
+      // A + B fanned out once per selected datasource, with unique refIds
+      expect(targets.map((t: DataQuery) => t.refId).sort()).toEqual(['A_0', 'A_1', 'B_0', 'B_1']);
+
+      const byRefId = (refId: string) => targets.find((t: DataQuery) => t.refId === refId);
+      // data-query clones pinned to concrete datasources
+      expect(byRefId('A_0').datasource.uid).toBe('ds1');
+      expect(byRefId('A_1').datasource.uid).toBe('ds2');
+      // expression clones reference their own fanned-out data query
+      expect(byRefId('B_0').expression).toBe('${A_0}');
+      expect(byRefId('B_1').expression).toBe('${A_1}');
     });
 
     it('should pass adhoc filters via request object', async () => {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -161,6 +161,147 @@ function shouldUseMixedRuntimeDatasource(
   return false;
 }
 
+function parseRefsFromMathExpression(input: string): string[] {
+  const bracket = /\$\{([A-Za-z0-9_ ]+?)\}/gm;
+  const simple = /\$([A-Za-z0-9_]+)/gm;
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = bracket.exec(input)) !== null) {
+    found.add(match[1]);
+  }
+  while ((match = simple.exec(input)) !== null) {
+    found.add(match[1]);
+  }
+  return Array.from(found);
+}
+
+// Returns the refIds a server-side expression query depends on.
+function getExpressionReferences(query: DataQueryExtended): string[] {
+  const { type, expression, conditions } = query;
+  if (type === 'math' || type === 'sql') {
+    return parseRefsFromMathExpression(expression ?? '');
+  }
+  if (type === 'classic_conditions') {
+    return (conditions ?? [])
+      .map((condition: { query?: { params?: string[] } }) => condition.query?.params?.[0])
+      .filter((refId: string | undefined): refId is string => Boolean(refId));
+  }
+  // reduce / resample / threshold: the whole `expression` is a single refId
+  return expression ? [expression] : [];
+}
+
+// Renames the refIds a server-side expression references, according to renameMap.
+function rewriteExpressionReferences(query: DataQueryExtended, renameMap: Record<string, string>): void {
+  const { type } = query;
+  if (type === 'math' || type === 'sql') {
+    let expression: string = query.expression ?? '';
+    for (const oldRef of Object.keys(renameMap)) {
+      const pattern = new RegExp('(\\$' + oldRef + '\\b)|(\\$\\{' + oldRef + '\\})', 'gm');
+      expression = expression.replace(pattern, '${' + renameMap[oldRef] + '}');
+    }
+    query.expression = expression;
+  } else if (type === 'classic_conditions') {
+    (query.conditions ?? []).forEach((condition: { query?: { params?: string[] } }) => {
+      const params = condition.query?.params;
+      if (params && params[0] && renameMap[params[0]]) {
+        params[0] = renameMap[params[0]];
+      }
+    });
+  } else if (query.expression && renameMap[query.expression]) {
+    query.expression = renameMap[query.expression];
+  }
+}
+
+/**
+ * When a data query using a multi-value datasource variable feeds a server-side expression, the
+ * whole graph must be evaluated once per selected datasource. We fan out by cloning the data query
+ * (pinned to a concrete datasource) and its dependent expression subgraph once per selected value,
+ * rewriting refIds so each replica is self-contained. Queries and expressions that do not depend on
+ * the multi-value variable are left untouched (they run once).
+ *
+ * Only a single multi-value datasource variable shared by the data queries is supported.
+ */
+function expandExpressionFanOut(sceneObject: SceneQueryRunner, targets: DataQueryExtended[]): DataQueryExtended[] {
+  const isExpression = (query: DataQueryExtended) =>
+    Boolean(isExpressionReference && isExpressionReference(query.datasource));
+
+  if (!targets.some(isExpression)) {
+    return targets;
+  }
+
+  // Find the multi-value datasource variable used by a data query (if any).
+  let variableName: string | undefined;
+  let uids: string[] | undefined;
+  for (const target of targets) {
+    if (isExpression(target)) {
+      continue;
+    }
+    const candidate = getSimpleVariableNameFromDatasourceUid(target.datasource?.uid);
+    if (!candidate) {
+      continue;
+    }
+    const value = sceneGraph.lookupVariable(candidate, sceneObject)?.getValue();
+    if (Array.isArray(value)) {
+      const selected = value.filter((item) => item !== 'default').map(String);
+      if (selected.length > 1) {
+        variableName = candidate;
+        uids = selected;
+        break;
+      }
+    }
+  }
+
+  if (!variableName || !uids) {
+    return targets;
+  }
+
+  // Data queries using the multi-value variable are the fan-out roots.
+  const fannedRootRefIds = new Set<string>();
+  for (const target of targets) {
+    if (!isExpression(target) && getSimpleVariableNameFromDatasourceUid(target.datasource?.uid) === variableName) {
+      fannedRootRefIds.add(target.refId);
+    }
+  }
+
+  // Transitive closure of expressions that (transitively) depend on a fan-out root.
+  const dependentRefIds = new Set<string>(fannedRootRefIds);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const target of targets) {
+      if (!isExpression(target) || dependentRefIds.has(target.refId)) {
+        continue;
+      }
+      if (getExpressionReferences(target).some((refId) => dependentRefIds.has(refId))) {
+        dependentRefIds.add(target.refId);
+        changed = true;
+      }
+    }
+  }
+
+  const expanded: DataQueryExtended[] = targets.filter((target) => !dependentRefIds.has(target.refId));
+  const toFanOut = targets.filter((target) => dependentRefIds.has(target.refId));
+
+  uids.forEach((uid, index) => {
+    const renameMap: Record<string, string> = {};
+    for (const target of toFanOut) {
+      renameMap[target.refId] = `${target.refId}_${index}`;
+    }
+    for (const target of toFanOut) {
+      const clone = cloneDeep(target);
+      clone.refId = renameMap[target.refId];
+      if (fannedRootRefIds.has(target.refId)) {
+        clone.datasource = { ...clone.datasource, uid };
+      } else {
+        rewriteExpressionReferences(clone, renameMap);
+      }
+      expanded.push(clone);
+    }
+  });
+
+  return expanded;
+}
+
 export interface DataQueryExtended extends DataQuery {
   [key: string]: any;
 
@@ -677,6 +818,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
       }
       return query;
     });
+
+    request.targets = expandExpressionFanOut(this, request.targets);
 
     const lowerIntervalLimit = minInterval ? interpolate(this, minInterval) : ds.interval;
     const norm = rangeUtil.calculateInterval(timeRange.state.value, request.maxDataPoints!, lowerIntervalLimit);


### PR DESCRIPTION
## What this PR does

When a dashboard
- has a variable for various datasources including an "all" (example all prometheus datasources)
- and then that dashboard has a query that uses that datasource variable

It is supposed to run that query on all of the datasources when "all" is selected

This generally works, but when you then
- and then you use that query with a **server-side expression** (Math, Reduce, etc.) there is a bug in the`SceneQueryRunner` where it would for some reason just use the first datasource from the list of datasources

This pr tries to properly fan out the server side expression to all of the datasources

For repro steps of the bug look here: https://github.com/grafana/grafana/issues/127694 (set up 3 prometheus datasources instances + import the dashboard in the issue and you'll see)

## Why

Multi-value datasource variables already fan out for direct queries (via the Mixed datasource), but not when the query feeds an expression — the request collapses to a single datasource, so the panel shows one result instead of one per selected datasource.

`prepareRequests` now expands the fan-out root data query and its dependent expression subgraph into one concrete clone per selected datasource, rewriting refIds so each replica is self-contained. Queries and expressions that do not depend on the multi-value variable are left untouched (they run once), so unrelated results are not duplicated.

Fixes [grafana/grafana#127694](https://github.com/grafana/grafana/issues/127694).

## Notes

- I am not very familiar with scenes and the release process. Feel free to take this pr over and do whatever needs to be done to get it fixed thanks! I also tried a different approach [here](https://github.com/grafana/grafana/pull/128125) if we like that one better I'd be happy to re-open. I wasn't really sure tbh. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
