### PR TITLE
QueryVariable: fan out metric-find across multi-value datasource variables

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,5 @@
   "useNx": false,
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "8.12.1",
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -49,6 +49,10 @@ import { DataLayersMerger } from './DataLayersMerger';
 import { interpolate } from '../core/sceneGraph/sceneGraph';
 import { wrapInSafeSerializableSceneObject } from '../utils/wrapInSafeSerializableSceneObject';
 import { DrilldownDependenciesManager } from '../variables/DrilldownDependenciesManager';
+import {
+  getDatasourceVariableSelectionCount,
+  getSimpleVariableNameFromDatasourceUid,
+} from '../variables/datasourceVariableRef';
 
 let counter = 100;
 const MIXED_DATASOURCE_UID = '-- Mixed --';
@@ -95,41 +99,6 @@ function isTemplatedDatasourceUid(uid: string | undefined): boolean {
 
 function isTemplatedDatasourceRef(datasource: DataSourceRef | null | undefined): boolean {
   return isTemplatedDatasourceUid(datasource?.uid);
-}
-
-function getSimpleVariableNameFromDatasourceUid(uid: string | undefined): string | undefined {
-  if (!uid) {
-    return undefined;
-  }
-  const shortMatch = uid.match(/^\$([A-Za-z0-9_]+)$/);
-  if (shortMatch) {
-    return shortMatch[1];
-  }
-
-  const bracketMatch = uid.match(/^\$\{([A-Za-z0-9_]+)\}$/);
-  if (bracketMatch) {
-    return bracketMatch[1];
-  }
-
-  return undefined;
-}
-
-function getDatasourceVariableSelectionCount(sceneObject: SceneQueryRunner, variableName: string): number | undefined {
-  const variable = sceneGraph.lookupVariable(variableName, sceneObject);
-  if (!variable) {
-    return undefined;
-  }
-
-  const value = variable.getValue();
-  if (Array.isArray(value)) {
-    return value.filter((item) => item !== 'default').length;
-  }
-
-  if (value === null || value === undefined) {
-    return undefined;
-  }
-
-  return value === 'default' ? 0 : 1;
 }
 
 function shouldUseMixedRuntimeDatasource(

--- a/packages/scenes/src/variables/datasourceVariableRef.test.ts
+++ b/packages/scenes/src/variables/datasourceVariableRef.test.ts
@@ -1,0 +1,63 @@
+import { getSimpleVariableNameFromDatasourceUid, expandMultiValueDatasourceUids } from './datasourceVariableRef';
+import { CustomVariable } from './variants/CustomVariable';
+import { SceneVariableSet } from './sets/SceneVariableSet';
+import { EmbeddedScene } from '../components/EmbeddedScene';
+import { SceneCanvasText } from '../components/SceneCanvasText';
+import { activateFullSceneTree } from '../utils/test/activateFullSceneTree';
+
+describe('datasourceVariableRef', () => {
+  describe('getSimpleVariableNameFromDatasourceUid', () => {
+    it('parses $name and ${name}', () => {
+      expect(getSimpleVariableNameFromDatasourceUid('$ds')).toBe('ds');
+      expect(getSimpleVariableNameFromDatasourceUid('${prom_datasource}')).toBe('prom_datasource');
+    });
+
+    it('returns undefined for concrete or unsupported UIDs', () => {
+      expect(getSimpleVariableNameFromDatasourceUid('prometheus')).toBeUndefined();
+      expect(getSimpleVariableNameFromDatasourceUid('${ds:raw}')).toBeUndefined();
+      expect(getSimpleVariableNameFromDatasourceUid(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('expandMultiValueDatasourceUids', () => {
+    it('returns selected UIDs when multi-value datasource variable has more than one selection', () => {
+      const dsVar = new CustomVariable({
+        name: 'ds',
+        query: 'ds1,ds2,ds3',
+        isMulti: true,
+        value: ['ds1', 'ds2'],
+        text: ['ds1', 'ds2'],
+      });
+      const scene = new EmbeddedScene({
+        $variables: new SceneVariableSet({ variables: [dsVar] }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+      const deactivate = activateFullSceneTree(scene);
+
+      expect(expandMultiValueDatasourceUids(scene, { uid: '$ds' })).toEqual(['ds1', 'ds2']);
+      expect(expandMultiValueDatasourceUids(scene, { uid: '${ds}' })).toEqual(['ds1', 'ds2']);
+
+      deactivate();
+    });
+
+    it('returns undefined for single selection or non-template datasource', () => {
+      const dsVar = new CustomVariable({
+        name: 'ds',
+        query: 'ds1,ds2',
+        isMulti: true,
+        value: ['ds1'],
+        text: ['ds1'],
+      });
+      const scene = new EmbeddedScene({
+        $variables: new SceneVariableSet({ variables: [dsVar] }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+      const deactivate = activateFullSceneTree(scene);
+
+      expect(expandMultiValueDatasourceUids(scene, { uid: '$ds' })).toBeUndefined();
+      expect(expandMultiValueDatasourceUids(scene, { uid: 'prometheus' })).toBeUndefined();
+
+      deactivate();
+    });
+  });
+});

--- a/packages/scenes/src/variables/datasourceVariableRef.ts
+++ b/packages/scenes/src/variables/datasourceVariableRef.ts
@@ -1,0 +1,84 @@
+import { DataSourceRef } from '@grafana/schema';
+
+import { sceneGraph } from '../core/sceneGraph';
+import { SceneObject } from '../core/types';
+
+/**
+ * Parses a simple templated datasource UID (`$ds` or `${ds}`) into the variable name.
+ * Returns undefined for non-template UIDs or unsupported formats.
+ */
+export function getSimpleVariableNameFromDatasourceUid(uid: string | undefined): string | undefined {
+  if (!uid) {
+    return undefined;
+  }
+  const shortMatch = uid.match(/^\$([A-Za-z0-9_]+)$/);
+  if (shortMatch) {
+    return shortMatch[1];
+  }
+
+  const bracketMatch = uid.match(/^\$\{([A-Za-z0-9_]+)\}$/);
+  if (bracketMatch) {
+    return bracketMatch[1];
+  }
+
+  return undefined;
+}
+
+/**
+ * Selected datasource UIDs for a named variable, excluding the sentinel `default`.
+ * Returns undefined when the variable is missing or has no value yet.
+ */
+export function getDatasourceVariableSelectedUids(
+  sceneObject: SceneObject,
+  variableName: string
+): string[] | undefined {
+  const variable = sceneGraph.lookupVariable(variableName, sceneObject);
+  if (!variable) {
+    return undefined;
+  }
+
+  const value = variable.getValue();
+  if (Array.isArray(value)) {
+    return value.filter((item) => item !== 'default').map(String);
+  }
+
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (value === 'default') {
+    return [];
+  }
+
+  return [String(value)];
+}
+
+export function getDatasourceVariableSelectionCount(
+  sceneObject: SceneObject,
+  variableName: string
+): number | undefined {
+  const uids = getDatasourceVariableSelectedUids(sceneObject, variableName);
+  return uids?.length;
+}
+
+/**
+ * When `datasource` is a multi-value template variable with more than one selected UID,
+ * returns those concrete UIDs for fan-out. Otherwise returns undefined so the caller
+ * keeps the normal single getDataSource path (including first-value interpolation).
+ */
+export function expandMultiValueDatasourceUids(
+  sceneObject: SceneObject,
+  datasource: DataSourceRef | null | undefined
+): string[] | undefined {
+  const variableName = getSimpleVariableNameFromDatasourceUid(datasource?.uid);
+  if (!variableName) {
+    return undefined;
+  }
+
+  const uids = getDatasourceVariableSelectedUids(sceneObject, variableName);
+  if (!uids || uids.length <= 1) {
+    return undefined;
+  }
+
+  return uids;
+}

--- a/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.test.tsx
@@ -32,6 +32,8 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { config, setRunRequest } from '@grafana/runtime';
 import { SafeSerializableSceneObject } from '../../../utils/SafeSerializableSceneObject';
+import { CustomVariable } from '../CustomVariable';
+import { activateFullSceneTree } from '../../../utils/test/activateFullSceneTree';
 import { VariableSort } from '@grafana/schema';
 
 function createMockData(valueValues: string[], textValues?: string[]) {
@@ -94,7 +96,12 @@ jest.mock('@grafana/runtime', () => ({
   getDataSourceSrv: () => ({
     get: (ds: DataSourceRef, vars: ScopedVars): Promise<DataSourceApi> => {
       getDataSourceMock(ds, vars);
-      return Promise.resolve(fakeDsMock);
+      const uid = typeof ds === 'string' ? ds : ds?.uid ?? 'fake-std';
+      return Promise.resolve({
+        ...fakeDsMock,
+        uid,
+        getRef: () => ({ type: 'fake-std', uid }),
+      } as DataSourceApi);
     },
   }),
   config: {
@@ -162,7 +169,7 @@ describe.each(['11.1.2', '11.1.1'])('QueryVariable', (v) => {
     describe('Issuing variable query', () => {
       const originalNow = Date.now;
       beforeEach(() => {
-        setCreateQueryVariableRunnerFactory(() => new FakeQueryRunner(fakeDsMock, runRequestMock));
+        setCreateQueryVariableRunnerFactory((ds) => new FakeQueryRunner(ds, runRequestMock));
       });
 
       beforeEach(() => {
@@ -173,6 +180,7 @@ describe.each(['11.1.2', '11.1.1'])('QueryVariable', (v) => {
         Date.now = originalNow;
         runRequestMock.mockClear();
         getDataSourceMock.mockClear();
+        runRequestMock.mockReturnValue(createMockData(['val1', 'val2', 'val11']));
       });
 
       it('Should resolve variable options via provided runner', (done) => {
@@ -195,6 +203,48 @@ describe.each(['11.1.2', '11.1.1'])('QueryVariable', (v) => {
         });
 
         expect(variable.state.loading).toEqual(true);
+      });
+
+      it('Should fan out metric-find across a multi-value datasource variable and union options', async () => {
+        runRequestMock.mockImplementation((ds: DataSourceApi) => {
+          if (ds.uid === 'ds1') {
+            return createMockData(['alpha', 'shared']);
+          }
+          if (ds.uid === 'ds2') {
+            return createMockData(['beta', 'shared']);
+          }
+          return createMockData(['unexpected']);
+        });
+
+        const dsVar = new CustomVariable({
+          name: 'ds',
+          query: 'ds1,ds2',
+          isMulti: true,
+          value: ['ds1', 'ds2'],
+          text: ['ds1', 'ds2'],
+        });
+
+        const variable = new QueryVariable({
+          name: 'job',
+          datasource: { uid: '$ds', type: 'fake-std' },
+          query: 'label_values(job)',
+          sort: VariableSort.alphabeticalAsc,
+        });
+
+        const scene = new EmbeddedScene({
+          $variables: new SceneVariableSet({ variables: [dsVar, variable] }),
+          body: new SceneCanvasText({ text: 'hello' }),
+        });
+        const deactivate = activateFullSceneTree(scene);
+
+        await lastValueFrom(variable.validateAndUpdate());
+
+        const requestedUids = getDataSourceMock.mock.calls.map((call) => call[0]?.uid);
+        expect(requestedUids).toEqual(expect.arrayContaining(['ds1', 'ds2']));
+        expect(runRequestMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(variable.state.options.map((o) => o.value)).toEqual(['alpha', 'beta', 'shared']);
+
+        deactivate();
       });
 
       describe('When properties are received', () => {

--- a/packages/scenes/src/variables/variants/query/QueryVariable.tsx
+++ b/packages/scenes/src/variables/variants/query/QueryVariable.tsx
@@ -1,10 +1,11 @@
-import { Observable, of, filter, take, mergeMap, catchError, throwError, from, lastValueFrom } from 'rxjs';
+import { Observable, of, filter, take, mergeMap, catchError, throwError, from, lastValueFrom, forkJoin } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
   CoreApp,
   DataQueryRequest,
   LoadingState,
+  MetricFindValue,
   PanelData,
   ScopedVars,
   VariableRefresh,
@@ -30,6 +31,7 @@ import { SEARCH_FILTER_VARIABLE } from '../../constants';
 import { debounce } from 'lodash';
 import { registerQueryWithController } from '../../../querying/registerQueryWithController';
 import { wrapInSafeSerializableSceneObject } from '../../../utils/wrapInSafeSerializableSceneObject';
+import { expandMultiValueDatasourceUids } from '../../datasourceVariableRef';
 import React from 'react';
 
 export interface QueryVariableState extends MultiValueVariableState {
@@ -79,64 +81,91 @@ export class QueryVariable extends MultiValueVariable<QueryVariableState> {
 
     this.setState({ loading: true, error: null });
 
-    return from(
-      getDataSource(this.state.datasource, {
-        __sceneObject: wrapInSafeSerializableSceneObject(this),
-      })
-    ).pipe(
-      mergeMap((ds) => {
-        const runner = createQueryVariableRunner(ds);
-        const target = runner.getTarget(this);
-        const request = this.getRequest(target, args.searchFilter);
+    const fanOutUids = expandMultiValueDatasourceUids(this, this.state.datasource);
+    const datasourceRefs: Array<DataSourceRef | null> = fanOutUids
+      ? fanOutUids.map((uid) => ({ ...this.state.datasource, uid }))
+      : [this.state.datasource];
 
-        return runner.runRequest({ variable: this, searchFilter: args.searchFilter }, request).pipe(
-          registerQueryWithController({
-            type: 'QueryVariable/getValueOptions',
-            request: request,
-            origin: this,
-          }),
-          filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error), // we only care about done or error for now
-          take(1), // take the first result, using first caused a bug where it in some situations throw an uncaught error because of no results had been received yet
-          mergeMap((data: PanelData) => {
-            if (data.state === LoadingState.Error) {
-              return throwError(() => data.error);
-            }
-            return of(data);
-          }),
-          toMetricFindValues(),
-          mergeMap((values) => {
-            let regex = '';
-            if (this.state.regex) {
-              regex = sceneGraph.interpolate(this, this.state.regex, undefined, 'regex');
-            }
-            let options = metricNamesToVariableValues({
-              variableRegEx: regex,
-              variableRegexApplyTo: this.state.regexApplyTo,
-              sort: this.state.sort,
-              metricNames: values,
-            });
-            if (this.state.staticOptions) {
-              const customOptions = this.state.staticOptions;
-              options = options.filter((option) => !customOptions.find((custom) => custom.value === option.value));
-              if (this.state.staticOptionsOrder === 'after') {
-                options.push(...customOptions);
-              } else if (this.state.staticOptionsOrder === 'sorted') {
-                options = sortVariableValues(options.concat(customOptions), this.state.sort);
-              } else {
-                options.unshift(...customOptions);
-              }
-            }
-            return of(options);
-          }),
-          catchError((error) => {
-            if (error.cancelled) {
-              return of([]);
-            }
-            return throwError(() => error);
-          })
-        );
+    const scopedSceneObject = {
+      __sceneObject: wrapInSafeSerializableSceneObject(this),
+    };
+
+    const perDatasource = datasourceRefs.map((datasource) =>
+      from(getDataSource(datasource, scopedSceneObject)).pipe(
+        mergeMap((ds) => this.runMetricFindForDatasource(ds, args)),
+        catchError((error) => {
+          if (error?.cancelled) {
+            return of({ values: [] as MetricFindValue[], error: undefined });
+          }
+          return of({ values: [] as MetricFindValue[], error });
+        })
+      )
+    );
+
+    return forkJoin(perDatasource).pipe(
+      mergeMap((results) => {
+        const values = results.flatMap((result) => result.values);
+        const errors = results.map((result) => result.error).filter(Boolean);
+
+        if (values.length === 0 && errors.length > 0) {
+          return throwError(() => errors[0]);
+        }
+
+        return of(this.metricFindValuesToOptions(values));
       })
     );
+  }
+
+  private runMetricFindForDatasource(
+    ds: Awaited<ReturnType<typeof getDataSource>>,
+    args: VariableGetOptionsArgs
+  ): Observable<{ values: MetricFindValue[]; error?: unknown }> {
+    const runner = createQueryVariableRunner(ds);
+    const target = runner.getTarget(this);
+    const request = this.getRequest(target, args.searchFilter);
+
+    return runner.runRequest({ variable: this, searchFilter: args.searchFilter }, request).pipe(
+      registerQueryWithController({
+        type: 'QueryVariable/getValueOptions',
+        request: request,
+        origin: this,
+      }),
+      filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error),
+      take(1),
+      mergeMap((data: PanelData) => {
+        if (data.state === LoadingState.Error) {
+          return throwError(() => data.error);
+        }
+        return of(data);
+      }),
+      toMetricFindValues(),
+      mergeMap((values) => of({ values, error: undefined as unknown }))
+    );
+  }
+
+  private metricFindValuesToOptions(values: MetricFindValue[]): VariableValueOption[] {
+    let regex = '';
+    if (this.state.regex) {
+      regex = sceneGraph.interpolate(this, this.state.regex, undefined, 'regex');
+    }
+    let options = metricNamesToVariableValues({
+      variableRegEx: regex,
+      variableRegexApplyTo: this.state.regexApplyTo,
+      sort: this.state.sort,
+      metricNames: values,
+    });
+    if (this.state.staticOptions) {
+      const customOptions = this.state.staticOptions;
+      options = options.filter((option) => !customOptions.find((custom) => custom.value === option.value));
+      if (this.state.staticOptionsOrder === 'after') {
+        options.push(...customOptions);
+      } else if (this.state.staticOptionsOrder === 'sorted') {
+        options = sortVariableValues(options.concat(customOptions), this.state.sort);
+      } else {
+        options.unshift(...customOptions);
+      }
+    }
+    return options;
   }
 
   private getRequest(target: DataQuery | string, searchFilter?: string) {


### PR DESCRIPTION
## What this PR does

When a dashboard has:
- a **multi-value datasource variable** (e.g. several Prometheus UIDs, or All)
- and a **Query variable** whose datasource is that variable (`${prom_datasource}` / `$ds`) — typically `label_values(...)` or similar metric-find

…options were only fetched from the **first** selected datasource. Other selected datasources were ignored, so the option list was incomplete.

`QueryVariable.getValueOptions` now expands a multi-value datasource variable into one metric-find request per selected UID, then **unions** the results (deduped/sorted via existing option helpers). Partial failures are tolerated if at least one datasource returns values.

Also extracts shared `$ds` / `${ds}` parsing helpers from `SceneQueryRunner` into `datasourceVariableRef.ts` so both query and variable paths share the same expansion logic.

## Why

Companion to #1572 (expression fan-out). Same multi-value DS variable pattern, different surface: query/template variables instead of panel expressions.

Related: [grafana/support-escalations#23088](https://github.com/grafana/support-escalations/issues/23088) (Bug B — incomplete `label_values` options).

### Before

https://github.com/user-attachments/assets/fa3546bf-b4ef-43ff-bdc4-be868951e85d

### After

https://github.com/user-attachments/assets/06fc8d27-0899-4563-887d-18d1b2f9feef


## Test plan

- [x] Unit: `datasourceVariableRef` helpers
- [x] Unit: QueryVariable fans out to multiple UIDs and unions options
- [x] Manual: 3 local Prometheus DSs with distinct `job` labels (`prom-a`/`prom-b`/`prom-c`); multi-value DS var selecting all three; Query var `label_values(job)` shows all three jobs; Network shows three `/label/job/values` calls

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.13.0--canary.1573.29259616108.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.13.0--canary.1573.29259616108.0
  npm install scenes-app@8.13.0--canary.1573.29259616108.0
  npm install @grafana/scenes-react@8.13.0--canary.1573.29259616108.0
  # or 
  yarn add @grafana/scenes@8.13.0--canary.1573.29259616108.0
  yarn add scenes-app@8.13.0--canary.1573.29259616108.0
  yarn add @grafana/scenes-react@8.13.0--canary.1573.29259616108.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
