### PR TITLE
UrlSyncManager: Support removing url state for removed scene objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in the scenes repository.
+
+## Project Overview
+
+Scenes is a react based framework to develop dashboard like applications for Grafana.
+
+## Principles
+
+- Follow existing patterns in the surrounding code
+- Write tests for new functionality
+- Keep changes focused — avoid over-engineering
+- Security: prevent XSS, SQL injection, command injection
+
+## Comments
+
+- Only add a comment when it explains **why** something is done or reveals non-obvious logic that a reader must know to safely change the code. If the code is self-explanatory, no comment is needed.
+- Never include links (Slack, GitHub, Jira, etc.) in code comments.
+
+## Human Review Gates
+
+Before running `git push`, stop and get explicit human approval. When changes are ready, show a summary of changes and wait for instruction. "Open a PR" in a task description is intent, not permission to push without review.
+
+## Commands
+
+### Build & Run
+
+```bash
+yarn dev                          # Build and watch for changes
+yarn build                        # Frontend production build
+```
+
+### Test
+
+````bash
+yarn test:scenes path/to/file                      # Run tests for a specific file inside scenes library
+yarn test:scenes -t "pattern"                      # Run tests by pattern for scenes library
+yarn test:scenes -u                                # Update snapshots for scenes library
+
+yarn test:scenes-react path/to/file                # Run tests for a specific file inside scenes-react library
+yarn test:scenes-react -t "pattern"                # Run tests by pattern for scenes-react library
+yarn test:scenes-react -u                          # Update snapshots for scenes-react library
+
+
+### Lint & Format
+
+```bash
+yarn lint                         # ESLint
+yarn lint:fix                     # ESLint auto-fix
+yarn prettier:write               # Prettier auto-format
+yarn typecheck                    # TypeScript check
+````
+
+## Architecture
+
+TODO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ yarn build                        # Frontend production build
 
 ### Test
 
-````bash
+```bash
 yarn test:scenes path/to/file  --watch=false                     # Run tests for a specific file inside scenes library
 yarn test:scenes -t "pattern"  --watch=false                     # Run tests by pattern for scenes library
 yarn test:scenes -u --watch=false                                # Update snapshots for scenes library
@@ -41,7 +41,7 @@ yarn test:scenes -u --watch=false                                # Update snapsh
 yarn test:scenes-react path/to/file --watch=false                # Run tests for a specific file inside scenes-react library
 yarn test:scenes-react -t "pattern" --watch=false                # Run tests by pattern for scenes-react library
 yarn test:scenes-react -u --watch=false                          # Update snapshots for scenes-react library
-
+```
 
 ### Lint & Format
 
@@ -50,8 +50,6 @@ yarn lint                         # ESLint
 yarn lint:fix                     # ESLint auto-fix
 yarn prettier:write               # Prettier auto-format
 yarn typecheck                    # TypeScript check
-````
+```
 
 ## Architecture
-
-TODO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,13 @@ yarn build                        # Frontend production build
 ### Test
 
 ````bash
-yarn test:scenes path/to/file                      # Run tests for a specific file inside scenes library
-yarn test:scenes -t "pattern"                      # Run tests by pattern for scenes library
-yarn test:scenes -u                                # Update snapshots for scenes library
+yarn test:scenes path/to/file  --watch=false                     # Run tests for a specific file inside scenes library
+yarn test:scenes -t "pattern"  --watch=false                     # Run tests by pattern for scenes library
+yarn test:scenes -u --watch=false                                # Update snapshots for scenes library
 
-yarn test:scenes-react path/to/file                # Run tests for a specific file inside scenes-react library
-yarn test:scenes-react -t "pattern"                # Run tests by pattern for scenes-react library
-yarn test:scenes-react -u                          # Update snapshots for scenes-react library
+yarn test:scenes-react path/to/file --watch=false                # Run tests for a specific file inside scenes-react library
+yarn test:scenes-react -t "pattern" --watch=false                # Run tests by pattern for scenes-react library
+yarn test:scenes-react -u --watch=false                          # Update snapshots for scenes-react library
 
 
 ### Lint & Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,5 @@
   "useNx": false,
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "8.11.0",
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -100,7 +100,12 @@ export { GroupByVariable } from './variables/groupby/GroupByVariable';
 export { type MacroVariableConstructor } from './variables/macros/types';
 export { escapeUrlPipeDelimiters, getQueriesForVariables } from './variables/utils';
 
-export { type UrlSyncManagerLike, UrlSyncManager, NewSceneObjectAddedEvent } from './services/UrlSyncManager';
+export {
+  type UrlSyncManagerLike,
+  UrlSyncManager,
+  NewSceneObjectAddedEvent,
+  SceneObjectRemovedEvent,
+} from './services/UrlSyncManager';
 export { useUrlSync } from './services/useUrlSync';
 export { UrlSyncContextProvider } from './services/UrlSyncContextProvider';
 export { SceneObjectUrlSyncConfig } from './services/SceneObjectUrlSyncConfig';

--- a/packages/scenes/src/services/UrlSyncManager.test.ts
+++ b/packages/scenes/src/services/UrlSyncManager.test.ts
@@ -8,7 +8,7 @@ import { SceneTimeRange } from '../core/SceneTimeRange';
 import { SceneObjectState, SceneObjectUrlSyncHandler, SceneObjectUrlValues } from '../core/types';
 
 import { SceneObjectUrlSyncConfig } from './SceneObjectUrlSyncConfig';
-import { UrlSyncManager } from './UrlSyncManager';
+import { SceneObjectRemovedEvent, UrlSyncManager } from './UrlSyncManager';
 import { activateFullSceneTree } from '../utils/test/activateFullSceneTree';
 import { updateUrlStateAndSyncState } from '../../utils/test/updateUrlStateAndSyncState';
 
@@ -256,6 +256,42 @@ describe.each([
 
         expect(locationService.getSearchObject()).toEqual({
           [valueKey]: 'b',
+        });
+      });
+    });
+
+    describe('When a scene object is removed', () => {
+      it('should clean up the URL keys the removed object owned', () => {
+        const objToKeep = new TestObj({ name: 'keep' });
+        const objToRemove = new TestObj({ name: 'remove' });
+        const keyPrefix = options?.namespace ? `${options.namespace}-` : '';
+
+        scene = new SceneFlexLayout({
+          children: [new SceneFlexItem({ body: objToKeep }), new SceneFlexItem({ body: objToRemove })],
+        });
+
+        urlManager = new UrlSyncManager(options);
+        urlManager.initSync(scene);
+        deactivate = scene.activate();
+
+        // Populate the url for both objects
+        objToKeep.setState({ optional: 'keep-optional' });
+        objToRemove.setState({ optional: 'remove-optional' });
+
+        expect(locationService.getSearchObject()).toEqual({
+          [`${keyPrefix}name`]: 'keep',
+          [`${keyPrefix}optional`]: 'keep-optional',
+          [`${keyPrefix}name-2`]: 'remove',
+          [`${keyPrefix}optional-2`]: 'remove-optional',
+        });
+
+        // When an object is removed from the scene
+        scene.publishEvent(new SceneObjectRemovedEvent(objToRemove), true);
+
+        // Should only remove the url keys that the removed object owned
+        expect(locationService.getSearchObject()).toEqual({
+          [`${keyPrefix}name`]: 'keep',
+          [`${keyPrefix}optional`]: 'keep-optional',
         });
       });
     });

--- a/packages/scenes/src/services/UrlSyncManager.ts
+++ b/packages/scenes/src/services/UrlSyncManager.ts
@@ -26,6 +26,14 @@ export class NewSceneObjectAddedEvent extends BusEventWithPayload<SceneObject> {
   public static readonly type = 'new-scene-object-added';
 }
 
+/**
+ * Notify the url sync manager of a scene object that has been removed from the scene
+ * and needs to clean up state from URL.
+ */
+export class SceneObjectRemovedEvent extends BusEventWithPayload<SceneObject> {
+  public static readonly type = 'scene-object-removed';
+}
+
 export class UrlSyncManager implements UrlSyncManagerLike {
   private _urlKeyMapper: UniqueUrlKeyMapper;
   private _lastSyncedObjectKeys = new WeakMap<SceneObject, string[]>();
@@ -70,6 +78,12 @@ export class UrlSyncManager implements UrlSyncManagerLike {
     this._subs.add(
       root.subscribeToEvent(NewSceneObjectAddedEvent, (evt) => {
         this.handleNewObject(evt.payload);
+      })
+    );
+
+    this._subs.add(
+      root.subscribeToEvent(SceneObjectRemovedEvent, (evt) => {
+        this.handleObjectRemoved(evt.payload);
       })
     );
 
@@ -134,6 +148,45 @@ export class UrlSyncManager implements UrlSyncManagerLike {
 
     syncStateFromUrl(sceneObj, this._paramsCache.getParams(), this._urlKeyMapper);
     this.cacheObjectUrlKeys(sceneObj);
+  }
+
+  /**
+   * When a scene object is removed from the scene we clean up the URL keys it owned.
+   * The removed object may already be detached from the scene tree, so we rely on the
+   * unique keys cached while it was synced rather than recomputing them from the tree.
+   */
+  private handleObjectRemoved(sceneObj: SceneObject) {
+    if (!this._sceneRoot) {
+      return;
+    }
+
+    const searchParams = this._locationService.getSearch();
+    const mappedUpdated: SceneObjectUrlValues = {};
+
+    const visitNode = (obj: SceneObject) => {
+      const keys = this._lastSyncedObjectKeys.get(obj);
+      if (keys) {
+        for (const uniqueKey of keys) {
+          if (searchParams.has(uniqueKey)) {
+            mappedUpdated[uniqueKey] = null;
+          }
+        }
+      }
+
+      this._lastSyncedObjectKeys.delete(obj);
+
+      obj.forEachChild(visitNode);
+    };
+
+    visitNode(sceneObj);
+
+    if (Object.keys(mappedUpdated).length > 0) {
+      writeSceneLog('UrlSyncManager', 'handleObjectRemoved, cleaning up URL keys');
+      this._locationService.partial(mappedUpdated, true);
+
+      // Mark the location already handled
+      this._lastLocation = this._locationService.getLocation();
+    }
   }
 
   private handleSceneObjectStateChanged(changedObject: SceneObject) {


### PR DESCRIPTION

For the new "View panel controls" pane feature I want to add url sync for the fanout and other controls. But want those url state keys to be removed from url when we exist the view panel view. 

This adds a new event to notify UrlSyncManager of removed scene objects. 

Also adds a first draft of a agents.md file 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.12.0--canary.1575.29244242274.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.12.0--canary.1575.29244242274.0
  npm install scenes-app@8.12.0--canary.1575.29244242274.0
  npm install @grafana/scenes-react@8.12.0--canary.1575.29244242274.0
  # or 
  yarn add @grafana/scenes@8.12.0--canary.1575.29244242274.0
  yarn add scenes-app@8.12.0--canary.1575.29244242274.0
  yarn add @grafana/scenes-react@8.12.0--canary.1575.29244242274.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
