### PR TITLE
SceneVariableSet: Fix repeated panels/rows stuck loading with render before activation

### DIFF
--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -250,6 +250,38 @@ describe('SceneVariableList', () => {
     });
   });
 
+  describe('When a variable completes while an ancestor is still inactive (RENDER_BEFORE_ACTIVATION = true)', () => {
+    beforeAll(() => (SceneObjectBase.RENDER_BEFORE_ACTIVATION_DEFAULT = true));
+    afterAll(() => (SceneObjectBase.RENDER_BEFORE_ACTIVATION_DEFAULT = false));
+
+    it('Should still notify active dependents deeper in the tree', () => {
+      const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });
+      const dependent = new TestObjectWithVariableDependency({ title: '$A' });
+
+      const scene = new TestScene({
+        $timeRange: new SceneTimeRange(),
+        $variables: new SceneVariableSet({ variables: [A] }),
+        nested: new TestScene({ nested: dependent }),
+      });
+
+      const varSet = scene.state.$variables!;
+
+      // Children activate before their common ancestors
+      varSet.activate();
+      dependent.activate();
+
+      expect(scene.isActive).toBe(false);
+      expect(dependent.isActive).toBe(true);
+      expect(A.state.loading).toBe(true);
+
+      act(() => {
+        A.signalUpdateCompleted();
+      });
+
+      expect(dependent.state.didSomethingCount).toBe(1);
+    });
+  });
+
   describe('When activated with variables update at the same time', () => {
     it('Should not start variables multiple times', async () => {
       const A = new TestVariable({ name: 'A', query: 'A.*', value: '', text: '', options: [] });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -328,11 +328,6 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       return;
     }
 
-    // Skip non active scene objects
-    if (!sceneObject.isActive) {
-      return;
-    }
-
     // If we find a nested SceneVariableSet that has a variable with the same name we stop the traversal
     if (sceneObject.state.$variables && sceneObject.state.$variables !== this) {
       const localVar = sceneObject.state.$variables.getByName(variable.state.name);
@@ -344,11 +339,15 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       }
     }
 
-    if (sceneObject.variableDependency) {
+    // Only notify active scene objects
+    if (sceneObject.isActive && sceneObject.variableDependency) {
       sceneObject.variableDependency.variableUpdateCompleted(variable, hasChanged);
     }
 
-    sceneObject.forEachChild((child) => this._traverseSceneAndNotify(child, variable, hasChanged));
+    // With render before activation an inactive parent can have active children, so keep traversing
+    if (sceneObject.isActive || SceneObjectBase.RENDER_BEFORE_ACTIVATION_DEFAULT) {
+      sceneObject.forEachChild((child) => this._traverseSceneAndNotify(child, variable, hasChanged));
+    }
   }
 
   /**


### PR DESCRIPTION
_traverseSceneAndNotify returned early on the first inactive scene object, skipping its entire subtree. With render before activation children activate before their parents, so when a variable resolves before its ancestors are active the notification traversal (which starts at the variable set's parent) stops there and never reaches active dependents deeper in the tree, such as repeat behaviors and query runners. They bail on the initial loading check and, without the completion notification, stay stuck on a loading spinner. Changing the variable later recovers them because by then the whole tree is active.

Only gate the variableUpdateCompleted call on isActive and keep traversing into children whenever the node is active or render before activation is enabled. The classic activation order is unchanged, since an inactive node only has inactive children there.

Fixes grafana/grafana#128393