### PR TITLE
AdHocFiltersVariable: Add controls render mode for dashboard-origin filters

### DIFF
--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -87,6 +87,7 @@ export {
   OPERATORS,
   GROUP_BY_OPERATOR,
   isGroupByFilter,
+  getOriginFilterControls,
   type OperatorDefinition,
 } from './variables/adhoc/AdHocFiltersVariable';
 export type { AdHocFilterWithLabels } from './variables/adhoc/AdHocFiltersVariable';

--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -171,7 +171,6 @@
       },
       "origin-filter-value-control": {
         "placeholder-all": "All",
-        "restore-aria-label": "Restore filter to its original value",
         "restore-tooltip": "Restore the filter set by this dashboard."
       },
       "test-object-with-variable-dependency": {

--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -169,6 +169,11 @@
       "options-error-placeholder": {
         "error-occurred-fetching-labels-click-retry": "An error has occurred fetching labels. Click to retry"
       },
+      "origin-filter-value-control": {
+        "placeholder-all": "All",
+        "restore-aria-label": "Restore filter to its original value",
+        "restore-tooltip": "Restore the filter set by this dashboard."
+      },
       "test-object-with-variable-dependency": {
         "title": {
           "hello": "Hello"

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -17,6 +17,7 @@ import {
   dataFromResponse,
   escapeOriginFilterUrlDelimiters,
   getQueriesForVariables,
+  getVariableControlId,
   renderPrometheusLabelFilters,
   responseHasError,
 } from '../utils';
@@ -39,6 +40,8 @@ import { getQueryController } from '../../core/sceneGraph/getQueryController';
 import { FILTER_REMOVED_INTERACTION, FILTER_RESTORED_INTERACTION } from '../../performance/interactionConstants';
 import { AdHocFiltersVariableController } from './controller/AdHocFiltersVariableController';
 import { AdHocFiltersRecommendations } from './AdHocFiltersRecommendations';
+import { OriginFilterValueControl } from './OriginFilterValueControl';
+import { ControlsLabel } from '../../utils/ControlsLabel';
 
 export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> extends AdHocVariableFilter {
   keyLabel?: string;
@@ -187,6 +190,19 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
    * When true, the "groupBy" operator is available and filters can be used as group-by dimensions.
    */
   enableGroupBy?: boolean;
+
+  /**
+   * @experimental
+   * Controls how dashboard-origin filters are rendered in the combobox layout.
+   * - 'pills' (default): rendered as pills inside the filters combobox.
+   * - 'controls': rendered as standalone, labeled, value-only controls before the
+   *   filters combobox. Their keys are removed from the combobox key suggestions so a
+   *   field is never managed in two places. The renderer also renders a label for the
+   *   combobox (using the variable label/name), so hosts that render their own variable
+   *   label should skip it when this mode is active.
+   * Scope-origin filters and group-by origin filters keep the pill rendering.
+   */
+  originFiltersRenderMode?: 'pills' | 'controls';
 }
 
 export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[]) => string;
@@ -1386,7 +1402,8 @@ function haveGroupByKeysChanged(prev: AdHocFilterWithLabels[], next: AdHocFilter
 }
 
 export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHocFiltersVariable>) {
-  const { filters, readOnly, addFilterButtonText } = model.useState();
+  const state = model.useState();
+  const { filters, readOnly, addFilterButtonText } = state;
   const styles = useStyles2(getStyles);
 
   // Create controller adapter for combobox mode
@@ -1396,6 +1413,28 @@ export function AdHocFiltersVariableRenderer({ model }: SceneComponentProps<AdHo
   );
 
   if (controller) {
+    const originFilterControls = getOriginFilterControls(state);
+
+    if (originFilterControls.length > 0) {
+      return (
+        <div className={styles.originControlsWrapper}>
+          {originFilterControls.map((filter) => (
+            <OriginFilterValueControl key={`${filter.origin}-${filter.key}`} filter={filter} model={model} />
+          ))}
+          <div className={styles.labeledCombobox}>
+            <ControlsLabel
+              htmlFor={getVariableControlId(state.type, state.key)}
+              label={state.label || state.name}
+              isLoading={state.loading}
+              error={state.error}
+              description={state.description || undefined}
+            />
+            <AdHocFiltersComboboxRenderer controller={controller} />
+          </div>
+        </div>
+      );
+    }
+
     return <AdHocFiltersComboboxRenderer controller={controller} />;
   }
 
@@ -1421,6 +1460,22 @@ const getStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'flex-end',
     columnGap: theme.spacing(2),
     rowGap: theme.spacing(1),
+  }),
+  originControlsWrapper: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  labeledCombobox: css({
+    display: 'flex',
+    alignItems: 'center',
+    flexGrow: 1,
+    // No left border radius for the combobox as the label and combobox share a border
+    '> :nth-child(2)': css({
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+    }),
   }),
 });
 
@@ -1481,6 +1536,20 @@ export function isFilterComplete(filter: AdHocFilterWithLabels): boolean {
 
 export function isFilterApplicable(filter: AdHocFilterWithLabels): boolean {
   return !filter.nonApplicable;
+}
+
+/**
+ * The dashboard-origin filters that render as standalone value-only controls when
+ * `originFiltersRenderMode` is 'controls'. Returns an empty array when the mode is not active.
+ */
+export function getOriginFilterControls(state: AdHocFiltersVariableState): AdHocFilterWithLabels[] {
+  if (state.originFiltersRenderMode !== 'controls' || (state.layout ?? 'combobox') !== 'combobox') {
+    return [];
+  }
+
+  return (state.originFilters ?? []).filter(
+    (filter) => filter.origin === 'dashboard' && !isGroupByFilter(filter) && !filter.hidden
+  );
 }
 
 function findLastAdhocFilterIndex(filters: AdHocFilterWithLabels[]): number {

--- a/packages/scenes/src/variables/adhoc/OriginFilterValueControl.test.tsx
+++ b/packages/scenes/src/variables/adhoc/OriginFilterValueControl.test.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import { act, fireEvent, getAllByRole, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { select } from 'react-select-event';
+
+import { DataSourceSrv, locationService, setDataSourceSrv, setTemplateSrv } from '@grafana/runtime';
+
+import { EmbeddedScene } from '../../components/EmbeddedScene';
+import { SceneFlexItem, SceneFlexLayout } from '../../components/layout/SceneFlexLayout';
+import { SceneCanvasText } from '../../components/SceneCanvasText';
+import { SceneTimeRange } from '../../core/SceneTimeRange';
+import { SceneVariableSet } from '../sets/SceneVariableSet';
+import { TestContextProvider } from '../../../utils/test/TestContextProvider';
+import { AdHocFiltersVariable, AdHocFiltersVariableState, getOriginFilterControls } from './AdHocFiltersVariable';
+import { AdHocFiltersVariableController } from './controller/AdHocFiltersVariableController';
+
+const getTagKeysSpy = jest.fn();
+const getTagValuesSpy = jest.fn();
+
+function setup(overrides?: Partial<AdHocFiltersVariableState>) {
+  setDataSourceSrv({
+    get() {
+      return {
+        getTagKeys(options: any) {
+          getTagKeysSpy(options);
+          return [
+            { text: 'region', value: 'region' },
+            { text: 'tier', value: 'tier' },
+          ];
+        },
+        getTagValues(options: any) {
+          getTagValuesSpy(options);
+          return [{ text: 'emea' }, { text: 'amer' }, { text: 'apac' }];
+        },
+        getRef() {
+          return { uid: 'my-ds-uid' };
+        },
+      };
+    },
+    getInstanceSettings() {
+      return { uid: 'my-ds-uid' };
+    },
+  } as unknown as DataSourceSrv);
+
+  setTemplateSrv({
+    getAdhocFilters: jest.fn().mockReturnValue([]),
+  } as any);
+
+  const filtersVar = new AdHocFiltersVariable({
+    datasource: { uid: 'my-ds-uid' },
+    name: 'Filters',
+    filters: [],
+    originFiltersRenderMode: 'controls',
+    supportsMultiValueOperators: true,
+    ...overrides,
+  });
+
+  const scene = new EmbeddedScene({
+    $timeRange: new SceneTimeRange(),
+    $variables: new SceneVariableSet({ variables: [filtersVar] }),
+    body: new SceneFlexLayout({
+      children: [new SceneFlexItem({ body: new SceneCanvasText({ text: 'hello' }) })],
+    }),
+  });
+
+  act(() => {
+    locationService.push('/');
+  });
+
+  // Render the variable component directly (without VariableValueSelectors) so the
+  // variable-level label rendered by the host is not part of the test surface
+  const { unmount } = render(
+    <TestContextProvider scene={scene}>
+      <filtersVar.Component model={filtersVar} />
+    </TestContextProvider>
+  );
+
+  return { filtersVar, unmount };
+}
+
+beforeEach(() => {
+  getTagKeysSpy.mockClear();
+  getTagValuesSpy.mockClear();
+});
+
+describe('originFiltersRenderMode: controls', () => {
+  it('renders dashboard-origin filters as standalone controls and strips them from the combobox', async () => {
+    setup({
+      originFilters: [
+        { key: 'region', operator: '=', value: 'emea', origin: 'dashboard' },
+        { key: 'tier', operator: '=', value: 'gold', origin: 'dashboard' },
+      ],
+    });
+
+    expect(await screen.findByTestId('origin-filter-control-region')).toBeInTheDocument();
+    expect(screen.getByTestId('origin-filter-control-tier')).toBeInTheDocument();
+
+    // No origin pills inside the combobox
+    expect(screen.queryByText('region = emea')).not.toBeInTheDocument();
+    expect(screen.queryByText('tier = gold')).not.toBeInTheDocument();
+
+    // Bulk combobox still rendered
+    expect(screen.getByPlaceholderText('+ label = value')).toBeInTheDocument();
+  });
+
+  it('keeps pill rendering for scope-origin filters', async () => {
+    setup({
+      originFilters: [
+        { key: 'region', operator: '=', value: 'emea', origin: 'dashboard' },
+        { key: 'env', operator: '=', value: 'prod', origin: 'scope' },
+      ],
+    });
+
+    expect(await screen.findByTestId('origin-filter-control-region')).toBeInTheDocument();
+    expect(screen.queryByTestId('origin-filter-control-env')).not.toBeInTheDocument();
+    expect(screen.getByText('env = prod')).toBeInTheDocument();
+  });
+
+  it('renders origin filters as pills when the mode is not set', async () => {
+    setup({
+      originFiltersRenderMode: undefined,
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    expect(screen.queryByTestId('origin-filter-control-region')).not.toBeInTheDocument();
+    expect(await screen.findByText('region = emea')).toBeInTheDocument();
+  });
+
+  it('shows the keyLabel as the control label', async () => {
+    setup({
+      originFilters: [{ key: 'region', keyLabel: 'Region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    const control = await screen.findByTestId('origin-filter-control-region');
+    expect(control).toHaveTextContent('Region');
+  });
+
+  it('renders a label for the bulk combobox using the variable label', async () => {
+    setup({
+      label: 'My filters',
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    expect(await screen.findByText('My filters')).toBeInTheDocument();
+  });
+
+  it('shows the All placeholder for match-all filters', async () => {
+    setup({
+      originFilters: [
+        {
+          key: 'region',
+          operator: '=~',
+          value: '.*',
+          values: ['.*'],
+          valueLabels: ['All'],
+          matchAllFilter: true,
+          origin: 'dashboard',
+        },
+      ],
+    });
+
+    const control = await screen.findByTestId('origin-filter-control-region');
+    expect(control).toHaveTextContent('All');
+  });
+
+  it('commits selected values with =| on blur', async () => {
+    const { filtersVar } = setup({
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    const control = await screen.findByTestId('origin-filter-control-region');
+    const selectEl = getAllByRole(control, 'combobox')[0];
+
+    // OptionWithCheckbox handles onPointerDown (not onClick), so use userEvent pointer events
+    await userEvent.click(selectEl);
+    const option = await screen.findByRole('option', { name: /amer/ });
+    await userEvent.click(option);
+
+    // Selection is uncommitted until blur
+    expect(filtersVar.state.originFilters![0].operator).toBe('=');
+
+    fireEvent.focusOut(selectEl);
+
+    await waitFor(() => {
+      expect(filtersVar.state.originFilters![0]).toMatchObject({
+        operator: '=|',
+        values: ['emea', 'amer'],
+        restorable: true,
+      });
+    });
+  });
+
+  it('turns the filter into match-all when the selection is cleared', async () => {
+    const { filtersVar } = setup({
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    const control = await screen.findByTestId('origin-filter-control-region');
+    const selectEl = getAllByRole(control, 'combobox')[0];
+
+    // Remove the selected value with backspace, then blur to commit
+    await userEvent.click(selectEl);
+    await userEvent.keyboard('{Backspace}');
+    fireEvent.focusOut(selectEl);
+
+    await waitFor(() => {
+      expect(filtersVar.state.originFilters![0]).toMatchObject({
+        operator: '=~',
+        value: '.*',
+        matchAllFilter: true,
+        restorable: true,
+      });
+    });
+  });
+
+  it('restores the original value via the history button', async () => {
+    const { filtersVar } = setup({
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    act(() => {
+      filtersVar.updateToMatchAll(filtersVar.state.originFilters![0]);
+    });
+
+    const restoreButton = await screen.findByLabelText('Restore the filter set by this dashboard.');
+    await userEvent.click(restoreButton);
+
+    await waitFor(() => {
+      expect(filtersVar.state.originFilters![0]).toMatchObject({
+        operator: '=',
+        value: 'emea',
+        restorable: false,
+      });
+    });
+
+    expect(screen.queryByLabelText('Restore the filter set by this dashboard.')).not.toBeInTheDocument();
+  });
+
+  it('commits with = when multi-value operators are not supported', async () => {
+    const { filtersVar } = setup({
+      supportsMultiValueOperators: false,
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+
+    const control = await screen.findByTestId('origin-filter-control-region');
+    const selectEl = getAllByRole(control, 'combobox')[0];
+
+    await waitFor(() => select(selectEl, 'amer', { container: document.body }));
+
+    await waitFor(() => {
+      expect(filtersVar.state.originFilters![0]).toMatchObject({
+        operator: '=',
+        value: 'amer',
+        restorable: true,
+      });
+    });
+  });
+});
+
+describe('AdHocFiltersVariableController key stripping', () => {
+  function createVariable(overrides?: Partial<AdHocFiltersVariableState>) {
+    return new AdHocFiltersVariable({
+      datasource: { uid: 'my-ds-uid' },
+      filters: [],
+      getTagKeysProvider: async () => ({
+        replace: true,
+        values: [
+          { text: 'region', value: 'region' },
+          { text: 'tier', value: 'tier' },
+          { text: 'env', value: 'env' },
+        ],
+      }),
+      ...overrides,
+    });
+  }
+
+  it('removes control-rendered keys from key suggestions', async () => {
+    const variable = createVariable({
+      originFiltersRenderMode: 'controls',
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+    const controller = new AdHocFiltersVariableController(variable);
+
+    const keys = await controller.getKeys(null);
+
+    expect(keys.map((key) => key.value)).toEqual(['tier', 'env']);
+  });
+
+  it('keeps all keys when the mode is not active', async () => {
+    const variable = createVariable({
+      originFilters: [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }],
+    });
+    const controller = new AdHocFiltersVariableController(variable);
+
+    const keys = await controller.getKeys(null);
+
+    expect(keys.map((key) => key.value)).toEqual(['region', 'tier', 'env']);
+  });
+});
+
+describe('getOriginFilterControls', () => {
+  it('returns only visible dashboard-origin non-groupBy filters when mode is controls', () => {
+    const state = {
+      layout: 'combobox',
+      originFiltersRenderMode: 'controls',
+      originFilters: [
+        { key: 'region', operator: '=', value: 'emea', origin: 'dashboard' },
+        { key: 'env', operator: '=', value: 'prod', origin: 'scope' },
+        { key: 'hiddenKey', operator: '=', value: 'x', origin: 'dashboard', hidden: true },
+        { key: 'groupKey', operator: 'groupBy', value: '', origin: 'dashboard' },
+      ],
+    } as unknown as AdHocFiltersVariableState;
+
+    expect(getOriginFilterControls(state).map((filter) => filter.key)).toEqual(['region']);
+  });
+
+  it('returns empty when the mode is not controls or the layout is not combobox', () => {
+    const originFilters = [{ key: 'region', operator: '=', value: 'emea', origin: 'dashboard' }];
+
+    expect(
+      getOriginFilterControls({ layout: 'combobox', originFilters } as unknown as AdHocFiltersVariableState)
+    ).toEqual([]);
+    expect(
+      getOriginFilterControls({
+        layout: 'horizontal',
+        originFiltersRenderMode: 'controls',
+        originFilters,
+      } as unknown as AdHocFiltersVariableState)
+    ).toEqual([]);
+  });
+});

--- a/packages/scenes/src/variables/adhoc/OriginFilterValueControl.tsx
+++ b/packages/scenes/src/variables/adhoc/OriginFilterValueControl.tsx
@@ -1,0 +1,196 @@
+import { t } from '@grafana/i18n';
+import React, { useEffect, useMemo, useState } from 'react';
+import { css } from '@emotion/css';
+import { isEqual } from 'lodash';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { IconButton, InputActionMeta, MultiSelect, Select, useStyles2 } from '@grafana/ui';
+
+import { ControlsLabel } from '../../utils/ControlsLabel';
+import { OptionWithCheckbox } from '../components/VariableValueSelect';
+import { getVariableControlId, handleOptionGroups } from '../utils';
+import { AdHocFiltersVariable, AdHocFilterWithLabels, isMatchAllFilter } from './AdHocFiltersVariable';
+import { getAdhocOptionSearcher } from './getAdhocOptionSearcher';
+
+interface Props {
+  filter: AdHocFilterWithLabels;
+  model: AdHocFiltersVariable;
+}
+
+const filterNoOp = () => true;
+
+function getSelectedOptions(filter: AdHocFilterWithLabels): Array<SelectableValue<string>> {
+  if (isMatchAllFilter(filter)) {
+    return [];
+  }
+
+  const values = filter.values ?? (filter.value !== '' ? [filter.value] : []);
+
+  return values.map((value, index) => ({
+    value,
+    label: filter.valueLabels?.[index] ?? value,
+  }));
+}
+
+/**
+ * Renders a dashboard-origin filter as a standalone, labeled, value-only control.
+ * The value picker reuses the same Select/MultiSelect components (and commit-on-blur
+ * semantics) as the classic variable value selects, so the control looks and behaves
+ * like a regular template variable picker. Clearing the selection puts the filter in
+ * the match-all state ("All").
+ */
+export function OriginFilterValueControl({ filter, model }: Props) {
+  const styles = useStyles2(getStyles);
+  const { supportsMultiValueOperators, readOnly, allowCustomValue = true } = model.useState();
+
+  const [values, setValues] = useState<SelectableValue[]>([]);
+  const [isValuesLoading, setIsValuesLoading] = useState(false);
+  const [isValuesOpen, setIsValuesOpen] = useState(false);
+  const [valueInputValue, setValueInputValue] = useState('');
+
+  const selectedOptions = useMemo(() => getSelectedOptions(filter), [filter]);
+  // To not trigger queries on every selection we store the selection locally and only commit onBlur
+  const [uncommittedValue, setUncommittedValue] = useState<Array<SelectableValue<string>>>(selectedOptions);
+
+  // Detect value changes outside (e.g. restore, clear all, URL sync)
+  useEffect(() => {
+    setUncommittedValue(selectedOptions);
+  }, [selectedOptions]);
+
+  const optionSearcher = useMemo(() => getAdhocOptionSearcher(values), [values]);
+  const filteredOptions = useMemo(
+    () => handleOptionGroups(optionSearcher(valueInputValue)),
+    [optionSearcher, valueInputValue]
+  );
+
+  const inputId = `${getVariableControlId(model.state.type, model.state.key)}-origin-${filter.key}`;
+  const label = filter.keyLabel ?? filter.key;
+  const disabled = readOnly || filter.nonApplicable;
+
+  const commitOptions = (options: Array<SelectableValue<string>>, operator: string) => {
+    if (options.length === 0) {
+      if (!isMatchAllFilter(filter)) {
+        model.updateToMatchAll(filter);
+      }
+      return;
+    }
+
+    const newValues = options.map((option) => option.value!);
+    const newLabels = options.map((option) => option.label ?? option.value!);
+    const currentValues = isMatchAllFilter(filter) ? [] : filter.values ?? [filter.value];
+
+    // Unchanged selection: don't touch the filter (also preserves an authored single-value operator)
+    if (isEqual(newValues, currentValues)) {
+      return;
+    }
+
+    model._updateFilter(filter, {
+      operator,
+      value: newValues[0],
+      values: newValues,
+      valueLabels: newLabels,
+    });
+  };
+
+  const onInputChange = (value: string, { action }: InputActionMeta) => {
+    if (action === 'input-change') {
+      setValueInputValue(value);
+    }
+    return value;
+  };
+
+  const commonSelectProps = {
+    inputId,
+    width: 'auto' as const,
+    virtualized: true,
+    disabled,
+    allowCustomValue,
+    isValidNewOption: (inputValue: string) => inputValue.trim().length > 0,
+    allowCreateWhileLoading: true,
+    placeholder: t('grafana-scenes.variables.origin-filter-value-control.placeholder-all', 'All'),
+    options: filteredOptions,
+    inputValue: valueInputValue,
+    onInputChange,
+    filterOption: filterNoOp,
+    isClearable: true,
+    // there's a bug in react-select where the menu doesn't recalculate its position when the options are loaded
+    // asynchronously, so we explicitly control the menu visibility until the options have fully loaded
+    isOpen: isValuesOpen && !isValuesLoading,
+    isLoading: isValuesLoading,
+    onOpenMenu: async () => {
+      setIsValuesLoading(true);
+      setIsValuesOpen(true);
+      const values = await model._getValuesFor(filter);
+      setIsValuesLoading(false);
+      setValues(values);
+    },
+    onCloseMenu: () => {
+      setIsValuesOpen(false);
+      setValueInputValue('');
+    },
+    'data-testid': `origin-filter-value-${filter.key}`,
+  };
+
+  const valueSelect = supportsMultiValueOperators ? (
+    <MultiSelect<string>
+      {...commonSelectProps}
+      value={uncommittedValue}
+      noMultiValueWrap={true}
+      maxVisibleValues={5}
+      tabSelectsValue={false}
+      components={{ Option: OptionWithCheckbox }}
+      closeMenuOnSelect={false}
+      hideSelectedOptions={false}
+      blurInputOnSelect={false}
+      onChange={(newValue) => {
+        setUncommittedValue(newValue.map((option) => ({ value: option.value, label: option.label ?? option.value })));
+        // clear input value when creating a new custom multi value
+        if (newValue.some((option) => option.__isNew__)) {
+          setValueInputValue('');
+        }
+      }}
+      onBlur={() => {
+        commitOptions(uncommittedValue, '=|');
+      }}
+    />
+  ) : (
+    <Select<string>
+      {...commonSelectProps}
+      value={selectedOptions[0] ?? null}
+      onChange={(newValue) => {
+        commitOptions(newValue && newValue.value != null ? [newValue] : [], '=');
+      }}
+    />
+  );
+
+  const restoreButton = filter.restorable ? (
+    <IconButton
+      name="history"
+      size="sm"
+      tooltip={t(
+        'grafana-scenes.variables.origin-filter-value-control.restore-tooltip',
+        'Restore the filter set by this dashboard.'
+      )}
+      onClick={() => model.restoreOriginalFilter(filter)}
+    />
+  ) : undefined;
+
+  return (
+    <div className={styles.container} data-testid={`origin-filter-control-${filter.key}`}>
+      <ControlsLabel htmlFor={inputId} label={label} suffix={restoreButton} />
+      {valueSelect}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    alignItems: 'center',
+    // No left border radius for the select as the label and select share a border
+    '> :nth-child(2)': css({
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+    }),
+  }),
+});

--- a/packages/scenes/src/variables/adhoc/controller/AdHocFiltersVariableController.ts
+++ b/packages/scenes/src/variables/adhoc/controller/AdHocFiltersVariableController.ts
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { AdHocFilterWithLabels, AdHocFiltersVariable } from '../AdHocFiltersVariable';
+import { AdHocFilterWithLabels, AdHocFiltersVariable, getOriginFilterControls } from '../AdHocFiltersVariable';
 import { AdHocFiltersController, AdHocFiltersControllerState } from './AdHocFiltersController';
 import { getQueryController } from '../../../core/sceneGraph/getQueryController';
 import { getInteractionTracker } from '../../../core/sceneGraph/getInteractionTracker';
@@ -15,9 +15,14 @@ export class AdHocFiltersVariableController implements AdHocFiltersController {
   public useState(): AdHocFiltersControllerState {
     const state = this.model.useState();
 
+    // Origin filters rendered as standalone controls are managed outside the combobox
+    const controlFilters = new Set(getOriginFilterControls(state));
+
     return {
       filters: state.filters,
-      originFilters: state.originFilters,
+      originFilters: controlFilters.size
+        ? state.originFilters?.filter((filter) => !controlFilters.has(filter))
+        : state.originFilters,
       readOnly: state.readOnly,
       allowCustomValue: state.allowCustomValue,
       supportsMultiValueOperators: state.supportsMultiValueOperators,
@@ -34,7 +39,16 @@ export class AdHocFiltersVariableController implements AdHocFiltersController {
   }
 
   public async getKeys(currentKey: string | null): Promise<Array<SelectableValue<string>>> {
-    return this.model._getKeys(currentKey);
+    const keys = await this.model._getKeys(currentKey);
+
+    // Keys managed by standalone origin filter controls are removed from the combobox
+    // suggestions so a field is never managed in two places
+    const controlKeys = new Set(getOriginFilterControls(this.model.state).map((filter) => filter.key));
+    if (controlKeys.size === 0) {
+      return keys;
+    }
+
+    return keys.filter((key) => key.value == null || !controlKeys.has(key.value));
   }
 
   public async getGroupByKeys(currentKey: string | null): Promise<Array<SelectableValue<string>>> {


### PR DESCRIPTION
## Summary

Adds an `originFiltersRenderMode` state option (`'pills' | 'controls'`) to `AdHocFiltersVariable` so dashboard-origin pinned filters can render with the same vanilla variable picker controls (Select/MultiSelect + OptionWithCheckbox) used by template variables, instead of combobox pills.

This is the scenes-side half of an in-scenes pinned filters PoC. Companion grafana PR wires `originFiltersRenderMode: 'controls'` at construction sites when the `grafana.pinnedFilters` toggle is on.

**Looks like:**
<img width="1586" height="630" alt="image" src="https://github.com/user-attachments/assets/7b63e6dc-6bf3-4e4a-82f4-ef3c028c4f69" />
<img width="1492" height="348" alt="image" src="https://github.com/user-attachments/assets/6d8f145d-3ea5-4b45-a70f-7292931ea71e" />
<img width="1580" height="1734" alt="image" src="https://github.com/user-attachments/assets/f9a3b39d-42f2-40a0-bc88-27dcc6a0f871" />




**Related:**
- Baseline app-side approach: https://github.com/grafana/grafana/pull/128243
- Companion grafana PoC PR: https://github.com/grafana/grafana/pull/128484
- Canary: `@grafana/scenes@8.14.0--canary.1578.29412900007.0`

## Changes

- `originFiltersRenderMode` state option on `AdHocFiltersVariable`
- `OriginFilterValueControl` component reusing scenes-internal Select/MultiSelect + ControlsLabel
- `getOriginFilterControls()` helper exported from `@grafana/scenes`
- Controller strips dashboard-origin controls from combobox pills/key suggestions when mode is `'controls'`
- 14 unit tests for `OriginFilterValueControl`

## Test plan

- [x] `yarn test OriginFilterValueControl` — 14 tests pass
- [x] Full scenes test suite — 1718 tests pass
- [x] Typecheck + lint pass
- [x] CI green
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.14.0--canary.1578.30471652233.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.14.0--canary.1578.30471652233.0
  npm install scenes-app@8.14.0--canary.1578.30471652233.0
  npm install @grafana/scenes-react@8.14.0--canary.1578.30471652233.0
  # or 
  yarn add @grafana/scenes@8.14.0--canary.1578.30471652233.0
  yarn add scenes-app@8.14.0--canary.1578.30471652233.0
  yarn add @grafana/scenes-react@8.14.0--canary.1578.30471652233.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
