### PR TITLE
Dashboards: Invalidate fieldConfig cache on variable change when vars are used

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -30,6 +30,8 @@ import { SceneDataTransformer } from '../../querying/SceneDataTransformer';
 import { EmptyDataNode } from '../../variables/interpolation/defaults';
 import { mockTransformationsRegistry } from '../../utils/mockTransformationsRegistry';
 import { SceneQueryRunner } from '../../querying/SceneQueryRunner';
+import { SceneVariableSet } from '../../variables/sets/SceneVariableSet';
+import { TestVariable } from '../../variables/variants/TestVariable';
 
 let pluginToLoad: PanelPlugin | undefined;
 
@@ -1215,6 +1217,59 @@ describe('VizPanel', () => {
       const result = panel.applyFieldConfig({ ...testData, series: [newFrame] });
 
       expect(result.series[0]).not.toBe(newFrame);
+    });
+  });
+
+  describe('field config cache invalidation on variable change', () => {
+    async function setup(state: Partial<VizPanelState<OptionsPlugin1, FieldConfigPlugin1>>) {
+      const variable = new TestVariable({
+        name: 'server',
+        value: 'A',
+        text: 'A',
+        query: 'A.*',
+        options: [],
+        delayMs: 0,
+      });
+      const panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+        pluginId: 'custom-plugin-id',
+        $timeRange: new SceneTimeRange(),
+        $variables: new SceneVariableSet({ variables: [variable] }),
+        ...state,
+      });
+      pluginToLoad = getTestPlugin1();
+      panel.activate();
+      variable.signalUpdateCompleted();
+      await Promise.resolve();
+      return { panel, variable };
+    }
+
+    it('should clear the cache when a variable referenced in fieldConfig changes', async () => {
+      const { panel, variable } = await setup({
+        fieldConfig: { defaults: { unit: '$server' }, overrides: [] },
+      });
+
+      const testData = getTestData();
+      const first = panel.applyFieldConfig(testData);
+      expect(panel.applyFieldConfig(testData)).toBe(first);
+
+      variable.changeValueTo('B');
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(panel.applyFieldConfig(testData)).not.toBe(first);
+    });
+
+    it('should keep the cache when the changed variable is only referenced in the title', async () => {
+      const { panel, variable } = await setup({ title: 'Panel $server' });
+      const forceRenderSpy = jest.spyOn(panel, 'forceRender');
+
+      const testData = getTestData();
+      const first = panel.applyFieldConfig(testData);
+
+      variable.changeValueTo('B');
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(forceRenderSpy).toHaveBeenCalled();
+      expect(panel.applyFieldConfig(testData)).toBe(first);
     });
   });
 });

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -1258,7 +1258,7 @@ describe('VizPanel', () => {
       expect(panel.applyFieldConfig(testData)).not.toBe(first);
     });
 
-    it('should keep the cache when the changed variable is only referenced in the title', async () => {
+    it('should clear the cache when a variable referenced in the title changes', async () => {
       const { panel, variable } = await setup({ title: 'Panel $server' });
       const forceRenderSpy = jest.spyOn(panel, 'forceRender');
 
@@ -1269,6 +1269,18 @@ describe('VizPanel', () => {
       await new Promise((r) => setTimeout(r, 1));
 
       expect(forceRenderSpy).toHaveBeenCalled();
+      expect(panel.applyFieldConfig(testData)).not.toBe(first);
+    });
+
+    it('should keep the cache when the changed variable is not referenced by the panel', async () => {
+      const { panel, variable } = await setup({ title: 'Panel with no variables' });
+
+      const testData = getTestData();
+      const first = panel.applyFieldConfig(testData);
+
+      variable.changeValueTo('B');
+      await new Promise((r) => setTimeout(r, 1));
+
       expect(panel.applyFieldConfig(testData)).toBe(first);
     });
   });

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -132,17 +132,10 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
   protected _variableDependency = new VariableDependencyConfig(this, {
     statePaths: ['title', 'options', 'fieldConfig'],
-    onReferencedVariableValueChanged: (variable) => {
-      if (this._fieldConfigDependency.hasDependencyOn(variable.state.name)) {
-        this.clearFieldConfigCache();
-      }
+    onReferencedVariableValueChanged: () => {
+      this.clearFieldConfigCache();
       this.forceRender();
     },
-  });
-
-  // Passive scan of fieldConfig only, so title/options-only variable changes skip the cache clear
-  private _fieldConfigDependency = new VariableDependencyConfig(this, {
-    statePaths: ['fieldConfig'],
   });
 
   // Not part of state as this is not serializable

--- a/packages/scenes/src/components/VizPanel/VizPanel.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.tsx
@@ -132,6 +132,17 @@ export class VizPanel<TOptions = {}, TFieldConfig extends {} = {}> extends Scene
 
   protected _variableDependency = new VariableDependencyConfig(this, {
     statePaths: ['title', 'options', 'fieldConfig'],
+    onReferencedVariableValueChanged: (variable) => {
+      if (this._fieldConfigDependency.hasDependencyOn(variable.state.name)) {
+        this.clearFieldConfigCache();
+      }
+      this.forceRender();
+    },
+  });
+
+  // Passive scan of fieldConfig only, so title/options-only variable changes skip the cache clear
+  private _fieldConfigDependency = new VariableDependencyConfig(this, {
+    statePaths: ['fieldConfig'],
   });
 
   // Not part of state as this is not serializable


### PR DESCRIPTION
Fixes an issue where field configs that would support variable interpolation would not properly update on var change due to the field config cache not being invalidated. 

So setting an existing interpolatable field like `displayName` to be a var would interpolate on set, but subsequent var changes would not update the panel.

This fixes that issue and supports this for other field configs that would become interpolatable, e.g.: thresholds.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.13.1--canary.1579.29419019328.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.13.1--canary.1579.29419019328.0
  npm install scenes-app@8.13.1--canary.1579.29419019328.0
  npm install @grafana/scenes-react@8.13.1--canary.1579.29419019328.0
  # or 
  yarn add @grafana/scenes@8.13.1--canary.1579.29419019328.0
  yarn add scenes-app@8.13.1--canary.1579.29419019328.0
  yarn add @grafana/scenes-react@8.13.1--canary.1579.29419019328.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
