### PR TITLE
Filters: propagate scopes and dashboard level filters to section vars

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -679,6 +679,292 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(runRequestCall[1].filters).toEqual([...filtersVar.state.originFilters!, ...filtersVar.state.filters]);
     });
 
+    it('should merge dashboard and section adhoc filters for the same datasource', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const dashboardFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'job', operator: '=', value: 'prom-a', condition: '' }],
+      });
+
+      const sectionFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'instance', operator: '=', value: 'localhost:9090', condition: '' }],
+      });
+
+      const innerScene = new TestScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [dashboardFilters] }),
+        $timeRange: new SceneTimeRange(),
+        nested: innerScene,
+      });
+
+      deactivationHandlers.push(scene.activate());
+      deactivationHandlers.push(innerScene.activate());
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[0];
+      expect(runRequestCall[1].filters).toEqual([
+        ...dashboardFilters.state.filters,
+        ...sectionFilters.state.filters,
+      ]);
+    });
+
+    it('should apply scope filters when only a section adhoc variable exists', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const scopesVariable = new ScopesVariable({
+        scopes: [
+          {
+            metadata: { name: 'Scope 1' },
+            spec: {
+              title: 'Scope 1',
+              type: 'test',
+              description: 'Test scope',
+              category: 'test',
+              filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
+            },
+          },
+        ],
+        loading: false,
+      });
+
+      const sectionFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'instance', operator: '=', value: 'localhost:9090', condition: '' }],
+      });
+
+      const innerScene = new TestScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [scopesVariable] }),
+        $timeRange: new SceneTimeRange(),
+        nested: innerScene,
+      });
+
+      deactivationHandlers.push(scene.activate());
+      deactivationHandlers.push(innerScene.activate());
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[0];
+      expect(runRequestCall[1].filters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: 'cluster', operator: '=', value: 'prod', origin: 'scope' }),
+          expect.objectContaining({ key: 'instance', operator: '=', value: 'localhost:9090' }),
+        ])
+      );
+    });
+
+    it('should not duplicate scope filters when both getScopes and originFilters provide them', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const scopesVariable = new ScopesVariable({
+        scopes: [
+          {
+            metadata: { name: 'Scope 1' },
+            spec: {
+              title: 'Scope 1',
+              type: 'test',
+              description: 'Test scope',
+              category: 'test',
+              filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
+            },
+          },
+        ],
+        loading: false,
+      });
+
+      const sectionFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'instance', operator: '=', value: 'localhost:9090', condition: '' }],
+        originFilters: [
+          { key: 'cluster', operator: '=', value: 'prod', values: ['prod'], origin: 'scope', condition: '' },
+        ],
+      });
+
+      const innerScene = new TestScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [scopesVariable] }),
+        $timeRange: new SceneTimeRange(),
+        nested: innerScene,
+      });
+
+      deactivationHandlers.push(scene.activate());
+      deactivationHandlers.push(innerScene.activate());
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const filters = runRequestMock.mock.calls[0][1].filters as Array<{ key: string; origin?: string }>;
+      expect(filters.filter((f) => f.key === 'cluster' && f.origin === 'scope')).toHaveLength(1);
+    });
+
+    it('should re-run queries when a parent adhoc filter changes', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const dashboardFilters = new AdHocFiltersVariable({
+        name: 'dashFilter',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'job', operator: '=', value: 'prom-a', condition: '' }],
+      });
+
+      const sectionFilters = new AdHocFiltersVariable({
+        name: 'sectionFilter',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'instance', operator: '=', value: 'localhost:9090', condition: '' }],
+      });
+
+      const innerScene = new TestScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [dashboardFilters] }),
+        $timeRange: new SceneTimeRange(),
+        nested: innerScene,
+      });
+
+      deactivationHandlers.push(scene.activate());
+      deactivationHandlers.push(innerScene.activate());
+
+      await new Promise((r) => setTimeout(r, 1));
+      expect(runRequestMock.mock.calls.length).toBe(1);
+
+      dashboardFilters._updateFilter(dashboardFilters.state.filters[0], { value: 'prom-b' });
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(runRequestMock.mock.calls.length).toBe(2);
+      expect(runRequestMock.mock.calls[1][1].filters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: 'job', value: 'prom-b' }),
+          expect.objectContaining({ key: 'instance', value: 'localhost:9090' }),
+        ])
+      );
+    });
+
+    it('should re-run queries when parent and section adhoc share the same name', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const dashboardFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'job', operator: '=', value: 'prom-a', condition: '' }],
+      });
+
+      const sectionFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'instance', operator: '=', value: 'localhost:9090', condition: '' }],
+      });
+
+      const innerScene = new TestScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [dashboardFilters] }),
+        $timeRange: new SceneTimeRange(),
+        nested: innerScene,
+      });
+
+      deactivationHandlers.push(scene.activate());
+      deactivationHandlers.push(innerScene.activate());
+
+      await new Promise((r) => setTimeout(r, 1));
+      expect(runRequestMock.mock.calls.length).toBe(1);
+
+      dashboardFilters._updateFilter(dashboardFilters.state.filters[0], { value: 'prom-b' });
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(runRequestMock.mock.calls.length).toBe(2);
+      expect(runRequestMock.mock.calls[1][1].filters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: 'job', value: 'prom-b' }),
+          expect.objectContaining({ key: 'instance', value: 'localhost:9090' }),
+        ])
+      );
+    });
+
+    it('should not merge adhoc filters from a different datasource', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const otherDsFilters = new AdHocFiltersVariable({
+        name: 'otherFilter',
+        datasource: { uid: 'other-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'job', operator: '=', value: 'other', condition: '' }],
+      });
+
+      const sectionFilters = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'instance', operator: '=', value: 'localhost:9090', condition: '' }],
+      });
+
+      const innerScene = new TestScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [otherDsFilters] }),
+        $timeRange: new SceneTimeRange(),
+        nested: innerScene,
+      });
+
+      deactivationHandlers.push(scene.activate());
+      deactivationHandlers.push(innerScene.activate());
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(runRequestMock.mock.calls[0][1].filters).toEqual(sectionFilters.state.filters);
+    });
+
     it('only passes fully completed adhoc filters', async () => {
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'test-uid' },

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -716,10 +716,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       await new Promise((r) => setTimeout(r, 1));
 
       const runRequestCall = runRequestMock.mock.calls[0];
-      expect(runRequestCall[1].filters).toEqual([
-        ...dashboardFilters.state.filters,
-        ...sectionFilters.state.filters,
-      ]);
+      expect(runRequestCall[1].filters).toEqual([...dashboardFilters.state.filters, ...sectionFilters.state.filters]);
     });
 
     it('should apply scope filters when only a section adhoc variable exists', async () => {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -464,7 +464,8 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
    */
   private onAnyVariableChanged(variable: SceneVariable) {
     if (
-      this._drilldownDependenciesManager.adHocFiltersVar === variable ||
+      (variable instanceof AdHocFiltersVariable &&
+        this._drilldownDependenciesManager.isSubscribedAdHocFiltersVar(variable)) ||
       this._drilldownDependenciesManager.groupByVar === variable ||
       !this.isQueryModeAuto()
     ) {

--- a/packages/scenes/src/variables/DrilldownDependenciesManager.ts
+++ b/packages/scenes/src/variables/DrilldownDependenciesManager.ts
@@ -1,5 +1,5 @@
 import {
-  findClosestAdHocFilterInHierarchy,
+  findAllAdHocFiltersInHierarchy,
   findGlobalAdHocFilterVariableByUid,
 } from '../variables/adhoc/patchGetAdhocFilters';
 import {
@@ -14,8 +14,11 @@ import {
   isFilterComplete,
   isGroupByFilter,
 } from '../variables/adhoc/AdHocFiltersVariable';
+import { getAdHocFiltersFromScopes } from '../variables/adhoc/getAdHocFiltersFromScopes';
 import { VariableDependencyConfig } from '../variables/VariableDependencyConfig';
 import { SceneObject, SceneObjectState } from '../core/types';
+import { getScopes } from '../core/sceneGraph/sceneGraph';
+import { SCOPES_VARIABLE_NAME } from '../variables/constants';
 
 /**
  * Manages ad-hoc filters and group-by variables for data providers.
@@ -23,10 +26,18 @@ import { SceneObject, SceneObjectState } from '../core/types';
  * When the AdHocFiltersVariable has enableGroupBy=true, groupBy keys are sourced
  * from the adhoc filters array (operator === 'groupBy').
  * Otherwise falls back to the legacy GroupByVariable for backwards compatibility.
+ *
+ * Ad-hoc filters from ancestor variable sets (e.g. dashboard-level) are merged with
+ * section-level filters at query time, and scope filters are injected so section
+ * filters do not shadow scopes.
  */
 export class DrilldownDependenciesManager<TState extends SceneObjectState> {
+  /** Closest (section/local) AdHocFiltersVariable — kept for groupBy and callers */
   private _adhocFiltersVar?: AdHocFiltersVariable;
+  /** All matching AdHocFiltersVariables from root → leaf for query-time merge */
+  private _adhocFiltersVars: AdHocFiltersVariable[] = [];
   private _groupByVar?: GroupByVariable;
+  private _sceneObject?: SceneObject;
   private _variableDependency: VariableDependencyConfig<TState>;
 
   public constructor(variableDependency: VariableDependencyConfig<TState>) {
@@ -35,25 +46,35 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
 
   /**
    * Find drilldown variables matching the given datasource UID.
-   * When sceneObject is provided, walks up the hierarchy to find the closest match.
+   * When sceneObject is provided, walks up the hierarchy and collects all matches
+   * so parent filters/scopes can be merged at query time.
    * Otherwise falls back to searching the global active variable sets.
    */
   public findAndSubscribeToDrilldowns(interpolatedUid: string | undefined, sceneObject?: SceneObject) {
-    const filtersVar = sceneObject
-      ? findClosestAdHocFilterInHierarchy(interpolatedUid, sceneObject)
-      : findGlobalAdHocFilterVariableByUid(interpolatedUid);
+    this._sceneObject = sceneObject;
 
-    // Only look for a legacy GroupByVariable when the adhoc var doesn't handle groupBy natively
+    const filtersVars = sceneObject
+      ? findAllAdHocFiltersInHierarchy(interpolatedUid, sceneObject)
+      : (() => {
+          const globalVar = findGlobalAdHocFilterVariableByUid(interpolatedUid);
+          return globalVar ? [globalVar] : [];
+        })();
+
+    // Closest is last in root → leaf order
+    const filtersVar = filtersVars.length > 0 ? filtersVars[filtersVars.length - 1] : undefined;
+
+    // Only look for a legacy GroupByVariable when the closest adhoc var doesn't handle groupBy natively
     const useAdhocGroupBy = filtersVar?.state.enableGroupBy === true;
     const groupByVar = useAdhocGroupBy
       ? undefined
       : sceneObject
-      ? findClosestGroupByInHierarchy(interpolatedUid, sceneObject)
-      : findGlobalGroupByVariableByUid(interpolatedUid);
+        ? findClosestGroupByInHierarchy(interpolatedUid, sceneObject)
+        : findGlobalGroupByVariableByUid(interpolatedUid);
 
     let hasChanges = false;
 
-    if (this._adhocFiltersVar !== filtersVar) {
+    if (!areSameAdHocVars(this._adhocFiltersVars, filtersVars)) {
+      this._adhocFiltersVars = filtersVars;
       this._adhocFiltersVar = filtersVar;
       hasChanges = true;
     }
@@ -71,8 +92,13 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
   private _updateExplicitDrilldownVariableDependencies(): void {
     const explicitDependencies: string[] = [];
 
-    if (this._adhocFiltersVar) {
-      explicitDependencies.push(this._adhocFiltersVar.state.name);
+    for (const filtersVar of this._adhocFiltersVars) {
+      explicitDependencies.push(filtersVar.state.name);
+    }
+
+    // Scope filters are merged into request.filters at query time; re-run when scopes change
+    if (this._adhocFiltersVars.length > 0) {
+      explicitDependencies.push(SCOPES_VARIABLE_NAME);
     }
 
     if (this._groupByVar) {
@@ -86,34 +112,87 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
     return this._adhocFiltersVar;
   }
 
+  public get adHocFiltersVars(): readonly AdHocFiltersVariable[] {
+    return this._adhocFiltersVars;
+  }
+
   public get groupByVar(): GroupByVariable | undefined {
     return this._groupByVar;
   }
 
-  private _getAllFilters(): AdHocFilterWithLabels[] {
-    if (!this._adhocFiltersVar) {
+  public isSubscribedAdHocFiltersVar(variable: AdHocFiltersVariable): boolean {
+    return this._adhocFiltersVars.includes(variable);
+  }
+
+  private _getMergedFilters(): AdHocFilterWithLabels[] {
+    if (this._adhocFiltersVars.length === 0) {
       return [];
     }
-    return [...(this._adhocFiltersVar.state.originFilters ?? []), ...this._adhocFiltersVar.state.filters];
+
+    const fromVars: AdHocFilterWithLabels[] = [];
+    const seen = new Set<string>();
+    const scopeKeysFromVars = new Set<string>();
+
+    // Ancestor then section AdHoc originFilters + filters (root → leaf)
+    for (const filtersVar of this._adhocFiltersVars) {
+      for (const filter of [...(filtersVar.state.originFilters ?? []), ...filtersVar.state.filters]) {
+        const key = filterIdentityKey(filter);
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+        if (filter.origin === 'scope') {
+          scopeKeysFromVars.add(filter.key);
+        }
+        fromVars.push(filter);
+      }
+    }
+
+    // Scope filters from the scene that are not already present on any AdHoc var
+    // (covers section-only AdHoc before originFilters are populated)
+    const fromScopes: AdHocFilterWithLabels[] = [];
+    if (this._sceneObject) {
+      const scopes = getScopes(this._sceneObject);
+      if (scopes?.length) {
+        for (const filter of getAdHocFiltersFromScopes(scopes)) {
+          if (scopeKeysFromVars.has(filter.key)) {
+            continue;
+          }
+          const key = filterIdentityKey(filter);
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          fromScopes.push(filter);
+        }
+      }
+    }
+
+    return [...fromScopes, ...fromVars];
   }
 
   /**
    * Returns only "real" ad-hoc filters, excluding groupBy entries embedded in the filters array.
+   * Merges scope + ancestor + section filters when multiple AdHoc vars exist in the hierarchy.
    */
   public getFilters(): AdHocFilterWithLabels[] | undefined {
-    return this._adhocFiltersVar
-      ? this._getAllFilters().filter((f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f))
-      : undefined;
+    if (this._adhocFiltersVars.length === 0) {
+      return undefined;
+    }
+
+    return this._getMergedFilters().filter(
+      (f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f)
+    );
   }
 
   /**
-   * Returns group-by keys. When the adhoc variable has enableGroupBy=true, extracts
-   * them from the filters array (operator === 'groupBy'). Otherwise falls back to
+   * Returns group-by keys. When the closest adhoc variable has enableGroupBy=true, extracts
+   * them from that variable's filters array (operator === 'groupBy'). Otherwise falls back to
    * the legacy GroupByVariable.
    */
   public getGroupByKeys(): string[] | undefined {
     if (this._adhocFiltersVar?.state.enableGroupBy) {
-      const groupByKeys = this._getAllFilters()
+      const groupByKeys = [...(this._adhocFiltersVar.state.originFilters ?? []), ...this._adhocFiltersVar.state.filters]
         .filter((f) => isGroupByFilter(f) && isFilterComplete(f) && isFilterApplicable(f))
         .map((f) => f.key);
 
@@ -125,6 +204,22 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
 
   public cleanup(): void {
     this._adhocFiltersVar = undefined;
+    this._adhocFiltersVars = [];
     this._groupByVar = undefined;
+    this._sceneObject = undefined;
   }
+}
+
+function areSameAdHocVars(a: AdHocFiltersVariable[], b: AdHocFiltersVariable[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((v, i) => v === b[i]);
+}
+
+function filterIdentityKey(filter: AdHocFilterWithLabels): string {
+  const values = filter.values?.join(',') ?? filter.value;
+  // Scope filters dedupe by key/operator/value so they are not applied twice when
+  // both getScopes() and a variable's originFilters contain the same scope filter.
+  return `${filter.origin ?? ''}|${filter.key}|${filter.operator}|${values}`;
 }

--- a/packages/scenes/src/variables/DrilldownDependenciesManager.ts
+++ b/packages/scenes/src/variables/DrilldownDependenciesManager.ts
@@ -68,8 +68,8 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
     const groupByVar = useAdhocGroupBy
       ? undefined
       : sceneObject
-        ? findClosestGroupByInHierarchy(interpolatedUid, sceneObject)
-        : findGlobalGroupByVariableByUid(interpolatedUid);
+      ? findClosestGroupByInHierarchy(interpolatedUid, sceneObject)
+      : findGlobalGroupByVariableByUid(interpolatedUid);
 
     let hasChanges = false;
 
@@ -180,9 +180,7 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
       return undefined;
     }
 
-    return this._getMergedFilters().filter(
-      (f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f)
-    );
+    return this._getMergedFilters().filter((f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f));
   }
 
   /**

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1817,6 +1817,82 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     }
   );
 
+  it('injects already-selected scopes into originFilters on activation', () => {
+    const scopes: Scope[] = [
+      {
+        metadata: { name: 'Scope' },
+        spec: {
+          title: 'Scope',
+          type: 'test',
+          description: 'Test scope',
+          category: 'test',
+          filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
+        },
+      },
+    ];
+
+    const scopesVar = new ScopesVariable({
+      scopes,
+      loading: false,
+    });
+
+    const { filtersVar } = setup({ filters: [], originFilters: [] }, undefined, scopesVar);
+
+    expect(filtersVar.state.originFilters).toEqual([
+      expect.objectContaining({
+        key: 'cluster',
+        operator: '=',
+        value: 'prod',
+        origin: 'scope',
+      }),
+    ]);
+  });
+
+  it('does not inject scopes into originFilters for nested (section) AdHoc variables', () => {
+    const scopes: Scope[] = [
+      {
+        metadata: { name: 'Scope' },
+        spec: {
+          title: 'Scope',
+          type: 'test',
+          description: 'Test scope',
+          category: 'test',
+          filters: [{ key: 'service', operator: 'equals', value: 'workers' }],
+        },
+      },
+    ];
+
+    const scopesVar = new ScopesVariable({
+      scopes,
+      loading: false,
+    });
+
+    const sectionFilters = new AdHocFiltersVariable({
+      name: 'filter0',
+      datasource: { uid: 'Prometheus' },
+      filters: [{ key: 'cluster', operator: '=', value: 'us-east', condition: '' }],
+      originFilters: [],
+    });
+
+    // Row/section: nested $variables under a child scene object
+    const section = new SceneFlexItem({
+      body: new SceneCanvasText({ text: 'section' }),
+      $variables: new SceneVariableSet({ variables: [sectionFilters] }),
+    });
+
+    const scene = new EmbeddedScene({
+      $variables: new SceneVariableSet({ variables: [scopesVar] }),
+      body: new SceneFlexLayout({ children: [section] }),
+    });
+
+    activateFullSceneTree(scene);
+
+    expect(sectionFilters.state.originFilters?.some((f) => f.origin === 'scope')).toBeFalsy();
+    expect(sectionFilters.state.filters).toEqual([
+      expect.objectContaining({ key: 'cluster', value: 'us-east' }),
+    ]);
+  });
+
   it('Removes scope originated filters when scopes themselves are removed', () => {
     const scopes: Scope[] = [
       {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1848,6 +1848,71 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     ]);
   });
 
+  it('preserves edited scope originFilters across deactivate/reactivate when parent stays active', () => {
+    const scopes: Scope[] = [
+      {
+        metadata: { name: 'Scope' },
+        spec: {
+          title: 'Scope',
+          filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
+        },
+      },
+    ];
+
+    const scopesVar = new ScopesVariable({
+      scopes,
+      loading: false,
+    });
+
+    const filtersVar = new AdHocFiltersVariable({
+      name: 'filters',
+      datasource: { uid: 'Prometheus' },
+      filters: [],
+      originFilters: [],
+    });
+
+    const scene = new EmbeddedScene({
+      $variables: new SceneVariableSet({ variables: [scopesVar, filtersVar] }),
+      body: new SceneFlexLayout({ children: [] }),
+    });
+
+    // Activate scene (and variable set) separately from the AdHoc so we can
+    // simulate panel-edit: AdHoc unmounts while the set stays active.
+    scene.activate();
+    scopesVar.activate();
+    const deactivateFilters = filtersVar.activate();
+
+    expect(filtersVar.state.originFilters).toEqual([
+      expect.objectContaining({ key: 'cluster', value: 'prod', origin: 'scope' }),
+    ]);
+
+    act(() => {
+      filtersVar._updateFilter(filtersVar.state.originFilters![0], {
+        value: 'staging',
+        valueLabels: ['staging'],
+      });
+    });
+
+    expect(filtersVar.state.originFilters![0]).toEqual(
+      expect.objectContaining({ key: 'cluster', value: 'staging', origin: 'scope', restorable: true })
+    );
+
+    expect(filtersVar.parent?.isActive).toBe(true);
+    deactivateFilters();
+
+    expect(filtersVar.isActive).toBe(false);
+    expect(filtersVar.parent?.isActive).toBe(true);
+    expect(filtersVar.state.originFilters![0].value).toBe('staging');
+
+    act(() => {
+      filtersVar.activate();
+    });
+
+    expect(filtersVar.state.originFilters![0]).toEqual(
+      expect.objectContaining({ key: 'cluster', value: 'staging', origin: 'scope', restorable: true })
+    );
+  });
+
   it('does not inject scopes into originFilters for nested (section) AdHoc variables', () => {
     const scopes: Scope[] = [
       {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1888,9 +1888,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     activateFullSceneTree(scene);
 
     expect(sectionFilters.state.originFilters?.some((f) => f.origin === 'scope')).toBeFalsy();
-    expect(sectionFilters.state.filters).toEqual([
-      expect.objectContaining({ key: 'cluster', value: 'us-east' }),
-    ]);
+    expect(sectionFilters.state.filters).toEqual([expect.objectContaining({ key: 'cluster', value: 'us-east' })]);
   });
 
   it('Removes scope originated filters when scopes themselves are removed', () => {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -60,6 +60,14 @@ function setTemplateSrvWithFilters(filters: AdHocVariableFilter[]): AdHocVariabl
   return filters;
 }
 
+/** CI @grafana/data still requires type/description/category; newer Grafana dropped them. */
+function testScope(name: string, filters: ScopeSpecFilter[]): Scope {
+  return {
+    metadata: { name },
+    spec: { title: name, filters },
+  } as Scope;
+}
+
 const getKeyComboboxElement = () => getAllByRole(screen.getByTestId('AdHocFilter-'), 'combobox')[0];
 const getAdHocInputElement = () => screen.getByPlaceholderText('+ label = value');
 
@@ -1785,13 +1793,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const scopes: Scope[] = [];
 
       for (let i = 0; i < scopeFilters.length; i++) {
-        scopes.push({
-          metadata: { name: `Scope ${i}` },
-          spec: {
-            title: `Scope ${i}`,
-            filters: scopeFilters[i] as ScopeSpecFilter[],
-          },
-        });
+        scopes.push(testScope(`Scope ${i}`, scopeFilters[i] as ScopeSpecFilter[]));
       }
       const scopesVar = new ScopesVariable({});
 
@@ -1815,15 +1817,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   );
 
   it('injects already-selected scopes into originFilters on activation', () => {
-    const scopes: Scope[] = [
-      {
-        metadata: { name: 'Scope' },
-        spec: {
-          title: 'Scope',
-          filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
-        },
-      },
-    ];
+    const scopes: Scope[] = [testScope('Scope', [{ key: 'cluster', operator: 'equals', value: 'prod' }])];
 
     const scopesVar = new ScopesVariable({
       scopes,
@@ -1843,15 +1837,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('preserves edited scope originFilters across deactivate/reactivate when parent stays active', () => {
-    const scopes: Scope[] = [
-      {
-        metadata: { name: 'Scope' },
-        spec: {
-          title: 'Scope',
-          filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
-        },
-      },
-    ];
+    const scopes: Scope[] = [testScope('Scope', [{ key: 'cluster', operator: 'equals', value: 'prod' }])];
 
     const scopesVar = new ScopesVariable({
       scopes,
@@ -1908,15 +1894,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('does not inject scopes into originFilters for nested (section) AdHoc variables', () => {
-    const scopes: Scope[] = [
-      {
-        metadata: { name: 'Scope' },
-        spec: {
-          title: 'Scope',
-          filters: [{ key: 'service', operator: 'equals', value: 'workers' }],
-        },
-      },
-    ];
+    const scopes: Scope[] = [testScope('Scope', [{ key: 'service', operator: 'equals', value: 'workers' }])];
 
     const scopesVar = new ScopesVariable({
       scopes,
@@ -1948,15 +1926,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
   });
 
   it('Removes scope originated filters when scopes themselves are removed', () => {
-    const scopes: Scope[] = [
-      {
-        metadata: { name: `Scope` },
-        spec: {
-          title: `Scope`,
-          filters: [{ key: 'scopeOriginFilter', operator: 'equals', value: 'val' }],
-        },
-      },
-    ];
+    const scopes: Scope[] = [testScope('Scope', [{ key: 'scopeOriginFilter', operator: 'equals', value: 'val' }])];
 
     const scopesVar = new ScopesVariable({ scopes });
     const { filtersVar } = setup(
@@ -3974,15 +3944,7 @@ function setup(
 }
 
 function newScopesVariableFromScopeFilters(filters: ScopeSpecFilter[]) {
-  const scopes: Scope[] = [
-    {
-      metadata: { name: `Scope 1` },
-      spec: {
-        title: `Scope 1`,
-        filters,
-      },
-    },
-  ];
+  const scopes: Scope[] = [testScope('Scope 1', filters)];
 
   const scopesVar = new ScopesVariable({});
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1789,9 +1789,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
           metadata: { name: `Scope ${i}` },
           spec: {
             title: `Scope ${i}`,
-            type: 'test',
-            description: 'Test scope',
-            category: 'test',
             filters: scopeFilters[i] as ScopeSpecFilter[],
           },
         });
@@ -1823,9 +1820,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         metadata: { name: 'Scope' },
         spec: {
           title: 'Scope',
-          type: 'test',
-          description: 'Test scope',
-          category: 'test',
           filters: [{ key: 'cluster', operator: 'equals', value: 'prod' }],
         },
       },
@@ -1919,9 +1913,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         metadata: { name: 'Scope' },
         spec: {
           title: 'Scope',
-          type: 'test',
-          description: 'Test scope',
-          category: 'test',
           filters: [{ key: 'service', operator: 'equals', value: 'workers' }],
         },
       },
@@ -1962,9 +1953,6 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         metadata: { name: `Scope` },
         spec: {
           title: `Scope`,
-          type: 'test',
-          description: 'Test scope',
-          category: 'test',
           filters: [{ key: 'scopeOriginFilter', operator: 'equals', value: 'val' }],
         },
       },
@@ -3991,9 +3979,6 @@ function newScopesVariableFromScopeFilters(filters: ScopeSpecFilter[]) {
       metadata: { name: `Scope 1` },
       spec: {
         title: `Scope 1`,
-        type: 'test',
-        description: 'Test scope',
-        category: 'test',
         filters,
       },
     },

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -4,7 +4,6 @@ import {
   GetTagResponse,
   GrafanaTheme2,
   MetricFindValue,
-  // @ts-expect-error (temporary till we update grafana/data)
   DrilldownsApplicability,
   Scope,
   SelectableValue,
@@ -1052,12 +1051,14 @@ export class AdHocFiltersVariable
     groupByKeys?: string[]
   ): Promise<DrilldownsApplicability[] | undefined> {
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);
+    // @ts-expect-error (temporary till we update grafana/data)
     if (!ds || !ds.getDrilldownsApplicability) {
       return;
     }
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
 
+    // @ts-expect-error (temporary till we update grafana/data)
     return await ds.getDrilldownsApplicability({
       filters,
       queries,
@@ -1229,6 +1230,7 @@ export class AdHocFiltersVariable
     }
 
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);
+    // @ts-expect-error (TODO: remove after upgrading with https://github.com/grafana/grafana/pull/118270)
     if (!ds || !ds.getGroupByKeys) {
       return override ? dataFromResponse(override.values).map(toSelectableValue) : [];
     }
@@ -1239,6 +1241,7 @@ export class AdHocFiltersVariable
     const queriesForKeys =
       queries ?? (this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined);
 
+    // @ts-expect-error (TODO: remove after upgrading with https://github.com/grafana/grafana/pull/118270)
     const response = await ds.getGroupByKeys({
       filters: [],
       queries: queriesForKeys,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -4,6 +4,7 @@ import {
   GetTagResponse,
   GrafanaTheme2,
   MetricFindValue,
+  // @ts-expect-error (temporary till we update grafana/data)
   DrilldownsApplicability,
   Scope,
   SelectableValue,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -361,10 +361,14 @@ export class AdHocFiltersVariable
     // (same as dashboard filters: background merge, not shown in the section UI).
     if (isNestedVariableSetMember(this)) {
       this._clearScopeOriginFilters();
-    } else if (sceneGraph.getScopes(this)?.length) {
-      // If scopes are already selected (activated after scopes), inject them now.
-      // Skip when scopes are empty so we do not clear pre-seeded / edited scope
-      // originFilters before scopes load.
+    } else if (
+      sceneGraph.getScopes(this)?.length &&
+      !this.state.originFilters?.some((filter) => filter.origin === 'scope')
+    ) {
+      // Late activation: scopes already selected but UI never got pills yet.
+      // Do not re-run when scope originFilters already exist — otherwise panel-edit
+      // deactivate/reactivate hits the _prevScopes path and clobbers edited values.
+      // Ongoing scope changes are handled by onReferencedVariableValueChanged.
       this._updateScopesFilters();
     }
     this._debouncedVerifyApplicability();
@@ -1048,14 +1052,12 @@ export class AdHocFiltersVariable
     groupByKeys?: string[]
   ): Promise<DrilldownsApplicability[] | undefined> {
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);
-    // @ts-expect-error (temporary till we update grafana/data)
     if (!ds || !ds.getDrilldownsApplicability) {
       return;
     }
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
 
-    // @ts-expect-error (temporary till we update grafana/data)
     return await ds.getDrilldownsApplicability({
       filters,
       queries,
@@ -1227,7 +1229,6 @@ export class AdHocFiltersVariable
     }
 
     const ds = await this._dataSourceSrv.get(this.state.datasource, this._scopedVars);
-    // @ts-expect-error (TODO: remove after upgrading with https://github.com/grafana/grafana/pull/118270)
     if (!ds || !ds.getGroupByKeys) {
       return override ? dataFromResponse(override.values).map(toSelectableValue) : [];
     }
@@ -1238,7 +1239,6 @@ export class AdHocFiltersVariable
     const queriesForKeys =
       queries ?? (this.state.useQueriesAsFilterForOptions ? getQueriesForVariables(this) : undefined);
 
-    // @ts-expect-error (TODO: remove after upgrading with https://github.com/grafana/grafana/pull/118270)
     const response = await ds.getGroupByKeys({
       filters: [],
       queries: queriesForKeys,

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -11,7 +11,7 @@ import {
 } from '@grafana/data';
 import { SceneObjectBase } from '../../core/SceneObjectBase';
 import { SceneVariable, SceneVariableState, SceneVariableValueChangedEvent, VariableValue } from '../types';
-import { ControlsLayout, SceneComponentProps, SceneDataQuery } from '../../core/types';
+import { ControlsLayout, SceneComponentProps, SceneDataQuery, SceneObject } from '../../core/types';
 import { DataSourceRef } from '@grafana/schema';
 import {
   dataFromResponse,
@@ -356,6 +356,17 @@ export class AdHocFiltersVariable
   }
 
   private _activationHandler = () => {
+    // Dashboard-level AdHoc shows scopes as originFilters in the filter bar.
+    // Section AdHoc must not — scopes apply at query time via DrilldownDependenciesManager
+    // (same as dashboard filters: background merge, not shown in the section UI).
+    if (isNestedVariableSetMember(this)) {
+      this._clearScopeOriginFilters();
+    } else if (sceneGraph.getScopes(this)?.length) {
+      // If scopes are already selected (activated after scopes), inject them now.
+      // Skip when scopes are empty so we do not clear pre-seeded / edited scope
+      // originFilters before scopes load.
+      this._updateScopesFilters();
+    }
     this._debouncedVerifyApplicability();
 
     return () => {
@@ -380,7 +391,23 @@ export class AdHocFiltersVariable
     return this._recommendations;
   }
 
+  private _clearScopeOriginFilters() {
+    if (!this.state.originFilters?.some((filter) => filter.origin === 'scope')) {
+      return;
+    }
+    this.setState({
+      originFilters: this.state.originFilters.filter((filter) => filter.origin !== 'scope'),
+    });
+  }
+
   private _updateScopesFilters() {
+    // Section / nested AdHoc: keep scopes out of originFilters (and thus the combobox UI).
+    // DrilldownDependenciesManager merges getScopes() into request.filters at query time.
+    if (isNestedVariableSetMember(this)) {
+      this._clearScopeOriginFilters();
+      return;
+    }
+
     const scopes = sceneGraph.getScopes(this);
 
     if (!scopes || !scopes.length) {
@@ -1422,6 +1449,22 @@ export const VALUE_KEY_DELIMITER = '::';
 
 export function isGroupByFilter(filter: AdHocFilterWithLabels): boolean {
   return filter.operator === GROUP_BY_OPERATOR;
+}
+
+/**
+ * True when this object lives under a nested SceneVariableSet (e.g. row/tab section
+ * variables). Looks for an ancestor `$variables` that is not this variable's own set.
+ */
+export function isNestedVariableSetMember(sceneObject: SceneObject): boolean {
+  const ownSet = sceneObject.parent;
+  let current = ownSet?.parent;
+  while (current) {
+    if (current.state.$variables && current.state.$variables !== ownSet) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
 }
 
 export function isFilterComplete(filter: AdHocFilterWithLabels): boolean {

--- a/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+++ b/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
@@ -54,18 +54,37 @@ export function findClosestAdHocFilterInHierarchy(
   dsUid: string | undefined,
   sceneObject: SceneObject
 ): AdHocFiltersVariable | undefined {
+  const all = findAllAdHocFiltersInHierarchy(dsUid, sceneObject);
+  // findAll returns root → leaf; closest is the last entry
+  return all.length > 0 ? all[all.length - 1] : undefined;
+}
+
+/**
+ * Walk up the scene graph from sceneObject and collect every AdHocFiltersVariable
+ * whose interpolated datasource UID matches dsUid.
+ *
+ * Returns variables in root → leaf order (dashboard first, then section). Use this
+ * when query-time filter merge should apply parent filters alongside section filters.
+ */
+export function findAllAdHocFiltersInHierarchy(
+  dsUid: string | undefined,
+  sceneObject: SceneObject
+): AdHocFiltersVariable[] {
+  const found: AdHocFiltersVariable[] = [];
   let current: SceneObject | undefined = sceneObject;
+
   while (current) {
     const variables = current.state.$variables?.state.variables ?? [];
     for (const variable of variables) {
       if (variable instanceof AdHocFiltersVariable && interpolate(variable, variable.state.datasource?.uid) === dsUid) {
-        return variable;
+        found.push(variable);
       }
     }
     current = current.parent;
   }
 
-  return undefined;
+  // Walk collected leaf → root; reverse so callers merge root first
+  return found.reverse();
 }
 
 /**

--- a/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.test.tsx
@@ -18,6 +18,7 @@ import { TestObjectWithVariableDependency, TestScene } from '../TestScene';
 import { activateFullSceneTree } from '../../utils/test/activateFullSceneTree';
 import { SceneVariable, SceneVariableState, VariableValue } from '../types';
 import { ObjectVariable } from '../variants/ObjectVariable';
+import { AdHocFiltersVariable } from '../adhoc/AdHocFiltersVariable';
 
 interface SceneTextItemState extends SceneObjectState {
   text: string;
@@ -1003,6 +1004,82 @@ describe('SceneVariableList', () => {
 
       // Change B while C is loading (They are on different levels but should behave the same as with A & B)
       expect(C.state.value).toBe('ABBA');
+    });
+  });
+
+  describe('When nested AdHoc shares name with parent AdHoc', () => {
+    it('notifies section dependents when parent AdHoc has the same datasource', () => {
+      const parentAdHoc = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'prom' },
+        filters: [{ key: 'env', operator: '=', value: 'prod', condition: '' }],
+      });
+      const sectionAdHoc = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'prom' },
+        filters: [{ key: 'cluster', operator: '=', value: 'us-east', condition: '' }],
+      });
+      const nestedObj = new TestObjectWithVariableDependency({
+        title: '$filter0',
+        variableValueChanged: 0,
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [parentAdHoc] }),
+        nested: new TestScene({
+          $variables: new SceneVariableSet({ variables: [sectionAdHoc] }),
+          nested: nestedObj,
+        }),
+      });
+
+      scene.activate();
+      scene.state.nested!.activate();
+      nestedObj.activate();
+
+      act(() => {
+        parentAdHoc.setState({
+          filters: [{ key: 'env', operator: '=', value: 'staging', condition: '' }],
+        });
+      });
+
+      expect(nestedObj.state.variableValueChanged).toBe(1);
+    });
+
+    it('does not notify section dependents when parent AdHoc has a different datasource', () => {
+      const parentAdHoc = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'prom' },
+        filters: [{ key: 'env', operator: '=', value: 'prod', condition: '' }],
+      });
+      const sectionAdHoc = new AdHocFiltersVariable({
+        name: 'filter0',
+        datasource: { uid: 'loki' },
+        filters: [{ key: 'cluster', operator: '=', value: 'us-east', condition: '' }],
+      });
+      const nestedObj = new TestObjectWithVariableDependency({
+        title: '$filter0',
+        variableValueChanged: 0,
+      });
+
+      const scene = new TestScene({
+        $variables: new SceneVariableSet({ variables: [parentAdHoc] }),
+        nested: new TestScene({
+          $variables: new SceneVariableSet({ variables: [sectionAdHoc] }),
+          nested: nestedObj,
+        }),
+      });
+
+      scene.activate();
+      scene.state.nested!.activate();
+      nestedObj.activate();
+
+      act(() => {
+        parentAdHoc.setState({
+          filters: [{ key: 'env', operator: '=', value: 'staging', condition: '' }],
+        });
+      });
+
+      expect(nestedObj.state.variableValueChanged).toBe(0);
     });
   });
 });

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -13,6 +13,7 @@ import {
   SceneVariableValueChangedEvent,
 } from '../types';
 import { VariableValueRecorder } from '../VariableValueRecorder';
+import { AdHocFiltersVariable } from '../adhoc/AdHocFiltersVariable';
 
 export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> implements SceneVariables {
   /** Variables that are scheduled to be validated and updated */
@@ -340,7 +341,12 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
       if (localVar?.isAncestorLoading) {
         variable = localVar;
       } else if (localVar) {
-        return;
+        // AdHoc filters merge across hierarchy at query time (section + dashboard + scopes).
+        // Continue notifying dependents so parent AdHoc changes still re-run section queries
+        // even when the section defines an AdHoc with the same name (e.g. filter0).
+        if (!(variable instanceof AdHocFiltersVariable && localVar instanceof AdHocFiltersVariable)) {
+          return;
+        }
       }
     }
 

--- a/packages/scenes/src/variables/sets/SceneVariableSet.ts
+++ b/packages/scenes/src/variables/sets/SceneVariableSet.ts
@@ -344,7 +344,14 @@ export class SceneVariableSet extends SceneObjectBase<SceneVariableSetState> imp
         // AdHoc filters merge across hierarchy at query time (section + dashboard + scopes).
         // Continue notifying dependents so parent AdHoc changes still re-run section queries
         // even when the section defines an AdHoc with the same name (e.g. filter0).
-        if (!(variable instanceof AdHocFiltersVariable && localVar instanceof AdHocFiltersVariable)) {
+        // Only pierce the shadow when datasources match — different-DS AdHocs do not merge,
+        // and continuing notify would needlessly re-run section queries on name collision.
+        if (
+          !(variable instanceof AdHocFiltersVariable) ||
+          !(localVar instanceof AdHocFiltersVariable) ||
+          sceneGraph.interpolate(variable, variable.state.datasource?.uid) !==
+            sceneGraph.interpolate(localVar, localVar.state.datasource?.uid)
+        ) {
           return;
         }
       }


### PR DESCRIPTION
## Summary

When a row/tab has its own filter variable, queries under that section previously used only the closest AdHoc (`findClosestAdHocFilterInHierarchy`). Dashboard filters and scope-origin filters were dropped, so panels lost scopes / parent filters (Automon-like “section filters only” broke).

This PR implements a proposal to apply scope + dashboard filters to section filters when **executing queries** only — do not merge them into the section filter UI.

Fixes https://github.com/grafana/hyperion-planning/issues/660

### Demo

https://github.com/user-attachments/assets/6a6b1de1-e7cb-42d7-8a20-4c54b3eba018

### Changes
- Collect all same-DS AdHoc variables up the scene hierarchy and merge filters at query time in `DrilldownDependenciesManager` (ancestor → section), plus scopes from `getScopes()` so scopes still apply with section-only AdHoc.
- Keep scopes out of nested (section) AdHoc `originFilters` so they don’t appear as pills in the section filter bar (dashboard filter bar still shows scopes).
- Continue notifying dependents when a parent AdHoc shares a name with a section AdHoc (`filter0`), so parent filter changes re-run section queries.
- Inject scopes into dashboard-level AdHoc `originFilters` on activation when scopes are already selected.

## Test plan
- [x] Manual: dashboard with scopes + section filter — section UI shows only section filters; query `request.filters` includes scopes + dashboard + section
- [x] Manual: section filter only (no dashboard AdHoc) — scopes still applied to queries
- [x] Manual: section group-by only — scopes still work (regression)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.13.1--canary.1582.29536064356.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.13.1--canary.1582.29536064356.0
  npm install scenes-app@8.13.1--canary.1582.29536064356.0
  npm install @grafana/scenes-react@8.13.1--canary.1582.29536064356.0
  # or 
  yarn add @grafana/scenes@8.13.1--canary.1582.29536064356.0
  yarn add scenes-app@8.13.1--canary.1582.29536064356.0
  yarn add @grafana/scenes-react@8.13.1--canary.1582.29536064356.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
