### PR TITLE
SceneTimeRangeCompare: make timeShiftAlignmentProcessor non-mutating and export it

### DIFF
--- a/packages/scenes-app/src/demos/index.ts
+++ b/packages/scenes-app/src/demos/index.ts
@@ -20,6 +20,7 @@ import { getRuntimeDataSourceDemo } from './runtimeDataSourceDemo';
 import { getDocsExamples } from './docs-examples';
 import { getTimeRangeComparisonTest } from './timeRangeComparison';
 import { getTimeCompareManyPanels } from './timeCompareManyPanels';
+import { getTimeCompareStreamingDemo } from './timeCompareStreamingDemo';
 import { getCursorSyncTest } from './cursorSync';
 import { getAnnotationsDemo } from './annotations';
 import { getAdhocFiltersDemo } from './adhocFiltersDemo';
@@ -204,6 +205,13 @@ export function getDemos(): DemoDescriptor[] {
       description: 'Performance test with per panel time compare and many panels ',
       getPage: getTimeCompareManyPanels,
       getSourceCodeModule: () => import('!!raw-loader!../demos/timeCompareManyPanels'),
+    },
+    {
+      title: 'Time compare + streaming duplicate series (regression demo)',
+      description:
+        'Reproduces the timeCompare duplicate-series bug on streaming/split-chunk queries (e.g. Loki). See grafana/scenes#1554.',
+      getPage: getTimeCompareStreamingDemo,
+      getSourceCodeModule: () => import('!!raw-loader!../demos/timeCompareStreamingDemo'),
     },
     {
       title: 'Data layers',

--- a/packages/scenes-app/src/demos/timeCompareStreamingDemo.tsx
+++ b/packages/scenes-app/src/demos/timeCompareStreamingDemo.tsx
@@ -1,0 +1,140 @@
+import { Observable, timer } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+
+import {
+  DataFrame,
+  DataQueryRequest,
+  DataQueryResponse,
+  FieldType,
+  TestDataSourceResponse,
+  toDataFrame,
+} from '@grafana/data';
+import { LoadingState } from '@grafana/schema';
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  RuntimeDataSource,
+  SceneAppPage,
+  SceneAppPageState,
+  SceneControlsSpacer,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneQueryRunner,
+  SceneRefreshPicker,
+  SceneTimePicker,
+  SceneTimeRange,
+  SceneTimeRangeCompare,
+  sceneUtils,
+} from '@grafana/scenes';
+
+const DATASOURCE_TYPE = 'timecompare-streaming-repro';
+const DATASOURCE_UID = 'timecompare-streaming-repro-uid';
+const NUM_CHUNKS = 8;
+const CHUNK_INTERVAL_MS = 200;
+
+/**
+ * Regression demo for the timeCompare + streaming duplicate-series bug (see grafana/scenes#1554,
+ * which changed forkJoin->combineLatest and made this reachable).
+ *
+ * Real Loki split queries stream several partial responses per query, merging each new chunk into
+ * a running accumulator keyed by refId+name (see the Loki datasource's combineResponses/mergeFrames) -
+ * the frame object handed to any downstream consumer for a given refId is the SAME object across
+ * chunks, just extended with more data. This datasource fakes that same shape: one frame per query,
+ * reused by reference and appended to on every emission, instead of a fresh frame each time.
+ *
+ * With the (fixed) non-mutating timeShiftAlignmentProcessor, every chunk computes the same
+ * "A-compare" identity from the untouched input frame, so the panel always shows exactly one
+ * comparison series. With the old, mutating processor, the shared frame's refId gets rewritten
+ * ("A" -> "A-compare" -> "A-compare-compare" -> ...) on every chunk, so each chunk looks like a
+ * brand new series to the legend/renderer and duplicates accumulate instead of being replaced.
+ */
+class TimeCompareStreamingRepro extends RuntimeDataSource {
+  query(request: DataQueryRequest): Observable<DataQueryResponse> {
+    const from = request.range.from.valueOf();
+    const to = request.range.to.valueOf();
+    const step = (to - from) / NUM_CHUNKS;
+
+    // Held across emissions of this one query() call - this is the accumulator. Its frame object
+    // identity never changes across chunks, only its contents grow, mirroring combineResponses.
+    let accumulated: DataFrame | undefined;
+
+    return timer(0, CHUNK_INTERVAL_MS).pipe(
+      take(NUM_CHUNKS),
+      map((i) => {
+        const time = from + step * (i + 1);
+        // Value is a continuous function of the timestamp so the shifted comparison query returns
+        // visibly different data for ANY compare offset. (A range-derived base aliases: e.g. a
+        // previous-period shift of 24h with a 12h modulus lands on the same value.) The 1.7h
+        // angular scale keeps common offsets (1h/24h/7d) well away from the sine's period.
+        const value = 10 + 5 * Math.sin(time / (60 * 60 * 1000) / 1.7);
+
+        if (!accumulated) {
+          accumulated = toDataFrame({
+            refId: request.targets[0]?.refId ?? 'A',
+            fields: [
+              { name: 'Time', type: FieldType.time, values: [time] },
+              { name: 'Value', type: FieldType.number, values: [value] },
+            ],
+          });
+        } else {
+          accumulated.fields[0].values.push(time);
+          accumulated.fields[1].values.push(value);
+        }
+
+        return {
+          key: request.requestId,
+          state: i === NUM_CHUNKS - 1 ? LoadingState.Done : LoadingState.Streaming,
+          data: [accumulated],
+        };
+      })
+    );
+  }
+
+  testDatasource(): Promise<TestDataSourceResponse> {
+    return Promise.resolve({ status: 'success', message: 'OK' });
+  }
+}
+
+export function getTimeCompareStreamingDemo(defaults: SceneAppPageState) {
+  sceneUtils.registerRuntimeDataSource({
+    dataSource: new TimeCompareStreamingRepro(DATASOURCE_TYPE, DATASOURCE_UID),
+  });
+
+  return new SceneAppPage({
+    ...defaults,
+    getScene: () => {
+      return new EmbeddedScene({
+        $timeRange: new SceneTimeRange({}),
+        controls: [
+          new SceneControlsSpacer(),
+          new SceneTimePicker({}),
+          // Comparison on by default - the whole point of this demo is watching the compare
+          // series stay singular while chunks stream in.
+          new SceneTimeRangeCompare({ compareWith: '__previousPeriod' }),
+          new SceneRefreshPicker({}),
+        ],
+        body: new SceneFlexLayout({
+          children: [
+            new SceneFlexItem({
+              minHeight: 400,
+              body: PanelBuilders.timeseries()
+                .setTitle('timeCompare + streaming duplicate series (regression demo)')
+                .setDescription(
+                  'Comparison is on by default. Each streamed chunk reuses the same frame ' +
+                    'object, like a Loki split query. On unfixed code the legend accumulates duplicate ' +
+                    '"(comparison)" entries per chunk; on fixed code it always shows exactly one.'
+                )
+                .setData(
+                  new SceneQueryRunner({
+                    datasource: { uid: DATASOURCE_UID, type: DATASOURCE_TYPE },
+                    queries: [{ refId: 'A' }],
+                  })
+                )
+                .build(),
+            }),
+          ],
+        }),
+      });
+    },
+  });
+}

--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
@@ -533,5 +533,22 @@ describe('SceneTimeRangeCompare', () => {
       expect(result.series).toHaveLength(1);
       expect(result.series[0].refId).toBe('A-compare');
     });
+
+    it('should not double-suffix frames whose refId already carries -compare', async () => {
+      // Consumers may pre-suffix the compare request's target refIds at request time (for cache
+      // identity), so response frames arrive already carrying -compare. Re-applying the suffix
+      // here must be idempotent.
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+      const comparer = new SceneTimeRangeCompare({ compareWith: '24h' });
+      const processor = getProcessor(comparer, timeRange);
+
+      const frame = toDataFrame({ refId: 'A-compare', fields: [] });
+      const primary = makePanelData('2024-01-10T00:00:00.000Z', '2024-01-10T01:00:00.000Z');
+      const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [frame]);
+
+      const result = await lastValueFrom(processor(primary, secondary));
+
+      expect(result.series[0].refId).toBe('A-compare');
+    });
   });
 });

--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
@@ -6,6 +6,24 @@ import { NO_COMPARE_OPTION, PREVIOUS_PERIOD_COMPARE_OPTION, SceneTimeRangeCompar
 import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import React from 'react';
+import { lastValueFrom } from 'rxjs';
+import { DataQueryRequest, LoadingState, PanelData, dateTime, toDataFrame } from '@grafana/data';
+
+const makeRequest = (range: SceneTimeRange): DataQueryRequest =>
+  ({
+    range: range.state.value,
+    targets: [{ refId: 'A' }],
+  } as unknown as DataQueryRequest);
+
+const makePanelData = (from: string, to: string, series: PanelData['series'] = []): PanelData => {
+  const fromTime = dateTime(from);
+  const toTime = dateTime(to);
+  return {
+    state: LoadingState.Done,
+    series,
+    timeRange: { from: fromTime, to: toTime, raw: { from: fromTime, to: toTime } },
+  };
+};
 
 describe('SceneTimeRangeCompare', () => {
   describe('given a time range', () => {
@@ -461,6 +479,59 @@ describe('SceneTimeRangeCompare', () => {
       // Should clear comparison when NO_PERIOD_VALUE is passed
       comparer.onCompareWithChanged('__noPeriod');
       expect(comparer.state.compareWith).toBeUndefined();
+    });
+  });
+
+  describe('timeShiftAlignmentProcessor (via getExtraQueries)', () => {
+    // The processor isn't exported directly - grab it off the ExtraQueryDescriptor, same as the
+    // query runner does.
+    function getProcessor(comparer: SceneTimeRangeCompare, timeRange: SceneTimeRange) {
+      const [{ processor }] = comparer.getExtraQueries(makeRequest(timeRange));
+      if (!processor) {
+        throw new Error('expected a processor');
+      }
+      return processor;
+    }
+
+    it('should not mutate the secondary PanelData, its series, or their frame objects', async () => {
+      // The frames here may be owned by a datasource's streaming/split-chunk response accumulator and
+      // re-processed on every chunk - mutating them in place caused duplicate compare series to
+      // accumulate instead of being replaced. The processor must return new objects instead.
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+      const comparer = new SceneTimeRangeCompare({ compareWith: '24h' });
+      const processor = getProcessor(comparer, timeRange);
+
+      const frame = toDataFrame({ refId: 'A', fields: [] });
+      const primary = makePanelData('2024-01-10T00:00:00.000Z', '2024-01-10T01:00:00.000Z');
+      const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [frame]);
+
+      const result = await lastValueFrom(processor(primary, secondary));
+
+      expect(result).not.toBe(secondary);
+      expect(secondary.series).toEqual([frame]);
+      expect(frame.refId).toBe('A');
+      expect(frame.meta).toBeUndefined();
+    });
+
+    it('should not accumulate duplicate compare series when re-processing the same shared input frame', async () => {
+      // Simulates the split-query accumulator pattern: the same frame object is passed through the
+      // processor repeatedly (e.g. once per streamed chunk). Each pass must produce exactly one
+      // compare series, never more.
+      const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+      const comparer = new SceneTimeRangeCompare({ compareWith: '24h' });
+      const processor = getProcessor(comparer, timeRange);
+
+      const sharedFrame = toDataFrame({ refId: 'A', fields: [] });
+      const primary = makePanelData('2024-01-10T00:00:00.000Z', '2024-01-10T01:00:00.000Z');
+      const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [sharedFrame]);
+
+      await lastValueFrom(processor(primary, secondary));
+      await lastValueFrom(processor(primary, secondary));
+      const result = await lastValueFrom(processor(primary, secondary));
+
+      expect(sharedFrame.refId).toBe('A');
+      expect(result.series).toHaveLength(1);
+      expect(result.series[0].refId).toBe('A-compare');
     });
   });
 });

--- a/packages/scenes/src/components/SceneTimeRangeCompare.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.tsx
@@ -6,12 +6,11 @@ import { sceneGraph } from '../core/sceneGraph';
 import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneComponentProps, SceneDataQuery, SceneObjectState, SceneObjectUrlValues } from '../core/types';
 import { DataQueryExtended } from '../querying/SceneQueryRunner';
-import { ExtraQueryDescriptor, ExtraQueryDataProcessor, ExtraQueryProvider } from '../querying/ExtraQueryProvider';
+import { ExtraQueryDescriptor, ExtraQueryProvider } from '../querying/ExtraQueryProvider';
 import { SceneObjectUrlSyncConfig } from '../services/SceneObjectUrlSyncConfig';
-import { getCompareSeriesRefId } from '../utils/getCompareSeriesRefId';
 import { parseUrlParam } from '../utils/parseUrlParam';
+import { timeShiftAlignmentProcessor } from '../utils/timeShiftAlignmentProcessor';
 import { css } from '@emotion/css';
-import { of } from 'rxjs';
 
 interface SceneTimeRangeCompareState extends SceneObjectState {
   compareWith?: string;
@@ -183,26 +182,6 @@ export class SceneTimeRangeCompare
     }
   }
 }
-
-// Processor function for use with time shifted comparison series.
-// This aligns the secondary series with the primary and adds custom
-// metadata and config to the secondary series' fields so that it is
-// rendered appropriately.
-const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary) => {
-  const diff = secondary.timeRange.from.diff(primary.timeRange.from);
-  secondary.series.forEach((series) => {
-    series.refId = getCompareSeriesRefId(series.refId || '');
-    series.meta = {
-      ...series.meta,
-      // @ts-ignore Remove when https://github.com/grafana/grafana/pull/71129 is released
-      timeCompare: {
-        diffMs: diff,
-        isTimeShiftQuery: true,
-      },
-    };
-  });
-  return of(secondary);
-};
 
 function SceneTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeRangeCompare>) {
   const styles = useStyles2(getStyles);

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -197,5 +197,7 @@ export const sceneUtils = {
 
 export { SafeSerializableSceneObject } from './utils/SafeSerializableSceneObject';
 export { getExploreURL } from './utils/explore';
+export { getCompareSeriesRefId } from './utils/getCompareSeriesRefId';
+export { timeShiftAlignmentProcessor } from './utils/timeShiftAlignmentProcessor';
 export { loadResources } from './utils/loadResources';
 export { PATH_ID_SEPARATOR } from './utils/pathId';

--- a/packages/scenes/src/utils/getCompareSeriesRefId.ts
+++ b/packages/scenes/src/utils/getCompareSeriesRefId.ts
@@ -1,1 +1,3 @@
-export const getCompareSeriesRefId = (refId: string) => `${refId}-compare`;
+// Idempotent: compare queries may already carry the -compare suffix on their refId
+// (set at request time for cache identity), so re-applying must not double-suffix.
+export const getCompareSeriesRefId = (refId: string) => (refId.endsWith('-compare') ? refId : `${refId}-compare`);

--- a/packages/scenes/src/utils/timeShiftAlignmentProcessor.ts
+++ b/packages/scenes/src/utils/timeShiftAlignmentProcessor.ts
@@ -1,0 +1,28 @@
+import { of } from 'rxjs';
+
+import { ExtraQueryDataProcessor } from '../querying/ExtraQueryProvider';
+import { getCompareSeriesRefId } from './getCompareSeriesRefId';
+
+// Processor function for use with time shifted comparison series.
+// This aligns the secondary series with the primary and adds custom
+// metadata and config to the secondary series' fields so that it is
+// rendered appropriately.
+export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary) => {
+  const diff = secondary.timeRange.from.diff(primary.timeRange.from);
+  // Build new frame objects rather than mutating secondary.series in place. With streaming/split-chunk
+  // queries (e.g. Loki), the frame objects here are owned by the datasource's response accumulator and
+  // get re-processed on every chunk - mutating refId in place made each re-processed chunk look like a
+  // brand new series to the merge layer, appending duplicate compare series instead of replacing one.
+  const series = secondary.series.map((frame) => ({
+    ...frame,
+    refId: getCompareSeriesRefId(frame.refId || ''),
+    meta: {
+      ...frame.meta,
+      timeCompare: {
+        diffMs: diff,
+        isTimeShiftQuery: true,
+      },
+    },
+  }));
+  return of({ ...secondary, series });
+};


### PR DESCRIPTION
Fixes duplicate comparison series when time compare runs against streaming/split-chunk queries (e.g. Loki). `timeShiftAlignmentProcessor` mutated `refId`/`meta` in place on frames owned by the datasource's response accumulator, so every re-emitted chunk registered as a brand-new series. Exposed by #1554.

The processor now returns new frame objects - per the contract `ExtraQueryProvider` already documents - and is exported so grafana core can delete its private fork of the same function: [grafana/grafana#128796](https://github.com/grafana/grafana/pull/128796).

**Test:** scenes-app → Demos → *Time compare + streaming duplicate series (regression demo)*, plus regression tests in `SceneTimeRangeCompare.test.tsx`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.14.0--canary.1583.29911997371.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.14.0--canary.1583.29911997371.0
  npm install scenes-app@8.14.0--canary.1583.29911997371.0
  npm install @grafana/scenes-react@8.14.0--canary.1583.29911997371.0
  # or 
  yarn add @grafana/scenes@8.14.0--canary.1583.29911997371.0
  yarn add scenes-app@8.14.0--canary.1583.29911997371.0
  yarn add @grafana/scenes-react@8.14.0--canary.1583.29911997371.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
