### PR TITLE
Scenes: add data-plugin-id to render boundary

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -264,6 +264,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
         data-viz-panel-key={model.state.key}
         data-viz-panel-id={model.getPathId()}
         data-testid={`${plugin.meta.id}-${model.state.key}`}
+        data-plugin-id={plugin.meta.id}
       >
         <PanelChrome
           title={titleInterpolated}


### PR DESCRIPTION
Follow up to https://github.com/grafana/scenes/pull/1557 and https://github.com/grafana/grafana/pull/127350 which introduced data-testid and data-plugin-id to the dom elements where plugins are rendered in Grafana.