### PR TITLE
AdHocFiltersCombobox: Show more pill text before truncating

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/BasePill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/BasePill.tsx
@@ -5,7 +5,8 @@ import React, { forwardRef, ReactNode } from 'react';
 import { t } from '@grafana/i18n';
 import { getNonApplicablePillStyles } from '../../utils';
 
-const LABEL_MAX_VISIBLE_LENGTH = 20;
+// Tooltip threshold, roughly matching how many characters fit in pillText's maxWidth
+const LABEL_MAX_VISIBLE_LENGTH = 28;
 
 export interface BasePillProps {
   label: string;
@@ -133,7 +134,7 @@ export const getBasePillStyles = (theme: GrafanaTheme2) => ({
     },
   }),
   pillText: css({
-    maxWidth: '200px',
+    maxWidth: '280px',
     width: '100%',
     textOverflow: 'ellipsis',
     overflow: 'hidden',

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/BasePill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/BasePill.tsx
@@ -140,6 +140,9 @@ export const getBasePillStyles = (theme: GrafanaTheme2) => ({
     overflow: 'hidden',
   }),
   tooltipText: css({
+    // Match pillText's maxWidth: a wider tooltip gets pushed off-centre by the
+    // viewport-edge shift logic when the pill is near the edge of the screen
+    maxWidth: '280px',
     textAlign: 'center',
   }),
   disabledPillIcon: css({


### PR DESCRIPTION
## What

Three proportional tweaks in `BasePill.tsx`:

- `pillText` `maxWidth`: `200px` -> `280px` (about 40% more)
- `LABEL_MAX_VISIBLE_LENGTH`: `20` -> `28` - this is the threshold at which the hover tooltip is shown, so it is kept in proportion with the width
- `tooltipText` `maxWidth`: capped at `280px` to match the pill - the tooltip content otherwise grows up to grafana-ui's 400px default, wider than the pill itself, so the viewport-edge shift logic pushes it off-centre for pills near the edge of the screen. Capping it keeps the bubble centred over the pill it describes.

As far as I can tell, this ellipsing/truncating code was added in https://github.com/grafana/scenes/pull/889, specifically here: https://github.com/grafana/scenes/commit/d44446765c163c7b87742cf0889bdc14f29639da#diff-0fb2431cb4ca154674811b4ad6cfc05265115368c1676d72fba0a22b1c32371dR136-R144

I didn't see that we have iterated on these values much, so maybe it's reasonable for me to propose a change to this now!

**Before:**
http://play.grafana.org/d/territory-navigator
<img width="400" alt="before" src="https://github.com/user-attachments/assets/b7116882-a83a-4e80-9734-b59beaba1e06" />

**After:**
<img width="400" alt="after" src="https://github.com/user-attachments/assets/d23d0a85-1482-4c95-879c-4cb394e5ca08" />

**Will this be enough?**
I don't know - our colleagues in RevOps may want us to increase this further.
RevOpe dashboard variables currently look like this:
https://play.grafana.org/d/territory-navigator-sql-only-version
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ec1c534a-6732-4532-9bb6-d5790b964340" />

As you can see the longest names are:
- `Attainment Band (vs Committed MRR), Last Month`
- `Projected Attainment Band (vs Committed MRR), Current Month`

When I try setting `keyLabel` to these labels, it looks like this:

**Before the `maxWidth` change**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/780e4d08-f896-4e99-b8a2-b6a758fdc6c8" />

**After the `maxWidth` change**
<img width="400" alt="tooltip-after" src="https://github.com/user-attachments/assets/fbaf409d-5c42-4cc8-90c4-16da45be5a9c" />


## Why

Ad hoc filter pills hit the ellipsis far too early. A pill like:

```
territory_navigator.owner_regio…
```

truncates before the operator or a single selected value is visible. The deeper problem is that related fields often share a long prefix - `territory_navigator.has_ae_sdr_meeting` vs `territory_navigator.has_ae_sdr_meeting_display`, or `Attainment Band (vs Committed MRR), Last Month` vs `Projected Attainment Band (vs Committed MRR), Current Month` - so the truncated tail is exactly the part that tells two filters apart, and narrow pills can render different filters near-identically.

This matters most once a dashboard has many pinned default filters (Territory Navigator has ~20): users want to eyeball their way to the right filter to interact with, without having to hover each pill in turn. Widening the pill gives each one room to breathe and keeps the distinguishing part of the label visible, while still truncating and offering a tooltip for genuinely long labels.

## Notes

- Verified visually against a local Grafana linked to this branch, with real multi-value default filters (screenshots above): the wider pill, the tooltip threshold, and the centred tooltip all behave as described.
- The tooltip cap trades a little height for the centring: long labels wrap onto roughly one extra line versus the 400px bubble.
- Existing behaviour is otherwise unchanged - no new props, no layout logic touched.
- CI provides the additional verification that this builds against published `@grafana/*` versions rather than a locally linked Grafana checkout.

Kept deliberately separate from #1591 (All value option for dashboard default filters), which came out of the same effort but is a much larger change.


