### PR TITLE
feat(SceneQueryController): add registerPendingWork to hold query readiness for non-query work (like repeat clone mounting)

### DIFF
--- a/packages/scenes/src/behaviors/SceneQueryController.ts
+++ b/packages/scenes/src/behaviors/SceneQueryController.ts
@@ -2,7 +2,12 @@ import { SceneObjectBase } from '../core/SceneObjectBase';
 import { SceneObject, SceneStatelessBehavior } from '../core/types';
 import { writeSceneLog } from '../utils/writeSceneLog';
 import { SceneRenderProfiler } from '../performance/SceneRenderProfiler';
-import { SceneQueryControllerEntry, SceneQueryControllerLike, SceneQueryStateControllerState } from './types';
+import {
+  SceneQueryControllerEntry,
+  SceneQueryControllerEntryType,
+  SceneQueryControllerLike,
+  SceneQueryStateControllerState,
+} from './types';
 
 export function isQueryController(s: SceneObject | SceneStatelessBehavior): s is SceneQueryControllerLike {
   return 'isQueryController' in s;
@@ -75,6 +80,17 @@ export class SceneQueryController
     if (this.#running.size === 0) {
       this.setState({ isRunning: false });
     }
+  }
+
+  /**
+   * Registers non-query pending work (e.g. repeat clone mounting) so that profile completion
+   * and readiness checks based on runningQueriesCount cannot fire while the work is pending.
+   * Returns a release function. Releasing more than once is a no-op.
+   */
+  public registerPendingWork(type: SceneQueryControllerEntryType, origin: SceneObject): () => void {
+    const entry: SceneQueryControllerEntry = { type, origin };
+    this.queryStarted(entry);
+    return () => this.queryCompleted(entry);
   }
 
   private changeRunningQueryCount(dir: 1 | -1, entry?: SceneQueryControllerEntry) {

--- a/packages/scenes/src/behaviors/types.ts
+++ b/packages/scenes/src/behaviors/types.ts
@@ -42,6 +42,12 @@ export interface SceneQueryControllerLike extends SceneObject<SceneQueryStateCon
 
   queryStarted(entry: SceneQueryControllerEntry): void;
   queryCompleted(entry: SceneQueryControllerEntry): void;
+  /**
+   * Registers non-query pending work (e.g. repeat clone mounting) that should hold
+   * runningQueriesCount above zero until the returned release function is called.
+   * Optional to stay backwards compatible with existing implementations.
+   */
+  registerPendingWork?(type: SceneQueryControllerEntryType, origin: SceneObject): () => void;
   startProfile(name: string): void;
   cancelProfile(): void;
   runningQueriesCount(): number;


### PR DESCRIPTION
Support for https://github.com/grafana/grafana/pull/129758