### PR TITLE
feat(AdHocFiltersVariable): add requestFilterBuilder to customize req…

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -679,6 +679,40 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(runRequestCall[1].filters).toEqual([...filtersVar.state.originFilters!, ...filtersVar.state.filters]);
     });
 
+    it('should apply requestFilterBuilder to exclude filters from the request object', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const filtersVar = new AdHocFiltersVariable({
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [
+          { key: '__name__', operator: '=', value: 'my_metric', condition: '' },
+          { key: 'instance', operator: '=', value: 'localhost:9090', condition: '' },
+        ],
+        requestFilterBuilder: (filters) => filters.filter((f) => f.key !== '__name__'),
+      });
+
+      const scene = new EmbeddedScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [filtersVar] }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      const deactivate = activateFullSceneTree(scene);
+      deactivationHandlers.push(deactivate);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[0];
+
+      expect(runRequestCall[1].filters).toEqual([
+        { key: 'instance', operator: '=', value: 'localhost:9090', condition: '' },
+      ]);
+    });
+
     it('should merge dashboard and section adhoc filters for the same datasource', async () => {
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'test-uid' },

--- a/packages/scenes/src/variables/DrilldownDependenciesManager.ts
+++ b/packages/scenes/src/variables/DrilldownDependenciesManager.ts
@@ -180,7 +180,15 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
       return undefined;
     }
 
-    return this._getMergedFilters().filter((f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f));
+    const filters = this._getMergedFilters().filter(
+      (f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f)
+    );
+
+    // The closest ad-hoc variable owns how its filters map onto the query. When it customizes
+    // the query expression it can also adjust the request filters here, so keys that are already
+    // encoded in the expression (like __name__) are not injected a second time by the datasource.
+    const requestFilterBuilder = this._adhocFiltersVar?.state.requestFilterBuilder;
+    return requestFilterBuilder ? requestFilterBuilder(filters) : filters;
   }
 
   /**

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -142,6 +142,15 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
   expressionBuilder?: AdHocVariableExpressionBuilderFn;
 
   /**
+   * Optionally transforms the filters that are attached to a query request (request.filters).
+   * The default behavior forwards every applied filter. Consumers that customize the query
+   * expression via expressionBuilder can use this to keep the request filters in sync, for
+   * example by excluding keys like __name__ that are already encoded in the expression and
+   * would otherwise be injected twice.
+   */
+  requestFilterBuilder?: AdHocVariableRequestFilterBuilderFn;
+
+  /**
    * Whether the filter supports new multi-value operators like =| and !=|
    */
   supportsMultiValueOperators?: boolean;
@@ -190,6 +199,7 @@ export interface AdHocFiltersVariableState extends SceneVariableState {
 }
 
 export type AdHocVariableExpressionBuilderFn = (filters: AdHocFilterWithLabels[]) => string;
+export type AdHocVariableRequestFilterBuilderFn = (filters: AdHocFilterWithLabels[]) => AdHocFilterWithLabels[];
 export type OnAddCustomValueFn = (
   item: SelectableValue<string> & { isCustom?: boolean },
   filter: AdHocFilterWithLabels


### PR DESCRIPTION
## What

This adds an optional `requestFilterBuilder` to `AdHocFiltersVariable` and applies it in `DrilldownDependenciesManager.getFilters()`, so consumers can control which ad hoc filters are attached to a query request (`request.filters`).

## Why

`getFilters()` forwards every applied ad hoc filter into `request.filters` without consulting the `expressionBuilder` configured on the variable. When a consumer uses `expressionBuilder` to strip a key such as `__name__` from the query expression, that key is still injected as a request filter, so the datasource receives it twice. On the Prometheus datasource this surfaces as "metric name must not be set twice".

This became more visible after v7 started walking the scene hierarchy to find the `AdHocFiltersVariable`, so `getFilters()` now returns filters where it previously returned nothing. The Metrics Drilldown app currently works around it with a runtime monkey patch on `SceneQueryRunner.prepareRequests`, and the upstream issue asks for a real fix here.

## How

`expressionBuilder` has the signature `(filters) => string`, so it produces the expression text and cannot be reused to derive the request filter array. Instead this introduces a small dedicated hook:

​```ts
requestFilterBuilder?: (filters: AdHocFilterWithLabels[]) => AdHocFilterWithLabels[];
​```

`getFilters()` applies the closest variable's `requestFilterBuilder` to the already computed filters when it is defined, and returns them unchanged otherwise. The prop is inert unless a consumer sets it, so existing behavior is fully preserved. A consumer can then strip keys that are already encoded in the expression:

​```ts
new AdHocFiltersVariable({
  // ...
  requestFilterBuilder: (filters) => filters.filter((f) => f.key !== '__name__'),
});
​```

## Alternative considered

I also considered having `getFilters()` skip `request.filters` entirely whenever a custom `expressionBuilder` is present, treating the expression as the single source of truth. That is smaller but changes behavior for anyone relying on both the expression and `request.filters`, and `getFilters()` is shared with the annotations layer and group by, so I preferred the additive opt in approach. Happy to switch if you would rather not add API.

## Testing

Added a unit test in `SceneQueryRunner.test.ts` that sets a `requestFilterBuilder` stripping `__name__` and asserts only the remaining filter reaches `request.filters`. The affected suites pass (554 tests), and typecheck, eslint, and prettier are clean.

Fixes #1436