### PR TITLE
TimeComparison: Warning when comparison is empty

### DIFF
--- a/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
+++ b/packages/scenes/src/components/SceneTimeRangeCompare.test.tsx
@@ -550,5 +550,105 @@ describe('SceneTimeRangeCompare', () => {
 
       expect(result.series[0].refId).toBe('A-compare');
     });
+
+    describe('empty comparison notice', () => {
+      // When the primary query returns data but the comparison query does not, the processor surfaces
+      // an informational notice so users understand the empty comparison was expected.
+      const NO_DATA_NOTICE = { severity: 'info', text: 'No data returned for time comparison' };
+
+      const primaryWithData = () =>
+        makePanelData('2024-01-10T00:00:00.000Z', '2024-01-10T01:00:00.000Z', [
+          toDataFrame({ refId: 'A', fields: [{ name: 'value', values: [1] }] }),
+        ]);
+
+      const getEmptyComparisonProcessor = () => {
+        const timeRange = new SceneTimeRange({ from: 'now-1h', to: 'now' });
+        const comparer = new SceneTimeRangeCompare({ compareWith: '24h' });
+        return getProcessor(comparer, timeRange);
+      };
+
+      it('should emit a notice frame from the request targets when the compare query returns no frames', async () => {
+        const processor = getEmptyComparisonProcessor();
+        const secondary: PanelData = {
+          ...makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', []),
+          request: { targets: [{ refId: 'A' }] } as DataQueryRequest,
+        };
+
+        const result = await lastValueFrom(processor(primaryWithData(), secondary));
+
+        expect(result.series[0]).toMatchObject({
+          refId: 'A-compare',
+          length: 0,
+          fields: [],
+          meta: { notices: [NO_DATA_NOTICE] },
+        });
+      });
+
+      it('should emit a notice when the compare query returns empty (fieldless) frames', async () => {
+        // Prometheus and other data sources return a frame without fields rather than no frames at all.
+        const processor = getEmptyComparisonProcessor();
+        const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [
+          toDataFrame({ refId: 'A', fields: [] }),
+        ]);
+
+        const result = await lastValueFrom(processor(primaryWithData(), secondary));
+
+        expect(result.series[0]).toMatchObject({
+          refId: 'A-compare',
+          meta: { notices: [NO_DATA_NOTICE] },
+        });
+      });
+
+      it('should fall back to a single empty frame when there are no frames and no request targets', async () => {
+        const processor = getEmptyComparisonProcessor();
+        const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', []);
+
+        const result = await lastValueFrom(processor(primaryWithData(), secondary));
+
+        expect(result.series).toHaveLength(1);
+        expect(result.series[0]).toMatchObject({
+          refId: '-compare',
+          length: 0,
+          fields: [],
+          meta: { notices: [NO_DATA_NOTICE] },
+        });
+      });
+
+      it('should not emit a notice when the comparison query returns data', async () => {
+        const processor = getEmptyComparisonProcessor();
+        const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [
+          toDataFrame({ refId: 'A', fields: [{ name: 'value', values: [2] }] }),
+        ]);
+
+        const result = await lastValueFrom(processor(primaryWithData(), secondary));
+
+        expect(result.series[0].meta?.notices).toBeUndefined();
+      });
+
+      it('should not emit a notice when the primary query also returned no data', async () => {
+        const processor = getEmptyComparisonProcessor();
+        const primary = makePanelData('2024-01-10T00:00:00.000Z', '2024-01-10T01:00:00.000Z', [
+          toDataFrame({ refId: 'A', fields: [] }),
+        ]);
+        const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [
+          toDataFrame({ refId: 'A', fields: [] }),
+        ]);
+
+        const result = await lastValueFrom(processor(primary, secondary));
+
+        expect(result.series[0].meta?.notices).toBeUndefined();
+      });
+
+      it('should preserve existing notices when adding the no-data notice', async () => {
+        const processor = getEmptyComparisonProcessor();
+        const frame = toDataFrame({ refId: 'A', fields: [] });
+        frame.meta = { notices: [{ severity: 'warning', text: 'existing' }] };
+        const secondary = makePanelData('2024-01-09T00:00:00.000Z', '2024-01-09T01:00:00.000Z', [frame]);
+
+        const result = await lastValueFrom(processor(primaryWithData(), secondary));
+
+        expect(result.series[0].meta?.notices).toEqual([{ severity: 'warning', text: 'existing' }, NO_DATA_NOTICE]);
+      });
+    });
   });
 });

--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -85,6 +85,9 @@
       },
       "loading-indicator": {
         "content-cancel-query": "Cancel query"
+      },
+      "time-shift-alignment-processor": {
+        "no-data-notice": "No data returned for time comparison"
       }
     },
     "variables": {

--- a/packages/scenes/src/utils/timeShiftAlignmentProcessor.ts
+++ b/packages/scenes/src/utils/timeShiftAlignmentProcessor.ts
@@ -1,3 +1,5 @@
+import { DataFrame, QueryResultMetaNotice } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { of } from 'rxjs';
 
 import { ExtraQueryDataProcessor } from '../querying/ExtraQueryProvider';
@@ -9,11 +11,39 @@ import { getCompareSeriesRefId } from './getCompareSeriesRefId';
 // rendered appropriately.
 export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary) => {
   const diff = secondary.timeRange.from.diff(primary.timeRange.from);
+
+  // Surface a notice when the primary query returned data but the comparison query did not, so
+  // users understand the empty comparison was expected rather than a silent failure. Frames without
+  // rows (length === 0) count as "no data"; some data sources (e.g. Prometheus) return a fieldless
+  // frame rather than no frames at all.
+  const primaryHasData = primary.series.some((frame) => frame.length > 0);
+  const secondaryHasData = secondary.series.some((frame) => frame.length > 0);
+  const isEmptyComparison = primaryHasData && !secondaryHasData;
+
+  // When the comparison returned no frames at all there is nothing to attach the notice to, so build
+  // empty placeholder frames from the requested targets (falling back to a single frame).
+  const sourceSeries: DataFrame[] =
+    isEmptyComparison && secondary.series.length === 0
+      ? secondary.request?.targets.map((target) => ({ refId: target.refId, fields: [], length: 0 })) ?? [
+          { refId: '', fields: [], length: 0 },
+        ]
+      : secondary.series;
+
+  const notice: QueryResultMetaNotice | undefined = isEmptyComparison
+    ? {
+        severity: 'info',
+        text: t(
+          'grafana-scenes.utils.time-shift-alignment-processor.no-data-notice',
+          'No data returned for time comparison'
+        ),
+      }
+    : undefined;
+
   // Build new frame objects rather than mutating secondary.series in place. With streaming/split-chunk
   // queries (e.g. Loki), the frame objects here are owned by the datasource's response accumulator and
   // get re-processed on every chunk - mutating refId in place made each re-processed chunk look like a
   // brand new series to the merge layer, appending duplicate compare series instead of replacing one.
-  const series = secondary.series.map((frame) => ({
+  const series = sourceSeries.map((frame) => ({
     ...frame,
     refId: getCompareSeriesRefId(frame.refId || ''),
     meta: {
@@ -22,7 +52,9 @@ export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, se
         diffMs: diff,
         isTimeShiftQuery: true,
       },
+      ...(notice ? { notices: [...(frame.meta?.notices ?? []), notice] } : {}),
     },
   }));
+
   return of({ ...secondary, series });
 };


### PR DESCRIPTION
I went ahead and moved the awesome contribution from @macayu17 in this [PR](https://github.com/grafana/grafana/pull/126918) to scenes because the `timeShiftAlignmentProcessor` was moved out of grafana and into scenes with https://github.com/grafana/grafana/pull/128796 and https://github.com/grafana/scenes/pull/1583.

This PR adds an informational notice when a panel time comparison query returns no data while the primary query still has data.

Before:
<img width="1750" height="821" alt="image" src="https://github.com/user-attachments/assets/2e2ce03f-d730-4477-bc10-84ad01ef09dc" />

After:
<img width="1757" height="857" alt="image" src="https://github.com/user-attachments/assets/460cf69e-016b-4586-8a0c-3cadea06a735" />

Fixes https://github.com/grafana/grafana/issues/126825