### PR TITLE
fix(SceneQueryRunner): secondary query behavior fixes

### DIFF
--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -2209,7 +2209,7 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
         expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
       });
 
-      it('emits error when secondary reports an error', async () => {
+      it('surfaces a secondary error without failing the panel', async () => {
         const primarySubject = new Subject<PanelData>();
         const secondarySubject = new Subject<PanelData>();
         runRequestMock.mockImplementationOnce(() => primarySubject).mockImplementationOnce(() => secondarySubject);
@@ -2233,9 +2233,9 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
         secondarySubject.complete();
         await tick();
 
-        // The merged state is taken from the primary, so the secondary error is masked,
-        // but its series are still merged in.
-        expect(queryRunner.state.data?.state).toBe(LoadingState.Error);
+        // The merged state follows the primary, so the secondary error does not fail the panel,
+        // but its series are still merged in and the error is still reported.
+        expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
         expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A', 'secCtrl']);
         expect(queryRunner.state.data?.errors ?? []).toEqual([{ message: 'secondary boom' }]);
       });
@@ -2528,6 +2528,66 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
     });
 
+    it('renders primary results while the secondary query is still in flight', async () => {
+      const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
+
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+      const provider = new TestExtraQueryProvider({ foo: 1 }, true);
+      const scene = new EmbeddedScene({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        controls: [provider],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      scene.activate();
+      await tick();
+
+      expect(queryRunner.isDataReadyToDisplay()).toBe(false);
+
+      // The primary resolving is enough to paint the panel, even though the merged state stays
+      // Loading (so the panel keeps its loading bar) until the secondary settles.
+      primarySubject.next({ state: LoadingState.Done, series: [toDataFrame({ refId: 'A', fields: [] })] });
+      secondarySubject.next({ state: LoadingState.Loading });
+      await tick();
+
+      expect(queryRunner.isDataReadyToDisplay()).toBe(true);
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Loading);
+      expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A']);
+
+      // The secondary series join the primary's once it lands.
+      secondarySubject.next({ state: LoadingState.Done, series: [toDataFrame({ refId: 'B', fields: [] })] });
+      await tick();
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
+      expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A', 'B']);
+    });
+
+    it('does not render before the primary resolves when the secondary finishes first', async () => {
+      const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
+
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+      const provider = new TestExtraQueryProvider({ foo: 1 }, true);
+      const scene = new EmbeddedScene({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        controls: [provider],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      scene.activate();
+      await tick();
+
+      // Secondary results are meaningless on their own - a time shifted frame can only be aligned
+      // against the primary frame - so a fast secondary must not paint the panel.
+      secondarySubject.next({ state: LoadingState.Done, series: [toDataFrame({ refId: 'B', fields: [] })] });
+      primarySubject.next({ state: LoadingState.Loading });
+      await tick();
+
+      expect(queryRunner.isDataReadyToDisplay()).toBe(false);
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Loading);
+    });
+
     it('emits errors when the secondary query fails', async () => {
       const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
 
@@ -2543,12 +2603,39 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       scene.activate();
       await tick();
 
-      primarySubject.next({ state: LoadingState.Done });
+      primarySubject.next({ state: LoadingState.Done, series: [toDataFrame({ refId: 'A', fields: [] })] });
       secondarySubject.next({ state: LoadingState.Error, errors: [{ message: 'secondary failed' }] });
       await tick();
 
-      expect(queryRunner.state.data?.state).toBe(LoadingState.Error);
+      // The error is surfaced, but the panel keeps rendering the primary results rather than
+      // going blank because of a failure in an extra query.
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Done);
       expect(queryRunner.state.data?.errors).toEqual([{ message: 'secondary failed' }]);
+      expect(queryRunner.isDataReadyToDisplay()).toBe(true);
+      expect(queryRunner.state.data?.series.map((s) => s.refId)).toEqual(['A']);
+    });
+
+    it('keeps the panel in an error state when the primary query fails', async () => {
+      const { primarySubject, secondarySubject } = mockPrimaryAndSecondaryStreams();
+
+      const queryRunner = new SceneQueryRunner({ queries: [{ refId: 'A' }] });
+      const provider = new TestExtraQueryProvider({ foo: 1 }, true);
+      const scene = new EmbeddedScene({
+        $timeRange: new SceneTimeRange(),
+        $data: queryRunner,
+        controls: [provider],
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      scene.activate();
+      await tick();
+
+      primarySubject.next({ state: LoadingState.Error, errors: [{ message: 'primary failed' }] });
+      secondarySubject.next({ state: LoadingState.Done });
+      await tick();
+
+      expect(queryRunner.state.data?.state).toBe(LoadingState.Error);
+      expect(queryRunner.state.data?.errors).toContainEqual({ message: 'primary failed' });
     });
 
     it('applies requestId suffix when the primary re-emits', async () => {

--- a/packages/scenes/src/querying/SceneQueryRunner.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, isEqual } from 'lodash';
-import { combineLatest, ReplaySubject, Unsubscribable } from 'rxjs';
+import { combineLatest, ReplaySubject, tap, Unsubscribable } from 'rxjs';
 
-import { DataQuery, DataSourceRef, LoadingState } from '@grafana/schema';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
 
 import {
   AlertStateInfo,
@@ -14,6 +14,7 @@ import {
   PanelData,
   preProcessPanelData,
   rangeUtil,
+  LoadingState,
 } from '@grafana/data';
 
 // TODO: Remove this ignore annotation when the grafana runtime dependency has been updated
@@ -315,6 +316,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
   private _isInView = true;
   private _bypassIsInView = false;
   private _queryNotExecutedWhenOutOfView = false;
+  private _primaryHasFetchedData = false;
 
   public getResultsStream() {
     return this._results;
@@ -675,9 +677,20 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
       writeSceneLog('SceneQueryRunner', 'Starting runRequest', this.state.key);
 
+      this._primaryHasFetchedData = false;
       let stream = runRequest(ds, primary);
 
       if (secondaries.length > 0) {
+        // Extra queries must not gate the panel's first paint. The merged loading state stays
+        // Loading until every secondary settles, so primary readiness is recorded separately.
+        stream = stream.pipe(
+          tap((primaryData) => {
+            if (primaryData.state !== LoadingState.Loading) {
+              this._primaryHasFetchedData = true;
+            }
+          })
+        );
+
         // Submit all secondary requests in parallel.
         const secondaryStreams = secondaries.map((r) => runRequest(ds, r));
         // Create the rxjs operator which will combine the primary and secondary responses
@@ -861,7 +874,7 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> implemen
 
     let hasFetchedData = this.state._hasFetchedData;
 
-    if (!hasFetchedData && preProcessedData.state !== LoadingState.Loading) {
+    if (!hasFetchedData && (preProcessedData.state !== LoadingState.Loading || this._primaryHasFetchedData)) {
       hasFetchedData = true;
     }
 

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
@@ -58,17 +58,21 @@ function collect(source: Observable<PanelData>): { emissions: PanelData[]; unsub
 }
 
 describe('combineLoadingStates', () => {
-  it('returns Error when any response is in the Error state', () => {
-    expect(combineLoadingStates([LoadingState.Loading, LoadingState.Error])).toBe(LoadingState.Error);
+  it('returns Error only when the primary response is in the Error state', () => {
     expect(combineLoadingStates([LoadingState.Error, LoadingState.Streaming])).toBe(LoadingState.Error);
+    expect(combineLoadingStates([LoadingState.Error, LoadingState.Error])).toBe(LoadingState.Error);
+
+    // A secondary error must not blank a panel whose primary data is fine.
+    expect(combineLoadingStates([LoadingState.Loading, LoadingState.Error])).toBe(LoadingState.Loading);
+    expect(combineLoadingStates([LoadingState.Done, LoadingState.Error])).toBe(LoadingState.Done);
   });
 
-  it('returns Loading when any response is loading (and none errored)', () => {
+  it('returns Loading when any response is loading (and the primary has not errored)', () => {
     expect(combineLoadingStates([LoadingState.Done, LoadingState.Loading])).toBe(LoadingState.Loading);
     expect(combineLoadingStates([LoadingState.Loading, LoadingState.Streaming])).toBe(LoadingState.Loading);
   });
 
-  it('returns Streaming when any response is streaming (and none errored or loading)', () => {
+  it('returns Streaming when any response is streaming (and nothing is errored or loading)', () => {
     expect(combineLoadingStates([LoadingState.Done, LoadingState.Streaming])).toBe(LoadingState.Streaming);
   });
 

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.test.ts
@@ -107,6 +107,68 @@ describe('extraQueryProcessingOperator', () => {
     expect(emissions[1].state).toBe(LoadingState.Done);
   });
 
+  it('withholds secondary series until the primary responds', () => {
+    const primarySubject = new Subject<PanelData>();
+    const secondarySubject = new Subject<PanelData>();
+    const processors = new Map<string, ExtraQueryDataProcessor>([['B', passthroughProcessor]]);
+
+    const { emissions } = collect(
+      combineLatest([primarySubject, secondarySubject]).pipe(extraQueryProcessingOperator(processors))
+    );
+
+    // The secondary finishes first. Its frames must not reach the panel on their own - a time shifted
+    // frame with no primary alongside it renders as data outside the panel's time range.
+    primarySubject.next(makePanelData(LoadingState.Loading, { requestId: 'A' }));
+    secondarySubject.next(
+      makePanelData(LoadingState.Done, { requestId: 'B', series: [toDataFrame({ refId: 'B', fields: [] })] })
+    );
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].series).toEqual([]);
+    // The secondary is done, but the primary still gates the combined state.
+    expect(emissions[0].state).toBe(LoadingState.Loading);
+
+    // Once the primary responds, both are merged.
+    primarySubject.next(
+      makePanelData(LoadingState.Done, { requestId: 'A', series: [toDataFrame({ refId: 'A', fields: [] })] })
+    );
+
+    expect(emissions[emissions.length - 1].series.map((s) => s.refId)).toEqual(['A', 'B']);
+    expect(emissions[emissions.length - 1].state).toBe(LoadingState.Done);
+  });
+
+  it('still merges secondary annotations while the primary is loading', () => {
+    const secondaryAnnotation = toDataFrame({ refId: 'secondary-annotation', fields: [] });
+
+    const { emissions } = collect(
+      of([
+        makePanelData(LoadingState.Loading, { requestId: 'A' }),
+        makePanelData(LoadingState.Done, { requestId: 'B', annotations: [secondaryAnnotation] }),
+      ] as [PanelData, PanelData]).pipe(extraQueryProcessingOperator(new Map([['B', passthroughProcessor]])))
+    );
+
+    // Only series are held back. Nothing time shifts or renders a secondary's annotations, so holding
+    // them back would change annotation behaviour without fixing anything.
+    expect(emissions[0].series).toEqual([]);
+    expect(emissions[0].annotations?.map((a) => a.refId)).toEqual(['secondary-annotation']);
+  });
+
+  it('still reports a secondary error while the primary is loading', () => {
+    const secondaryError: DataQueryError = { message: 'secondary boom', refId: 'B' };
+
+    const { emissions } = collect(
+      of([
+        makePanelData(LoadingState.Loading, { requestId: 'A' }),
+        makePanelData(LoadingState.Error, { requestId: 'B', errors: [secondaryError] }),
+      ] as [PanelData, PanelData]).pipe(extraQueryProcessingOperator(new Map([['B', passthroughProcessor]])))
+    );
+
+    // Held-back series must not mean a held-back error - the failure still has to reach the panel header.
+    expect(emissions[0].series).toEqual([]);
+    expect(emissions[0].errors).toEqual([secondaryError]);
+    expect(emissions[0].error).toEqual(secondaryError);
+  });
+
   it('emits and aggregates errors', () => {
     const primaryError: DataQueryError = { message: 'primary boom', refId: 'A' };
     const secondaryError: DataQueryError = { message: 'secondary boom', refId: 'B' };

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.ts
@@ -6,15 +6,18 @@ import { ExtraQueryDataProcessor } from './ExtraQueryProvider';
 export const passthroughProcessor: ExtraQueryDataProcessor = (_, secondary) => of(secondary);
 
 /**
- * Combines loading responseState across multiple responses
- * If any response contains an error => Error
- * Otherwise, if any response is loading => Loading
- * Otherwise, if any response is streaming => Streaming
- * otherwise return the first/primary response state
+ * Combines loading state across the primary response and any secondary (extra query) responses.
+ *
+ * If primary response is error => Error (set series warning meta instead?)
+ * Else if any response is loading => Loading
+ * Else if any response is streaming => Streaming
+ * Else => primary state
  * @param responseState
  */
 export function combineLoadingStates(responseState: LoadingState[]): LoadingState {
-  if (responseState.some((s) => s === LoadingState.Error)) {
+  const primaryState = responseState[0];
+
+  if (primaryState === LoadingState.Error) {
     return LoadingState.Error;
   }
   if (responseState.some((s) => s === LoadingState.Loading)) {
@@ -23,8 +26,7 @@ export function combineLoadingStates(responseState: LoadingState[]): LoadingStat
   if (responseState.some((s) => s === LoadingState.Streaming)) {
     return LoadingState.Streaming;
   }
-  // If nothing is Error, Loading, or Streaming, return the LoadingState of the primary (zero index) response.
-  return responseState[0] ?? LoadingState.Done;
+  return primaryState;
 }
 
 /**
@@ -57,6 +59,7 @@ export const extraQueryProcessingOperator =
       map(([processedPrimary, ...processedSecondaries]) => {
         const allResponses = [processedPrimary, ...processedSecondaries];
         const allResponseErrors = allResponses.flatMap((d) => d.errors ?? []);
+
         return {
           ...processedPrimary,
           state: combineLoadingStates(allResponses.map((d) => d.state)),

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.ts
@@ -15,7 +15,7 @@ export const passthroughProcessor: ExtraQueryDataProcessor = (_, secondary) => o
  * @param responseState
  */
 export function combineLoadingStates(responseState: LoadingState[]): LoadingState {
-  const primaryState = responseState[0];
+  const primaryState = responseState[0] ?? LoadingState.Done;
 
   if (primaryState === LoadingState.Error) {
     return LoadingState.Error;

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.ts
@@ -8,7 +8,7 @@ export const passthroughProcessor: ExtraQueryDataProcessor = (_, secondary) => o
 /**
  * Combines loading state across the primary response and any secondary (extra query) responses.
  *
- * If primary response is error => Error (set series warning meta instead?)
+ * If primary response is error => Error
  * Else if any response is loading => Loading
  * Else if any response is streaming => Streaming
  * Else => primary state

--- a/packages/scenes/src/querying/extraQueryProcessingOperator.ts
+++ b/packages/scenes/src/querying/extraQueryProcessingOperator.ts
@@ -57,10 +57,15 @@ export const extraQueryProcessingOperator =
       map(([processedPrimary, ...processedSecondaries]) => {
         const allResponses = [processedPrimary, ...processedSecondaries];
         const allResponseErrors = allResponses.flatMap((d) => d.errors ?? []);
+        // Hold secondary series until primary is no longer loading:
+        // A time shifted frame rendered alone currently breaks the panel and shows the unwanted "Data outside time range" message.
+        // Annotations are deliberately not held back: no processor time shifts a secondary's annotations
+        const secondarySeries =
+          processedPrimary.state === LoadingState.Loading ? [] : processedSecondaries.flatMap((s) => s.series);
         return {
           ...processedPrimary,
           state: combineLoadingStates(allResponses.map((d) => d.state)),
-          series: [...processedPrimary.series, ...processedSecondaries.flatMap((s) => s.series)],
+          series: [...processedPrimary.series, ...secondarySeries],
           annotations: [
             ...(processedPrimary.annotations ?? []),
             ...processedSecondaries.flatMap((s) => s.annotations ?? []),


### PR DESCRIPTION
**What**
Avoid outside range notice when secondary returns before primary. 
Avoids dropping into error/no-data state when secondary returns error, but primary returns valid data.
Drops into no-data/error state when primary returns error, even if secondary returns valid data.
Prevents panel from rendering without visible data and no y-axis with "Data outside range" when primary is still loading.

Fixes https://github.com/grafana/grafana/issues/126186

**How**
Secondary queries should not set hasFetchedData in SceneQueryRunner.

**Why**
Secondary time compare queries should not visualize without something to compare against. 
But if the secondary fails, the primary should still be visualized. 