### PR TITLE
Share the All exclusivity rule between MultiValueVariable and the picker

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -1,7 +1,6 @@
 import { t } from '@grafana/i18n';
 import { isArray } from 'lodash';
 import React, { RefCallback, useEffect, useMemo, useState } from 'react';
-import { type ActionMeta } from 'react-select';
 import {
   Checkbox,
   InputActionMeta,
@@ -13,7 +12,7 @@ import {
   useTheme2,
 } from '@grafana/ui';
 
-import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
+import { applyAllValueExclusivity, MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
 import { ALL_VARIABLE_VALUE } from '../constants';
 import { VariableValue, VariableValueSingle } from '../types';
 import { selectors } from '@grafana/e2e-selectors';
@@ -27,27 +26,6 @@ import { getVariableControlId } from '../utils';
 const filterNoOp = () => true;
 
 const filterAll = (v: SelectableValue<VariableValueSingle>) => v.value !== ALL_VARIABLE_VALUE;
-
-/**
- * Mirrors changeValueTo's commit-time normalisation so the open dropdown reflects what will
- * actually be committed: selecting All deselects the other values, and selecting another
- * value deselects All. Without this the dropdown can show mixed selections that are
- * silently rewritten on blur.
- */
-const enforceAllExclusivity = (
-  values: VariableValueSingle[],
-  action: ActionMeta<SelectableValue<VariableValueSingle>>
-): VariableValueSingle[] => {
-  if (action.action === 'select-option' && action.option?.value === ALL_VARIABLE_VALUE) {
-    return [ALL_VARIABLE_VALUE];
-  }
-
-  if (values.length > 1) {
-    return values.filter((v) => v !== ALL_VARIABLE_VALUE);
-  }
-
-  return values;
-};
 
 const determineToggleAllState = (
   selectedValues: Array<SelectableValue<VariableValueSingle>>,
@@ -221,12 +199,7 @@ export function VariableValueSelectMulti({
           model.changeValueTo([], undefined, true);
         }
 
-        setUncommittedValue(
-          enforceAllExclusivity(
-            newValue.map((x) => x.value!),
-            action
-          )
-        );
+        setUncommittedValue(applyAllValueExclusivity(newValue.map((x) => x.value!)).value);
       }}
     />
   );

--- a/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.test.ts
@@ -4,7 +4,7 @@ import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { VariableFormatID } from '@grafana/schema';
 
 import { SceneVariableValueChangedEvent } from '../types';
-import { CustomAllValue } from '../variants/MultiValueVariable';
+import { applyAllValueExclusivity, CustomAllValue } from '../variants/MultiValueVariable';
 import { TestVariable } from './TestVariable';
 import { subscribeToStateUpdates } from '../../../utils/test/utils';
 import { CustomVariable } from './CustomVariable';
@@ -1078,5 +1078,49 @@ describe('MultiValueVariable', () => {
         });
       });
     });
+  });
+});
+
+describe('applyAllValueExclusivity', () => {
+  it('collapses the selection when the all value was added last', () => {
+    expect(applyAllValueExclusivity(['1', '2', ALL_VARIABLE_VALUE], ['A', 'B', ALL_VARIABLE_TEXT])).toEqual({
+      value: [ALL_VARIABLE_VALUE],
+      text: [ALL_VARIABLE_TEXT],
+    });
+  });
+
+  it('removes the all value wherever it sits when another value was added after it', () => {
+    expect(applyAllValueExclusivity(['1', ALL_VARIABLE_VALUE, '2'], ['A', ALL_VARIABLE_TEXT, 'B'])).toEqual({
+      value: ['1', '2'],
+      text: ['A', 'B'],
+    });
+
+    expect(applyAllValueExclusivity([ALL_VARIABLE_VALUE, '1'], [ALL_VARIABLE_TEXT, 'A'])).toEqual({
+      value: ['1'],
+      text: ['A'],
+    });
+  });
+
+  it('leaves selections that do not mix the all value untouched', () => {
+    expect(applyAllValueExclusivity(['1', '2'], ['A', 'B'])).toEqual({ value: ['1', '2'], text: ['A', 'B'] });
+    expect(applyAllValueExclusivity([], [])).toEqual({ value: [], text: [] });
+  });
+
+  it('handles a missing or non array text', () => {
+    expect(applyAllValueExclusivity(['1', ALL_VARIABLE_VALUE, '2'])).toEqual({ value: ['1', '2'], text: undefined });
+    expect(applyAllValueExclusivity(['1', ALL_VARIABLE_VALUE, '2'], 'A + All + B')).toEqual({
+      value: ['1', '2'],
+      text: 'A + All + B',
+    });
+  });
+
+  it('does not mutate the value and text it is given', () => {
+    const value = ['1', ALL_VARIABLE_VALUE, '2'];
+    const text = ['A', ALL_VARIABLE_TEXT, 'B'];
+
+    applyAllValueExclusivity(value, text);
+
+    expect(value).toEqual(['1', ALL_VARIABLE_VALUE, '2']);
+    expect(text).toEqual(['A', ALL_VARIABLE_TEXT, 'B']);
   });
 });

--- a/packages/scenes/src/variables/variants/MultiValueVariable.ts
+++ b/packages/scenes/src/variables/variants/MultiValueVariable.ts
@@ -331,20 +331,9 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
         text = state.text;
       }
 
-      // If the last (most recently added) value is the All value it replaces the rest
-      if (value[value.length - 1] === ALL_VARIABLE_VALUE) {
-        value = [ALL_VARIABLE_VALUE];
-        text = [ALL_VARIABLE_TEXT];
-      }
-      // Otherwise a value was added after the All value, so the All value is
-      // deselected wherever it sits in the selection
-      else if (value.length > 1 && value.includes(ALL_VARIABLE_VALUE)) {
-        const allIndex = value.indexOf(ALL_VARIABLE_VALUE);
-        value.splice(allIndex, 1);
-        if (Array.isArray(text)) {
-          text.splice(allIndex, 1);
-        }
-      }
+      const exclusive = applyAllValueExclusivity(value, text);
+      value = exclusive.value;
+      text = exclusive.text;
     }
 
     // Do nothing if value and text are the same
@@ -420,6 +409,40 @@ export abstract class MultiValueVariable<TState extends MultiValueVariableState 
    * Can be used by subclasses to do custom handling of option search based on search input
    */
   public onSearchChange?(searchFilter: string): void;
+}
+
+/**
+ * The All value is exclusive: it cannot be selected together with concrete values. Selection order
+ * decides which wins, as the most recently added value sits last in the array, so selecting All
+ * collapses the selection to All and selecting anything else drops All from it.
+ *
+ * Both the commit path (changeValueTo) and the picker's uncommitted selection go through this, so
+ * the open dropdown always shows what will be committed.
+ */
+export function applyAllValueExclusivity(
+  value: VariableValueSingle[],
+  text?: VariableValue
+): { value: VariableValueSingle[]; text?: VariableValue } {
+  if (value[value.length - 1] === ALL_VARIABLE_VALUE) {
+    return { value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] };
+  }
+
+  const allIndex = value.indexOf(ALL_VARIABLE_VALUE);
+
+  if (value.length > 1 && allIndex >= 0) {
+    const newValue = [...value];
+    newValue.splice(allIndex, 1);
+
+    let newText = text;
+    if (Array.isArray(text)) {
+      newText = [...text];
+      newText.splice(allIndex, 1);
+    }
+
+    return { value: newValue, text: newText };
+  }
+
+  return { value, text };
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1596 — this targets `sj/query-var-all-exclusivity`, so the diff here is only the refactor. Opened for comparison; fold it into #1596 or drop it.

## What

#1596 implements the All exclusivity rule twice:

- `changeValueTo` decides by **array position** — if the last value is the All value it wins, otherwise the All value is dropped from a mixed selection.
- `enforceAllExclusivity` in `VariableValueSelect` decides by **react-select action** — if the user selected the All option it wins, otherwise the All value is filtered out of a selection with more than one entry.

This extracts a single `applyAllValueExclusivity` helper and calls it from both.

## Why

The duplication is the same shape as the bug #1596 fixes: the picker and the commit path each carrying their own copy of the rule is exactly how they drifted apart. Two copies also means two behaviours — they agree for every picker-driven path, but only the model's copy applies to programmatic updates, URL values and anything else that reaches `changeValueTo` directly.

The position rule subsumes the action rule because react-select appends a newly selected option to the end of the value array, so "the user just selected All" and "the All value is last" are the same statement for the picker. That is why every existing test, including the three interaction tests and the toggle-all header test added in #1596, passes unchanged.

Side effect worth noting: the helper copies rather than splices in place, so `changeValueTo` no longer mutates the `value` and `text` arrays its caller handed it.

The helper is exported from the module but deliberately not added to the package index — it stays internal until something outside needs it.

## Testing

- Full suite (1753 passed), typecheck, lint and prettier pass. No existing test needed changing.
- New unit tests for `applyAllValueExclusivity`: the All value added last, mid-array and first; selections without the All value; missing and non-array text; and that it does not mutate its inputs.
- Verified in a real Grafana (12.4.0, `scenes-app` "Variables with object values" demo) that the picker behaviour is byte-for-byte the same as #1596: ticking a value with All selected deselects All and commits the concrete value; ticking All then another value commits only that value, with no `$__all` reaching state.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb92a-b9c5-7181-8a47-3e340808a3e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb92a-b9c5-7181-8a47-3e340808a3e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

