### PR TITLE
AdHocFiltersVariable: clear origin filters to `=| All` when multi-value operators are supported

### DIFF
--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -2,12 +2,14 @@
   "grafana-scenes": {
     "components": {
       "adhoc-filter-pill": {
+        "all-values": "All",
         "edit-filter-with-key": "Edit filter with key {{keyLabel}}",
         "managed-filter": "{{origin}} managed filter",
         "non-applicable": "Filter is not applicable",
         "remove-filter-with-key": "Remove filter with key {{keyLabel}}"
       },
       "adhoc-filters-combobox": {
+        "all-values": "All",
         "remove-filter-value": "Remove filter value - {{itemLabel}}",
         "use-custom-value": "Use custom value: {{itemLabel}}"
       },

--- a/packages/scenes/src/querying/SceneQueryRunner.test.ts
+++ b/packages/scenes/src/querying/SceneQueryRunner.test.ts
@@ -679,6 +679,38 @@ describe.each(['11.1.2', '11.1.1'])('SceneQueryRunner', (v) => {
       expect(runRequestCall[1].filters).toEqual([...filtersVar.state.originFilters!, ...filtersVar.state.filters]);
     });
 
+    it('should not pass All-value origin filters via request object', async () => {
+      const queryRunner = new SceneQueryRunner({
+        datasource: { uid: 'test-uid' },
+        queries: [{ refId: 'A' }],
+      });
+
+      const filtersVar = new AdHocFiltersVariable({
+        datasource: { uid: 'test-uid' },
+        applyMode: 'auto',
+        filters: [{ key: 'A', operator: '=', value: 'B', condition: '' }],
+        originFilters: [
+          { key: 'C', operator: '=|', value: '$__all', values: ['$__all'], condition: '', origin: 'dashboard' },
+        ],
+      });
+
+      const scene = new EmbeddedScene({
+        $data: queryRunner,
+        $variables: new SceneVariableSet({ variables: [filtersVar] }),
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      const deactivate = activateFullSceneTree(scene);
+      deactivationHandlers.push(deactivate);
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      const runRequestCall = runRequestMock.mock.calls[0];
+
+      // the All-value origin filter lifts its restriction, so only the user filter is passed
+      expect(runRequestCall[1].filters).toEqual(filtersVar.state.filters);
+    });
+
     it('should merge dashboard and section adhoc filters for the same datasource', async () => {
       const queryRunner = new SceneQueryRunner({
         datasource: { uid: 'test-uid' },

--- a/packages/scenes/src/variables/DrilldownDependenciesManager.ts
+++ b/packages/scenes/src/variables/DrilldownDependenciesManager.ts
@@ -10,6 +10,7 @@ import { GroupByVariable } from '../variables/groupby/GroupByVariable';
 import {
   AdHocFilterWithLabels,
   AdHocFiltersVariable,
+  isAllValueFilter,
   isFilterApplicable,
   isFilterComplete,
   isGroupByFilter,
@@ -180,7 +181,9 @@ export class DrilldownDependenciesManager<TState extends SceneObjectState> {
       return undefined;
     }
 
-    return this._getMergedFilters().filter((f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f));
+    return this._getMergedFilters().filter(
+      (f) => isFilterComplete(f) && isFilterApplicable(f) && !isGroupByFilter(f) && !isAllValueFilter(f)
+    );
   }
 
   /**

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -4,6 +4,7 @@ import { useStyles2, IconButton, Tooltip, Icon } from '@grafana/ui';
 import React from 'react';
 import { AdHocCombobox } from './AdHocFiltersCombobox';
 import { AdHocFilterWithLabels, FilterOrigin, isMatchAllFilter } from '../AdHocFiltersVariable';
+import { ALL_VARIABLE_VALUE } from '../../constants';
 import { AdHocFiltersController } from '../controller/AdHocFiltersController';
 import { t } from '@grafana/i18n';
 import { BasePill } from './BasePill';
@@ -24,7 +25,13 @@ export function AdHocFilterPill({ filter, controller, readOnly, focusOnWipInputR
     useEditablePill({ filter, controller, readOnly, focusOnWipInputRef, isFilterEmpty: isAdhocFilterEmpty });
 
   const keyLabel = filter.keyLabel ?? filter.key;
-  const valueLabel = filter.valueLabels?.join(', ') || filter.values?.join(', ') || filter.value;
+  // The special $__all value always displays as "All", even when no valueLabels were stored
+  const valueLabel =
+    (filter.valueLabels?.length ? filter.valueLabels : filter.values ?? [filter.value])
+      .map((label) =>
+        label === ALL_VARIABLE_VALUE ? t('grafana-scenes.components.adhoc-filter-pill.all-values', 'All') : label
+      )
+      .join(', ') || filter.value;
 
   const getOriginFilterTooltips = (origin: FilterOrigin): { info: string; restore: string } => {
     if (origin === 'dashboard') {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -25,11 +25,14 @@ export function AdHocFilterPill({ filter, controller, readOnly, focusOnWipInputR
     useEditablePill({ filter, controller, readOnly, focusOnWipInputRef, isFilterEmpty: isAdhocFilterEmpty });
 
   const keyLabel = filter.keyLabel ?? filter.key;
-  // The special $__all value always displays as "All", even when no valueLabels were stored
+  // Labels are paired with values so the special $__all value always displays with the
+  // current All translation, even when a stale label was persisted for it
   const valueLabel =
-    (filter.valueLabels?.length ? filter.valueLabels : filter.values ?? [filter.value])
-      .map((label) =>
-        label === ALL_VARIABLE_VALUE ? t('grafana-scenes.components.adhoc-filter-pill.all-values', 'All') : label
+    (filter.values ?? (filter.value ? [filter.value] : []))
+      .map((value, i) =>
+        value === ALL_VARIABLE_VALUE
+          ? t('grafana-scenes.components.adhoc-filter-pill.all-values', 'All')
+          : filter.valueLabels?.[i] || value
       )
       .join(', ') || filter.value;
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -15,6 +15,7 @@ import { Spinner, Text, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { AdHocFilterWithLabels, isMultiValueOperator, OPERATORS } from '../AdHocFiltersVariable';
+import { ALL_VARIABLE_VALUE } from '../../constants';
 import { AdHocFiltersController } from '../controller/AdHocFiltersController';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
@@ -188,10 +189,15 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const handleLocalMultiValueChange = useCallback((selectedItem: SelectableValue<string>) => {
     setFilterMultiValues((items) => {
-      if (items.some((item) => item.value === selectedItem.value)) {
-        return items.filter((item) => item.value !== selectedItem.value);
+      // "All" is exclusive: selecting it clears other values, selecting a value clears "All"
+      if (selectedItem.value === ALL_VARIABLE_VALUE) {
+        return items.some((item) => item.value === ALL_VARIABLE_VALUE) ? [] : [selectedItem];
       }
-      return [...items, selectedItem];
+      const itemsWithoutAll = items.filter((item) => item.value !== ALL_VARIABLE_VALUE);
+      if (itemsWithoutAll.some((item) => item.value === selectedItem.value)) {
+        return itemsWithoutAll.filter((item) => item.value !== selectedItem.value);
+      }
+      return [...itemsWithoutAll, selectedItem];
     });
   }, []);
 
@@ -312,6 +318,17 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     } else {
       filteredDropDownItems.push(customOptionValue);
     }
+  }
+
+  // Origin (default) filters with the "one of" operator offer an explicit "All" option,
+  // like query variables. Selecting it commits the special $__all value, which lifts the
+  // filter's restriction from queries. Not offered for "not one of" where "All" would read
+  // as excluding everything.
+  if (isMultiValueEdit && filter?.origin && filter?.operator === '=|' && !inputValue) {
+    filteredDropDownItems.unshift({
+      label: t('grafana-scenes.components.adhoc-filters-combobox.all-values', 'All'),
+      value: ALL_VARIABLE_VALUE,
+    });
   }
 
   // calculate width and populate listRef and disabledIndicesRef for arrow key navigation
@@ -683,7 +700,10 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           (acc, value, i) => [
             ...acc,
             {
-              label: filter.valueLabels?.[i] || value,
+              label:
+                value === ALL_VARIABLE_VALUE
+                  ? t('grafana-scenes.components.adhoc-filters-combobox.all-values', 'All')
+                  : filter.valueLabels?.[i] || value,
               value: value,
             },
           ],

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -103,6 +103,8 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
   const hasMultiValueOperator = isMultiValueOperator(filter?.operator || '');
   const isMultiValueEdit = hasMultiValueOperator && filterInputType === 'value';
+  // Origin (default) filters with the "one of" operator offer an explicit "All" option
+  const offersAllOption = Boolean(filter?.origin) && filter?.operator === '=|';
 
   // used to identify operator element and prevent dismiss because it registers as outside click
   const operatorIdentifier = useId();
@@ -276,6 +278,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       setActiveIndex(null);
     } else if (!nextFilteredItems.length && allowCustomValue) {
       setActiveIndex(0);
+    } else if (isMultiValueEdit && offersAllOption && !value) {
+      // An empty input re-prepends the All row, which shifts every index by one
+      setActiveIndex(0);
     } else {
       setActiveIndex(getFirstSelectableIndex(nextFilteredItems));
     }
@@ -320,11 +325,9 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
     }
   }
 
-  // Origin (default) filters with the "one of" operator offer an explicit "All" option,
-  // like query variables. Selecting it commits the special $__all value, which lifts the
-  // filter's restriction from queries. Not offered for "not one of" where "All" would read
-  // as excluding everything.
-  if (isMultiValueEdit && filter?.origin && filter?.operator === '=|' && !inputValue) {
+  // Selecting All commits the special $__all value, which lifts the filter's restriction
+  // from queries. Not offered for "not one of" where "All" would read as excluding everything.
+  if (isMultiValueEdit && offersAllOption && !inputValue) {
     filteredDropDownItems.unshift({
       label: t('grafana-scenes.components.adhoc-filters-combobox.all-values', 'All'),
       value: ALL_VARIABLE_VALUE,
@@ -369,7 +372,11 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
           return;
         }
         setOptions(options);
-        if (options[0]?.group) {
+        if (inputType === 'value' && offersAllOption) {
+          // The prepended All row takes the initial highlight, keeping the index valid
+          // when the first fetched option is a group header
+          setActiveIndex(0);
+        } else if (options[0]?.group) {
           setActiveIndex(1);
         } else {
           setActiveIndex(0);
@@ -382,7 +389,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
 
       controller.stopInteraction?.();
     },
-    [filter, controller, isGroupBy]
+    [filter, controller, isGroupBy, offersAllOption]
   );
 
   const rowVirtualizer = useVirtualizer({

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1443,6 +1443,45 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     expect(filtersVar.state.originFilters![0].restorable).toBe(false);
   });
 
+  it('should clear dashboard filter to the =| All sentinel when multi-value operators are supported (issue #1602)', () => {
+    const { filtersVar } = setup({
+      supportsMultiValueOperators: true,
+      originFilters: [
+        {
+          key: 'dbFilter1',
+          operator: '=|',
+          value: 'dbValue1',
+          values: ['dbValue1', 'dbValue2'],
+          origin: 'dashboard',
+        },
+      ],
+    });
+
+    act(() => {
+      filtersVar.updateToMatchAll(filtersVar.state.originFilters![0]);
+    });
+
+    // Cleared state is the same one selecting "All" in the combobox produces:
+    // stripped from queries (neutral by construction), never the regex
+    // match-all that non-Prometheus datasources misinterpret.
+    const cleared = filtersVar.state.originFilters![0];
+    expect(cleared.key).toBe('dbFilter1');
+    expect(cleared.operator).toBe('=|');
+    expect(cleared.value).toBe('$__all');
+    expect(cleared.values).toEqual(['$__all']);
+    expect(cleared.valueLabels).toEqual(['All']);
+    expect(cleared.matchAllFilter).toBe(false);
+    expect(cleared.restorable).toBe(true);
+
+    act(() => {
+      filtersVar.restoreOriginalFilter(filtersVar.state.originFilters![0]);
+    });
+
+    expect(filtersVar.state.originFilters![0].operator).toBe('=|');
+    expect(filtersVar.state.originFilters![0].values).toEqual(['dbValue1', 'dbValue2']);
+    expect(filtersVar.state.originFilters![0].restorable).toBe(false);
+  });
+
   it('will save the original value and set filter as restorable if it has an origin', () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -2028,6 +2028,21 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(variable.getValue('["env"]')).toEqual(['prod', 'staging']);
     });
 
+    it('skips All-value filters', () => {
+      const variable = makeVariable({
+        originFilters: [{ key: 'env', operator: '=|', value: '$__all', values: ['$__all'], origin: 'dashboard' }],
+      });
+      expect(variable.getValue('["env"]')).toBe('');
+    });
+
+    it('returns only concrete values when an All-value filter shares the key', () => {
+      const variable = makeVariable({
+        originFilters: [{ key: 'env', operator: '=|', value: '$__all', values: ['$__all'], origin: 'dashboard' }],
+        filters: [{ key: 'env', operator: '=', value: 'prod' }],
+      });
+      expect(variable.getValue('["env"]')).toBe('prod');
+    });
+
     it('flattens multiple filters sharing a key into one array', () => {
       const variable = makeVariable({
         filters: [
@@ -3314,6 +3329,63 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       const valuesCallFilters = getTagValuesSpy.mock.calls[0][0].filters;
       expect(valuesCallFilters.some((f: AdHocFilterWithLabels) => f.key === 'cluster')).toBe(true);
       expect(valuesCallFilters.some((f: AdHocFilterWithLabels) => f.key === 'pod')).toBe(false);
+    });
+
+    it('treats the sentinel as a literal value for operators other than one-of', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [
+          { key: 'key1', operator: '=', value: '$__all' },
+          { key: 'key2', operator: '!=|', value: '$__all', values: ['$__all'] },
+        ],
+      });
+
+      variable.activate();
+
+      const expression = String(variable.getValue());
+      expect(expression).toContain('key1="$__all"');
+      expect(expression).toContain('key2');
+    });
+
+    it('keeps Enter on the All row when options are grouped', async () => {
+      setup({
+        getTagValuesProvider: async () => ({
+          replace: true,
+          values: [
+            { text: 'v1', value: 'v1', group: 'Group 1' },
+            { text: 'v2', value: 'v2', group: 'Group 1' },
+          ],
+        }),
+        originFilters: [{ key: 'pod', operator: '=|', value: 'test1', values: ['test1'], origin: 'dashboard' }],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod =| test1'));
+      await screen.findByTestId(allOptionTestId);
+
+      // The initial highlight sits on the prepended All row, not the group header
+      await userEvent.keyboard('{Enter}');
+
+      expect(within(screen.getByTestId(allOptionTestId)).getByRole('checkbox')).toBeChecked();
+    });
+
+    it('renders the current All label even when a stale label was persisted', async () => {
+      setup({
+        originFilters: [
+          {
+            key: 'pod',
+            operator: '=|',
+            value: '$__all',
+            values: ['$__all'],
+            valueLabels: ['Alle'],
+            origin: 'dashboard',
+          },
+        ],
+        layout: 'combobox',
+      });
+
+      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
     });
   });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, getAllByRole, render, waitFor, screen } from '@testing-library/react';
+import { act, getAllByRole, render, waitFor, screen, within } from '@testing-library/react';
 import { SceneVariable, SceneVariableValueChangedEvent } from '../types';
 import {
   AdHocFiltersVariable,
@@ -3132,6 +3132,188 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       await userEvent.keyboard('{Escape}');
 
       expect(screen.getByText('pod =~ All')).toBeInTheDocument();
+    });
+  });
+
+  describe('origin filter "All" value option', () => {
+    // jsdom layout mocks for floating-ui positioning and @tanstack/react-virtual measurement
+    beforeAll(() => {
+      Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({
+          width: 200,
+          height: 32,
+          top: 0,
+          left: 0,
+          bottom: 32,
+          right: 200,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }),
+      });
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 480 });
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 200 });
+      globalThis.ResizeObserver ??= class {
+        public observe() {}
+        public unobserve() {}
+        public disconnect() {}
+      } as unknown as typeof ResizeObserver;
+    });
+
+    const allOptionTestId = 'data-testid ad hoc filter option value All';
+
+    it('offers All as the first option when editing a one-of origin filter', async () => {
+      setup({
+        originFilters: [
+          { key: 'pod', operator: '=|', value: 'test1', values: ['test1', 'test2'], origin: 'dashboard' },
+        ],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod =| test1, test2'));
+
+      expect(await screen.findByTestId(allOptionTestId)).toBeInTheDocument();
+      expect(screen.getAllByRole('option')[0]).toHaveTextContent('All');
+    });
+
+    it('does not offer All for user-added filters', async () => {
+      setup({
+        filters: setTemplateSrvWithFilters([
+          { key: 'key1', operator: '=|', value: 'val3', values: ['val3'] } as AdHocVariableFilter,
+        ]),
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('key1 =| val3'));
+
+      expect(await screen.findByTestId('data-testid ad hoc filter option value val3')).toBeInTheDocument();
+      expect(screen.queryByTestId(allOptionTestId)).not.toBeInTheDocument();
+    });
+
+    it('does not offer All for not-one-of origin filters', async () => {
+      setup({
+        originFilters: [{ key: 'pod', operator: '!=|', value: 'test1', values: ['test1'], origin: 'dashboard' }],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod !=| test1'));
+
+      expect(await screen.findByTestId('data-testid ad hoc filter option value val3')).toBeInTheDocument();
+      expect(screen.queryByTestId(allOptionTestId)).not.toBeInTheDocument();
+    });
+
+    it('selecting All clears other selections and applies the special $__all value', async () => {
+      const { filtersVar } = setup({
+        originFilters: [
+          { key: 'pod', operator: '=|', value: 'test1', values: ['test1', 'test2'], origin: 'dashboard' },
+        ],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod =| test1, test2'));
+      await userEvent.click(await screen.findByTestId(allOptionTestId));
+
+      // selecting All clears the test1/test2 multi-value pills
+      expect(screen.queryByText('test1')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
+      expect(filtersVar.state.originFilters?.[0]).toMatchObject({
+        operator: '=|',
+        value: '$__all',
+        values: ['$__all'],
+        valueLabels: ['All'],
+        restorable: true,
+      });
+    });
+
+    it('selecting a value after All replaces the All selection', async () => {
+      const { filtersVar } = setup({
+        originFilters: [
+          { key: 'pod', operator: '=|', value: 'test1', values: ['test1', 'test2'], origin: 'dashboard' },
+        ],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod =| test1, test2'));
+      await userEvent.click(await screen.findByTestId(allOptionTestId));
+      await userEvent.click(screen.getByTestId('data-testid ad hoc filter option value val3'));
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(await screen.findByText('pod =| val3')).toBeInTheDocument();
+      expect(filtersVar.state.originFilters?.[0]).toMatchObject({ values: ['val3'] });
+    });
+
+    it('shows All as checked and restorable=false when All is the dashboard default', async () => {
+      const { filtersVar } = setup({
+        originFilters: [{ key: 'pod', operator: '=|', value: '$__all', values: ['$__all'], origin: 'dashboard' }],
+        layout: 'combobox',
+      });
+
+      // pill label falls back to "All" from the sentinel even without valueLabels
+      await userEvent.click(await screen.findByText('pod =| All'));
+
+      const allOption = await screen.findByTestId(allOptionTestId);
+      expect(within(allOption).getByRole('checkbox')).toBeChecked();
+      expect(filtersVar.state.originFilters?.[0].restorable).toBeFalsy();
+    });
+
+    it('restores the dashboard default from All', async () => {
+      setup({
+        originFilters: [
+          { key: 'pod', operator: '=|', value: 'test1', values: ['test1', 'test2'], origin: 'dashboard' },
+        ],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod =| test1, test2'));
+      await userEvent.click(await screen.findByTestId(allOptionTestId));
+      await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Restore the value set by this dashboard.' }));
+
+      expect(await screen.findByText('pod =| test1, test2')).toBeInTheDocument();
+    });
+
+    it('excludes All-value filters from the filter expression', () => {
+      const variable = new AdHocFiltersVariable({
+        datasource: { uid: 'hello' },
+        applyMode: 'manual',
+        filters: [
+          { key: 'key1', operator: '=', value: 'val1' },
+          { key: 'key2', operator: '=|', value: '$__all', values: ['$__all'] },
+        ],
+      });
+
+      variable.activate();
+
+      expect(variable.getValue()).toBe(`key1="val1"`);
+    });
+
+    it('excludes All-value origin filters from getTagKeys and getTagValues calls', async () => {
+      const { filtersVar, getTagKeysSpy, getTagValuesSpy } = setup({
+        originFilters: [
+          { key: 'pod', operator: '=|', value: '$__all', values: ['$__all'], origin: 'dashboard' },
+          { key: 'cluster', operator: '=', value: 'us-east', origin: 'dashboard' },
+        ],
+        layout: 'combobox',
+      });
+
+      await filtersVar._getKeys(null);
+
+      const keysCallFilters = getTagKeysSpy.mock.calls[0][0].filters;
+      expect(keysCallFilters.some((f: AdHocFilterWithLabels) => f.key === 'cluster')).toBe(true);
+      expect(keysCallFilters.some((f: AdHocFilterWithLabels) => f.key === 'pod')).toBe(false);
+
+      await filtersVar._getValuesFor(filtersVar.state.filters[0]);
+
+      const valuesCallFilters = getTagValuesSpy.mock.calls[0][0].filters;
+      expect(valuesCallFilters.some((f: AdHocFilterWithLabels) => f.key === 'cluster')).toBe(true);
+      expect(valuesCallFilters.some((f: AdHocFilterWithLabels) => f.key === 'pod')).toBe(false);
     });
   });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -39,6 +39,7 @@ import { getQueryController } from '../../core/sceneGraph/getQueryController';
 import { FILTER_REMOVED_INTERACTION, FILTER_RESTORED_INTERACTION } from '../../performance/interactionConstants';
 import { AdHocFiltersVariableController } from './controller/AdHocFiltersVariableController';
 import { AdHocFiltersRecommendations } from './AdHocFiltersRecommendations';
+import { ALL_VARIABLE_VALUE } from '../constants';
 
 export interface AdHocFilterWithLabels<M extends Record<string, any> = {}> extends AdHocVariableFilter {
   keyLabel?: string;
@@ -1178,9 +1179,14 @@ export class AdHocFiltersVariable
     await this._waitForVariables();
 
     const applicableOriginFilters =
-      this.state.originFilters?.filter((f) => !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f)) ?? [];
+      this.state.originFilters?.filter(
+        (f) => !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f) && !isAllValueFilter(f)
+      ) ?? [];
     const otherFilters = this.state.filters
-      .filter((f) => f.key !== currentKey && !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f))
+      .filter(
+        (f) =>
+          f.key !== currentKey && !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f) && !isAllValueFilter(f)
+      )
       .concat(this.state.baseFilters ?? [])
       .concat(applicableOriginFilters);
     const timeRange = sceneGraph.getTimeRange(this).state.value;
@@ -1287,10 +1293,11 @@ export class AdHocFiltersVariable
     await this._waitForVariables();
 
     const originFilters =
-      this.state.originFilters?.filter((f) => f.key !== filter.key && !isGroupByFilter(f) && !isMatchAllFilter(f)) ??
-      [];
+      this.state.originFilters?.filter(
+        (f) => f.key !== filter.key && !isGroupByFilter(f) && !isMatchAllFilter(f) && !isAllValueFilter(f)
+      ) ?? [];
     const otherFilters = this.state.filters
-      .filter((f) => f.key !== filter.key && !isGroupByFilter(f) && !isMatchAllFilter(f))
+      .filter((f) => f.key !== filter.key && !isGroupByFilter(f) && !isMatchAllFilter(f) && !isAllValueFilter(f))
       .concat(originFilters);
 
     const timeRange = sceneGraph.getTimeRange(this).state.value;
@@ -1363,7 +1370,7 @@ function renderExpression(
   filters: AdHocFilterWithLabels[] | undefined
 ) {
   return (builder ?? renderPrometheusLabelFilters)(
-    filters?.filter((f) => isFilterApplicable(f) && !isGroupByFilter(f)) ?? []
+    filters?.filter((f) => isFilterApplicable(f) && !isGroupByFilter(f) && !isAllValueFilter(f)) ?? []
   );
 }
 
@@ -1446,6 +1453,15 @@ export function toSelectableValue(input: MetricFindValue): SelectableValue<strin
 
 export function isMatchAllFilter(filter: AdHocFilterWithLabels): boolean {
   return filter.operator === '=~' && filter.value === '.*';
+}
+
+/**
+ * True when the filter has the special "All" value selected, meaning it should not
+ * restrict queries. Origin (default) filters offer "All" in the multi-value combobox
+ * so dashboard authors can pre-select a key without restricting its values.
+ */
+export function isAllValueFilter(filter: AdHocFilterWithLabels): boolean {
+  return filter.values ? filter.values.includes(ALL_VARIABLE_VALUE) : filter.value === ALL_VARIABLE_VALUE;
 }
 
 export const GROUP_BY_OPERATOR = 'groupBy';

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -1185,7 +1185,11 @@ export class AdHocFiltersVariable
     const otherFilters = this.state.filters
       .filter(
         (f) =>
-          f.key !== currentKey && !f.nonApplicable && !isGroupByFilter(f) && !isMatchAllFilter(f) && !isAllValueFilter(f)
+          f.key !== currentKey &&
+          !f.nonApplicable &&
+          !isGroupByFilter(f) &&
+          !isMatchAllFilter(f) &&
+          !isAllValueFilter(f)
       )
       .concat(this.state.baseFilters ?? [])
       .concat(applicableOriginFilters);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -938,6 +938,22 @@ export class AdHocFiltersVariable
 
       this.setState({ originFilters: updatedOrigins });
       getAdHocFilterInteractionHandler(this)?.onGroupByRemoved?.({ key: filter.key, origin: filter.origin });
+    } else if (this.state.supportsMultiValueOperators) {
+      // Clear to the all-value sentinel (`=| $__all`) — the same state selecting
+      // "All" in the combobox produces. It is stripped from queries before any
+      // datasource sees it, so it is neutral by construction. The legacy `=~ .*`
+      // match-all below IS passed to queries, which is only neutral for
+      // datasources with Prometheus-style regex semantics (issue #1602).
+      this._updateFilter(filter, {
+        operator: '=|',
+        value: ALL_VARIABLE_VALUE,
+        values: [ALL_VARIABLE_VALUE],
+        valueLabels: ['All'],
+        matchAllFilter: false,
+        nonApplicable: false,
+        restorable: true,
+      });
+      getAdHocFilterInteractionHandler(this)?.onFilterMatchAll?.({ key: filter.key, origin: filter.origin });
     } else {
       this._updateFilter(filter, {
         operator: '=~',

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.tsx
@@ -801,7 +801,7 @@ export class AdHocFiltersVariable
     const { originFilters, filters, _wip } = this.state;
 
     const matches = [...(originFilters ?? []), ...filters].filter(
-      (f) => f !== _wip && !isGroupByFilter(f) && f.key === key
+      (f) => f !== _wip && !isGroupByFilter(f) && !isAllValueFilter(f) && f.key === key
     );
 
     if (matches.length === 0) {
@@ -1463,8 +1463,13 @@ export function isMatchAllFilter(filter: AdHocFilterWithLabels): boolean {
  * True when the filter has the special "All" value selected, meaning it should not
  * restrict queries. Origin (default) filters offer "All" in the multi-value combobox
  * so dashboard authors can pre-select a key without restricting its values.
+ * Only the "one of" operator supports the All value - for any other operator a
+ * $__all value is treated as a literal so legitimate filters are not dropped.
  */
 export function isAllValueFilter(filter: AdHocFilterWithLabels): boolean {
+  if (filter.operator !== '=|') {
+    return false;
+  }
   return filter.values ? filter.values.includes(ALL_VARIABLE_VALUE) : filter.value === ALL_VARIABLE_VALUE;
 }
 


### PR DESCRIPTION
Fixes #1602. **Stacked on #1591** (base branch is `sj/adhoc-default-filters-all-option`) - the diff shows only the delta. Could equally be folded into #1591 as one more commit; draft until we decide.

## Problem

Clearing (X) a dashboard-origin filter rewrites it to the legacy regex match-all (`=~` / `.*`), which is deliberately passed through to panel queries. That is neutral only for datasources with Prometheus-style regex semantics. Non-regex datasources misinterpret it - e.g. the Cube datasource maps `=~` to equals, so the cleared state becomes `WHERE x = '.*'` and every panel shows **No data** while the pill reads "All".

## Change

In `updateToMatchAll`, when the variable has `supportsMultiValueOperators`, clear to the all-value sentinel (`operator: '=|'`, value `$__all`) introduced by #1591 - the exact state selecting "All" in the combobox produces. It is stripped from queries in `DrilldownDependenciesManager.getFilters()` before any datasource sees it: neutral by construction, regardless of the datasource's regex semantics.

Gating rationale:
- The cleared state should be an operator the user could have picked themselves; `=| All` only exists where `=|` is offered.
- No first-party datasource (Prometheus, Loki, ...) declares `multiValueFilterOperators`, so their `=~ .*` behaviour is untouched exactly where it is load-bearing.
- `supportsMultiValueOperators` already flows from the datasource's plugin meta - no new capability concept needed (the longer-term operator-capability design is grafana/grafana#130279).

All clear paths route through `updateToMatchAll` (pill X, combobox backspace, committing an emptied multi-value selection), so one branch covers them all. Restore is unaffected: `originalValueKey` is keyed on `key::origin`, not operator - covered in the new test.

## Tests

- New: clearing with `supportsMultiValueOperators: true` yields `=| $__all` / `valueLabels: ['All']` / `restorable: true`, and restore returns the original values.
- Existing match-all tests (default state, no multi-value support) pass unchanged - the legacy path is preserved.
- Full adhoc + DrilldownDependenciesManager + SceneQueryRunner suites: 669/669.