### PR TITLE
Variables: Add xxhash and xxh3 template variable format functions

### DIFF
--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -58,7 +58,8 @@
     "react-select": "^5.10.2",
     "react-use": "^17.5.0",
     "react-virtualized-auto-sizer": "^1.0.24",
-    "uuid": "^11.0.0"
+    "uuid": "^11.0.0",
+    "xxhashjs": "^0.2.2"
   },
   "peerDependencies": {
     "@grafana/data": ">=11.6",
@@ -84,6 +85,7 @@
     "@types/react-grid-layout": "1.3.6",
     "@types/react-virtualized-auto-sizer": "1.0.8",
     "@types/systemjs": "^6.15.1",
+    "@types/xxhashjs": "^0.2.4",
     "eslint": "^9.28.0",
     "i18next-parser": "9.4.0",
     "jest": "30.4.2",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -52,6 +52,7 @@
     "@floating-ui/react": "^0.27.0",
     "@leeoniya/ufuzzy": "^1.0.16",
     "@tanstack/react-virtual": "^3.9.0",
+    "hash-wasm": "^4.12.0",
     "history": "^4.9.0",
     "lodash": "^4.17.21",
     "react-grid-layout": "^1.3.4",

--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -159,6 +159,66 @@ describe('formatRegistry', () => {
     });
   });
 
+  describe('xxhash', () => {
+    // Well-known xxhash64 reference vector for the empty string with seed=0.
+    it('hashes the empty string to the reference xxhash64 vector (seed=0)', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      expect(formatValue('xxhash', '')).toBe('ef46db3751d8e999');
+    });
+
+    it('produces zero-padded 16-char lowercase hex', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const out = formatValue('xxhash', 'serial-12345');
+      expect(out).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('is deterministic for the same input and seed', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const first = formatValue('xxhash', 'SN-42');
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const second = formatValue('xxhash', 'SN-42');
+      expect(first).toBe(second);
+    });
+
+    it('changes when the seed changes', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const withoutSeed = formatValue('xxhash', 'SN-42');
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const withDecimalSeed = formatValue('xxhash', 'SN-42', 'text', ['1']);
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const withHexSeed = formatValue('xxhash', 'SN-42', 'text', ['0x1']);
+      expect(withoutSeed).not.toBe(withDecimalSeed);
+      expect(withDecimalSeed).toBe(withHexSeed);
+    });
+
+    it('coerces non-string values before hashing', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const numeric = formatValue('xxhash', 12345);
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const stringified = formatValue('xxhash', '12345');
+      expect(numeric).toBe(stringified);
+      expect(numeric).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('joins array elements as comma-separated hashes', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const out = formatValue('xxhash', ['SN-1', 'SN-2']);
+      const parts = out.split(',');
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toMatch(/^[0-9a-f]{16}$/);
+      expect(parts[1]).toMatch(/^[0-9a-f]{16}$/);
+      expect(parts[0]).not.toBe(parts[1]);
+    });
+
+    it('falls back to seed=0 when the seed argument is invalid', () => {
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const explicit = formatValue('xxhash', 'SN-42', 'text', ['0']);
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const invalid = formatValue('xxhash', 'SN-42', 'text', ['not-a-number']);
+      expect(invalid).toBe(explicit);
+    });
+  });
+
   describe('queryparam', () => {
     it('should url encode value', () => {
       const result = formatValue(VariableFormatID.QueryParam, 'helloAZ%=');

--- a/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.test.ts
@@ -2,7 +2,7 @@ import { AdHocFiltersVariable } from '../adhoc/AdHocFiltersVariable';
 import { VariableValue } from '../types';
 import { TestVariable } from '../variants/TestVariable';
 
-import { formatRegistry } from './formatRegistry';
+import { _xxh3Ready, formatRegistry } from './formatRegistry';
 import { VariableFormatID } from '@grafana/schema';
 
 jest.mock('@grafana/runtime', () => ({
@@ -156,6 +156,61 @@ describe('formatRegistry', () => {
       const result = formatter('10', [], variable, 'username');
       expect(getValueText).toHaveBeenCalledWith('username');
       expect(result).toBe('alice');
+    });
+  });
+
+  describe('xxh3', () => {
+    // hash-wasm's createXXHash3 is async. formatRegistry fires this at module
+    // load; tests explicitly wait for that promise before asserting.
+    beforeAll(async () => {
+      await _xxh3Ready();
+    });
+
+    // Well-known xxh3-64 reference vector for the empty string with seed=0.
+    it('hashes the empty string to the reference xxh3-64 vector (seed=0)', () => {
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      expect(formatValue('xxh3', '')).toBe('2d06800538d394c2');
+    });
+
+    it('produces 16-char lowercase hex', () => {
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const out = formatValue('xxh3', 'serial-12345');
+      expect(out).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('is deterministic for the same input', () => {
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const first = formatValue('xxh3', 'SN-42');
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const second = formatValue('xxh3', 'SN-42');
+      expect(first).toBe(second);
+    });
+
+    it('coerces non-string values before hashing', () => {
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const numeric = formatValue('xxh3', 12345);
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const stringified = formatValue('xxh3', '12345');
+      expect(numeric).toBe(stringified);
+      expect(numeric).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('joins array elements as comma-separated hashes', () => {
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const out = formatValue('xxh3', ['SN-1', 'SN-2']);
+      const parts = out.split(',');
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toMatch(/^[0-9a-f]{16}$/);
+      expect(parts[1]).toMatch(/^[0-9a-f]{16}$/);
+      expect(parts[0]).not.toBe(parts[1]);
+    });
+
+    it('produces a different digest than xxhash64 for the same input', () => {
+      // @ts-expect-error xxh3 not in depended @grafana/schema yet
+      const xxh3Out = formatValue('xxh3', 'SN-42');
+      // @ts-expect-error xxhash not in depended @grafana/schema yet
+      const xxhashOut = formatValue('xxhash', 'SN-42');
+      expect(xxh3Out).not.toBe(xxhashOut);
     });
   });
 

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -1,4 +1,5 @@
 import { t } from '@grafana/i18n';
+import { createXXHash3, IHasher } from 'hash-wasm';
 import { isArray, map, replace } from 'lodash';
 import { h64 as xxhashH64 } from 'xxhashjs';
 
@@ -389,6 +390,20 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
         return xxhash64Hex(value, seed);
       },
     },
+    {
+      id: 'xxh3', // not yet available in depended @grafana/schema version
+      name: 'xxh3',
+      description: t(
+        'grafana-scenes.variables.format-registry.formats.description.xxh3',
+        'Hash value with xxh3 (64-bit) as zero-padded hex. Seeds are not supported; seed is always 0.'
+      ),
+      formatter: (value) => {
+        if (isArray(value)) {
+          return value.map((v) => xxh3Hex(v)).join(',');
+        }
+        return xxh3Hex(value);
+      },
+    },
   ];
 
   return formats;
@@ -463,4 +478,34 @@ function parseXxhashSeed(arg: string | undefined): number {
   }
   const parsed = arg.startsWith('0x') || arg.startsWith('0X') ? parseInt(arg.slice(2), 16) : parseInt(arg, 10);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+// hash-wasm's xxh3 requires an async WASM init. The format registry API is
+// synchronous, so we kick off init once at module load and cache the resolved
+// hasher. If a formatter call arrives before init completes we return the raw
+// input value with a console warning so the query still fires; a subsequent
+// dashboard refresh will interpolate the correct hash.
+let xxh3Hasher: IHasher | null = null;
+const xxh3HasherPromise: Promise<void> = createXXHash3(0, 0)
+  .then((h) => {
+    xxh3Hasher = h;
+  })
+  .catch(() => {
+    // Leaving xxh3Hasher null keeps the graceful-degradation path active.
+  });
+
+// Exported for tests only. Consumers should not depend on this being a
+// documented API surface.
+export const _xxh3Ready = (): Promise<void> => xxh3HasherPromise;
+
+function xxh3Hex(value: VariableValueSingle): string {
+  const input = typeof value === 'string' ? value : String(value);
+  if (xxh3Hasher === null) {
+    // eslint-disable-next-line no-console
+    console.warn('[scenes] xxh3 WASM not yet initialized; returning unhashed value for ${var:xxh3}');
+    return input;
+  }
+  xxh3Hasher.init();
+  xxh3Hasher.update(input);
+  return xxh3Hasher.digest('hex');
 }

--- a/packages/scenes/src/variables/interpolation/formatRegistry.ts
+++ b/packages/scenes/src/variables/interpolation/formatRegistry.ts
@@ -1,5 +1,6 @@
 import { t } from '@grafana/i18n';
 import { isArray, map, replace } from 'lodash';
+import { h64 as xxhashH64 } from 'xxhashjs';
 
 import { dateTime, Registry, RegistryItem, textUtil, escapeRegex, urlUtil } from '@grafana/data';
 import { VariableType, VariableFormatID } from '@grafana/schema';
@@ -373,6 +374,21 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
         return encodeURIStrict(value);
       },
     },
+    {
+      id: 'xxhash', // not yet available in depended @grafana/schema version
+      name: 'xxhash',
+      description: t(
+        'grafana-scenes.variables.format-registry.formats.description.xxhash',
+        'Hash value with xxhash64 as zero-padded hex. Useful when a datasource stores hashed identifiers.'
+      ),
+      formatter: (value, args) => {
+        const seed = parseXxhashSeed(args[0]);
+        if (isArray(value)) {
+          return value.map((v) => xxhash64Hex(v, seed)).join(',');
+        }
+        return xxhash64Hex(value, seed);
+      },
+    },
   ];
 
   return formats;
@@ -433,4 +449,18 @@ function sqlStringFormatter(value: VariableValue) {
 
   let strVal = typeof value === 'string' ? value : String(value);
   return `'${replace(strVal, regExp, (match) => SQL_ESCAPE_MAP[match] ?? '')}'`;
+}
+
+function xxhash64Hex(value: VariableValueSingle, seed: number): string {
+  const input = typeof value === 'string' ? value : String(value);
+  // xxhashjs returns a UINT64 whose toString(16) is unpadded; pad to a stable 16 hex chars.
+  return xxhashH64(input, seed).toString(16).padStart(16, '0');
+}
+
+function parseXxhashSeed(arg: string | undefined): number {
+  if (arg === undefined || arg === '') {
+    return 0;
+  }
+  const parsed = arg.startsWith('0x') || arg.startsWith('0X') ? parseInt(arg.slice(2), 16) : parseInt(arg, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
 }


### PR DESCRIPTION
## Summary

Adds two new template variable format functions:

- **`${var:xxhash}`** — hashes with **xxhash64**, zero-padded 16-char lowercase hex, seed-configurable. Pure-JS synchronous implementation.
- **`${var:xxh3}`** — hashes with **xxh3-64**, zero-padded 16-char lowercase hex, seed fixed at 0. WebAssembly implementation with a lazy-init warmup at module load.

### Motivation

Some data sources store hashed identifiers (a common pattern for high-cardinality labels in Loki/Prometheus, where the emitter replaces a serial number, tenant id, or account id with a hash at ingest for faster label matching). Users querying those data sources today have no way to type the original unhashed value in a variable input — they have to compute the hash themselves, out-of-band, and paste it. `${var:xxhash}` and `${var:xxh3}` close that gap: users type the raw value, Grafana hashes it client-side before the query is sent to the data source.

Two formatters are shipped because different producers pick different xxHash variants: `xxhash64` is the older widely-adopted default; `xxh3-64` is the newer default that many recent tools have moved to.

### Behavior

```
serial = 'SN-42'
${serial:xxhash}         -> 16-char lowercase hex xxhash64 digest, seed=0
${serial:xxhash:1234}    -> same, but with decimal seed 1234
${serial:xxhash:0x1234}  -> same, but with hex seed 0x1234
${serial:xxh3}           -> 16-char lowercase hex xxh3-64 digest, seed=0

serials = ['SN-1', 'SN-2']
${serials:xxhash}        -> '<digest-1>,<digest-2>'
${serials:xxh3}          -> '<digest-1>,<digest-2>'
```

Non-string values are stringified via `String(value)` before hashing. Invalid seed args for `xxhash` fall back to 0.

## Design notes

### `${var:xxhash}` — synchronous via `xxhashjs`

`xxhashjs` (pierrec/js-xxhash, ~298 stars, MIT, updated Jul 2026) is a pure-JS xxhash implementation with a synchronous API. Fits Grafana's synchronous `FormatRegistryItem.formatter(value, args, variable): string` contract without any redesign. Matches Cyan4973/xxHash reference output.

### `${var:xxh3}` — WebAssembly via `hash-wasm` with lazy init

xxh3 in pure sync JS in the browser is a puzzle: there is no widely-adopted, actively-maintained pure-JS xxh3 implementation. The realistic options were:

| Library | xxh3 variants | Sync? | Stars |
|---|---|---|---|
| `xxh3-ts` | XXH3-128 only | ✅ sync | 11 ★ |
| `hash-wasm` | XXH3-64 + XXH3-128 | ❌ async init | 1,152 ★ |
| `xxhash-wasm` | none (h32/h64 only) | — | 184 ★ |

`xxh3-ts` was tempting for its sync API but only ships XXH3-128 and has a low supply-chain score. `hash-wasm` is the mature choice, and it provides both XXH3-64 and XXH3-128 with a factory-hasher pattern whose per-call `update`/`digest` are synchronous once the WebAssembly module has initialized.

To fit `hash-wasm` into the synchronous formatter contract:

- `createXXHash3(0, 0)` is fired at module load and its resolved `IHasher` is cached in a module-level variable.
- The `${var:xxh3}` formatter checks whether the hasher is ready and, if so, calls `init()`/`update(input)`/`digest('hex')` synchronously.
- If a formatter call arrives before init has resolved (typically only on the very first render after a hard reload), the formatter returns the raw input value with a `console.warn`. A dashboard refresh interpolates the correct hash. This is the least-surprising graceful degradation given the contract mismatch.
- The initialization promise is exported as an internal `_xxh3Ready` helper for tests only. This is not intended as a public API surface.

**Seeds are intentionally not supported for `${var:xxh3}`.** `hash-wasm` binds the seed at `createXXHash3()` time (not per-hash), so supporting arbitrary per-call seeds would require a hasher-per-seed cache with an async init on each unseen seed. Users who need a seeded hash can use `${var:xxhash}`.

### Enum entries

Both formatters are registered with string-literal `id`s (`'xxhash'` and `'xxh3'`) with the standard `// not yet available in depended @grafana/schema version` comment, matching the `join` and `customqueryparam` precedent. A companion PR against `grafana/grafana` adds `XXHash = 'xxhash'` and `XXH3 = 'xxh3'` to `VariableFormatID`.

### Sync + tree-shaking

`sideEffects: false` is preserved for the `xxhash` formatter (`xxhashH64` is only invoked inside the formatter closure). The `xxh3` formatter has one intentional top-level side effect: `createXXHash3(0, 0).then(...)`. Because `formatRegistry` is imported and used by grafana's `formatVariableValue`, the module always evaluates and the init always fires; `sideEffects: false` remains truthful at the package level for consumers that never touch the registry.

## Companion PR

- grafana/grafana#130648 — adds the `VariableFormatID.XXHash` and `VariableFormatID.XXH3` enum entries and the user-facing docs.

## Test plan

- [x] `formatRegistry.test.ts` — new `describe('xxhash')` block with 7 tests (empty-string reference vector, output shape, determinism, seed variance, non-string coercion, multi-value arrays, invalid seed fallback).
- [x] `formatRegistry.test.ts` — new `describe('xxh3')` block with 6 tests, gated on `_xxh3Ready()` in `beforeAll` so tests wait for WASM init (empty-string reference vector `2d06800538d394c2`, output shape, determinism, non-string coercion, multi-value arrays, cross-formatter divergence vs xxhash).
- [ ] Reviewer: run `yarn test packages/scenes/src/variables/interpolation/formatRegistry.test.ts` after `yarn install` picks up the new `xxhashjs` and `hash-wasm` deps. `hash-wasm` uses WASM; if the jest jsdom env cannot instantiate the WebAssembly module, the `xxh3` tests may need a jest-environment tweak — please flag if that happens.