### PR TITLE
feat: add system transformations

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -26,6 +26,7 @@ import { subscribeToStateUpdates } from '../../utils/test/utils';
 import { SceneVariableSet } from '../variables/sets/SceneVariableSet';
 import { TextBoxVariable } from '../variables/variants/TextBoxVariable';
 import { activateFullSceneTree } from '../utils/test/activateFullSceneTree';
+import { setWindowGrafanaSceneContext } from '../utils/compatibility/setWindowGrafanaSceneContext';
 
 class TestSceneObject extends SceneObjectBase<{}> {}
 
@@ -40,6 +41,14 @@ const transformer2config = {
   id: 'transformer2',
   options: {
     option: 'value2',
+  },
+};
+
+// Adds instead of multiplying, so ordering against transformer1/transformer2 is observable
+const transformer3config = {
+  id: 'transformer3',
+  options: {
+    option: 'value3',
   },
 };
 
@@ -180,6 +189,27 @@ describe('SceneDataTransformer', () => {
                     return {
                       ...field,
                       values: field.values.map((v) => v * 3),
+                    };
+                  }),
+                };
+              });
+            })
+          );
+        },
+      },
+      {
+        id: 'transformer3',
+        name: 'Custom Transformer3',
+        operator: (options) => (source) => {
+          return source.pipe(
+            map((data) => {
+              return data.map((frame) => {
+                return {
+                  ...frame,
+                  fields: frame.fields.map((field) => {
+                    return {
+                      ...field,
+                      values: field.values.map((v) => v + 10),
                     };
                   }),
                 };
@@ -1243,6 +1273,280 @@ describe('SceneDataTransformer', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('systemTransformations', () => {
+    // Each transformer needs its own source node, as $data is re-parented to its owner
+    const buildSourceDataNode = () =>
+      new SceneDataNode({
+        data: {
+          state: LoadingState.Done,
+          timeRange: getDefaultTimeRange(),
+          series: [
+            toDataFrame([
+              [100, 1],
+              [200, 2],
+              [300, 3],
+            ]),
+          ],
+          annotations: toAnnotationDataFrame([
+            toDataFrame([
+              [400, 1],
+              [500, 2],
+              [600, 3],
+            ]),
+          ]),
+        },
+      });
+
+    it('applies system transformations before user transformations', () => {
+      const systemFirst = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [transformer3config],
+        systemTransformations: { prepend: [transformer1config] },
+      });
+
+      systemFirst.activate();
+
+      // system (* 2) then user (+ 10)
+      expect(systemFirst.state.data?.series[0].fields[0].values).toEqual([210, 410, 610]);
+
+      // Swapping which list each config sits in swaps the result, so the order is the
+      // prepend/user split and not the order the configs were written in
+      const userFirst = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [transformer1config],
+        systemTransformations: { prepend: [transformer3config] },
+      });
+
+      userFirst.activate();
+
+      // system (+ 10) then user (* 2)
+      expect(userFirst.state.data?.series[0].fields[0].values).toEqual([220, 420, 620]);
+    });
+
+    it('applies system transformations when the user transformations list is empty', () => {
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [],
+        systemTransformations: { prepend: [transformer1config] },
+      });
+
+      transformer.activate();
+
+      expect(transformer.state.data?.series[0].fields[0].values).toEqual([200, 400, 600]);
+    });
+
+    it('does not add system transformations to state.transformations', () => {
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [transformer2config],
+        systemTransformations: { prepend: [transformer1config] },
+      });
+
+      transformer.activate();
+
+      expect(transformer.state.transformations).toEqual([transformer2config]);
+      expect(transformer.getEffectiveTransformations()).toEqual([transformer1config, transformer2config]);
+    });
+
+    it('getEffectiveTransformations preserves array identity when there are no system transformations', () => {
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [transformer1config],
+      });
+
+      expect(transformer.getEffectiveTransformations()).toBe(transformer.state.transformations);
+
+      transformer.setState({ systemTransformations: { prepend: [] } });
+
+      expect(transformer.getEffectiveTransformations()).toBe(transformer.state.transformations);
+    });
+
+    it('applies a system transformation with the annotations topic to annotation frames only', () => {
+      const annotationSpy = jest.fn();
+
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [],
+        systemTransformations: { prepend: [getCustomAnnotationTransformOperator(annotationSpy)] },
+      });
+
+      transformer.activate();
+
+      const data = transformer.state.data;
+
+      expect(annotationSpy).toHaveBeenCalledTimes(1);
+      // annotations divided by 10
+      expect(data?.annotations?.[0].fields[0].values).toEqual([40, 50, 60]);
+      expect(data?.annotations?.[0].fields[1].values).toEqual([0.1, 0.2, 0.3]);
+      // series untouched, and not reclassified as annotations
+      expect(data?.annotations).toHaveLength(1);
+      expect(data?.series).toHaveLength(1);
+      expect(data?.series[0].fields[0].values).toEqual([100, 200, 300]);
+    });
+
+    it('interpolates variables in user transformations but not in system transformations', () => {
+      const transformationNode = new SceneDataTransformer({
+        transformations: [
+          {
+            ...annotationTransformerConfig,
+            options: {
+              options: '$myVariable',
+            },
+          },
+        ],
+        systemTransformations: {
+          prepend: [
+            {
+              ...transformer1config,
+              options: {
+                options: '$myVariable',
+              },
+            },
+          ],
+        },
+      });
+
+      const consumer = new TestSceneObject({
+        $data: transformationNode,
+      });
+
+      const textVar = new TextBoxVariable({ name: 'myVariable', value: 'Text Variable Value' });
+      const scene = new SceneFlexLayout({
+        $data: sourceDataNode,
+        $variables: new SceneVariableSet({ variables: [textVar] }),
+        children: [new SceneFlexItem({ body: consumer })],
+      });
+
+      // Inside a scene context @grafana/data leaves transformation options alone and lets scenes
+      // interpolate them. Outside one it interpolates option strings itself via ctx.interpolate,
+      // which would interpolate the system config too and mask what this test measures.
+      const restoreSceneContext = setWindowGrafanaSceneContext(scene);
+
+      activateFullSceneTree(scene);
+
+      expect(annotationTransformerSpy).toHaveBeenLastCalledWith({ options: 'Text Variable Value' });
+      expect(transformerSpy).toHaveBeenLastCalledWith({ options: '$myVariable' });
+
+      textVar.setValue('New Text Variable Value');
+
+      expect(annotationTransformerSpy).toHaveBeenLastCalledWith({ options: 'New Text Variable Value' });
+      expect(transformerSpy).toHaveBeenLastCalledWith({ options: '$myVariable' });
+
+      restoreSceneContext();
+    });
+
+    it('does not become variable dependent through a system transformation', () => {
+      const transformationNode = new SceneDataTransformer({
+        transformations: [],
+        systemTransformations: {
+          prepend: [
+            {
+              ...transformer1config,
+              options: {
+                options: '$myVariable',
+              },
+            },
+          ],
+        },
+      });
+
+      const consumer = new TestSceneObject({
+        $data: transformationNode,
+      });
+
+      const textVar = new TextBoxVariable({ name: 'myVariable', value: 'Text Variable Value' });
+      const scene = new SceneFlexLayout({
+        $data: sourceDataNode,
+        $variables: new SceneVariableSet({ variables: [textVar] }),
+        children: [new SceneFlexItem({ body: consumer })],
+      });
+
+      activateFullSceneTree(scene);
+
+      expect(transformerSpy).toHaveBeenCalledTimes(1);
+
+      // systemTransformations is deliberately not in _variableDependency.statePaths, so a variable
+      // referenced only from there does not re-run the pipeline
+      textVar.setValue('New Text Variable Value');
+
+      expect(transformerSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('clone keeps a callable operator in systemTransformations', () => {
+      const systemSpy = jest.fn();
+
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [],
+        systemTransformations: { prepend: [getCustomTransformOperator(systemSpy)] },
+      });
+
+      const clone = transformer.clone();
+
+      // cloneSceneObjectState cloneDeeps plain-object state props and lodash passes nested
+      // functions through by reference. Anything relying on a cloned operator staying callable
+      // depends on that undocumented behaviour, so pin it.
+      expect(typeof clone.state.systemTransformations?.prepend?.[0]).toBe('function');
+
+      clone.activate();
+
+      expect(systemSpy).toHaveBeenCalledTimes(1);
+      expect(clone.state.data?.series[0].fields[0].values).toEqual([1, 2, 3]);
+    });
+
+    it('reprocessTransformations re-runs system and user transformations', () => {
+      const systemSpy = jest.fn();
+
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [transformer1config],
+        systemTransformations: { prepend: [getCustomTransformOperator(systemSpy)] },
+      });
+
+      transformer.activate();
+
+      expect(systemSpy).toHaveBeenCalledTimes(1);
+      expect(transformerSpy).toHaveBeenCalledTimes(1);
+      // system (/ 100) then user (* 2)
+      expect(transformer.state.data?.series[0].fields[0].values).toEqual([2, 4, 6]);
+
+      // The source data is unchanged, so this only re-runs because reprocessTransformations forces it
+      transformer.reprocessTransformations();
+
+      expect(systemSpy).toHaveBeenCalledTimes(2);
+      expect(transformerSpy).toHaveBeenCalledTimes(2);
+      expect(transformer.state.data?.series[0].fields[0].values).toEqual([2, 4, 6]);
+    });
+
+    it('reports an error from a system transformation and keeps the source data', () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const throwingOperator: CustomTransformOperator = () => (source) =>
+        source.pipe(
+          map(() => {
+            throw new Error('system transformation failed');
+          })
+        );
+
+      const transformer = new SceneDataTransformer({
+        $data: buildSourceDataNode(),
+        transformations: [transformer1config],
+        systemTransformations: { prepend: [throwingOperator] },
+      });
+
+      transformer.activate();
+
+      const data = transformer.state.data;
+
+      expect(data?.state).toBe(LoadingState.Error);
+      expect(data?.errors?.[0].message).toBe('Error transforming data: system transformation failed');
+      // One pipeline means one error boundary, so the user's transformation does not run either
+      expect(data?.series[0].fields[0].values).toEqual([100, 200, 300]);
+
+      consoleError.mockRestore();
     });
   });
 });

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -27,8 +27,11 @@ export interface SceneDataTransformerState extends SceneDataState {
   /**
    * Transformations contributed by this object's owner rather than by the user.
    *
-   * Spliced ahead of `transformations` at transform time, after variable interpolation —
-   * so entries here are NOT interpolated.
+   * Spliced ahead of `transformations` at transform time, after variable interpolation, so
+   * scenes never interpolates these entries. Note that `@grafana/data` still interpolates the
+   * option strings of series-topic configs when no scene is registered in
+   * `window.__grafanaSceneContext` — that is, outside an `EmbeddedScene` or `SceneApp` — so
+   * treat variable syntax here as unsupported rather than reliably literal.
    *
    * Not part of the object's user-editable or persisted configuration. Owners are
    * responsible for excluding this field from serialization and from any dirty-state
@@ -287,7 +290,8 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
     const interpolatedTransformations = this._interpolateVariablesInTransformationConfigs(data);
 
-    // Splice after interpolation so system transformations are not interpolated
+    // Splice after interpolation so system configs skip it, and so the user array stays
+    // function-free for the single-stringify fast path in the call above
     const prepend = this.state.systemTransformations?.prepend ?? [];
     const effectiveTransformations = prepend.length
       ? [...prepend, ...interpolatedTransformations]

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -29,9 +29,7 @@ export interface SceneDataTransformerState extends SceneDataState {
    *
    * Spliced ahead of `transformations` at transform time, after variable interpolation, so
    * scenes never interpolates these entries. Note that `@grafana/data` still interpolates the
-   * option strings of series-topic configs when no scene is registered in
-   * `window.__grafanaSceneContext` — that is, outside an `EmbeddedScene` or `SceneApp` — so
-   * treat variable syntax here as unsupported rather than reliably literal.
+   * option strings of series-topic configs when no scene is registered in `window.__grafanaSceneContext`.
    *
    * Not part of the object's user-editable or persisted configuration. Owners are
    * responsible for excluding this field from serialization and from any dirty-state

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -23,6 +23,19 @@ export interface SceneDataTransformerState extends SceneDataState {
    * Array of standard transformation configs and custom transform operators
    */
   transformations: Array<DataTransformerConfig | CustomTransformerDefinition>;
+
+  /**
+   * Transformations contributed by this object's owner rather than by the user.
+   *
+   * Spliced ahead of `transformations` at transform time, after variable interpolation —
+   * so entries here are NOT interpolated.
+   *
+   * Not part of the object's user-editable or persisted configuration. Owners are
+   * responsible for excluding this field from serialization and from any dirty-state
+   * tracking. Write-once at construction is the supported pattern: changing it does not
+   * by itself re-run the pipeline — call `reprocessTransformations()`.
+   */
+  systemTransformations?: { prepend?: Array<DataTransformerConfig | CustomTransformerDefinition> };
 }
 
 /**
@@ -103,6 +116,16 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
   public reprocessTransformations() {
     this.transform(this.getSourceData().state.data, true);
+  }
+
+  /**
+   * The transformations that will actually run: `systemTransformations.prepend` followed by
+   * the user's `transformations`. Returns the `transformations` array itself when there are
+   * no system transformations, so array identity is preserved for consumers that memoize on it.
+   */
+  public getEffectiveTransformations(): Array<DataTransformerConfig | CustomTransformerDefinition> {
+    const prepend = this.state.systemTransformations?.prepend;
+    return prepend?.length ? [...prepend, ...this.state.transformations] : this.state.transformations;
   }
 
   /**
@@ -224,7 +247,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
         ) => void)
       | null = null;
 
-    if (this.state.transformations.length === 0 || !data) {
+    if (this.getEffectiveTransformations().length === 0 || !data) {
       this._prevDataFromSource = data;
       this.setState({ data });
 
@@ -242,7 +265,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
     // S3.1: Start transformation tracking
     if (profiler) {
       // Create meaningful transformation identifier from actual transformations
-      const transformationTypes = this.state.transformations
+      const transformationTypes = this.getEffectiveTransformations()
         .map((t) => {
           if ('id' in t) {
             // Standard DataTransformerConfig
@@ -256,7 +279,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
       transformationId = transformationTypes || 'no-transforms';
 
       // Calculate transformation complexity metrics
-      const metrics = this._calculateTransformationMetrics(data, this.state.transformations);
+      const metrics = this._calculateTransformationMetrics(data, this.getEffectiveTransformations());
 
       // Start the DataProcessing phase with centralized logging - get end callback
       endTransformCallback = profiler.onDataTransformStart(timestamp, transformationId, metrics);
@@ -264,8 +287,14 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
 
     const interpolatedTransformations = this._interpolateVariablesInTransformationConfigs(data);
 
+    // Splice after interpolation so system transformations are not interpolated
+    const prepend = this.state.systemTransformations?.prepend ?? [];
+    const effectiveTransformations = prepend.length
+      ? [...prepend, ...interpolatedTransformations]
+      : interpolatedTransformations;
+
     const seriesTransformations = this._filterAndPrepareTransformationsByTopic(
-      interpolatedTransformations,
+      effectiveTransformations,
       (transformation) => {
         if ('options' in transformation || 'topic' in transformation) {
           return transformation.topic == null || transformation.topic === DataTopic.Series;
@@ -274,7 +303,7 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
       }
     );
     const annotationsTransformations = this._filterAndPrepareTransformationsByTopic(
-      interpolatedTransformations,
+      effectiveTransformations,
       (transformation) => {
         if ('options' in transformation || 'topic' in transformation) {
           return transformation.topic === DataTopic.Annotations;


### PR DESCRIPTION
Alternative approach to [Adaptor panel transformations](https://docs.google.com/document/d/1aexw7SD_zs8P4AXD46tEmyLtK60OuQ3EglWkqe8ru7g): system transformations that are registered by panels, but ran "flat" with the other transformations instead of nested before like in https://github.com/grafana/grafana/pull/129992.

This gives us the same panel API and behavior as in the prior approach, but uses existing scene state so additional accessors are no longer required. 

Grafana side changes: https://github.com/grafana/grafana/pull/130860

Follow ups:
https://github.com/grafana/scenes/issues/1612 : pre-existing bug with panels that transform, but panels with system transforms are also impacted. Fixing in Scenes avoids needing to patch individual consumer panels

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.14.0--canary.1611.32055313142.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.14.0--canary.1611.32055313142.0
  npm install scenes-app@8.14.0--canary.1611.32055313142.0
  npm install @grafana/scenes-react@8.14.0--canary.1611.32055313142.0
  # or 
  yarn add @grafana/scenes@8.14.0--canary.1611.32055313142.0
  yarn add scenes-app@8.14.0--canary.1611.32055313142.0
  yarn add @grafana/scenes-react@8.14.0--canary.1611.32055313142.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
