### PR TITLE
AdHocFilters: forward value meta to filter

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/utils.ts
@@ -117,6 +117,7 @@ export const generateFilterUpdatePayload = ({
     return {
       value: item.value,
       valueLabels: [item.label ? item.label : item.value!],
+      meta: item?.meta ?? filter?.meta,
     };
   }
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -2172,6 +2172,85 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
+  it('Can define custom meta in getTagValuesProvider which will have precedence over any meta passed from getTagKeysProvider', async () => {
+    type FilterMeta = Record<string, string>;
+
+    const { filtersVar } = setup({
+      getTagKeysProvider: () => {
+        // getTagKeysProvider API call returns metadata needed in the value
+        return Promise.resolve({
+          replace: true,
+          values: [{ text: 'keyLabel', value: 'keyValue', meta: { parser: 'parserValue' } }],
+        });
+      },
+      getTagValuesProvider: (variable, filter: AdHocFilterWithLabels<FilterMeta>) => {
+        // getTagValuesProvider can receive this metadata, add it to the value and define its own metadata
+        expect(filter.meta).toEqual({ parser: 'parserValue' });
+        return Promise.resolve({
+          replace: true,
+          values: [
+            {
+              text: 'valueLabel',
+              value: JSON.stringify({ value: 'v', parser: filter.meta?.parser }),
+              meta: { valueType: 'string' },
+            },
+          ],
+        });
+      },
+    });
+
+    const keys = await filtersVar._getKeys(null);
+    expect(keys).toEqual([{ label: 'keyLabel', value: 'keyValue', meta: { parser: 'parserValue' } }]);
+
+    // Simulate the update of the filter key after the user selects a particular key
+    act(() =>
+      filtersVar._updateFilter(
+        filtersVar.state.filters[0],
+        generateFilterUpdatePayload({
+          filterInputType: 'key',
+          item: keys[0],
+          filter: filtersVar.state.filters[0],
+          setFilterMultiValues: jest.fn(),
+        })
+      )
+    );
+
+    // Get the values for the ad-hoc variable
+    const values = await filtersVar._getValuesFor(filtersVar.state.filters[0]);
+
+    // The value keeps its own meta from getTagValuesProvider, ignoring the key meta
+    expect(values).toEqual([
+      {
+        label: 'valueLabel',
+        value: JSON.stringify({ value: 'v', parser: 'parserValue' }),
+        meta: { valueType: 'string' },
+      },
+    ]);
+
+    // Simulate the update of the filter value after the user selects a particular value
+    act(() =>
+      filtersVar._updateFilter(
+        filtersVar.state.filters[0],
+        generateFilterUpdatePayload({
+          filterInputType: 'value',
+          item: values[0],
+          filter: filtersVar.state.filters[0],
+          setFilterMultiValues: jest.fn(),
+        })
+      )
+    );
+
+    // Assert that the saved filter contains the expected meta and value
+    expect(filtersVar.state.filters[0]).toEqual({
+      operator: '=',
+      keyLabel: 'keyLabel',
+      key: 'keyValue',
+      meta: { valueType: 'string' },
+      value: JSON.stringify({ value: 'v', parser: 'parserValue' }),
+      valueLabels: ['valueLabel'],
+    });
+  });
+
   it('Can encode a custom value', async () => {
     const { filtersVar, runRequest } = setup({
       layout: 'horizontal',


### PR DESCRIPTION
**What is this feature?**

Forwards the selected value's `meta` onto the saved filter, so metadata returned from `getTagValuesProvider` (e.g. `valueType`) is kept on the filter. Value meta takes precedence over any meta set on the key, and falls back to the key meta when the value has none.

```ts
return {
  value: item.value,
  valueLabels: [item.label ? item.label : item.value!],
  meta: item?.meta ?? filter?.meta,
};
```

**Why do we need this feature?**

So consumers can read value level metadata (like `valueType`) off the filter, e.g. to quote numeric TraceQL values correctly.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/traces-drilldown/issues/575

**Special notes for your reviewer:**

This is the scenes piece of a larger fix. https://github.com/grafana/grafana-tempo-datasource/pull/239 exposes `valueType` through `getTagValues`, and traces-drilldown consumes it off the filter `meta` to build correctly quoted TraceQL. Previously only key `meta` was forwarded, so value `meta` was dropped on select.
