### PR TITLE
Performance: Export POST_STORM_WINDOW from SceneRenderProfiler

### DIFF
--- a/packages/scenes/src/performance/SceneRenderProfiler.ts
+++ b/packages/scenes/src/performance/SceneRenderProfiler.ts
@@ -10,7 +10,7 @@ import { SceneObject } from '../core/types';
 import { VizPanel } from '../components/VizPanel/VizPanel';
 import { LongFrameDetector } from './LongFrameDetector';
 
-const POST_STORM_WINDOW = 2000; // Time after last query to observe slow frames
+export const POST_STORM_WINDOW = 2000; // Time after last query to observe slow frames
 const DEFAULT_LONG_FRAME_THRESHOLD = 30; // Threshold for tail recording slow frames
 
 /**

--- a/packages/scenes/src/performance/index.ts
+++ b/packages/scenes/src/performance/index.ts
@@ -1,5 +1,5 @@
 // Performance tracking exports - EXTERNAL API ONLY (used by Grafana)
-export { SceneRenderProfiler } from './SceneRenderProfiler';
+export { SceneRenderProfiler, POST_STORM_WINDOW } from './SceneRenderProfiler';
 
 // Performance observer pattern - essential external API
 export {


### PR DESCRIPTION
Grafana's report-render readiness observer tests needs this value to drive fake timers on the same cadence as the profiler's trailing-frame window, and currently has to hardcode a shadow copy with a keep-in-sync comment since nothing exports it.

Relevant to this PR: https://github.com/grafana/grafana/pull/128536