### PR TITLE
VizPanel: Link the alert icon to its alert rule

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -11,6 +11,7 @@ import {
   toDataFrame,
   PanelPluginDataSupport,
   AlertState,
+  type AlertStateInfo,
   PanelData,
   PanelProps,
   toUtc,
@@ -968,6 +969,51 @@ describe('VizPanel', () => {
         });
 
         expect(panelRenderCount).toBe(2);
+      });
+    });
+
+    describe('alert state icon', () => {
+      function setup(alertState: AlertStateInfo & { ruleUID?: string }) {
+        const panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          pluginId: 'custom-plugin-id',
+          $timeRange: new SceneTimeRange(),
+          $data: new SceneDataNode({ data: { ...getTestData(), alertState } }),
+        });
+
+        pluginToLoad = getTestPlugin1({ alertStates: true, annotations: false });
+
+        return render(<panel.Component model={panel} />);
+      }
+
+      it('links to the alert rule when a ruleUID is present', async () => {
+        const { container } = setup({
+          dashboardId: 1,
+          panelId: 1,
+          id: 1,
+          state: AlertState.Alerting,
+          ruleUID: 'rule-abc',
+        });
+
+        await screen.findByText('My custom panel');
+
+        const icon = container.querySelector('.panel-alert-icon');
+        const link = icon?.closest('a');
+        expect(link).toHaveAttribute('href', '/alerting/grafana/rule-abc/view');
+      });
+
+      it('renders a non-interactive icon when there is no ruleUID', async () => {
+        const { container } = setup({
+          dashboardId: 1,
+          panelId: 1,
+          id: 1,
+          state: AlertState.OK,
+        });
+
+        await screen.findByText('My custom panel');
+
+        const icon = container.querySelector('.panel-alert-icon');
+        expect(icon).toBeInTheDocument();
+        expect(icon?.closest('a')).toBeNull();
       });
     });
   });

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -5,6 +5,7 @@ import { useMeasure, usePrevious } from 'react-use';
 // @ts-ignore
 import {
   AlertState,
+  type AlertStateInfo,
   DataFrame,
   GrafanaTheme2,
   PanelData,
@@ -17,7 +18,7 @@ import {
   SetPanelAttentionEvent,
 } from '@grafana/data';
 
-import { getAppEvents } from '@grafana/runtime';
+import { config, getAppEvents } from '@grafana/runtime';
 import { PanelChrome, ErrorBoundaryAlert, PanelContextProvider, Tooltip, useStyles2, Icon } from '@grafana/ui';
 
 import { sceneGraph } from '../../core/sceneGraph';
@@ -196,17 +197,25 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   }
 
   if (dataWithFieldConfig.alertState) {
+    // ruleUID isn't in the @grafana/data types installed here until a new version is published,
+    // but the app's alert states data layer already populates it on the underlying data frame.
+    const alertState = dataWithFieldConfig.alertState as AlertStateInfo & { ruleUID?: string };
+    const alertRuleHref = alertState.ruleUID
+      ? `${config.appSubUrl ?? ''}/alerting/grafana/${alertState.ruleUID}/view`
+      : undefined;
+
     titleItemsElement.push(
-      <Tooltip content={dataWithFieldConfig.alertState.state ?? 'unknown'} key={`alert-states-icon-${model.state.key}`}>
+      <Tooltip content={alertState.state ?? 'unknown'} key={`alert-states-icon-${model.state.key}`}>
         <PanelChrome.TitleItem
+          href={alertRuleHref}
           className={cx({
-            [alertStateStyles.ok]: dataWithFieldConfig.alertState.state === AlertState.OK,
-            [alertStateStyles.pending]: dataWithFieldConfig.alertState.state === AlertState.Pending,
-            [alertStateStyles.alerting]: dataWithFieldConfig.alertState.state === AlertState.Alerting,
+            [alertStateStyles.ok]: alertState.state === AlertState.OK,
+            [alertStateStyles.pending]: alertState.state === AlertState.Pending,
+            [alertStateStyles.alerting]: alertState.state === AlertState.Alerting,
           })}
         >
           <Icon
-            name={dataWithFieldConfig.alertState.state === 'alerting' ? 'heart-break' : 'heart'}
+            name={alertState.state === 'alerting' ? 'heart-break' : 'heart'}
             className="panel-alert-icon"
             size="md"
           />

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -5,7 +5,6 @@ import { useMeasure, usePrevious } from 'react-use';
 // @ts-ignore
 import {
   AlertState,
-  type AlertStateInfo,
   DataFrame,
   GrafanaTheme2,
   PanelData,
@@ -197,12 +196,10 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   }
 
   if (dataWithFieldConfig.alertState) {
-    // ruleUID isn't in the @grafana/data types installed here until a new version is published,
-    // but the app's alert states data layer already populates it on the underlying data frame.
-    const alertState = dataWithFieldConfig.alertState as AlertStateInfo & { ruleUID?: string };
-    const alertRuleHref = alertState.ruleUID
-      ? `${config.appSubUrl ?? ''}/alerting/grafana/${alertState.ruleUID}/view`
-      : undefined;
+    const alertState = dataWithFieldConfig.alertState;
+    // @ts-expect-error ruleUID is added in a newer @grafana/data version
+    const ruleUID: string | undefined = alertState.ruleUID;
+    const alertRuleHref = ruleUID ? `${config.appSubUrl ?? ''}/alerting/grafana/${ruleUID}/view` : undefined;
 
     titleItemsElement.push(
       <Tooltip content={alertState.state ?? 'unknown'} key={`alert-states-icon-${model.state.key}`}>


### PR DESCRIPTION
Today, the alert icon on a panel header does not link anywhere. This change makes it a real link. A click opens the alert rule page.

The link needs a rule ID. [grafana/grafana#131129](https://github.com/grafana/grafana/pull/131129) adds this ID to the data. Until that change merges and publishes, the link does not show, and the icon works as it does today.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.16.1--canary.1619.32347826335.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.16.1--canary.1619.32347826335.0
  npm install scenes-app@8.16.1--canary.1619.32347826335.0
  npm install @grafana/scenes-react@8.16.1--canary.1619.32347826335.0
  # or 
  yarn add @grafana/scenes@8.16.1--canary.1619.32347826335.0
  yarn add scenes-app@8.16.1--canary.1619.32347826335.0
  yarn add @grafana/scenes-react@8.16.1--canary.1619.32347826335.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
