### PR TITLE
AdHocFiltersVariable: Stop rendering match all pills as disabled

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFilterPill.tsx
@@ -24,8 +24,9 @@ export function AdHocFilterPill({ filter, controller, readOnly, focusOnWipInputR
     useEditablePill({ filter, controller, readOnly, focusOnWipInputRef, isFilterEmpty: isAdhocFilterEmpty });
 
   const keyLabel = filter.keyLabel ?? filter.key;
+  const isMatchAll = isMatchAllFilter(filter);
   // A saved All default can arrive without valueLabels, so the sentinel always renders as All
-  const isAllValueSelected = filter.operator === ONE_OF_OPERATOR && isMatchAllFilter(filter);
+  const isAllValueSelected = filter.operator === ONE_OF_OPERATOR && isMatchAll;
   const valueLabel = isAllValueSelected
     ? t('grafana-scenes.components.adhoc-filter-pill.all-values', 'All')
     : filter.valueLabels?.join(', ') || filter.values?.join(', ') || filter.value;
@@ -52,7 +53,11 @@ export function AdHocFilterPill({ filter, controller, readOnly, focusOnWipInputR
   const cleanFilter = !filter.restorable && !filter.readOnly && !filter.nonApplicable;
 
   if (viewMode) {
-    const pillTextContent = `${keyLabel} ${filter.operator} ${valueLabel}`;
+    // A match all filter is not narrowing anything, so its value is muted. The key, operator,
+    // border and hover stay normal - the pill is still fully interactive.
+    const pillTextContent = isMatchAll
+      ? `${keyLabel} ${filter.operator}`
+      : `${keyLabel} ${filter.operator} ${valueLabel}`;
 
     const handleRemove = () => {
       if (filter.origin && filter.origin === 'dashboard') {
@@ -67,14 +72,15 @@ export function AdHocFilterPill({ filter, controller, readOnly, focusOnWipInputR
     // Removing a dashboard default turns it into a match all one, so there is nowhere left to go
     // once it already is. Derived rather than read off filter.matchAllFilter, because a default
     // authored as All in the editor arrives without the flag.
-    const showRemove = !readOnly && (!filter.origin || (filter.origin === 'dashboard' && !isMatchAllFilter(filter)));
+    const showRemove = !readOnly && (!filter.origin || (filter.origin === 'dashboard' && !isMatchAll));
 
     return (
       <BasePill
         ref={pillWrapperRef}
         label={pillTextContent}
+        mutedValue={isMatchAll ? valueLabel : undefined}
         readOnly={readOnly}
-        disabled={isMatchAllFilter(filter) || filter.nonApplicable}
+        disabled={filter.nonApplicable}
         isFilterReadOnly={filter.readOnly}
         strikethrough={filter.nonApplicable}
         onClick={handlePillClick}
@@ -118,7 +124,7 @@ export function AdHocFilterPill({ filter, controller, readOnly, focusOnWipInputR
                 }}
                 name="history"
                 size="md"
-                className={isMatchAllFilter(filter) ? styles.matchAllPillIcon : styles.pillIcon}
+                className={styles.pillIcon}
                 tooltip={getOriginFilterTooltips(filter.origin).restore}
               />
             )}
@@ -165,10 +171,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
     '&:hover': {
       color: theme.colors.text.primary,
     },
-  }),
-  matchAllPillIcon: css({
-    marginInline: theme.spacing(0.5),
-    cursor: 'pointer',
-    color: theme.colors.text.disabled,
   }),
 });

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/BasePill.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/BasePill.tsx
@@ -10,6 +10,12 @@ const LABEL_MAX_VISIBLE_LENGTH = 28;
 
 export interface BasePillProps {
   label: string;
+  /**
+   * Trailing portion of the pill text rendered in a muted colour - e.g. the value of a filter
+   * that is not currently narrowing anything. Deliberately not the `disabled` treatment: the
+   * pill stays interactive, so it keeps its border, its hover state and its primary text colour.
+   */
+  mutedValue?: string;
   removable?: boolean;
   onRemove?: () => void;
   onClick?: (e: React.MouseEvent) => void;
@@ -26,6 +32,7 @@ export interface BasePillProps {
 export const BasePill = forwardRef<HTMLDivElement, BasePillProps>(function BasePill(
   {
     label,
+    mutedValue,
     onRemove,
     removable = !!onRemove,
     onClick,
@@ -42,7 +49,16 @@ export const BasePill = forwardRef<HTMLDivElement, BasePillProps>(function BaseP
 ) {
   const styles = useStyles2(getStyles);
 
-  const pillText = <span className={cx(styles.pillText, strikethrough && styles.strikethrough)}>{label}</span>;
+  // Tooltip, truncation and the remove-button label all describe the pill as the user reads it,
+  // so they use the full text rather than just the unmuted leading portion.
+  const fullLabel = mutedValue ? `${label} ${mutedValue}` : label;
+
+  const pillText = (
+    <span className={cx(styles.pillText, strikethrough && styles.strikethrough)}>
+      {label}
+      {mutedValue ? <span className={styles.mutedPillValue}>{` ${mutedValue}`}</span> : null}
+    </span>
+  );
 
   return (
     <div
@@ -59,10 +75,10 @@ export const BasePill = forwardRef<HTMLDivElement, BasePillProps>(function BaseP
       tabIndex={0}
       ref={ref}
     >
-      {label.length < LABEL_MAX_VISIBLE_LENGTH ? (
+      {fullLabel.length < LABEL_MAX_VISIBLE_LENGTH ? (
         pillText
       ) : (
-        <Tooltip content={<div className={styles.tooltipText}>{label}</div>} placement="top">
+        <Tooltip content={<div className={styles.tooltipText}>{fullLabel}</div>} placement="top">
           {pillText}
         </Tooltip>
       )}
@@ -83,7 +99,9 @@ export const BasePill = forwardRef<HTMLDivElement, BasePillProps>(function BaseP
           name="times"
           size="md"
           className={cx(styles.pillIcon, disabled && styles.disabledPillIcon)}
-          tooltip={removeAriaLabel ?? t('grafana-scenes.components.base-pill.remove', 'Remove {{label}}', { label })}
+          tooltip={
+            removeAriaLabel ?? t('grafana-scenes.components.base-pill.remove', 'Remove {{label}}', { label: fullLabel })
+          }
         />
       )}
 
@@ -132,6 +150,9 @@ export const getBasePillStyles = (theme: GrafanaTheme2) => ({
     '&:hover': {
       color: theme.colors.text.primary,
     },
+  }),
+  mutedPillValue: css({
+    color: theme.colors.text.disabled,
   }),
   pillText: css({
     maxWidth: '280px',

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -3199,7 +3199,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
       await userEvent.keyboard('{Escape}');
 
-      expect(screen.getByText('pod =~ All')).toBeInTheDocument();
+      expect(screen.getByLabelText('Edit filter with key pod')).toHaveTextContent('pod =~ All');
     });
 
     it('should turn multi value origin filter to match-all when value is removed', async () => {
@@ -3226,7 +3226,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       await userEvent.keyboard('{Escape}');
 
       // one-of filters keep their operator and carry the All value instead of the regex form
-      expect(screen.getByText('pod =| All')).toBeInTheDocument();
+      expect(screen.getByLabelText('Edit filter with key pod')).toHaveTextContent('pod =| All');
     });
   });
 
@@ -3320,7 +3320,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
       expect(updateToMatchAllSpy).not.toHaveBeenCalled();
 
-      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Edit filter with key pod')).toHaveTextContent('pod =| All');
       expect(filtersVar.state.originFilters?.[0]).toMatchObject({
         operator: '=|',
         value: '$__all',
@@ -3357,7 +3357,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       });
 
       // pill label falls back to "All" from the sentinel even without valueLabels
-      await userEvent.click(await screen.findByText('pod =| All'));
+      await userEvent.click(await screen.findByLabelText('Edit filter with key pod'));
 
       const allOption = await screen.findByTestId(allOptionTestId);
       expect(within(allOption).getByRole('checkbox')).toBeChecked();
@@ -3371,8 +3371,37 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         layout: 'combobox',
       });
 
-      expect(await screen.findByText('job =~ .*')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Edit filter with key job')).toHaveTextContent('job =~ .*');
       expect(screen.getByRole('button', { name: 'Remove filter with key job' })).toBeInTheDocument();
+    });
+
+    it('mutes only the value, leaving the pill interactive rather than disabled', async () => {
+      setup({
+        originFilters: [{ key: 'pod', operator: '=|', value: '$__all', values: ['$__all'], origin: 'dashboard' }],
+        layout: 'combobox',
+      });
+
+      const pill = await screen.findByLabelText('Edit filter with key pod');
+      expect(pill).toHaveTextContent('pod =| All');
+
+      // The value sits in its own node so it alone can be muted. The pill keeps its primary
+      // text colour, border and hover, because a match all filter is still fully interactive -
+      // it must not get the disabled treatment.
+      const value = within(pill).getByText('All');
+      expect(value).not.toBe(pill);
+      expect(value.textContent?.trim()).toBe('All');
+      expect(pill).toHaveAttribute('role', 'button');
+    });
+
+    it('mutes the value of the regex match-all form too', async () => {
+      setup({
+        filters: [{ key: 'job', operator: '=~', value: '.*' }],
+        layout: 'combobox',
+      });
+
+      const pill = await screen.findByLabelText('Edit filter with key job');
+      expect(pill).toHaveTextContent('job =~ .*');
+      expect(within(pill).getByText('.*').textContent?.trim()).toBe('.*');
     });
 
     it('does not offer removal for a default authored as All', async () => {
@@ -3382,7 +3411,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         layout: 'combobox',
       });
 
-      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Edit filter with key pod')).toHaveTextContent('pod =| All');
       expect(screen.queryByRole('button', { name: 'Remove filter with key pod' })).not.toBeInTheDocument();
     });
 
@@ -3398,7 +3427,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       await userEvent.click(await screen.findByTestId(allOptionTestId));
       await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
-      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Edit filter with key pod')).toHaveTextContent('pod =| All');
 
       await userEvent.click(screen.getByRole('button', { name: 'Restore the value set by this dashboard.' }));
 
@@ -3511,7 +3540,7 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
         layout: 'combobox',
       });
 
-      expect(await screen.findByText('pod =| All')).toBeInTheDocument();
+      expect(await screen.findByLabelText('Edit filter with key pod')).toHaveTextContent('pod =| All');
     });
   });
 

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -3391,6 +3391,11 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(value).not.toBe(pill);
       expect(value.textContent?.trim()).toBe('All');
       expect(pill).toHaveAttribute('role', 'button');
+
+      await userEvent.click(pill);
+
+      expect(screen.queryByLabelText('Edit filter with key pod')).not.toBeInTheDocument();
+      expect(await screen.findByTestId(allOptionTestId)).toBeInTheDocument();
     });
 
     it('mutes the value of the regex match-all form too', async () => {
@@ -3401,7 +3406,16 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
 
       const pill = await screen.findByLabelText('Edit filter with key job');
       expect(pill).toHaveTextContent('job =~ .*');
-      expect(within(pill).getByText('.*').textContent?.trim()).toBe('.*');
+
+      const value = within(pill).getByText('.*');
+      expect(value).not.toBe(pill);
+      expect(value.textContent?.trim()).toBe('.*');
+      expect(pill).toHaveAttribute('role', 'button');
+
+      await userEvent.click(pill);
+
+      expect(screen.queryByLabelText('Edit filter with key job')).not.toBeInTheDocument();
+      expect(await screen.findByTestId('data-testid ad hoc filter option value val3')).toBeInTheDocument();
     });
 
     it('does not offer removal for a default authored as All', async () => {


### PR DESCRIPTION
Closes #1621

<img width="1085" height="362" alt="image" src="https://github.com/user-attachments/assets/67ae14c7-68b7-48eb-8f88-2bde00e450a9" />


## What

`isMatchAllFilter` is a query-semantics predicate - "this filter does not restrict results, so strip it". It was also driving three presentation decisions, so when #1591 widened it to cover the `=| $__all` sentinel, All pills silently inherited the **disabled pill treatment**: `text.disabled`, `border: 0`, hover removed.

That asserts "you cannot interact with this" about a pill that is fully interactive - and on dashboards that pin dimensions as origin defaults, it is the pill users most need to click. They read it as unavailable and leave it alone.

## Changes

1. **`disabled={filter.nonApplicable}`** - `isMatchAllFilter` comes out of the expression, so `disabled` means only what it says.
2. **"Not narrowing" moves onto the value.** `BasePill` gains an optional `mutedValue`: the value keeps its current muted colour while the key, operator, border and hover return to normal. Applies to **both** match all forms, not just the sentinel.
3. **The restore button drops `matchAllPillIcon`**, so a live button (it still sets `cursor: pointer`) no longer renders as though it were disabled.

`showRemove` is deliberately unchanged - hiding a control whose action would be a no-op is a different statement from greying out an active one.

Visually the only difference on a match all pill is that the key, operator and border come back. The value grey is unchanged, so the "this is not filtering" cue survives.

## Testing

- `packages/scenes` adhoc suites: 487 passed, 0 failed.
- Two new tests: match-all value in its own node, pill still a button, click enters edit mode — for both `=| All` and `=~ .*`.
- Full `packages/scenes` suite: 1785 passed. The 15 failures in `VizPanelBuilder` / `SceneDataTransformer` / `calculateField` / `filterByName` reproduce identically on an unmodified tree and are unrelated to this change.
- Match-all pill text is now split across two nodes, so RTL `getByText('key =| All')` no longer matches. Tests here query by `Edit filter with key ...` instead. Grepped grafana/grafana: no in-tree tests assert that concatenated string.
