### PR TITLE
fix(SceneDataTransformer): preserve undefined annotations when source has none

### DIFF
--- a/packages/scenes/src/querying/SceneDataTransformer.test.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.test.ts
@@ -242,6 +242,41 @@ describe('SceneDataTransformer', () => {
     annotationTransformerSpy.mockClear();
   });
 
+  it('preserves undefined annotations when source data has no annotations', () => {
+    const transformationNode = new SceneDataTransformer({
+      transformations: [transformer1config],
+    });
+
+    const sourceDataWithoutAnnotations = new SceneDataNode({
+      data: {
+        state: LoadingState.Done,
+        timeRange: getDefaultTimeRange(),
+        series: [
+          toDataFrame([
+            [100, 1],
+            [200, 2],
+          ]),
+        ],
+      },
+    });
+
+    const consumer = new TestSceneObject({
+      $data: transformationNode,
+    });
+
+    // @ts-expect-error
+    const scene = new SceneFlexLayout({
+      $data: sourceDataWithoutAnnotations,
+      children: [new SceneFlexItem({ body: consumer })],
+    });
+
+    sourceDataWithoutAnnotations.activate();
+    transformationNode.activate();
+
+    const data = sceneGraph.getData(consumer).state.data;
+    expect(data?.annotations).toBeUndefined();
+  });
+
   it('applies transformations to closest data node', () => {
     const transformationNode = new SceneDataTransformer({
       transformations: [transformer1config, transformer2config, annotationTransformerConfig],

--- a/packages/scenes/src/querying/SceneDataTransformer.ts
+++ b/packages/scenes/src/querying/SceneDataTransformer.ts
@@ -314,7 +314,11 @@ export class SceneDataTransformer extends SceneObjectBase<SceneDataTransformerSt
             }
           });
 
-          return { ...data, series, annotations };
+          return {
+            ...data,
+            series,
+            annotations: annotations.length > 0 || data.annotations !== undefined ? annotations : undefined,
+          };
         }),
         catchError((err) => {
           const timestamp = performance.now();


### PR DESCRIPTION
## Summary

Fixes #1612.

`SceneDataTransformer.transform()` was previously always returning `annotations: []` even when the input `data.annotations` was `undefined` and no annotations were created.

In consumers like Grafana's `TimeSeriesPanel` and `CandlestickPanel`, components guard on presence of `data.annotations` (e.g. `{data.annotations && <ExemplarsPlugin ... />}`). Promoting `undefined` to `[]` caused `ExemplarsPlugin` (and its `EventsCanvas` with uPlot draw hook) to mount on every panel with a transformation, resulting in unnecessary React re-renders on pan/zoom/cursor redraws.

## Changes

- In `packages/scenes/src/querying/SceneDataTransformer.ts`:
  Set `annotations: annotations.length > 0 || data.annotations !== undefined ? annotations : undefined`.
  This preserves `undefined` when no annotations existed on the source data and none were produced by transformations, while correctly retaining `[]` if a transformer explicitly reduced existing annotations to empty.
- In `packages/scenes/src/querying/SceneDataTransformer.test.ts`:
  Added a unit test verifying that `data.annotations` remains `undefined` when transforming source data without annotations.

## Verification

- `yarn workspace @grafana/scenes test packages/scenes/src/querying/SceneDataTransformer.test.ts --watchAll=false` passed 100% (20 passed, 1 skipped).
- `yarn turbo typecheck --filter=@grafana/scenes` passed with 0 errors.
