### PR TITLE
AdhocFilters: Fixes incorrect border color

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersComboboxRenderer.tsx
@@ -259,7 +259,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     rowGap: theme.spacing(0.5),
     minHeight: theme.spacing(4),
     backgroundColor: theme.components.input.background,
-    border: `1px solid ${theme.colors.border.strong}`,
+    border: `1px solid ${theme.components.input.borderColor}`,
     borderRadius: theme.shape.radius.default,
     paddingInline: theme.spacing(1),
     paddingBlock: theme.spacing(0.5),


### PR DESCRIPTION
Noticed that adhoc filters combobox used the wrong border color 

<img width="257" height="81" alt="Screenshot 2026-08-22 at 11 19 53" src="https://github.com/user-attachments/assets/fffdbec7-9b70-4f87-9c78-96b8aeb1334a" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.17.0--canary.1624.32564673500.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.17.0--canary.1624.32564673500.0
  npm install scenes-app@8.17.0--canary.1624.32564673500.0
  npm install @grafana/scenes-react@8.17.0--canary.1624.32564673500.0
  # or 
  yarn add @grafana/scenes@8.17.0--canary.1624.32564673500.0
  yarn add scenes-app@8.17.0--canary.1624.32564673500.0
  yarn add @grafana/scenes-react@8.17.0--canary.1624.32564673500.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
