### PR TITLE
Filter invalid time picker history before converting ranges

### DIFF
--- a/packages/scenes/src/components/SceneTimePicker.test.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.test.tsx
@@ -24,6 +24,7 @@ function setupScene(
   const timeRange = new SceneTimeRange({
     from: timeRangeProps.from,
     to: timeRangeProps.to,
+    timeZone: timeRangeProps.timeZone,
   });
   const timePicker = new SceneTimePicker({
     hidePicker: timePickerProps.hidePicker,
@@ -41,6 +42,10 @@ function setupScene(
 }
 
 describe('SceneTimePicker', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
   it('does not render if hidePicker', () => {
     const { scene } = setupScene(
       {
@@ -91,6 +96,34 @@ describe('SceneTimePicker', () => {
     render(<scene.Component model={scene} />);
     await userEvent.click(screen.getByTestId(Components.TimePicker.openButton));
     expect(screen.getByText(/it looks like you haven't used this time picker before/i)).toBeInTheDocument();
+  });
+
+  it('should load with valid time picker history only', async () => {
+    const HISTORY_LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
+    const mixedHistory = [
+      { from: '2022-12-03T00:00:00.000Z', to: '2022-12-03T23:59:59.000Z' },
+      {
+        from: '2022-12-01T00:00:00.000Z',
+        to: '2022-12-01T23:59:59.000Z',
+        raw: { from: '2022-12-01T00:00:00.000Z', to: '022-12-01T23:59:59.000Z' },
+      },
+      {},
+      { from: null, to: null },
+      { from: '2022-12-04T00:00:00.000Z', to: null },
+    ];
+    window.localStorage.setItem(HISTORY_LOCAL_STORAGE_KEY, JSON.stringify(mixedHistory));
+
+    const { scene } = setupScene({
+      from: 'now-12h',
+      to: 'now',
+      timeZone: 'utc',
+    });
+
+    render(<scene.Component model={scene} />);
+    await userEvent.click(screen.getByTestId(Components.TimePicker.openButton));
+
+    expect(screen.queryByText(/it looks like you haven't used this time picker before/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/2022-12-03 00:00:00 to 2022-12-03 23:59:59/i)).toBeInTheDocument();
   });
 
   it('should add new absolute time range to list', async () => {

--- a/packages/scenes/src/components/SceneTimePicker.tsx
+++ b/packages/scenes/src/components/SceneTimePicker.tsx
@@ -197,9 +197,56 @@ interface TimePickerHistoryItem {
 }
 
 function deserializeHistory(value: string): TimeRange[] {
-  const values: TimePickerHistoryItem[] = JSON.parse(value);
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return [];
+  }
+
+  const values = getValidHistory(parsed);
   // The history is saved in UTC and with the default date format, so we need to pass those values to the convertRawToRange
   return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined, 'YYYY-MM-DD HH:mm:ss'));
+}
+
+function getValidHistory(values: unknown): TimePickerHistoryItem[] {
+  const result: TimePickerHistoryItem[] = [];
+
+  if (!Array.isArray(values)) {
+    return result;
+  }
+
+  for (const item of values) {
+    const parsed = getValidHistoryItem(item);
+    if (parsed) {
+      result.push(parsed);
+    }
+  }
+
+  return result;
+}
+
+function getValidHistoryItem(value: unknown): TimePickerHistoryItem | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  // Extra keys like raw do not match the stored { from, to } shape and can crash convertRawToRange
+  if (Object.keys(value).length !== 2) {
+    return null;
+  }
+
+  if (!('from' in value) || !('to' in value)) {
+    return null;
+  }
+
+  const { from, to } = value;
+  if (typeof from === 'string' && typeof to === 'string') {
+    return { from, to };
+  }
+
+  return null;
 }
 
 function serializeHistory(values: TimeRange[]) {


### PR DESCRIPTION
Fixes #1161

SceneTimePicker currently maps every localStorage history item into convertRawToRange. A null from or to crashes the page. The picker now keeps only items with string from and to, matching Grafana core.

## Tests
* Mixed valid and invalid history in localStorage
* Only the valid range shows
* Placeholder test still passes