### PR TITLE
Dashboards: Add assistant button in panel status popup

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -257,6 +257,10 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
   // legacy single status message.
   // @ts-expect-error onOpenInspector is added in a newer @grafana/ui version
   const showNewPanelErrorsUI = Boolean(context.onOpenInspector);
+  // The host only provides this when it wants an "Investigate errors" action offered in the
+  // status popover (e.g. gated on assistant availability); PanelChrome renders it generically.
+  // @ts-expect-error onInvestigateErrors is added in a newer @grafana/ui version
+  const onInvestigateErrors: (() => void) | undefined = context.onInvestigateErrors;
   const panelId = model.getLegacyPanelId();
   const outdatedPluginError = t(
     'grafana-scenes.components.viz-panel-renderer.outdated-plugin-error',
@@ -279,6 +283,7 @@ export function VizPanelRenderer({ model }: SceneComponentProps<VizPanel>) {
         // @ts-expect-error onOpenInspector is added in a newer @grafana/ui version
         context.onOpenInspector?.();
       }}
+      onInvestigateErrors={showNewPanelErrorsUI ? onInvestigateErrors : undefined}
       width={width === 0 ? undefined : width}
       // In fit-content mode the height is content-driven: leave it undefined so
       // PanelChrome flows. A min-height floor keeps the chrome filled when


### PR DESCRIPTION
Injects the assistant from panel context so we can tap into it within a panels errors and use it to fix errors.

Needed for - https://github.com/grafana/grafana/pull/131576

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.16.2--canary.1629.32951652632.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.16.2--canary.1629.32951652632.0
  npm install scenes-app@8.16.2--canary.1629.32951652632.0
  npm install @grafana/scenes-react@8.16.2--canary.1629.32951652632.0
  # or 
  yarn add @grafana/scenes@8.16.2--canary.1629.32951652632.0
  yarn add scenes-app@8.16.2--canary.1629.32951652632.0
  yarn add @grafana/scenes-react@8.16.2--canary.1629.32951652632.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
