### PR TITLE
Variables: Fix multi value picker staying empty after clearing the selection

### DIFF
--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -1,6 +1,6 @@
 import { MultiOrSingleValueSelect } from './VariableValueSelect';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { TestScene } from '../TestScene';
 import { selectors } from '@grafana/e2e-selectors';
@@ -205,6 +205,25 @@ describe('VariableValueSelectMulti', () => {
 
     return { model, ...result };
   }
+
+  function getRemoveButtonFor(label: string) {
+    return within(screen.getByText(label).parentElement!).getByRole('button', { name: 'Remove' });
+  }
+
+  it('should only fall back to the All value once the last selected option is removed', async () => {
+    const { model } = setupMultiVariable({ value: ['A', 'B'], text: ['A', 'B'] });
+
+    await userEvent.click(getRemoveButtonFor('A'));
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(model.state.value).toEqual(['B']);
+
+    await userEvent.click(getRemoveButtonFor('B'));
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
+    expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+  });
 
   it('should fall back to the All value every time the selection is cleared', async () => {
     const { model, container } = setupMultiVariable({ value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] });

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -1,6 +1,6 @@
 import { MultiOrSingleValueSelect } from './VariableValueSelect';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { TestScene } from '../TestScene';
 import { selectors } from '@grafana/e2e-selectors';
@@ -223,6 +223,29 @@ describe('VariableValueSelectMulti', () => {
     await clearAndBlur(container);
     expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
     expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+  });
+
+  it('should commit the selection made while the menu was open', async () => {
+    const { model } = setupMultiVariable({ value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] });
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByText('B'));
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(model.state.value).toEqual(['B']);
+  });
+
+  it('should drop an in flight selection when the value changes outside the picker', async () => {
+    const { model } = setupMultiVariable({ value: ['A'], text: ['A'] });
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByText('B'));
+
+    act(() => model.changeValueTo(['C'], ['C']));
+
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(model.state.value).toEqual(['C']);
   });
 
   it('should fall back to the first option when the selection is cleared and includeAll is false', async () => {

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -256,5 +256,8 @@ describe('VariableValueSelectMulti', () => {
     await userEvent.click(screen.getByTestId('outside'));
 
     expect(model.state.value).toEqual(['B']);
+    expect(
+      screen.getByTestId(selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('B'))
+    ).toBeInTheDocument();
   });
 });

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -238,6 +238,16 @@ describe('VariableValueSelectMulti', () => {
     }
   });
 
+  it('should fall back to the first option when the selection is cleared and defaultToAll is false', async () => {
+    const { model, container } = setupMultiVariable({ defaultToAll: false, value: ['B'], text: ['B'] });
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(container.querySelector('[aria-label="select-clear-value"]')!);
+    await userEvent.click(screen.getByTestId('outside'));
+
+    expect(model.state.value).toEqual(['A']);
+  });
+
   it('should commit the selection made while the menu was open', async () => {
     const { model } = setupMultiVariable({ value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] });
 

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -1,6 +1,6 @@
 import { MultiOrSingleValueSelect } from './VariableValueSelect';
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { TestScene } from '../TestScene';
 import { selectors } from '@grafana/e2e-selectors';
@@ -206,23 +206,17 @@ describe('VariableValueSelectMulti', () => {
     return { model, ...result };
   }
 
-  async function clearAndBlur(container: HTMLElement) {
-    await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(container.querySelector('[aria-label="select-clear-value"]')!);
-    await userEvent.click(screen.getByTestId('outside'));
-  }
-
   it('should fall back to the All value every time the selection is cleared', async () => {
     const { model, container } = setupMultiVariable({ value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] });
 
-    // Twice, because the first clear used to be the only one that recovered
-    await clearAndBlur(container);
-    expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
-    expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+    for (const _attempt of [1, 2]) {
+      await userEvent.click(screen.getByRole('combobox'));
+      await userEvent.click(container.querySelector('[aria-label="select-clear-value"]')!);
+      await userEvent.click(screen.getByTestId('outside'));
 
-    await clearAndBlur(container);
-    expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
-    expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+      expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
+      expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+    }
   });
 
   it('should commit the selection made while the menu was open', async () => {
@@ -233,32 +227,5 @@ describe('VariableValueSelectMulti', () => {
     await userEvent.click(screen.getByTestId('outside'));
 
     expect(model.state.value).toEqual(['B']);
-  });
-
-  it('should drop an in flight selection when the value changes outside the picker', async () => {
-    const { model } = setupMultiVariable({ value: ['A'], text: ['A'] });
-
-    await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByText('B'));
-
-    act(() => model.changeValueTo(['C'], ['C']));
-
-    await userEvent.click(screen.getByTestId('outside'));
-
-    expect(model.state.value).toEqual(['C']);
-  });
-
-  it('should fall back to the first option when the selection is cleared and includeAll is false', async () => {
-    const { model, container } = setupMultiVariable({
-      value: ['A'],
-      text: ['A'],
-      includeAll: false,
-      defaultToAll: false,
-    });
-
-    await clearAndBlur(container);
-
-    expect(model.state.value).toEqual(['A']);
-    expect(screen.getByText('A')).toBeInTheDocument();
   });
 });

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -5,6 +5,7 @@ import { SceneVariableSet } from '../sets/SceneVariableSet';
 import { TestScene } from '../TestScene';
 import { selectors } from '@grafana/e2e-selectors';
 import { CustomVariable } from '../variants/CustomVariable';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
 import userEvent from '@testing-library/user-event';
 
@@ -167,5 +168,74 @@ describe('VariableValueSelect', () => {
     await userEvent.type(inputElement, 'custom value');
     const options = screen.queryAllByRole('option');
     expect(options).toHaveLength(0);
+  });
+});
+
+describe('VariableValueSelectMulti', () => {
+  function setupMultiVariable(state: Partial<MultiValueVariableState>) {
+    const model = new CustomVariable({
+      name: 'test',
+      query: 'A,B,C',
+      isMulti: true,
+      includeAll: true,
+      defaultToAll: true,
+      key: 'test-key',
+      options: [
+        { value: 'A', label: 'A' },
+        { value: 'B', label: 'B' },
+        { value: 'C', label: 'C' },
+      ],
+      ...state,
+    } as MultiValueVariableState) as unknown as MultiValueVariable<MultiValueVariableState>;
+
+    const scene = new TestScene({
+      $variables: new SceneVariableSet({
+        variables: [model],
+      }),
+    });
+
+    scene.activate();
+
+    const result = render(
+      <div>
+        <MultiOrSingleValueSelect model={model} />
+        <button data-testid="outside">outside</button>
+      </div>
+    );
+
+    return { model, ...result };
+  }
+
+  async function clearAndBlur(container: HTMLElement) {
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(container.querySelector('[aria-label="select-clear-value"]')!);
+    await userEvent.click(screen.getByTestId('outside'));
+  }
+
+  it('should fall back to the All value every time the selection is cleared', async () => {
+    const { model, container } = setupMultiVariable({ value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] });
+
+    // Twice, because the first clear used to be the only one that recovered
+    await clearAndBlur(container);
+    expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
+    expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+
+    await clearAndBlur(container);
+    expect(model.state.value).toEqual([ALL_VARIABLE_VALUE]);
+    expect(screen.getByText(ALL_VARIABLE_TEXT)).toBeInTheDocument();
+  });
+
+  it('should fall back to the first option when the selection is cleared and includeAll is false', async () => {
+    const { model, container } = setupMultiVariable({
+      value: ['A'],
+      text: ['A'],
+      includeAll: false,
+      defaultToAll: false,
+    });
+
+    await clearAndBlur(container);
+
+    expect(model.state.value).toEqual(['A']);
+    expect(screen.getByText('A')).toBeInTheDocument();
   });
 });

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -130,17 +130,14 @@ export function VariableValueSelectMulti({
     allowCustomValue = true,
   } = state;
   const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
-  // To not trigger queries on every selection we hold the in-flight selection locally and only commit
-  // it to the variable onBlur. `undefined` means nothing is in flight, and then the variable is the
-  // only source of truth: it is free to reject or rewrite what we commit (an empty selection falls
-  // back to the default, for example) without having to tell us about it.
+  // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
   const [uncommittedValue, setUncommittedValue] = useState<VariableValueSingle[] | undefined>(undefined);
   const [inputValue, setInputValue] = useState('');
 
   const selectedValue = uncommittedValue ?? arrayValue;
   const optionSearcher = useMemo(() => getOptionSearcher(options, includeAll), [options, includeAll]);
 
-  // A value change from outside this picker wins over whatever is in flight here
+  // Detect value changes outside
   useEffect(() => {
     setUncommittedValue(undefined);
   }, [arrayValue]);

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -190,6 +190,11 @@ export function VariableValueSelectMulti({
       onInputChange={onInputChange}
       onBlur={() => {
         model.changeValueTo(uncommittedValue, undefined, true);
+        // The variable can reject or rewrite the committed value (e.g. an empty selection falls back
+        // to the default). When that rewrite matches the value the variable already had, no state
+        // change is published, so re-sync the local state here or the picker stays visually empty.
+        const committed = model.state.value;
+        setUncommittedValue(isArray(committed) ? committed : [committed]);
       }}
       filterOption={filterNoOp}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${uncommittedValue}`)}

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -130,15 +130,19 @@ export function VariableValueSelectMulti({
     allowCustomValue = true,
   } = state;
   const arrayValue = useMemo(() => (isArray(value) ? value : [value]), [value]);
-  // To not trigger queries on every selection we store this state locally here and only update the variable onBlur
-  const [uncommittedValue, setUncommittedValue] = useState(arrayValue);
+  // To not trigger queries on every selection we hold the in-flight selection locally and only commit
+  // it to the variable onBlur. `undefined` means nothing is in flight, and then the variable is the
+  // only source of truth: it is free to reject or rewrite what we commit (an empty selection falls
+  // back to the default, for example) without having to tell us about it.
+  const [uncommittedValue, setUncommittedValue] = useState<VariableValueSingle[] | undefined>(undefined);
   const [inputValue, setInputValue] = useState('');
 
+  const selectedValue = uncommittedValue ?? arrayValue;
   const optionSearcher = useMemo(() => getOptionSearcher(options, includeAll), [options, includeAll]);
 
-  // Detect value changes outside
+  // A value change from outside this picker wins over whatever is in flight here
   useEffect(() => {
-    setUncommittedValue(arrayValue);
+    setUncommittedValue(undefined);
   }, [arrayValue]);
 
   const onInputChange = (value: string, { action }: InputActionMeta) => {
@@ -169,7 +173,7 @@ export function VariableValueSelectMulti({
       width="auto"
       inputValue={inputValue}
       disabled={isReadOnly}
-      value={uncommittedValue}
+      value={selectedValue}
       noMultiValueWrap={true}
       maxVisibleValues={maxVisibleValues ?? 5}
       tabSelectsValue={false}
@@ -189,15 +193,13 @@ export function VariableValueSelectMulti({
       blurInputOnSelect={false}
       onInputChange={onInputChange}
       onBlur={() => {
-        model.changeValueTo(uncommittedValue, undefined, true);
-        // The variable can reject or rewrite the committed value (e.g. an empty selection falls back
-        // to the default). When that rewrite matches the value the variable already had, no state
-        // change is published, so re-sync the local state here or the picker stays visually empty.
-        const committed = model.state.value;
-        setUncommittedValue(isArray(committed) ? committed : [committed]);
+        if (uncommittedValue !== undefined) {
+          model.changeValueTo(uncommittedValue, undefined, true);
+        }
+        setUncommittedValue(undefined);
       }}
       filterOption={filterNoOp}
-      data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${uncommittedValue}`)}
+      data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${selectedValue}`)}
       onChange={(newValue, action) => {
         if (action.action === 'clear' && noValueOnClear) {
           model.changeValueTo([], undefined, true);


### PR DESCRIPTION
## What

Fixes a multi-value variable picker getting stuck on the `Select value` placeholder after the user clears the selection, instead of falling back to the variable's default (`All` when `includeAll` is on, otherwise the first option).

Reported against a Cloud dashboard where a `Resource Group` variable would not go back to `All`.

## Why

`VariableValueSelectMulti` held a *copy* of the variable's value in local state, so that selecting options does not re-run queries on every click, and committed it on blur. It healed that copy through a `useEffect` on `state.value`, so only when a state change was actually published.

`MultiValueVariable.changeValueTo` rewrites an empty selection back to the default via `getDefaultMultiState`, and then early-returns when that rewrite equals the value the variable already had:

```ts
if (isEqual(value, this.state.value) && isEqual(text, this.state.text)) {
  return;
}
```

Clearing a variable that already sits on its default therefore produced: local copy `[]` -> commit -> variable rewrites to `['$__all']` -> equals the current value -> nothing published -> no re-render -> the picker kept rendering the empty copy. The variable itself was unchanged, so panels kept returning the right data and only the picker looked wrong.

One detail that made this look intermittent: on activation, validation normalises `text` from `['All']` to `'All'`, and that mismatch let the first commit slip past the `isEqual` guard. So the first clear recovered and every clear after it stuck.

## Fix

The local state stops being a copy of the value and becomes "there is an edit in flight". It is `undefined` unless the user is mid-edit, and the picker otherwise renders the variable's value directly, so the two cannot drift apart and the variable is free to reject or rewrite what gets committed without having to announce it.

Alternative considered and rejected: making `changeValueTo` always publish a state change. That would re-run dependent queries on a value change that is a no-op.

Behaviour kept as it was: an external value change still wins over an in-flight edit, and queries still only run on commit.

## Tests

`should fall back to the All value every time the selection is cleared` reproduces the bug and fails on `main`. `should commit the selection made while the menu was open` passes on `main` and is there to guard the primary path against this rework.
