### PR TITLE
Filters: Do not store empty groupBy values

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -1173,6 +1173,25 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
     });
   });
 
+  it('drops the dismissed-groupBy URL marker instead of surfacing it as a normal filter', () => {
+    // this dashboard has no matching groupBy default either
+    const { filtersVar } = setup();
+
+    // the previous dashboard serialized "default groupBy was dismissed, but restorable"
+    // as this key-less marker (see AdHocFiltersVariableUrlSyncHandler#getUrlState), which
+    // survives navigation to this unrelated dashboard via the shared var-filters URL param
+    const urlValues = {
+      'var-filters': ['|groupBy#dashboard#restorable'],
+    };
+
+    act(() => {
+      locationService.partial(urlValues);
+    });
+
+    expect(filtersVar.state.filters).toEqual([]);
+    expect(filtersVar.state.originFilters).toEqual([]);
+  });
+
   it('url updates origin filters properly', async () => {
     const scopesVariable = newScopesVariableFromScopeFilters([
       {

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariableUrlSyncHandler.ts
@@ -77,7 +77,10 @@ export class AdHocFiltersVariableUrlSyncHandler implements SceneObjectUrlSyncHan
     const originFilters = updateOriginFilters([...(this._variable.state.originFilters || [])], filters);
 
     this._variable.setState({
-      filters: filters.filter((f) => !f.origin),
+      // A groupBy filter with no key is never real filter data - it's the "default groupBy
+      // dismissed, nothing left to serialize" URL marker (see getUrlState) - so it must never
+      // surface as an active filter, regardless of what updateOriginFilters did with its origin.
+      filters: filters.filter((f) => !f.origin && !(isGroupByFilter(f) && f.key === '')),
       originFilters,
     });
   }


### PR DESCRIPTION
This PR removes empty groupBys from being stored in the filter variable -- for example a default groupBy that has no values must be kept in the URL for bookkeeping (so it can be restored), but the empty key doesn't need to be passed further to the datasource, for example, as it is basically a non-value
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.16.2--canary.1633.34108773006.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.16.2--canary.1633.34108773006.0
  npm install scenes-app@8.16.2--canary.1633.34108773006.0
  npm install @grafana/scenes-react@8.16.2--canary.1633.34108773006.0
  # or 
  yarn add @grafana/scenes@8.16.2--canary.1633.34108773006.0
  yarn add scenes-app@8.16.2--canary.1633.34108773006.0
  yarn add @grafana/scenes-react@8.16.2--canary.1633.34108773006.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
