### PR TITLE
QueryVariable: interpolate legacy variable queries against their own scene

### DIFF
--- a/packages/scenes/src/variables/variants/query/createQueryVariableRunner.test.ts
+++ b/packages/scenes/src/variables/variants/query/createQueryVariableRunner.test.ts
@@ -1,6 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { DataSourceApi, MetricFindValue } from '@grafana/data';
+import { waitFor } from '@testing-library/react';
 
 import { EmbeddedScene } from '../../../components/EmbeddedScene';
 import { SceneCanvasText } from '../../../components/SceneCanvasText';
@@ -129,9 +130,11 @@ describe('LegacyQueryRunner', () => {
   it('interpolates through the global scene context when the datasource ignores scopedVars', async () => {
     const { scene, queryVariable } = buildScene('prod', 'hosts');
 
+    // Activation runs the query on its own, so nothing else may trigger a refresh here: the
+    // assertion below pins the exact calls the datasource saw.
     activateFullSceneTree(scene);
 
-    await lastValueFrom(queryVariable.validateAndUpdate());
+    await waitFor(() => expect(queryVariable.state.options).toEqual([{ label: 'prod.*', value: 'prod.*' }]));
 
     expect(metricFindQueryCalls).toEqual([{ variableName: 'hosts', interpolated: 'prod.*' }]);
   });

--- a/packages/scenes/src/variables/variants/query/createQueryVariableRunner.test.ts
+++ b/packages/scenes/src/variables/variants/query/createQueryVariableRunner.test.ts
@@ -1,0 +1,138 @@
+import { lastValueFrom } from 'rxjs';
+
+import { DataSourceApi, MetricFindValue } from '@grafana/data';
+
+import { EmbeddedScene } from '../../../components/EmbeddedScene';
+import { SceneCanvasText } from '../../../components/SceneCanvasText';
+import { SceneTimeRange } from '../../../core/SceneTimeRange';
+import { sceneGraph } from '../../../core/sceneGraph';
+import { SceneObject } from '../../../core/types';
+import { activateFullSceneTree } from '../../../utils/test/activateFullSceneTree';
+import { SceneVariableSet } from '../../sets/SceneVariableSet';
+import { CustomVariable } from '../CustomVariable';
+
+import { QueryVariable } from './QueryVariable';
+
+interface MetricFindQueryCall {
+  variableName: string;
+  interpolated: string;
+}
+
+const metricFindQueryCalls: MetricFindQueryCall[] = [];
+
+function getGlobalSceneContext(): SceneObject | undefined {
+  return (window as unknown as { __grafanaSceneContext?: SceneObject }).__grafanaSceneContext;
+}
+
+function setGlobalSceneContext(scene: SceneObject | undefined) {
+  (window as unknown as { __grafanaSceneContext?: SceneObject }).__grafanaSceneContext = scene;
+}
+
+/**
+ * Stands in for a datasource with legacy variable support (Graphite, Snowflake): it has no
+ * `variables` property, and it interpolates through the global scene context instead of the
+ * scopedVars it is handed, which is what templateSrv.replace() falls back to.
+ */
+const legacyDsMock = {
+  name: 'legacy',
+  type: 'legacy',
+  uid: 'legacy',
+  id: 1,
+  getRef: () => ({ type: 'legacy', uid: 'legacy' }),
+  query: () => Promise.resolve({ data: [] }),
+  testDatasource: () => Promise.resolve({ status: 'success', message: '' }),
+  async metricFindQuery(query: string, options: { variable: { name: string } }): Promise<MetricFindValue[]> {
+    const sceneContext = getGlobalSceneContext();
+    const interpolated = sceneContext ? sceneGraph.interpolate(sceneContext, query) : query;
+
+    metricFindQueryCalls.push({ variableName: options.variable.name, interpolated });
+
+    // Legacy datasources reach the network after interpolating, which is where a competing scene
+    // would get the chance to take over the global context.
+    await Promise.resolve();
+
+    return [{ text: interpolated }];
+  },
+} as unknown as DataSourceApi;
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({
+    get: (): Promise<DataSourceApi> => Promise.resolve(legacyDsMock),
+  }),
+}));
+
+function buildScene(environment: string, variableName: string) {
+  const queryVariable = new QueryVariable({
+    name: variableName,
+    query: '$env.*',
+    datasource: { uid: 'legacy', type: 'legacy' },
+  });
+
+  const scene = new EmbeddedScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    $variables: new SceneVariableSet({
+      variables: [
+        new CustomVariable({ name: 'env', query: environment, value: environment, text: environment }),
+        queryVariable,
+      ],
+    }),
+    body: new SceneCanvasText({ text: environment }),
+  });
+
+  return { scene, queryVariable };
+}
+
+describe('LegacyQueryRunner', () => {
+  beforeEach(() => {
+    metricFindQueryCalls.length = 0;
+    setGlobalSceneContext(undefined);
+  });
+
+  it('interpolates the query against the variable own scene, not whichever scene owns the global context', async () => {
+    const first = buildScene('prod', 'hostsA');
+    const second = buildScene('dev', 'hostsB');
+
+    // Activating both leaves the second scene owning the global context, the way a report editor
+    // holding one scene per dashboard does.
+    activateFullSceneTree(first.scene);
+    activateFullSceneTree(second.scene);
+
+    expect(getGlobalSceneContext()).toBe(second.scene);
+
+    // Resolved concurrently: both queries are in flight at the same time.
+    await Promise.all([
+      lastValueFrom(first.queryVariable.validateAndUpdate()),
+      lastValueFrom(second.queryVariable.validateAndUpdate()),
+    ]);
+
+    expect(metricFindQueryCalls).toEqual(
+      expect.arrayContaining([
+        { variableName: 'hostsA', interpolated: 'prod.*' },
+        { variableName: 'hostsB', interpolated: 'dev.*' },
+      ])
+    );
+    expect(first.queryVariable.state.options).toEqual([{ label: 'prod.*', value: 'prod.*' }]);
+    expect(second.queryVariable.state.options).toEqual([{ label: 'dev.*', value: 'dev.*' }]);
+  });
+
+  it('restores the global scene context after the query', async () => {
+    const { scene, queryVariable } = buildScene('prod', 'hosts');
+
+    activateFullSceneTree(scene);
+
+    await lastValueFrom(queryVariable.validateAndUpdate());
+
+    expect(getGlobalSceneContext()).toBe(scene);
+  });
+
+  it('interpolates through the global scene context when the datasource ignores scopedVars', async () => {
+    const { scene, queryVariable } = buildScene('prod', 'hosts');
+
+    activateFullSceneTree(scene);
+
+    await lastValueFrom(queryVariable.validateAndUpdate());
+
+    expect(metricFindQueryCalls).toEqual([{ variableName: 'hosts', interpolated: 'prod.*' }]);
+  });
+});

--- a/packages/scenes/src/variables/variants/query/createQueryVariableRunner.ts
+++ b/packages/scenes/src/variables/variants/query/createQueryVariableRunner.ts
@@ -5,10 +5,13 @@ import {
   DataSourceApi,
   getDefaultTimeRange,
   LoadingState,
+  MetricFindValue,
   PanelData,
   StandardVariableQuery,
 } from '@grafana/data';
 import { getRunRequest } from '@grafana/runtime';
+
+import { setWindowGrafanaSceneContext } from '../../../utils/compatibility/setWindowGrafanaSceneContext';
 
 import {
   hasCustomVariableSupport,
@@ -70,8 +73,22 @@ class LegacyQueryRunner implements QueryRunner {
       return getEmptyMetricFindValueObservable();
     }
 
-    return from(
-      this.datasource.metricFindQuery(variable.state.query, {
+    // Legacy datasources interpolate via templateSrv.replace() without forwarding the scopedVars
+    // passed below, so they resolve against window.__grafanaSceneContext instead. Point it at this
+    // variable's set for the duration of the call, otherwise a chained query interpolates against
+    // whichever scene happened to activate last. The variable set is used rather than the variable
+    // because templateSrv only honours the global while it is active, and a variable is only
+    // activated once its picker renders.
+    const restoreSceneContext = setWindowGrafanaSceneContext(variable.parent ?? variable);
+
+    // metricFindQuery must be invoked inside the window above, but the window must close before we
+    // await it: it stays open only for the synchronous part of the call, which is where these
+    // datasources interpolate. Holding it across the await would let concurrently resolving scenes
+    // overwrite each other's context.
+    let values: Promise<MetricFindValue[]>;
+
+    try {
+      values = this.datasource.metricFindQuery(variable.state.query, {
         ...request,
         // variable is used by SQL common data source
         variable: {
@@ -79,8 +96,12 @@ class LegacyQueryRunner implements QueryRunner {
           type: variable.state.type,
         },
         searchFilter,
-      })
-    ).pipe(
+      });
+    } finally {
+      restoreSceneContext();
+    }
+
+    return from(values).pipe(
       mergeMap((values) => {
         if (!values || !values.length) {
           return getEmptyMetricFindValueObservable();


### PR DESCRIPTION
## Summary
- Legacy datasources (Graphite, Snowflake, and others that predate the `variables` API) interpolate via `templateSrv.replace()` and ignore the `scopedVars` `LegacyQueryRunner` passes them. They read `window.__grafanaSceneContext` instead.
- When more than one scene is active (for example a reporting form with one scene per dashboard), only the last scene to activate owns that global, so chained queries on the others run uninterpolated (`$env.*`).
- Point the global at the variable’s own `SceneVariableSet` for the synchronous part of `metricFindQuery`, then restore it in `finally` before awaiting the promise so concurrent scenes cannot overwrite each other.

## Steps to reproduce (report drawer)

Needs Grafana Enterprise. The redesigned reporting UI is behind the `newShareReportDrawer` feature toggle.

1. Enable `newShareReportDrawer` (`[feature_toggles]` in `grafana.ini`, or Admin → Feature toggles) and restart if you used the ini file.
2. Create two dashboards that each have a chained query variable on a **legacy** datasource (Graphite, Snowflake, or any plugin without the `variables` API). Example:
   - Custom variable `env` with values `prod` on dashboard A and `dev` on dashboard B
   - Query variable `hosts` with query `$env.*`
3. Open **Reporting** (`/reports`) and click **Create report** (or from a dashboard: Share → Schedule report). The form should open as a drawer, not the old full-page wizard.
4. In **Dashboards**, pick dashboard A, then **Add dashboard** and pick dashboard B. Both scenes stay mounted at once.
5. Expand the variable pickers on each dashboard row.

**Before this change:** the picker for `hosts` is empty on both rows. The report form's dashboard rows never own `window.__grafanaSceneContext`, so `$env` resolves against no variable and both the scene interpolator and `templateSrv` return the token unchanged — the datasource is queried for a literal `$env.*`, which matches no metrics. If a scene that does define `env` happens to own the global (for example the drawer opened from a dashboard that has its own `env`), the picker shows that scene's values instead of the row's.
**After this change:** A's picker shows `prod.*` and B's shows `dev.*`.

## Test plan
- [ ] `yarn test:scenes packages/scenes/src/variables/variants/query/createQueryVariableRunner.test.ts --watch=false`
- [ ] Confirm two scenes with different `$env` values both interpolate correctly when activated together
- [ ] Confirm the previous `__grafanaSceneContext` is restored after the query
- [ ] Spot-check a Graphite/Snowflake query variable that depends on another variable
- [ ] Reproduce via the report drawer steps above against a linked scenes build
