### PR TITLE
Skip clearing frozen field values in VizPanelRenderer

### DIFF
--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -911,6 +911,48 @@ describe('VizPanel', () => {
         expect(panelProps?.timeRange.from.toISOString()).toEqual('2022-01-01T00:00:00.000Z');
         expect(panelProps?.data.timeRange.from.toISOString()).toEqual('2022-01-01T00:00:00.000Z');
       });
+
+      it('Should not throw when previous field values are frozen', async () => {
+        const frozenA = Object.freeze(['A', 'B', 'C']);
+        const frozenB = Object.freeze(['A', 'B', 'C']);
+        const data = new SceneDataNode({
+          data: {
+            ...getTestData(),
+            series: [
+              toDataFrame({
+                fields: [
+                  { name: 'A', type: FieldType.string, values: frozenA },
+                  { name: 'B', type: FieldType.string, values: frozenB },
+                ],
+              }),
+            ],
+          },
+        });
+        panel = new VizPanel<OptionsPlugin1, FieldConfigPlugin1>({
+          pluginId: 'custom-plugin-id',
+          $timeRange: new SceneTimeRange(),
+          $data: data,
+        });
+
+        pluginToLoad = getTestPlugin1();
+
+        render(<panel.Component model={panel} />);
+
+        expect(await screen.findByText('My custom panel')).toBeInTheDocument();
+
+        act(() => {
+          data.setState({
+            data: {
+              ...data.state.data,
+              series: getTestData().series,
+            },
+          });
+        });
+
+        expect(await screen.findByText('My custom panel')).toBeInTheDocument();
+        expect(frozenA.length).toBe(3);
+        expect(frozenB.length).toBe(3);
+      });
     });
 
     describe('Non data plugin', () => {

--- a/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanel.test.tsx
@@ -932,6 +932,7 @@ describe('VizPanel', () => {
           pluginId: 'custom-plugin-id',
           $timeRange: new SceneTimeRange(),
           $data: data,
+          _UNSAFE_clearPreviousFieldValues: true,
         });
 
         pluginToLoad = getTestPlugin1();

--- a/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
+++ b/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx
@@ -425,7 +425,10 @@ function useClearPreviousData(data?: DataFrame[]) {
     // empty out all prev not seen in new
     prevVals.current.forEach((vals) => {
       if (!currVals.current!.has(vals)) {
-        vals.length = 0;
+        // Panel edit can freeze field value arrays. Mutating length throws.
+        if (Object.isExtensible(vals)) {
+          vals.length = 0;
+        }
       }
     });
     prevVals.current.clear();


### PR DESCRIPTION
Fixes #1632

Editing a panel can freeze field value arrays. Clearing stale values by setting length to 0 then throws.

Skip that clear when the array is not extensible. Mutable arrays still get emptied.

## Tests
* Frozen field values then a new series
* Page does not throw
* Frozen arrays keep their length
