### PR TITLE
Variables: Localize the native All option label

### DIFF
--- a/packages/scenes/src/locales/en-US/grafana-scenes.json
+++ b/packages/scenes/src/locales/en-US/grafana-scenes.json
@@ -188,6 +188,7 @@
         "placeholder-enter-value": "Enter value"
       },
       "variable-value-select": {
+        "all-label": "All",
         "placeholder-select-value": "Select value"
       }
     }

--- a/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.test.tsx
@@ -9,6 +9,15 @@ import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
 import userEvent from '@testing-library/user-event';
 
+const translations: Record<string, string> = {};
+
+jest.mock('@grafana/i18n', () => ({
+  ...jest.requireActual('@grafana/i18n'),
+  t: (id: string, defaultMessage: string) => translations[id] ?? defaultMessage,
+}));
+
+const ALL_LABEL_KEY = 'grafana-scenes.variables.variable-value-select.all-label';
+
 describe('VariableValueSelect', () => {
   let model: MultiValueVariable<MultiValueVariableState>;
 
@@ -268,5 +277,68 @@ describe('VariableValueSelectMulti', () => {
     expect(
       screen.getByTestId(selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('B'))
     ).toBeInTheDocument();
+  });
+});
+
+describe('All option localization', () => {
+  beforeEach(() => {
+    translations[ALL_LABEL_KEY] = 'Tout';
+  });
+
+  afterEach(() => {
+    delete translations[ALL_LABEL_KEY];
+  });
+
+  function setupVariable(state: Partial<MultiValueVariableState>) {
+    const model = new CustomVariable({
+      name: 'test',
+      query: 'A,B,C',
+      includeAll: true,
+      key: 'test-key',
+      options: [
+        { value: 'A', label: 'A' },
+        { value: 'B', label: 'B' },
+        { value: 'C', label: 'C' },
+      ],
+      ...state,
+    } as MultiValueVariableState) as unknown as MultiValueVariable<MultiValueVariableState>;
+
+    const scene = new TestScene({
+      $variables: new SceneVariableSet({
+        variables: [model],
+      }),
+    });
+
+    scene.activate();
+
+    render(<MultiOrSingleValueSelect model={model} />);
+
+    return { model };
+  }
+
+  it('should show the translated All label as the selected single value', async () => {
+    setupVariable({ isMulti: false, value: ALL_VARIABLE_VALUE, text: ALL_VARIABLE_TEXT });
+
+    expect(screen.getByText('Tout')).toBeInTheDocument();
+    expect(screen.queryByText(ALL_VARIABLE_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('should show the translated All label as a selected multi value', async () => {
+    setupVariable({ isMulti: true, value: [ALL_VARIABLE_VALUE], text: [ALL_VARIABLE_TEXT] });
+
+    expect(screen.getByText('Tout')).toBeInTheDocument();
+    expect(screen.queryByText(ALL_VARIABLE_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('should keep the untranslated text in variable state when selecting All', async () => {
+    const { model } = setupVariable({ isMulti: false, value: 'A', text: 'A' });
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByText('Tout'));
+
+    expect(model.state.value).toBe(ALL_VARIABLE_VALUE);
+    // ${var:text} and the legacy `All` URL value depend on this staying untranslated
+    expect(model.state.text).toBe(ALL_VARIABLE_TEXT);
+    expect(model.getValueText()).toBe(ALL_VARIABLE_TEXT);
   });
 });

--- a/packages/scenes/src/variables/components/VariableValueSelect.tsx
+++ b/packages/scenes/src/variables/components/VariableValueSelect.tsx
@@ -13,6 +13,7 @@ import {
 } from '@grafana/ui';
 
 import { MultiValueVariable, MultiValueVariableState } from '../variants/MultiValueVariable';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { VariableValue, VariableValueSingle } from '../types';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
@@ -24,7 +25,7 @@ import { getVariableControlId } from '../utils';
 
 const filterNoOp = () => true;
 
-const filterAll = (v: SelectableValue<VariableValueSingle>) => v.value !== '$__all';
+const filterAll = (v: SelectableValue<VariableValueSingle>) => v.value !== ALL_VARIABLE_VALUE;
 
 const determineToggleAllState = (
   selectedValues: Array<SelectableValue<VariableValueSingle>>,
@@ -34,7 +35,7 @@ const determineToggleAllState = (
     return ToggleAllState.allSelected;
   } else if (
     selectedValues.length === 0 ||
-    (selectedValues.length === 1 && selectedValues[0] && selectedValues[0].value === '$__all')
+    (selectedValues.length === 1 && selectedValues[0] && selectedValues[0].value === ALL_VARIABLE_VALUE)
   ) {
     return ToggleAllState.noneSelected;
   } else {
@@ -53,7 +54,12 @@ export function VariableValueSelect({ model, state }: { model: MultiValueVariabl
   const { value, text, key, options, includeAll, isReadOnly, allowCustomValue = true } = state;
   const [inputValue, setInputValue] = useState('');
   const [hasCustomValue, setHasCustomValue] = useState(false);
-  const selectValue = toSelectableValue(value, String(text));
+  // The All option is only localized for display. state.text stays ALL_VARIABLE_TEXT because it
+  // feeds interpolation (${var:text}) and the legacy `All` URL value.
+  const selectValue = toSelectableValue(
+    value,
+    value === ALL_VARIABLE_VALUE ? t('grafana-scenes.variables.variable-value-select.all-label', 'All') : String(text)
+  );
   const queryController = sceneGraph.getQueryController(model);
   const optionSearcher = useMemo(() => getOptionSearcher(options, includeAll), [options, includeAll]);
 
@@ -101,7 +107,9 @@ export function VariableValueSelect({ model, state }: { model: MultiValueVariabl
       options={filteredOptions}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${value}`)}
       onChange={(newValue) => {
-        model.changeValueTo(newValue.value!, newValue.label!, true);
+        // Never let the localized All label reach the variable state, see selectValue above
+        const text = newValue.value === ALL_VARIABLE_VALUE ? ALL_VARIABLE_TEXT : newValue.label!;
+        model.changeValueTo(newValue.value!, text, true);
         queryController?.startProfile(VARIABLE_VALUE_CHANGED_INTERACTION);
 
         if (hasCustomValue !== newValue.__isNew__) {
@@ -150,7 +158,10 @@ export function VariableValueSelectMulti({
     return inputValue;
   };
 
-  const placeholder = options.length > 0 ? 'Select value' : '';
+  const placeholder =
+    options.length > 0
+      ? t('grafana-scenes.variables.variable-value-select.placeholder-select-value', 'Select value')
+      : '';
   const filteredOptions = optionSearcher(inputValue);
 
   return (

--- a/packages/scenes/src/variables/components/getOptionSearcher.test.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.test.ts
@@ -1,7 +1,20 @@
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
 import { getOptionSearcher } from './getOptionSearcher';
 
+const translations: Record<string, string> = {};
+
+jest.mock('@grafana/i18n', () => ({
+  ...jest.requireActual('@grafana/i18n'),
+  t: (id: string, defaultMessage: string) => translations[id] ?? defaultMessage,
+}));
+
 describe('getOptionSearcher', () => {
+  afterEach(() => {
+    for (const key of Object.keys(translations)) {
+      delete translations[key];
+    }
+  });
+
   it('Should return options', async () => {
     const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], false);
     expect(optionSearcher('')).toEqual([{ label: 'A', value: '1' }]);
@@ -13,6 +26,23 @@ describe('getOptionSearcher', () => {
       { label: ALL_VARIABLE_TEXT, value: ALL_VARIABLE_VALUE },
       { label: 'A', value: '1' },
     ]);
+  });
+
+  it('Should localize the All option label', async () => {
+    translations['grafana-scenes.variables.variable-value-select.all-label'] = 'Tout';
+
+    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], true);
+    expect(optionSearcher('')).toEqual([
+      { label: 'Tout', value: ALL_VARIABLE_VALUE },
+      { label: 'A', value: '1' },
+    ]);
+  });
+
+  it('Can filter the localized All option by its translated label', async () => {
+    translations['grafana-scenes.variables.variable-value-select.all-label'] = 'Tout';
+
+    const optionSearcher = getOptionSearcher([{ label: 'A', value: '1' }], true);
+    expect(optionSearcher('Tou')).toEqual([{ label: 'Tout', value: ALL_VARIABLE_VALUE }]);
   });
 
   it('Can filter options by search query', async () => {

--- a/packages/scenes/src/variables/components/getOptionSearcher.ts
+++ b/packages/scenes/src/variables/components/getOptionSearcher.ts
@@ -1,12 +1,17 @@
+import { t } from '@grafana/i18n';
+
 import { VariableValueOption } from '../types';
-import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../constants';
+import { ALL_VARIABLE_VALUE } from '../constants';
 import { fuzzyFind } from '../filter';
 
 export function getOptionSearcher(options: VariableValueOption[], includeAll = false) {
   let allOptions = options;
 
   if (includeAll) {
-    allOptions = [{ value: ALL_VARIABLE_VALUE, label: ALL_VARIABLE_TEXT }, ...allOptions];
+    allOptions = [
+      { value: ALL_VARIABLE_VALUE, label: t('grafana-scenes.variables.variable-value-select.all-label', 'All') },
+      ...allOptions,
+    ];
   }
 
   const haystack = allOptions.map((o) => o.label);


### PR DESCRIPTION
Fixes the native `All` option in multi-value variable pickers staying English under a non-English locale. The surrounding dashboard UI is translated, but `ALL_VARIABLE_TEXT` was rendered directly without going through `@grafana/i18n`.

The label is now translated in the two display paths:

- `getOptionSearcher` — the dropdown option, which also drives multi-select chip labels via value → option matching
- `VariableValueSelect` — the single-select selected-value display

The state layer is deliberately untouched. `MultiValueVariable`'s `state.text` keeps the untranslated `ALL_VARIABLE_TEXT` because it feeds `${var:text}` interpolation, the legacy `All` URL value handled by `handleLegacyUrlAllValue`, and the `isAllValueFix` check in `interceptStateUpdateAfterValidation`. To keep that invariant, single-select `onChange` no longer forwards the (now localized) option label for `$__all` — without that guard, picking All would write the translated string into variable state.

Also in `VariableValueSelectMulti`: the placeholder was a hardcoded `'Select value'` literal — switched to the existing `placeholder-select-value` key.

Only the `en-US` catalog is updated; other languages arrive via Crowdin. After a release, grafana/grafana needs a `@grafana/scenes` bump for the fix to reach dashboards.

### Testing

Reverting only the two source files makes exactly the 5 new tests fail. With the fix, the full suite passes (1823 tests / 84 suites), along with `tsc --noEmit`, eslint and prettier.

Reported via grafana/support-escalations#24072.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.16.2--canary.1638.34332984248.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.16.2--canary.1638.34332984248.0
  npm install scenes-app@8.16.2--canary.1638.34332984248.0
  npm install @grafana/scenes-react@8.16.2--canary.1638.34332984248.0
  # or 
  yarn add @grafana/scenes@8.16.2--canary.1638.34332984248.0
  yarn add scenes-app@8.16.2--canary.1638.34332984248.0
  yarn add @grafana/scenes-react@8.16.2--canary.1638.34332984248.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
