### PR TITLE
Macros: Add $__namespace macro

### DIFF
--- a/packages/scenes/src/variables/macros/contextMacros.test.ts
+++ b/packages/scenes/src/variables/macros/contextMacros.test.ts
@@ -39,3 +39,16 @@ describe('org macro', () => {
     expect(sceneInterpolator(scene, '${__org.name}')).toBe('My cool org');
   });
 });
+
+describe('namespace macro', () => {
+  it.each(['stacks-123', 'default', 'org-15'])('Can interpolate $__namespace as %s', (namespace) => {
+    const scene = new TestScene({});
+
+    config.namespace = namespace;
+
+    expect(sceneInterpolator(scene, '$__namespace')).toBe(namespace);
+    expect(sceneInterpolator(scene, 'apis/dashboard.grafana.app/v1beta1/namespaces/${__namespace}/dashboards')).toBe(
+      `apis/dashboard.grafana.app/v1beta1/namespaces/${namespace}/dashboards`
+    );
+  });
+});

--- a/packages/scenes/src/variables/macros/contextMacros.ts
+++ b/packages/scenes/src/variables/macros/contextMacros.ts
@@ -49,3 +49,19 @@ export class OrgMacro implements FormatVariable {
     }
   }
 }
+
+/**
+ * Handles expressions like ${__namespace}, the Kubernetes namespace of the current instance.
+ * Grafana APIs are namespaced, so queries against them need it to build the URL.
+ */
+export class NamespaceMacro implements FormatVariable {
+  public state: { name: string; type: string };
+
+  public constructor(name: string, _: SceneObject) {
+    this.state = { name: name, type: 'namespace_macro' };
+  }
+
+  public getValue(): string {
+    return config.namespace;
+  }
+}

--- a/packages/scenes/src/variables/macros/index.ts
+++ b/packages/scenes/src/variables/macros/index.ts
@@ -4,7 +4,7 @@ import { IntervalMacro, TimeFromAndToMacro, TimezoneMacro, UrlTimeRangeMacro } f
 import { AllVariablesMacro } from './AllVariablesMacro';
 import { DataMacro, FieldMacro, SeriesMacro, ValueMacro } from './dataMacros';
 import { UrlMacro } from './urlMacros';
-import { OrgMacro, UserMacro } from './contextMacros';
+import { NamespaceMacro, OrgMacro, UserMacro } from './contextMacros';
 
 export const macrosIndex = new Map<string, MacroVariableConstructor>([
   [DataLinkBuiltInVars.includeVars, AllVariablesMacro],
@@ -19,6 +19,7 @@ export const macrosIndex = new Map<string, MacroVariableConstructor>([
   ['__timezone', TimezoneMacro],
   ['__user', UserMacro],
   ['__org', OrgMacro],
+  ['__namespace', NamespaceMacro],
   ['__interval', IntervalMacro],
   ['__interval_ms', IntervalMacro],
 ]);


### PR DESCRIPTION
Adds `$__namespace`, a macro that resolves to `config.namespace`: the Kubernetes namespace of the current instance, `stacks-<id>` in Grafana Cloud and `default` or `org-<id>` self-managed.

**Use case.** Grafana API paths are namespaced (`/apis/<group>/<version>/namespaces/<ns>/<resource>`). Dashboarding those resources, for example with the Infinity data source pointed back at the instance, means the namespace has to appear in the query URL, and there is no supported way to get it into a dashboard today. People either hardcode it, which makes the dashboard non-portable across instances, or read it from `/bootdata`, which is undocumented and being removed.

**Why here.** The value is instance identity, the same class as `$__org` and `$__user`, so it sits next to them in `contextMacros.ts` and in the built-in macro index. `config.namespace` has been on `GrafanaBootConfig` since grafana/grafana#78090 and is present in `@grafana/data` 11.6, so no peer dependency bump is needed.

Originally written as a core-only macro in grafana/grafana#132167, moved here after review; that PR becomes a scenes bump plus the docs page.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.17.0--canary.1639.34358408040.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/scenes@8.17.0--canary.1639.34358408040.0
  npm install scenes-app@8.17.0--canary.1639.34358408040.0
  npm install @grafana/scenes-react@8.17.0--canary.1639.34358408040.0
  # or 
  yarn add @grafana/scenes@8.17.0--canary.1639.34358408040.0
  yarn add scenes-app@8.17.0--canary.1639.34358408040.0
  yarn add @grafana/scenes-react@8.17.0--canary.1639.34358408040.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
