### PR TITLE
CI: Release through a pull request instead of committing to main

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+  # Manual re-drive for `publish`. Pushing to main is forbidden by the ruleset, so
+  # without this a publish that never fired could not be recovered.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -127,8 +130,9 @@ jobs:
   # forbids committing to main directly: this job opens a release PR, and the
   # `publish` job below reacts to that PR being merged. The marker is the commit
   # subject, which for a squash merge (the only method enabled here) is the PR
-  # title. `publish` also has a version-based fallback so a retitled or manually
-  # landed release still ships.
+  # title. `publish` re-checks npm before acting, so a re-run is a no-op rather
+  # than a double publish, and workflow_dispatch is the manual re-drive if the
+  # subject-based trigger ever misses.
   release-pr:
     name: Open release PR
     runs-on: ubuntu-latest
@@ -138,7 +142,8 @@ jobs:
       group: release-main
       cancel-in-progress: false
     permissions:
-      contents: read
+      # create-github-app-token fetches its credentials over OIDC.
+      id-token: write
     steps:
       - name: Get GitHub App Token
         id: get-github-app-token
@@ -206,7 +211,7 @@ jobs:
         # recomputes cumulatively, so closing the old one and opening a fresh PR
         # always yields the correct version.
         run: |
-          for NUM in $(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("release/")) | .number'); do
+          for NUM in $(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | test("^release/v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .number'); do
             echo "Closing superseded release PR #${NUM}"
             gh pr close "$NUM" --delete-branch --comment "Superseded by the release PR for v${VERSION}."
           done
@@ -263,9 +268,12 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     needs: [test, test-react-18]
-    if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v')"
+    if: "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v'))"
     concurrency:
-      group: release-main
+      # Deliberately NOT release-main: GitHub keeps a single pending entry per
+      # group, so sharing one let a queued publish be cancelled by a later
+      # release-pr, silently dropping an already-merged release.
+      group: release-publish
       cancel-in-progress: false
     permissions:
       id-token: write
@@ -295,24 +303,39 @@ jobs:
       - name: Build library
         run: yarn run lerna run build --no-private
 
-      - name: Resolve version to publish
+      - name: Resolve what still needs releasing
         id: version
-        # Fallback for the commit-subject trigger: if this version is already on
-        # npm there is nothing to do, so a re-run (or a push whose subject merely
-        # looks like a release) is a no-op rather than a failure.
+        # Probe every publishable package, not just one. lerna publishes
+        # topologically, so a failure partway through leaves some packages on npm
+        # and some not; gating on a single package would make the retry a silent
+        # no-op and strand the rest. The GitHub release is tracked separately so a
+        # failed `auto release` can be retried after a successful npm publish.
         run: |
           VERSION="$(node -p "require('./lerna.json').version")"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          if npm view "@grafana/scenes@${VERSION}" version >/dev/null 2>&1; then
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "v${VERSION} is already published; nothing to do."
+          PUBLISH=false
+          SPECS="$(yarn lerna list --json --no-private --loglevel silent \
+            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).map(p=>p.name+'@'+p.version).join('\n')))")"
+          for SPEC in $SPECS; do
+            if npm view "$SPEC" version >/dev/null 2>&1; then
+              echo "${SPEC} is already published."
+            else
+              echo "${SPEC} is not on npm."
+              PUBLISH=true
+            fi
+          done
+          echo "publish=${PUBLISH}" >> "$GITHUB_OUTPUT"
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
           else
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "Publishing v${VERSION}."
+            echo "release=true" >> "$GITHUB_OUTPUT"
           fi
+          echo "Needs npm publish: ${PUBLISH}"
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
 
       - name: Push release tag
-        if: steps.version.outputs.publish == 'true'
+        if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true'
         # Tag before publishing to npm: a publish failure then leaves git fully
         # consistent, and this step is skipped on a re-run if the tag already
         # points at the right commit.
@@ -331,7 +354,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
 
       - name: Create local tag
-        if: steps.version.outputs.publish == 'true'
+        if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true'
         # `auto release` resolves the release version from `git describe --tags`
         # on HEAD, so the tag has to exist locally as well as on the remote.
         run: git tag "v${VERSION}" "${GITHUB_SHA}" || true
@@ -346,7 +369,7 @@ jobs:
         run: yarn lerna publish from-package --yes --no-verify-access
 
       - name: Create GitHub release
-        if: steps.version.outputs.publish == 'true'
+        if: steps.version.outputs.release == 'true'
         run: yarn auto release
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -86,7 +86,7 @@ jobs:
     name: Canary release
     runs-on: ubuntu-latest
     needs: [test, test-react-18]
-    if: github.event_name == 'pull_request'
+    if: "github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/')"
     permissions:
       id-token: write
     steps:
@@ -123,11 +123,147 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
 
-  release:
-    name: Release
+  # Releasing is split in two because the org-level "Repo required PRs" ruleset
+  # forbids committing to main directly: this job opens a release PR, and the
+  # `publish` job below reacts to that PR being merged. The marker is the commit
+  # subject, which for a squash merge (the only method enabled here) is the PR
+  # title. `publish` also has a version-based fallback so a retitled or manually
+  # landed release still ships.
+  release-pr:
+    name: Open release PR
     runs-on: ubuntu-latest
     needs: [test, test-react-18]
-    if: "github.event_name == 'push' && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: "github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'Release v') && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    concurrency:
+      group: release-main
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - name: Get GitHub App Token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: scenes-repo-bot-access-token
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.get-github-app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
+
+      - name: Test using Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        uses: ./.github/actions/yarn-nm-install
+
+      # No build here: nothing is published from this job, so the build only
+      # needs to happen in `publish`.
+      - name: Calculate version bump
+        id: bump
+        run: |
+          AUTO_OUTPUT="$(yarn auto version)"
+          BUMP="$(echo "$AUTO_OUTPUT" | grep -oE '^(major|minor|patch)$' | tail -n1)"
+          if [ -z "$BUMP" ]; then
+            echo "No version bump detected. Output of \`auto version\`:"
+            echo "$AUTO_OUTPUT"
+          fi
+          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
+          echo "Calculated version bump: ${BUMP:-none (skipping release)}"
+        env:
+          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+
+      - name: Update changelogs
+        if: steps.bump.outputs.bump != ''
+        # `auto changelog` writes the root and per-package changelogs and commits
+        # them locally (unsigned). Drop the commit but keep the file changes so the
+        # release branch can be built from them below.
+        run: |
+          BEFORE_CHANGELOG="$(git rev-parse HEAD)"
+          yarn auto changelog
+          git reset --mixed "$BEFORE_CHANGELOG"
+        env:
+          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+
+      - name: Bump versions
+        id: version
+        if: steps.bump.outputs.bump != ''
+        # --no-git-tag-version so lerna only rewrites lerna.json and the
+        # package.json files without creating a commit or tag.
+        run: |
+          yarn lerna version "${{ steps.bump.outputs.bump }}" --force-publish --no-commit-hooks --yes --no-push --no-git-tag-version
+          echo "version=$(node -p "require('./lerna.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Replace any superseded release PR
+        if: steps.bump.outputs.bump != ''
+        # A release PR left open while another labelled PR merges is stale: its
+        # version no longer reflects everything since the last tag. `auto version`
+        # recomputes cumulatively, so closing the old one and opening a fresh PR
+        # always yields the correct version.
+        run: |
+          for NUM in $(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("release/")) | .number'); do
+            echo "Closing superseded release PR #${NUM}"
+            gh pr close "$NUM" --delete-branch --comment "Superseded by the release PR for v${VERSION}."
+          done
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Create release branch
+        if: steps.bump.outputs.bump != ''
+        # createCommitOnBranch (used by ghcommit-action below) needs the ref to
+        # already exist. Recreate it if a previous attempt left one behind.
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v${VERSION}" >/dev/null 2>&1 \
+            && gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/v${VERSION}"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/heads/release/v${VERSION}" -f "sha=${GITHUB_SHA}"
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Commit changelogs and version bump
+        id: release-commit
+        if: steps.bump.outputs.bump != ''
+        # One commit for both, unlike the previous direct-to-main flow which
+        # needed two. Created through the API so it is signed ("Verified"), which
+        # the org-wide "Signed Commits" ruleset requires on every branch.
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: 'Release v${{ steps.version.outputs.version }}'
+          repo: ${{ github.repository }}
+          branch: release/v${{ steps.version.outputs.version }}
+          file_pattern: 'CHANGELOG.md packages/*/CHANGELOG.md lerna.json packages/*/package.json'
+        env:
+          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+
+      - name: Open release PR
+        if: steps.bump.outputs.bump != ''
+        # `no-changelog` keeps this PR out of the next release's changelog via the
+        # omit-commits plugin. It carries no major/minor/patch label, so with
+        # onlyPublishWithReleaseLabel it contributes no bump of its own.
+        run: |
+          PR_URL="$(gh pr create \
+            --base main \
+            --head "release/v${VERSION}" \
+            --title "Release v${VERSION}" \
+            --label no-changelog \
+            --body "Automated release of v${VERSION}. Merging publishes to npm and creates the git tag and GitHub release.")"
+          echo "Opened ${PR_URL}"
+          gh pr merge "$PR_URL" --auto --squash
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: [test, test-react-18]
+    if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v')"
     concurrency:
       group: release-main
       cancel-in-progress: false
@@ -159,119 +295,58 @@ jobs:
       - name: Build library
         run: yarn run lerna run build --no-private
 
-      # `auto shipit` is decomposed into the steps below so that the changelog and
-      # version-bump commits can be created through the GitHub GraphQL API
-      # (createCommitOnBranch) instead of `git push`. Commits created that way are
-      # signed by GitHub ("Verified"), which the branch protection on main requires.
-
-      - name: Calculate version bump
-        id: bump
-        run: |
-          AUTO_OUTPUT="$(yarn auto version)"
-          BUMP="$(echo "$AUTO_OUTPUT" | grep -oE '^(major|minor|patch)$' | tail -n1)"
-          if [ -z "$BUMP" ]; then
-            echo "No version bump detected. Output of \`auto version\`:"
-            echo "$AUTO_OUTPUT"
-          fi
-          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
-          echo "Calculated version bump: ${BUMP:-none (skipping release)}"
-        env:
-          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
-
-      - name: Update changelogs
-        if: steps.bump.outputs.bump != ''
-        # `auto changelog` writes the root and per-package changelogs and commits
-        # them locally (unsigned). Drop the commit but keep the file changes so the
-        # next step can re-create it through the API.
-        run: |
-          BEFORE_CHANGELOG="$(git rev-parse HEAD)"
-          yarn auto changelog
-          git reset --mixed "$BEFORE_CHANGELOG"
-        env:
-          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
-
-      - name: Commit changelogs
-        id: changelog-commit
-        if: steps.bump.outputs.bump != ''
-        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
-        with:
-          commit_message: 'Update CHANGELOG.md [skip ci]'
-          repo: ${{ github.repository }}
-          branch: main
-          file_pattern: 'CHANGELOG.md packages/*/CHANGELOG.md'
-        env:
-          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
-
-      - name: Sync with remote
-        if: steps.bump.outputs.bump != ''
-        run: |
-          git fetch origin main
-          git reset --hard "${CHANGELOG_COMMIT:-FETCH_HEAD}"
-        env:
-          CHANGELOG_COMMIT: ${{ steps.changelog-commit.outputs.commit-hash }}
-
-      - name: Bump versions
+      - name: Resolve version to publish
         id: version
-        if: steps.bump.outputs.bump != ''
-        # Same command `auto shipit` runs internally, plus --no-git-tag-version so
-        # that lerna only updates lerna.json and the package.json files without
-        # creating a commit or tag.
+        # Fallback for the commit-subject trigger: if this version is already on
+        # npm there is nothing to do, so a re-run (or a push whose subject merely
+        # looks like a release) is a no-op rather than a failure.
         run: |
-          yarn lerna version "${{ steps.bump.outputs.bump }}" --force-publish --no-commit-hooks --yes --no-push --no-git-tag-version
-          echo "version=$(node -p "require('./lerna.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Commit version bump
-        id: version-commit
-        if: steps.bump.outputs.bump != ''
-        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
-        with:
-          commit_message: 'Bump version to: v${{ steps.version.outputs.version }} [skip ci]'
-          repo: ${{ github.repository }}
-          branch: main
-          file_pattern: 'lerna.json packages/*/package.json'
-        env:
-          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
-
-      - name: Check out version bump commit
-        if: steps.bump.outputs.bump != ''
-        # The local tag is not pushed; it is what `auto release` below uses to
-        # resolve the release version (`git describe --tags` on HEAD).
-        run: |
-          git fetch origin main
-          git reset --hard "$VERSION_COMMIT"
-          git tag "v$VERSION" "$VERSION_COMMIT"
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          VERSION_COMMIT: ${{ steps.version-commit.outputs.commit-hash }}
+          VERSION="$(node -p "require('./lerna.json').version")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          if npm view "@grafana/scenes@${VERSION}" version >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "v${VERSION} is already published; nothing to do."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Publishing v${VERSION}."
+          fi
 
       - name: Push release tag
-        if: steps.bump.outputs.bump != ''
+        if: steps.version.outputs.publish == 'true'
         # Tag before publishing to npm: a publish failure then leaves git fully
         # consistent, and this step is skipped on a re-run if the tag already
         # points at the right commit.
         run: |
           EXISTING="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || EXISTING=""
           if [ -z "$EXISTING" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/tags/v${VERSION}" -f "sha=${VERSION_COMMIT}"
-          elif [ "$EXISTING" = "$VERSION_COMMIT" ]; then
-            echo "Tag v${VERSION} already exists at ${VERSION_COMMIT}, skipping"
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/tags/v${VERSION}" -f "sha=${GITHUB_SHA}"
+          elif [ "$EXISTING" = "$GITHUB_SHA" ]; then
+            echo "Tag v${VERSION} already exists at ${GITHUB_SHA}, skipping"
           else
-            echo "Tag v${VERSION} already exists but points at ${EXISTING} instead of ${VERSION_COMMIT}" >&2
+            echo "Tag v${VERSION} already exists but points at ${EXISTING} instead of ${GITHUB_SHA}" >&2
             exit 1
           fi
         env:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
-          VERSION_COMMIT: ${{ steps.version-commit.outputs.commit-hash }}
+
+      - name: Create local tag
+        if: steps.version.outputs.publish == 'true'
+        # `auto release` resolves the release version from `git describe --tags`
+        # on HEAD, so the tag has to exist locally as well as on the remote.
+        run: git tag "v${VERSION}" "${GITHUB_SHA}" || true
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Publish to npm
-        if: steps.bump.outputs.bump != ''
-        # Same command the npm plugin runs from `auto shipit`. Publishing
-        # authenticates via npm trusted publishing (OIDC), hence id-token: write.
+        if: steps.version.outputs.publish == 'true'
+        # Publishing authenticates via npm trusted publishing (OIDC), hence
+        # id-token: write. from-package skips anything already on npm, so a
+        # partially completed publish can be re-run safely.
         run: yarn lerna publish from-package --yes --no-verify-access
 
       - name: Create GitHub release
-        if: steps.bump.outputs.bump != ''
+        if: steps.version.outputs.publish == 'true'
         run: yarn auto release
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -257,8 +257,9 @@ jobs:
             --head "release/v${VERSION}" \
             --title "Release v${VERSION}" \
             --label no-changelog \
-            --body "Automated release of v${VERSION}. Merging publishes to npm and creates the git tag and GitHub release.")"
+            --body "Automated release of v${VERSION}. Needs one approval; merging then publishes to npm and creates the git tag and GitHub release.")"
           echo "Opened ${PR_URL}"
+          echo "Release PR for v${VERSION} is open and needs an approval before it can merge: ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"
           gh pr merge "$PR_URL" --auto --squash
         env:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
@@ -317,11 +318,14 @@ jobs:
           SPECS="$(yarn lerna list --json --no-private --loglevel silent \
             | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).map(p=>p.name+'@'+p.version).join('\n')))")"
           for SPEC in $SPECS; do
-            if npm view "$SPEC" version >/dev/null 2>&1; then
+            if NPM_OUT="$(npm view "$SPEC" version 2>&1)"; then
               echo "${SPEC} is already published."
-            else
+            elif printf '%s' "$NPM_OUT" | grep -q 'E404'; then
               echo "${SPEC} is not on npm."
               PUBLISH=true
+            else
+              echo "npm view ${SPEC} failed: ${NPM_OUT}" >&2
+              exit 1
             fi
           done
           echo "publish=${PUBLISH}" >> "$GITHUB_OUTPUT"
@@ -335,18 +339,28 @@ jobs:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
 
       - name: Push release tag
+        id: tag
         if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true'
         # Tag before publishing to npm: a publish failure then leaves git fully
         # consistent, and this step is skipped on a re-run if the tag already
-        # points at the right commit.
+        # points at the right commit. The sha is resolved from the `Release v`
+        # commit rather than GITHUB_SHA, which on a workflow_dispatch re-drive is
+        # whatever sits at the tip of the chosen branch. Prefix match, because a
+        # squash subject is the PR title plus " (#N)".
         run: |
+          RELEASE_SHA="$(git rev-list -1 --grep "^Release v${VERSION}" HEAD)"
+          if [ -z "$RELEASE_SHA" ]; then
+            echo "No 'Release v${VERSION}' commit reachable from HEAD" >&2
+            exit 1
+          fi
+          echo "sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
           EXISTING="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || EXISTING=""
           if [ -z "$EXISTING" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/tags/v${VERSION}" -f "sha=${GITHUB_SHA}"
-          elif [ "$EXISTING" = "$GITHUB_SHA" ]; then
-            echo "Tag v${VERSION} already exists at ${GITHUB_SHA}, skipping"
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/tags/v${VERSION}" -f "sha=${RELEASE_SHA}"
+          elif [ "$EXISTING" = "$RELEASE_SHA" ]; then
+            echo "Tag v${VERSION} already exists at ${RELEASE_SHA}, skipping"
           else
-            echo "Tag v${VERSION} already exists but points at ${EXISTING} instead of ${GITHUB_SHA}" >&2
+            echo "Tag v${VERSION} already exists but points at ${EXISTING} instead of ${RELEASE_SHA}" >&2
             exit 1
           fi
         env:
@@ -357,9 +371,10 @@ jobs:
         if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true'
         # `auto release` resolves the release version from `git describe --tags`
         # on HEAD, so the tag has to exist locally as well as on the remote.
-        run: git tag "v${VERSION}" "${GITHUB_SHA}" || true
+        run: git tag "v${VERSION}" "${RELEASE_SHA}" || true
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_SHA: ${{ steps.tag.outputs.sha }}
 
       - name: Publish to npm
         if: steps.version.outputs.publish == 'true'

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -269,7 +269,11 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     needs: [test, test-react-18]
-    if: "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v'))"
+    # The dispatch path is restricted to main: dispatching from an open
+    # release/v* branch would read its bumped lerna.json, match its own
+    # "Release v" commit, then publish and tag a commit that is not on main and
+    # becomes unreachable once the branch is deleted on merge.
+    if: "(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Release v'))"
     concurrency:
       # Deliberately NOT release-main: GitHub keeps a single pending entry per
       # group, so sharing one let a queued publish be cancelled by a later


### PR DESCRIPTION
Releases have failed since 2026-08-25 with `Changes must be made through a pull request` — the org ruleset **Repo required PRs** forbids committing to `main`, which is what the release job did. No stable release since 8.16.1. Platform Productivity declined a bypass and asked for a release-PR model.

## Change

The `release` job becomes two:

| Job | Trigger | Does |
|---|---|---|
| `release-pr` | push to `main` | Writes changelog + version bump to `release/vX.Y.Z`, opens a PR, enables auto-merge |
| `publish` | that PR merging | Tag, npm publish, GitHub release — existing logic, unchanged |

This works because `Repo required PRs` targets only the default branch, so a release branch is writable. `Signed Commits` covers *all* branches, so commits still go through `ghcommit-action`.

The jobs discriminate on commit subject: squash is the only merge method enabled here, so a merged release PR lands as `Release vX.Y.Z`. `publish` additionally checks whether the version is already on npm, so a retitled PR or a re-run is a no-op rather than a failure or double publish.

Also: canary is skipped on `release/*` (it would otherwise publish a canary of the release PR itself), and `release-pr` drops the build step since it publishes nothing.

## Note on releases

Releases are no longer fully unattended — the ruleset requires 1 approving review, and auto-merge waits for it rather than bypassing it. So a release is now: merge a labelled PR → approve the release PR it opens → publish happens automatically.

## Review findings (second commit)

A six-lens adversarial review raised 25 findings; 13 were refuted, 6 distinct real defects fixed:

| Severity | Defect |
|---|---|
| Critical | `release-pr` set `contents: read`, but `create-github-app-token` uses OIDC and needs `id-token: write` — the job would have failed on its first step |
| High | `release-pr` and `publish` shared one concurrency group. GitHub keeps a single pending entry per group, so a queued `publish` could be cancelled by a later `release-pr` — version bumped on main, nothing tagged or published, and reported as *cancelled* rather than *failed*, so nothing alerts |
| High | The publish gate probed only `@grafana/scenes`. lerna publishes topologically, so a partial failure left `scenes-react` unpublished, and the retry went green having skipped everything |
| Medium | The GitHub release was gated on the same npm probe, so a failed `auto release` could never be retried |
| Medium | The superseded-PR loop matched any `release/*` branch and closed it with `--delete-branch` — a human's `release/my-refactor` would have been deleted |
| Medium | No recovery path if the trigger ever missed; added `workflow_dispatch` |

Verified locally: YAML parses; version bumps don't dirty `yarn.lock` (workspaces record as `0.0.0-use.local`), so the release PR's own `yarn install --immutable` stays green and auto-merge isn't blocked; `npm view` exit codes and `lerna list --json --no-private` behave as the gate assumes; the branch matcher accepts `release/v8.17.0` and rejects `release/my-refactor`.

## Reviewer feedback (third commit)

All three comments applied:

- **Tag commit on re-drive.** On a `workflow_dispatch` re-drive `GITHUB_SHA` is the tip of the chosen branch, and dispatch cannot target a commit, so the tag would have landed on whatever merged since. Now resolved from the `Release v` commit subject. (`auto release` still describes from HEAD, so notes can widen on a late dispatch — noted in the step.)
- **npm probe error handling.** `2>&1` conflated E404 with registry/network errors and both set `PUBLISH=true`; harmless for `from-package` itself, but it also unblocked the tag push, so an npm outage would tag a release that never published. Now only E404 counts as "not published".
- **Approval visibility.** The PR body and run summary now say an approval is required, since `--auto` waits for a review rather than bypassing it.

**One finding I could not confirm** and did not act on: a claim that an unlabelled merge landing while a release PR is open drops that commit from the changelog permanently. My reading is that `auto version` still sees the earlier release-labelled PR (untagged until the release PR merges), so the job proceeds and regenerates the PR including the new commit. Worth watching on the first real release.
