### PR TITLE
CI: Harden the release pipeline after the v8.17.0 release

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -297,6 +297,22 @@ jobs:
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
+      # On the workflow_dispatch path the checkout is main's tip, not the release
+      # commit, and everything below reads the working tree: the build, lerna.json,
+      # the gitHead lerna stamps into the npm metadata, and the commit range
+      # `auto release` turns into release notes. Pin the tree to the same commit
+      # `Push release tag` tags, so the tarballs, the tag and the notes all describe
+      # one commit. On the push path HEAD is already that commit, so this is a no-op.
+      - name: Check out the release commit
+        run: |
+          RELEASE_SHA="$(git rev-list -1 --grep "^Release v[0-9]" HEAD)"
+          if [ -z "$RELEASE_SHA" ]; then
+            echo "No 'Release v' commit reachable from HEAD" >&2
+            exit 1
+          fi
+          echo "Publishing from ${RELEASE_SHA}"
+          git checkout --detach "$RELEASE_SHA"
+
       - name: Test using Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -321,6 +337,12 @@ jobs:
           PUBLISH=false
           SPECS="$(yarn lerna list --json --no-private --loglevel silent \
             | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).map(p=>p.name+'@'+p.version).join('\n')))")"
+          # An empty list would leave PUBLISH=false and skip the publish silently green.
+          if [ -z "$SPECS" ]; then
+            echo "lerna list returned no publishable packages" >&2
+            exit 1
+          fi
+          echo "specs=$(printf '%s' "$SPECS" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
           for SPEC in $SPECS; do
             if NPM_OUT="$(npm view "$SPEC" version 2>&1)"; then
               echo "${SPEC} is already published."
@@ -383,12 +405,112 @@ jobs:
       - name: Publish to npm
         if: steps.version.outputs.publish == 'true'
         # Publishing authenticates via npm trusted publishing (OIDC), hence
-        # id-token: write. from-package skips anything already on npm, so a
-        # partially completed publish can be re-run safely.
-        run: yarn lerna publish from-package --yes --no-verify-access
+        # id-token: write. from-package recomputes the publish set from the registry
+        # on every call, so repeating it is safe and is exactly what a human does by
+        # hand: provenance signing intermittently aborts partway through a
+        # multi-package publish with a Rekor 409 (TLOG_CREATE_ENTRY_ERROR), which is
+        # how v8.17.0 left one package published and one not. The registry, not
+        # lerna's exit code, decides when we are done.
+        run: |
+          for ATTEMPT in 1 2 3; do
+            if yarn lerna publish from-package --yes --no-verify-access; then
+              exit 0
+            fi
+            echo "lerna publish attempt ${ATTEMPT} exited non-zero"
+            MISSING=""
+            for SPEC in $SPECS; do
+              npm view "$SPEC" version >/dev/null 2>&1 || MISSING="${MISSING} ${SPEC}"
+            done
+            if [ -z "$MISSING" ]; then
+              echo "Every package is on npm; treating the publish as complete."
+              exit 0
+            fi
+            echo "Still missing:${MISSING}"
+            if [ "$ATTEMPT" -eq 3 ]; then break; fi
+            sleep $((ATTEMPT * 30))
+          done
+          echo "npm publish still incomplete after 3 attempts:${MISSING}" >&2
+          exit 1
+        env:
+          SPECS: ${{ steps.version.outputs.specs }}
 
       - name: Create GitHub release
         if: steps.version.outputs.release == 'true'
-        run: yarn auto release
+        # `auto release` creates the release, then the `released` plugin comments on
+        # every PR and on every issue referenced by a "Closes #N". Upstream guards the
+        # PR path with a try/catch but not the issue path, so a failure there fails
+        # this step after the release is already correct — which is what happened on
+        # v8.17.0 (403, the app has pull_requests:write but not issues:write). Assert
+        # on the release itself and keep a post-release failure visible as a warning.
+        run: |
+          AUTO_RC=0
+          yarn auto release || AUTO_RC=$?
+          if ! gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::auto release exited ${AUTO_RC} and no GitHub release exists for v${VERSION}"
+            exit 1
+          fi
+          if [ "$AUTO_RC" -ne 0 ]; then
+            echo "::warning::GitHub release v${VERSION} was created, but auto exited ${AUTO_RC} afterwards; a post-release comment or label failed"
+          fi
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Report release state
+        # Always runs, because the end state is least obvious exactly when a step
+        # above failed: v8.17.0 attempt 1 was half-published and attempt 2 was fully
+        # released but still red, and both looked like a bare red X.
+        if: always() && steps.version.outputs.version != ''
+        run: |
+          INCOMPLETE=false
+          {
+            echo "## Release v${VERSION}"
+            echo
+            echo "| Artifact | State |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for SPEC in $SPECS; do
+            # Retried: this can run seconds after publishing, and a packument read can
+            # lag. A false MISSING would red a release that actually landed.
+            STATE=""
+            for _ in 1 2 3; do
+              if NPM_OUT="$(npm view "$SPEC" version 2>&1)"; then
+                STATE="published"
+                break
+              fi
+              sleep 5
+            done
+            if [ -z "$STATE" ]; then
+              if printf '%s' "$NPM_OUT" | grep -q 'E404'; then
+                STATE="**MISSING from npm**"
+              else
+                STATE="unknown (npm view failed)"
+              fi
+              INCOMPLETE=true
+            fi
+            echo "| npm \`${SPEC}\` | ${STATE} |" >> "$GITHUB_STEP_SUMMARY"
+          done
+          EXPECTED_SHA="$(git rev-list -1 --grep "^Release v${VERSION}" HEAD || true)"
+          TAG_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || TAG_SHA=""
+          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" = "$EXPECTED_SHA" ]; then
+            echo "| tag \`v${VERSION}\` | \`${TAG_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| tag \`v${VERSION}\` | **MISSING or wrong commit** (\`${TAG_SHA:-none}\`) |" >> "$GITHUB_STEP_SUMMARY"
+            INCOMPLETE=true
+          fi
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "| GitHub release | created |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| GitHub release | **MISSING** |" >> "$GITHUB_STEP_SUMMARY"
+            INCOMPLETE=true
+          fi
+          if [ "$INCOMPLETE" = true ]; then
+            printf '\n**v%s is INCOMPLETE - re-run this job.**\n' "$VERSION" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          printf '\nv%s is fully released on npm, git and GitHub. Any failure above is post-release; re-running will change nothing.\n' "$VERSION" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SPECS: ${{ steps.version.outputs.specs }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -304,13 +304,22 @@ jobs:
       # `Push release tag` tags, so the tarballs, the tag and the notes all describe
       # one commit. On the push path HEAD is already that commit, so this is a no-op.
       - name: Check out the release commit
+        id: release-commit
+        # `--grep` matches ANY line of a commit message, so an unrelated commit whose
+        # body quotes a "Release v..." line resolves ahead of the real release commit.
+        # Candidates are therefore filtered on the subject, which also skips the decoy
+        # rather than failing the release outright. Resolved once here and exported:
+        # every later step reads this output instead of re-deriving it, so a wrong
+        # value stays a single point of failure instead of being confirmed twice.
         run: |
-          RELEASE_SHA="$(git rev-list -1 --grep "^Release v[0-9]" HEAD)"
+          RELEASE_SHA="$(git log --grep "^Release v[0-9]" --format='%H%x09%s' HEAD \
+            | awk -F'\t' '$2 ~ /^Release v[0-9]/ {print $1; exit}')"
           if [ -z "$RELEASE_SHA" ]; then
-            echo "No 'Release v' commit reachable from HEAD" >&2
+            echo "No commit whose subject starts with 'Release v' is reachable from HEAD" >&2
             exit 1
           fi
-          echo "Publishing from ${RELEASE_SHA}"
+          echo "sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Publishing from ${RELEASE_SHA} ($(git log -1 --format=%s "$RELEASE_SHA"))"
           git checkout --detach "$RELEASE_SHA"
 
       - name: Test using Node.js
@@ -360,26 +369,28 @@ jobs:
           else
             echo "release=true" >> "$GITHUB_OUTPUT"
           fi
+          # Tracked separately from publish/release: if both packages are on npm and
+          # the release exists but the tag is missing or on the wrong commit, gating the
+          # tag step on those two would skip it on every re-run, leaving it unfixable.
+          TAG_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || TAG_SHA=""
+          if [ "$TAG_SHA" = "$RELEASE_SHA" ]; then
+            echo "tag=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=true" >> "$GITHUB_OUTPUT"
+          fi
           echo "Needs npm publish: ${PUBLISH}"
         env:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          RELEASE_SHA: ${{ steps.release-commit.outputs.sha }}
 
       - name: Push release tag
-        id: tag
-        if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true'
+        if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true' || steps.version.outputs.tag == 'true'
         # Tag before publishing to npm: a publish failure then leaves git fully
-        # consistent, and this step is skipped on a re-run if the tag already
-        # points at the right commit. The sha is resolved from the `Release v`
-        # commit rather than GITHUB_SHA, which on a workflow_dispatch re-drive is
-        # whatever sits at the tip of the chosen branch. Prefix match, because a
-        # squash subject is the PR title plus " (#N)".
+        # consistent, and this step is a no-op on a re-run if the tag already points
+        # at the right commit. The sha comes from `Check out the release commit`,
+        # since on a workflow_dispatch re-drive GITHUB_SHA is whatever sits at the tip
+        # of the chosen branch.
         run: |
-          RELEASE_SHA="$(git rev-list -1 --grep "^Release v${VERSION}" HEAD)"
-          if [ -z "$RELEASE_SHA" ]; then
-            echo "No 'Release v${VERSION}' commit reachable from HEAD" >&2
-            exit 1
-          fi
-          echo "sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
           EXISTING="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || EXISTING=""
           if [ -z "$EXISTING" ]; then
             gh api "repos/${GITHUB_REPOSITORY}/git/refs" -f "ref=refs/tags/v${VERSION}" -f "sha=${RELEASE_SHA}"
@@ -392,15 +403,16 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_SHA: ${{ steps.release-commit.outputs.sha }}
 
       - name: Create local tag
-        if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true'
+        if: steps.version.outputs.publish == 'true' || steps.version.outputs.release == 'true' || steps.version.outputs.tag == 'true'
         # `auto release` resolves the release version from `git describe --tags`
         # on HEAD, so the tag has to exist locally as well as on the remote.
         run: git tag "v${VERSION}" "${RELEASE_SHA}" || true
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          RELEASE_SHA: ${{ steps.tag.outputs.sha }}
+          RELEASE_SHA: ${{ steps.release-commit.outputs.sha }}
 
       - name: Publish to npm
         if: steps.version.outputs.publish == 'true'
@@ -458,10 +470,12 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
 
       - name: Report release state
-        # Always runs, because the end state is least obvious exactly when a step
-        # above failed: v8.17.0 attempt 1 was half-published and attempt 2 was fully
-        # released but still red, and both looked like a bare red X.
-        if: always() && steps.version.outputs.version != ''
+        # Runs on success and failure, because the end state is least obvious exactly
+        # when a step above failed: v8.17.0 attempt 1 was half-published and attempt 2
+        # was fully released but still red, and both looked like a bare red X.
+        # `!cancelled()` rather than `always()`, so a cancelled run does not report an
+        # incomplete release and fail.
+        if: ${{ !cancelled() && steps.version.outputs.version != '' }}
         run: |
           INCOMPLETE=false
           {
@@ -482,18 +496,21 @@ jobs:
               sleep 5
             done
             if [ -z "$STATE" ]; then
+              # Only a confirmed E404 means "not published". Reddening the job because
+              # npm was unreachable would recreate the false red this step exists to
+              # remove, so an inconclusive probe is a warning.
               if printf '%s' "$NPM_OUT" | grep -q 'E404'; then
                 STATE="**MISSING from npm**"
+                INCOMPLETE=true
               else
                 STATE="unknown (npm view failed)"
+                echo "::warning::npm view failed for ${SPEC}, could not confirm it is published"
               fi
-              INCOMPLETE=true
             fi
             echo "| npm \`${SPEC}\` | ${STATE} |" >> "$GITHUB_STEP_SUMMARY"
           done
-          EXPECTED_SHA="$(git rev-list -1 --grep "^Release v${VERSION}" HEAD || true)"
           TAG_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${VERSION}" --jq .object.sha 2>/dev/null)" || TAG_SHA=""
-          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" = "$EXPECTED_SHA" ]; then
+          if [ -n "$TAG_SHA" ] && [ "$TAG_SHA" = "$RELEASE_SHA" ]; then
             echo "| tag \`v${VERSION}\` | \`${TAG_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "| tag \`v${VERSION}\` | **MISSING or wrong commit** (\`${TAG_SHA:-none}\`) |" >> "$GITHUB_STEP_SUMMARY"
@@ -514,3 +531,4 @@ jobs:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
           SPECS: ${{ steps.version.outputs.specs }}
+          RELEASE_SHA: ${{ steps.release-commit.outputs.sha }}


### PR DESCRIPTION
Hardening for the release pipeline, driven by what actually happened releasing **v8.17.0** — the first live run of the release-PR flow. Every change below traces to a real failure in that run, not a hypothetical.

Recap of the run: the release PR opened, was approved and auto-merged correctly, and `release-pr`/`canary` skipped exactly as designed. Then `publish` failed twice — once half-published, once fully released but still red — and needed a manual re-run.

## 1. Pin the publish tree to the release commit

On the `workflow_dispatch` path `actions/checkout` takes **main's tip**, not the release commit, and everything downstream reads that tree: the build, `lerna.json`, the `gitHead` lerna stamps into npm metadata, and the commit range `auto release` turns into notes.

A re-drive after later merges would publish a tree the tag doesn't describe. `Push release tag` already resolved the `Release v` commit; the working tree now follows it. **No-op on the push path**, where HEAD is already that commit.

This was a gap in the earlier `workflow_dispatch` fix — that pinned the tag's SHA but left the checkout on the tip.

## 2. Retry the npm publish

v8.17.0 aborted partway with a Rekor 409 (`TLOG_CREATE_ENTRY_ERROR`), leaving `@grafana/scenes` published and `@grafana/scenes-react` not. The *identical* command succeeded minutes later on a manual re-run — so the retry is precisely what a human was doing by hand.

The registry, not lerna's exit code, decides completion: after a non-zero exit the step re-probes npm, treats "everything is on npm" as success, and only fails once packages are still missing after three attempts. Safe because `from-package` recomputes the publish set from the registry each call.

Deliberately **not** applied to `Create GitHub release` — `auto release` calls `repos.createRelease` unconditionally, so an in-job retry would 422 once the release exists and turn a good release permanently red. Its re-entrancy correctly comes from the `release` gate across runs.

## 3. Assert the GitHub release exists, don't trust `auto`'s exit code

`auto release` created the release and commented on 10 PRs, then hit issue #1621 with `403 Resource not accessible by integration` and failed the step — after the release was already correct.

This is not a one-off. In `@auto-it/released`, the PR-comment path is wrapped in `try/catch` but **the issue-comment path is not**, so any release containing a `Closes #N` PR fails the same way. A post-release failure is now a `::warning`; a genuinely missing release is still an error.

Granting the app `issues: write` is still worth doing, but it's now a quality-of-life fix rather than a blocker.

## 4. Report the end state to the step summary

Both v8.17.0 attempts surfaced only a bare red X — one half-published, one fully released. Working out which took reading ~2,000 log lines. The summary now lists each package, the tag (and whether it points at the right commit) and the release, then says plainly whether a re-run would change anything.

Also: `Resolve` now fails if `lerna list` returns no publishable packages, which would otherwise leave `PUBLISH=false` and skip the publish **silently green**.

## Verification

The release path can't be exercised by CI, so this is verified by targeted local testing rather than a live run:

- YAML parses; `publish` has the expected 13 steps; `canary` untouched
- Release-commit resolution returns `f52184de` on main — the correct v8.17.0 commit
- Retry loop tested across four cases: success first try → 0; non-zero exit but registry complete → 0; transient then success → 0; genuinely broken → **1** (failure detection preserved)
- `specs` output format verified as space-separated

Honest caveat: **the real test is the next release.** These paths only execute during a publish. The design intent is that every change either fails closed or is a no-op on the happy path.
