### PR TITLE
fix: expose multi-value Apply button to assistive technology

### DIFF
--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/AdHocFiltersCombobox.tsx
@@ -100,6 +100,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
   } = controller.useState();
 
   const multiValuePillWrapperRef = useRef<HTMLDivElement>(null);
+  const multiValueApplyButtonRef = useRef<HTMLDivElement>(null);
 
   const hasMultiValueOperator = isMultiValueOperator(filter?.operator || '');
   const isMultiValueEdit = hasMultiValueOperator && filterInputType === 'value';
@@ -870,7 +871,13 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
       {optionsLoading ? <Spinner className={styles.loadingIndicator} inline={true} /> : null}
       <FloatingPortal>
         {open && (
-          <FloatingFocusManager context={context} initialFocus={-1} visuallyHiddenDismiss modal={true}>
+          <FloatingFocusManager
+            context={context}
+            initialFocus={-1}
+            visuallyHiddenDismiss
+            modal={true}
+            getInsideElements={() => (multiValueApplyButtonRef.current ? [multiValueApplyButtonRef.current] : [])}
+          >
             <>
               <div
                 style={{
@@ -1032,6 +1039,7 @@ export const AdHocCombobox = forwardRef(function AdHocCombobox(
               </div>
               {isMultiValueEdit && !optionsLoading && !optionsError && filteredDropDownItems.length ? (
                 <MultiValueApplyButton
+                  ref={multiValueApplyButtonRef}
                   onApply={() => {
                     handleMultiValueFilterCommit(controller, filter!, filterMultiValues);
                     handleResetWip();

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersCombobox/DropdownItem.tsx
@@ -159,28 +159,26 @@ interface MultiValueApplyButtonProps {
   menuHeight: number;
 }
 
-export const MultiValueApplyButton = ({
-  onApply,
-  floatingElement,
-  maxOptionWidth,
-  menuHeight,
-}: MultiValueApplyButtonProps) => {
-  const styles = useStyles2(getStyles);
+export const MultiValueApplyButton = forwardRef<HTMLDivElement, MultiValueApplyButtonProps>(
+  function MultiValueApplyButton({ onApply, floatingElement, maxOptionWidth, menuHeight }, ref) {
+    const styles = useStyles2(getStyles);
 
-  const floatingElementRect = floatingElement?.getBoundingClientRect();
-  return (
-    <div
-      className={styles.multiValueApplyWrapper}
-      style={{
-        width: `${maxOptionWidth}px`,
-        transform: `translate(${floatingElementRect?.left}px,${
-          floatingElementRect ? floatingElementRect.top + menuHeight : 0
-        }px)`,
-      }}
-    >
-      <Button onClick={onApply} size="sm" tabIndex={-1}>
-        <Trans i18nKey="grafana-scenes.variables.multi-value-apply-button.apply">Apply</Trans>
-      </Button>
-    </div>
-  );
-};
+    const floatingElementRect = floatingElement?.getBoundingClientRect();
+    return (
+      <div
+        ref={ref}
+        className={styles.multiValueApplyWrapper}
+        style={{
+          width: `${maxOptionWidth}px`,
+          transform: `translate(${floatingElementRect?.left}px,${
+            floatingElementRect ? floatingElementRect.top + menuHeight : 0
+          }px)`,
+        }}
+      >
+        <Button onClick={onApply} size="sm">
+          <Trans i18nKey="grafana-scenes.variables.multi-value-apply-button.apply">Apply</Trans>
+        </Button>
+      </div>
+    );
+  }
+);

--- a/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
+++ b/packages/scenes/src/variables/adhoc/AdHocFiltersVariable.test.tsx
@@ -3291,6 +3291,20 @@ describe.each(['11.1.2', '11.1.1'])('AdHocFiltersVariable', (v) => {
       expect(screen.getAllByRole('option')[0]).toHaveTextContent('All');
     });
 
+    it('gives the Apply button a native tab stop while editing multi-value filters', async () => {
+      setup({
+        originFilters: [
+          { key: 'pod', operator: '=|', value: 'test1', values: ['test1', 'test2'], origin: 'dashboard' },
+        ],
+        layout: 'combobox',
+      });
+
+      await userEvent.click(await screen.findByText('pod =| test1, test2'));
+
+      const applyButton = await screen.findByRole('button', { name: 'Apply' });
+      expect(applyButton).toHaveProperty('tabIndex', 0);
+    });
+
     it('does not offer All for user-added filters', async () => {
       setup({
         filters: setTemplateSrvWithFilters([


### PR DESCRIPTION
Fixes #1600

## Summary

The multi-value ad hoc filter Apply button is rendered as a sibling of the floating dropdown. Floating UI therefore marks its wrapper as aria-hidden, and the explicit tabIndex=-1 prevents keyboard users from reaching it.

This change:

- registers the Apply button wrapper with Floating UI getInsideElements so it remains in the accessibility tree;
- restores the button native tab stop.

## Validation

- corepack yarn workspace @grafana/scenes test src/variables/adhoc/AdHocFiltersVariable.test.tsx --watch=false --runInBand (362 passed)
- corepack yarn workspace @grafana/scenes typecheck
- corepack yarn workspace @grafana/scenes lint
- corepack yarn workspace @grafana/scenes build
- Prettier check on all changed files
- git diff --check